### PR TITLE
BAU: Incorporate improvements to compressed notes

### DIFF
--- a/app/models/tariff_knowledge/compressed_note.rb
+++ b/app/models/tariff_knowledge/compressed_note.rb
@@ -22,6 +22,10 @@ module TariffKnowledge
         where(goods_nomenclature_item_id: item_ids)
       end
 
+      def usable_for_search
+        where(stale: false, expired: false, needs_review: false)
+      end
+
       def needing_regeneration
         where(stale: true, manually_edited: false)
       end

--- a/app/models/tariff_knowledge/node.rb
+++ b/app/models/tariff_knowledge/node.rb
@@ -27,6 +27,10 @@ module TariffKnowledge
         where(node_type: GOODS_NOMENCLATURE)
       end
 
+      def non_hidden_goods_nomenclatures
+        goods_nomenclatures.exclude(goods_nomenclature_item_id: HiddenGoodsNomenclature.codes)
+      end
+
       def note_fragments
         where(node_type: NOTE_FRAGMENT)
       end

--- a/app/services/interactive_search_service.rb
+++ b/app/services/interactive_search_service.rb
@@ -111,12 +111,24 @@ class InteractiveSearchService
   end
 
   def build_context
-    context = configured_context.to_s
+    context = context_with_compressed_notes(configured_context.to_s)
     context
       .gsub('%{search_input}', query.to_s)
       .gsub('%{expanded_query}', expanded_query.to_s)
       .gsub('%{answers_opensearch}', format_opensearch_results.to_s)
       .gsub('%{questions}', format_questions_and_answers.to_s)
+  end
+
+  def context_with_compressed_notes(context)
+    if context.include?('%{compressed_notes}')
+      context.gsub('%{compressed_notes}', format_compressed_notes)
+    elsif compressed_note_contexts.any?
+      context.sub(/^.*%{answers_opensearch}.*$/) do |answers_opensearch_line|
+        "Relevant compressed notes: #{format_compressed_notes}\n#{answers_opensearch_line}"
+      end
+    else
+      context
+    end
   end
 
   def format_opensearch_results
@@ -126,26 +138,52 @@ class InteractiveSearchService
         description: result.full_description.presence || result.description,
         score: result.score,
       }
-      compressed_note = compressed_notes_by_item_id[result.goods_nomenclature_item_id]
-      formatted_result[:compressed_note] = compressed_note.content if compressed_note
+      note_key = selected_compressed_note_keys_by_item_id[result.goods_nomenclature_item_id]
+      formatted_result[:compressed_note_refs] = [compressed_note_ref(note_key)] if note_key
       formatted_result
     end
     results.to_json
   end
+
+  def format_compressed_notes = compressed_note_contexts.to_json
 
   def compressed_notes_by_item_id
     return {} unless AdminConfiguration.enabled?('search_compressed_notes_enabled')
 
     @compressed_notes_by_item_id ||= begin
       item_ids = opensearch_results.map(&:goods_nomenclature_item_id).compact_blank.uniq
-      notes = TariffKnowledge::CompressedNote
-        .where(approved: true, stale: false, expired: false)
+      TariffKnowledge::CompressedNote.where(approved: true, stale: false, expired: false)
         .by_item_ids(item_ids)
-
-      notes.each_with_object({}) do |note, by_item_id|
+        .order(Sequel.desc(:generated_at), Sequel.desc(:updated_at))
+        .each_with_object({}) do |note, by_item_id|
         by_item_id[note.goods_nomenclature_item_id] ||= note
       end
     end
+  end
+
+  def compressed_note_contexts
+    return @compressed_note_contexts if defined?(@compressed_note_contexts)
+
+    @compressed_note_contexts = selected_compressed_note_contexts.map do |context|
+      { note_ref: compressed_note_ref(context[:key]), commodity_codes: context[:commodity_codes], fragments: context[:fragments] }
+    end
+  end
+
+  def selected_compressed_note_keys_by_item_id
+    @selected_compressed_note_keys_by_item_id ||= begin
+      selected_note_keys = selected_compressed_note_contexts.pluck(:key).to_set
+
+      compressed_notes_by_item_id.each_with_object({}) do |(item_id, note), by_item_id|
+        by_item_id[item_id] = note.context_hash if selected_note_keys.include?(note.context_hash)
+      end
+    end
+  end
+
+  def selected_compressed_note_contexts = @selected_compressed_note_contexts ||= TariffKnowledge::RelevantNoteFragmentSelector.call(query:, search_results: opensearch_results, notes_by_item_id: compressed_notes_by_item_id)
+
+  def compressed_note_ref(compressed_note_key)
+    @compressed_note_refs ||= {}
+    @compressed_note_refs[compressed_note_key] ||= "compressed_note_#{@compressed_note_refs.size + 1}"
   end
 
   def format_questions_and_answers

--- a/app/services/interactive_search_service.rb
+++ b/app/services/interactive_search_service.rb
@@ -156,7 +156,7 @@ class InteractiveSearchService
 
     @compressed_notes_by_item_id ||= begin
       item_ids = opensearch_results.map(&:goods_nomenclature_item_id).compact_blank.uniq
-      TariffKnowledge::CompressedNote.where(approved: true, stale: false, expired: false)
+      TariffKnowledge::CompressedNote.usable_for_search
         .by_item_ids(item_ids)
         .order(Sequel.desc(:generated_at), Sequel.desc(:updated_at))
         .each_with_object({}) do |note, by_item_id|

--- a/app/services/interactive_search_service.rb
+++ b/app/services/interactive_search_service.rb
@@ -121,7 +121,7 @@ class InteractiveSearchService
 
   def context_with_compressed_notes(context)
     if context.include?('%{compressed_notes}')
-      context.gsub('%{compressed_notes}', format_compressed_notes)
+      compressed_note_contexts.any? ? context.gsub('%{compressed_notes}', format_compressed_notes) : remove_compressed_notes_line(context)
     elsif compressed_note_contexts.any?
       context.sub(/^.*%{answers_opensearch}.*$/) do |answers_opensearch_line|
         "Relevant compressed notes: #{format_compressed_notes}\n#{answers_opensearch_line}"
@@ -129,6 +129,10 @@ class InteractiveSearchService
     else
       context
     end
+  end
+
+  def remove_compressed_notes_line(context)
+    context.gsub(/^.*%{compressed_notes}.*$\n?/, '')
   end
 
   def format_opensearch_results

--- a/app/services/interactive_search_service.rb
+++ b/app/services/interactive_search_service.rb
@@ -132,7 +132,9 @@ class InteractiveSearchService
   end
 
   def remove_compressed_notes_line(context)
-    context.gsub(/^.*%{compressed_notes}.*$\n?/, '')
+    context
+      .gsub(/^[^\n]*RELEVANT_COMPRESSED_NOTES[^\n]*\n[^\n]*%\{compressed_notes\}[^\n]*\n[^\n]*END RELEVANT_COMPRESSED_NOTES[^\n]*\n?/, '')
+      .gsub(/^.*%{compressed_notes}.*$\n?/, '')
   end
 
   def format_opensearch_results

--- a/app/services/tariff_knowledge/compressed_note_generator.rb
+++ b/app/services/tariff_knowledge/compressed_note_generator.rb
@@ -39,6 +39,8 @@ module TariffKnowledge
         metadata: Sequel.pg_jsonb(metadata_for(evidence)),
         context_hash: Digest::SHA256.hexdigest(content),
         generated_at: Time.zone.now,
+        # Pipeline generation resets lifecycle flags. Reviewers can later mark
+        # generated content as needing review if it is suspect.
         needs_review: false,
         approved: false,
         manually_edited: false,
@@ -178,11 +180,6 @@ module TariffKnowledge
     def source_context(fragment_node, source_node)
       return fragment_node.content.to_s.squish unless source_node
 
-      # A fragment can be a short list item whose meaning depends on the lead-in
-      # immediately before it, for example "This chapter does not cover:".
-      # Include that lead-in in metadata so prompt-time selection can classify
-      # the fragment as inclusion/exclusion/reference without sending the whole
-      # source note.
       fragment_nodes = source_fragment_nodes(source_node)
       fragment_index = fragment_nodes.index { |node| node.id == fragment_node.id }
       return fragment_node.content.to_s.squish unless fragment_index

--- a/app/services/tariff_knowledge/compressed_note_generator.rb
+++ b/app/services/tariff_knowledge/compressed_note_generator.rb
@@ -120,17 +120,13 @@ module TariffKnowledge
       end
     end
 
-    def content_for(declarable_node, evidence)
+    def content_for(_declarable_node, evidence)
       general_rule_evidence, note_evidence = evidence.partition do |fragment_node, _range_node, _source_node|
         general_rule_fragment?(fragment_node)
-      end
-      proxy_chapter_evidence, note_evidence = note_evidence.partition do |fragment_node, _range_node, _source_node|
-        broad_proxy_chapter_fragment?(declarable_node, fragment_node)
       end
       content = note_evidence.map { |fragment_node, _range_node, _source_node|
         "#{fragment_node.title}\n#{fragment_node.content}"
       }.uniq
-      content << proxy_chapter_summary(proxy_chapter_evidence) if proxy_chapter_evidence.any?
       content << general_rule_summary(general_rule_evidence) if general_rule_evidence.any?
 
       content.compact.join("\n\n")
@@ -139,39 +135,6 @@ module TariffKnowledge
     def general_rule_fragment?(fragment_node)
       fragment_node.source_type == 'customs_tariff_general_rule' ||
         fragment_node.key.include?(':customs_tariff_general_rule:')
-    end
-
-    def broad_proxy_chapter_fragment?(declarable_node, fragment_node)
-      # Special/proxy codes can represent goods from many CN chapters. Rendering
-      # every applicable chapter note would produce huge, mostly unusable notes,
-      # so broad multi-chapter provenance is summarised in content and retained
-      # in metadata for audit/drill-down.
-      proxy_chapter_codes(declarable_node).many? &&
-        (fragment_node.source_type == 'customs_tariff_chapter_note' ||
-          fragment_node.key.include?(':customs_tariff_chapter_note:')) &&
-        proxy_chapter_codes(declarable_node).include?(fragment_node.source_id.to_s.rjust(2, '0'))
-    end
-
-    def proxy_chapter_codes(declarable_node)
-      @proxy_chapter_codes_by_node_id ||= {}
-      @proxy_chapter_codes_by_node_id[declarable_node.id] ||= Array(declarable_node.metadata.to_h['chapter_scope_codes']).map { |code| sprintf('%02d', code.to_i) }.uniq
-    end
-
-    def proxy_chapter_summary(evidence)
-      chapter_range = compact_chapter_range(evidence.map { |fragment_node, _range_node, _source_node| fragment_node.source_id.to_s.rjust(2, '0') }.uniq.sort)
-      "Chapter note provenance for CN #{chapter_range} applies because this special code covers goods from those chapters. " \
-        'The full chapter-note fragments are retained in this note provenance; use the underlying CN chapter when detailed legal note text is needed.'
-    end
-
-    def compact_chapter_range(chapter_ids)
-      return "chapter #{chapter_ids.first}" if chapter_ids.one?
-
-      chapter_numbers = chapter_ids.map(&:to_i)
-      if chapter_numbers.each_cons(2).all? { |left, right| right == left + 1 }
-        "chapters #{chapter_ids.first} to #{chapter_ids.last}"
-      else
-        "chapters #{chapter_ids.join(', ')}"
-      end
     end
 
     def general_rule_summary(evidence)

--- a/app/services/tariff_knowledge/compressed_note_generator.rb
+++ b/app/services/tariff_knowledge/compressed_note_generator.rb
@@ -9,8 +9,11 @@ module TariffKnowledge
     end
 
     def call
-      declarable_nodes.filter_map do |declarable_node|
-        generate_for(declarable_node)
+      nodes = declarable_nodes
+      evidence_by_node_id = evidence_by_declarable_node_id(nodes)
+
+      nodes.filter_map do |declarable_node|
+        generate_for(declarable_node, evidence_by_node_id.fetch(declarable_node.id, []))
       end
     end
 
@@ -24,11 +27,10 @@ module TariffKnowledge
           .all
     end
 
-    def generate_for(declarable_node)
-      evidence = evidence_for(declarable_node)
+    def generate_for(declarable_node, evidence)
       return if evidence.empty?
 
-      content = content_for(evidence)
+      content = content_for(declarable_node, evidence)
       attributes = {
         goods_nomenclature_item_id: declarable_node.goods_nomenclature_item_id,
         producline_suffix: declarable_node.producline_suffix,
@@ -37,7 +39,7 @@ module TariffKnowledge
         metadata: Sequel.pg_jsonb(metadata_for(evidence)),
         context_hash: Digest::SHA256.hexdigest(content),
         generated_at: Time.zone.now,
-        needs_review: true,
+        needs_review: false,
         approved: false,
         manually_edited: false,
         stale: false,
@@ -47,65 +49,209 @@ module TariffKnowledge
       upsert_note(declarable_node, attributes)
     end
 
-    def evidence_for(declarable_node)
-      range_nodes = range_nodes_for(declarable_node)
-      indexed_range_nodes = range_nodes_by_id(range_nodes)
-      evidence = fragment_nodes_by_range_node_id(range_nodes).flat_map do |range_node_id, fragment_nodes|
-        range_node = indexed_range_nodes[range_node_id]
-        fragment_nodes.map { |fragment_node| [fragment_node, range_node] }
+    def evidence_by_declarable_node_id(declarable_nodes)
+      declarable_node_ids = declarable_nodes.map(&:id)
+      return {} if declarable_node_ids.empty?
+
+      # Evidence can reach a declarable commodity in two ways:
+      # - directly, via APPLIES_TO from a note fragment to the commodity
+      # - indirectly, where a fragment REFERENCES a chapter/heading range and
+      #   that range EXPANDS_TO the commodity.
+      #
+      # When both paths exist, keep the range-aware evidence because it tells the
+      # prompt selector which candidate chapter/heading made the fragment useful.
+      expansion_edges = Edge.by_relationship(Edge::EXPANDS_TO).where(target_node_id: declarable_node_ids).all
+      range_nodes = nodes_by_id(expansion_edges.map(&:source_node_id), Node.where(node_type: Node::RANGE))
+      reference_edges = Edge.by_relationship(Edge::REFERENCES).where(target_node_id: range_nodes.keys).all
+      apply_edges = Edge.by_relationship(Edge::APPLIES_TO).where(target_node_id: declarable_node_ids).all
+      fragment_nodes = nodes_by_id((reference_edges + apply_edges).map(&:source_node_id), Node.note_fragments)
+      expansion_edges_by_target_id = expansion_edges.group_by(&:target_node_id)
+      reference_edges_by_range_id = reference_edges.group_by(&:target_node_id)
+      apply_edges_by_target_id = apply_edges.group_by(&:target_node_id)
+      source_nodes_by_fragment_id = source_nodes_by_fragment_node_id(fragment_nodes.values)
+
+      declarable_nodes.each_with_object({}) do |declarable_node, grouped|
+        applicable_fragment_ids = apply_edges_by_target_id.fetch(declarable_node.id, []).map(&:source_node_id).to_set
+
+        referenced_evidence = expansion_edges_by_target_id
+          .fetch(declarable_node.id, [])
+          .flat_map do |edge|
+            range_node = range_nodes[edge.source_node_id]
+            reference_edges_by_range_id.fetch(range_node&.id, []).filter_map do |reference_edge|
+              fragment_node = fragment_nodes[reference_edge.source_node_id]
+              if fragment_node && applicable_fragment_ids.include?(fragment_node.id)
+                [fragment_node, range_node, source_nodes_by_fragment_id[fragment_node.id]]
+              end
+            end
+          end
+
+        referenced_fragment_node_ids = referenced_evidence.map { |fragment_node, _range_node, _source_node| fragment_node.id }.to_set
+        applied_evidence = applicable_fragment_ids.filter_map do |fragment_node_id|
+          next if referenced_fragment_node_ids.include?(fragment_node_id)
+
+          fragment_node = fragment_nodes[fragment_node_id]
+          [fragment_node, nil, source_nodes_by_fragment_id[fragment_node_id]] if fragment_node
+        end
+        evidence = (referenced_evidence + applied_evidence)
+          .uniq { |fragment_node, range_node, _source_node| [fragment_node.id, range_node&.id] }
+        grouped[declarable_node.id] = sort_evidence(evidence) if evidence.any?
       end
-
-      evidence.sort_by { |fragment_node, range_node| [fragment_node.source_type.to_s, fragment_node.source_id.to_s, fragment_node.key, range_node.key] }
     end
 
-    def range_nodes_for(declarable_node)
-      range_node_ids = Edge
-        .by_relationship(Edge::EXPANDS_TO)
-        .where(target_node_id: declarable_node.id)
-        .select_map(:source_node_id)
-      return [] if range_node_ids.empty?
-
-      Node.where(id: range_node_ids, node_type: Node::RANGE).all
+    def nodes_by_id(ids, dataset)
+      ids = ids.compact.uniq
+      ids.empty? ? {} : dataset.where(id: ids).all.index_by(&:id)
     end
 
-    def fragment_nodes_by_range_node_id(range_nodes)
-      range_node_ids = range_nodes.map(&:id)
-      return {} if range_node_ids.empty?
+    def source_nodes_by_fragment_node_id(fragment_nodes)
+      fragment_node_ids = fragment_nodes.map(&:id).uniq
+      return {} if fragment_node_ids.empty?
 
-      reference_edges = Edge
-        .by_relationship(Edge::REFERENCES)
-        .where(target_node_id: range_node_ids)
-        .all
-      fragment_nodes = Node
-        .note_fragments
-        .where(id: reference_edges.map(&:source_node_id).uniq)
-        .all
-        .index_by(&:id)
-
-      reference_edges.each_with_object({}) do |edge, grouped|
-        fragment_node = fragment_nodes[edge.source_node_id]
-        next unless fragment_node
-
-        grouped[edge.target_node_id] ||= []
-        grouped[edge.target_node_id] << fragment_node
+      contains_edges = Edge.by_relationship(Edge::CONTAINS).where(target_node_id: fragment_node_ids).all
+      source_nodes = nodes_by_id(contains_edges.map(&:source_node_id), Node.where(node_type: Node::NOTE_SOURCE))
+      contains_edges.each_with_object({}) do |edge, grouped|
+        grouped[edge.target_node_id] = source_nodes[edge.source_node_id]
       end
     end
 
-    def range_nodes_by_id(range_nodes)
-      range_nodes.index_by(&:id)
+    def sort_evidence(evidence)
+      evidence.sort_by do |fragment_node, range_node, _source_node|
+        [fragment_node.source_type.to_s, fragment_node.source_id.to_s, fragment_node.key, range_node&.key.to_s]
+      end
     end
 
-    def content_for(evidence)
-      evidence.map { |fragment_node, _range_node|
+    def content_for(declarable_node, evidence)
+      general_rule_evidence, note_evidence = evidence.partition do |fragment_node, _range_node, _source_node|
+        general_rule_fragment?(fragment_node)
+      end
+      proxy_chapter_evidence, note_evidence = note_evidence.partition do |fragment_node, _range_node, _source_node|
+        broad_proxy_chapter_fragment?(declarable_node, fragment_node)
+      end
+      content = note_evidence.map { |fragment_node, _range_node, _source_node|
         "#{fragment_node.title}\n#{fragment_node.content}"
-      }.uniq.join("\n\n")
+      }.uniq
+      content << proxy_chapter_summary(proxy_chapter_evidence) if proxy_chapter_evidence.any?
+      content << general_rule_summary(general_rule_evidence) if general_rule_evidence.any?
+
+      content.compact.join("\n\n")
+    end
+
+    def general_rule_fragment?(fragment_node)
+      fragment_node.source_type == 'customs_tariff_general_rule' ||
+        fragment_node.key.include?(':customs_tariff_general_rule:')
+    end
+
+    def broad_proxy_chapter_fragment?(declarable_node, fragment_node)
+      # Special/proxy codes can represent goods from many CN chapters. Rendering
+      # every applicable chapter note would produce huge, mostly unusable notes,
+      # so broad multi-chapter provenance is summarised in content and retained
+      # in metadata for audit/drill-down.
+      proxy_chapter_codes(declarable_node).many? &&
+        (fragment_node.source_type == 'customs_tariff_chapter_note' ||
+          fragment_node.key.include?(':customs_tariff_chapter_note:')) &&
+        proxy_chapter_codes(declarable_node).include?(fragment_node.source_id.to_s.rjust(2, '0'))
+    end
+
+    def proxy_chapter_codes(declarable_node)
+      @proxy_chapter_codes_by_node_id ||= {}
+      @proxy_chapter_codes_by_node_id[declarable_node.id] ||= Array(declarable_node.metadata.to_h['chapter_scope_codes']).map { |code| sprintf('%02d', code.to_i) }.uniq
+    end
+
+    def proxy_chapter_summary(evidence)
+      chapter_range = compact_chapter_range(evidence.map { |fragment_node, _range_node, _source_node| fragment_node.source_id.to_s.rjust(2, '0') }.uniq.sort)
+      "Chapter note provenance for CN #{chapter_range} applies because this special code covers goods from those chapters. " \
+        'The full chapter-note fragments are retained in this note provenance; use the underlying CN chapter when detailed legal note text is needed.'
+    end
+
+    def compact_chapter_range(chapter_ids)
+      return "chapter #{chapter_ids.first}" if chapter_ids.one?
+
+      chapter_numbers = chapter_ids.map(&:to_i)
+      if chapter_numbers.each_cons(2).all? { |left, right| right == left + 1 }
+        "chapters #{chapter_ids.first} to #{chapter_ids.last}"
+      else
+        "chapters #{chapter_ids.join(', ')}"
+      end
+    end
+
+    def general_rule_summary(evidence)
+      rule_labels = evidence.map { |fragment_node, _range_node, _source_node| fragment_node.source_id.presence || fragment_node.key.split(':')[3] }.uniq.sort_by { |label| label.to_s.to_i }
+      "General Interpretive Rules #{rule_labels.join(', ')} apply when classifying goods. " \
+        'The full rule fragments are retained in this note provenance.'
     end
 
     def metadata_for(evidence)
       {
-        'source_node_keys' => evidence.map { |fragment_node, _range_node| fragment_node.key }.uniq,
-        'range_node_keys' => evidence.map { |_fragment_node, range_node| range_node.key }.uniq,
+        'source_node_keys' => evidence.map { |fragment_node, _range_node, _source_node| fragment_node.key }.uniq,
+        'range_node_keys' => evidence.filter_map { |_fragment_node, range_node, _source_node| range_node&.key }.uniq,
+        'evidence' => evidence.map { |fragment_node, range_node, source_node| evidence_metadata(fragment_node, range_node, source_node) },
       }
+    end
+
+    def evidence_metadata(fragment_node, range_node, source_node)
+      range_metadata = range_node ? range_node.metadata.to_h : {}
+      context = source_context(fragment_node, source_node)
+
+      {
+        'source_node_key' => fragment_node.key,
+        'source_type' => fragment_node.source_type.to_s.underscore,
+        'source_id' => fragment_node.source_id,
+        'source_version' => fragment_node.source_version,
+        'source_title' => fragment_node.title,
+        'parent_source_node_key' => source_node&.key,
+        'parent_source_title' => source_node&.title,
+        'source_context' => context,
+        'context_type' => context_type(context),
+        'range_node_key' => range_node&.key,
+        'range_type' => range_metadata['range_type'],
+        'range_code' => range_metadata['code'],
+        'range_title' => range_node&.title,
+        'relationships' => relationships_for(range_node),
+      }
+    end
+
+    def relationships_for(range_node) = range_node ? [Edge::REFERENCES, Edge::EXPANDS_TO, Edge::APPLIES_TO] : [Edge::APPLIES_TO]
+
+    def source_context(fragment_node, source_node)
+      return fragment_node.content.to_s.squish unless source_node
+
+      # A fragment can be a short list item whose meaning depends on the lead-in
+      # immediately before it, for example "This chapter does not cover:".
+      # Include that lead-in in metadata so prompt-time selection can classify
+      # the fragment as inclusion/exclusion/reference without sending the whole
+      # source note.
+      fragment_nodes = source_fragment_nodes(source_node)
+      fragment_index = fragment_nodes.index { |node| node.id == fragment_node.id }
+      return fragment_node.content.to_s.squish unless fragment_index
+
+      preceding_fragments = fragment_nodes.first(fragment_index).map { |node| node.content.to_s.squish }
+      preceding_fragment = preceding_fragments.reverse.find { |fragment| context_lead_in?(fragment) } || preceding_fragments.last
+
+      [preceding_fragment, fragment_node.content].compact_blank.join(' ').squish
+    end
+
+    def source_fragment_nodes(source_node)
+      @source_fragment_nodes_by_source_node_id ||= {}
+      @source_fragment_nodes_by_source_node_id[source_node.id] ||= begin
+        contains_edges = Edge.by_relationship(Edge::CONTAINS).where(source_node_id: source_node.id).all
+        fragment_nodes = nodes_by_id(contains_edges.map(&:target_node_id), Node.note_fragments)
+        contains_edges.filter_map { |edge| fragment_nodes[edge.target_node_id] }
+                      .sort_by { |node| [fragment_sequence(node), node.key.to_s, node.id] }
+      end
+    end
+
+    def fragment_sequence(fragment_node) = fragment_node.key.to_s[/:(\d+)\z/, 1].to_i
+
+    def context_lead_in?(fragment) = fragment.match?(/:\z|\b(does not cover|not cover|excluded|excluding|does not include|do not include|includes|include|covers|cover)\b/i)
+
+    def context_type(context)
+      if context.match?(/\b(does not cover|not cover|excluded|excluding|does not include|do not include)\b/i)
+        'exclusion'
+      elsif context.match?(/\b(includes|include|covers|cover)\b/i)
+        'inclusion'
+      else
+        'reference'
+      end
     end
 
     def upsert_note(declarable_node, attributes)

--- a/app/services/tariff_knowledge/compressed_note_refresh.rb
+++ b/app/services/tariff_knowledge/compressed_note_refresh.rb
@@ -38,6 +38,7 @@ module TariffKnowledge
         .actual
         .with_leaf_column
         .declarable
+        .non_hidden
         .unordered
         .select_map(Sequel[:goods_nomenclatures][:goods_nomenclature_sid])
         .compact

--- a/app/services/tariff_knowledge/declarable_node_loader.rb
+++ b/app/services/tariff_knowledge/declarable_node_loader.rb
@@ -1,6 +1,17 @@
 module TariffKnowledge
   class DeclarableNodeLoader
     BATCH_SIZE = 500
+    # Proxy/special declarables can describe their real CN chapter scope in the
+    # hierarchy descriptions rather than in the item id. Capture the phrases we
+    # currently see in those descriptions and store normalized chapter codes in
+    # metadata so later graph loading does not need to parse hierarchy prose.
+    CHAPTER_SCOPE_CODE_PATTERNS = [
+      /\bClassified in Chapter\s+(\d{1,2})\b/i,
+      /\bGoods from CN chapter\s+(\d{1,2})\b/i,
+    ].freeze
+    CHAPTER_SCOPE_RANGE_PATTERNS = [
+      /\bGoods from CN chapters\s+(\d{1,2})\s+to\s+(\d{1,2})\b/i,
+    ].freeze
 
     def self.call
       new.call
@@ -11,6 +22,7 @@ module TariffKnowledge
         GoodsNomenclature.actual
                          .with_leaf_column
                          .declarable
+                         .eager(:goods_nomenclature_descriptions, ancestors: :goods_nomenclature_descriptions)
                          .paged_each(rows_per_fetch: BATCH_SIZE)
                          .each_slice(BATCH_SIZE) do |goods_nomenclatures|
           upsert_goods_nomenclature_nodes(goods_nomenclatures.map(&:sti_cast))
@@ -36,8 +48,8 @@ module TariffKnowledge
         node_type: Node::GOODS_NOMENCLATURE,
         key: "goods_nomenclature:#{goods_nomenclature.goods_nomenclature_sid}",
         title: goods_nomenclature.goods_nomenclature_item_id,
-        content: goods_nomenclature.description,
-        metadata: Sequel.pg_jsonb({}),
+        content: nil,
+        metadata: Sequel.pg_jsonb(scope_metadata(goods_nomenclature)),
         goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid,
         goods_nomenclature_item_id: goods_nomenclature.goods_nomenclature_item_id,
         producline_suffix: goods_nomenclature.producline_suffix,
@@ -47,6 +59,23 @@ module TariffKnowledge
         created_at: now,
         updated_at: now,
       }
+    end
+
+    def scope_metadata(goods_nomenclature)
+      chapter_scope_codes = chapter_scope_codes(goods_nomenclature)
+      chapter_scope_codes.any? ? { 'chapter_scope_codes' => chapter_scope_codes } : {}
+    end
+
+    def chapter_scope_codes(goods_nomenclature)
+      descriptions = (goods_nomenclature.ancestors + [goods_nomenclature]).map do |item|
+        item.description_plain.presence || item.description.presence
+      end
+      content = descriptions.compact.join(' ')
+      codes = CHAPTER_SCOPE_CODE_PATTERNS.flat_map { |pattern| content.scan(pattern).flatten }
+      codes += CHAPTER_SCOPE_RANGE_PATTERNS.flat_map do |pattern|
+        content.scan(pattern).flat_map { |from_chapter, to_chapter| (from_chapter.to_i..to_chapter.to_i).to_a }
+      end
+      codes.map { |code| sprintf('%02d', code.to_i) }.uniq
     end
 
     def update_values

--- a/app/services/tariff_knowledge/declarable_node_loader.rb
+++ b/app/services/tariff_knowledge/declarable_node_loader.rb
@@ -1,17 +1,6 @@
 module TariffKnowledge
   class DeclarableNodeLoader
     BATCH_SIZE = 500
-    # Proxy/special declarables can describe their real CN chapter scope in the
-    # hierarchy descriptions rather than in the item id. Capture the phrases we
-    # currently see in those descriptions and store normalized chapter codes in
-    # metadata so later graph loading does not need to parse hierarchy prose.
-    CHAPTER_SCOPE_CODE_PATTERNS = [
-      /\bClassified in Chapter\s+(\d{1,2})\b/i,
-      /\bGoods from CN chapter\s+(\d{1,2})\b/i,
-    ].freeze
-    CHAPTER_SCOPE_RANGE_PATTERNS = [
-      /\bGoods from CN chapters\s+(\d{1,2})\s+to\s+(\d{1,2})\b/i,
-    ].freeze
 
     def self.call
       new.call
@@ -22,7 +11,7 @@ module TariffKnowledge
         GoodsNomenclature.actual
                          .with_leaf_column
                          .declarable
-                         .eager(:goods_nomenclature_descriptions, ancestors: :goods_nomenclature_descriptions)
+                         .non_hidden
                          .paged_each(rows_per_fetch: BATCH_SIZE)
                          .each_slice(BATCH_SIZE) do |goods_nomenclatures|
           upsert_goods_nomenclature_nodes(goods_nomenclatures.map(&:sti_cast))
@@ -49,7 +38,7 @@ module TariffKnowledge
         key: "goods_nomenclature:#{goods_nomenclature.goods_nomenclature_sid}",
         title: goods_nomenclature.goods_nomenclature_item_id,
         content: nil,
-        metadata: Sequel.pg_jsonb(scope_metadata(goods_nomenclature)),
+        metadata: Sequel.pg_jsonb({}),
         goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid,
         goods_nomenclature_item_id: goods_nomenclature.goods_nomenclature_item_id,
         producline_suffix: goods_nomenclature.producline_suffix,
@@ -59,23 +48,6 @@ module TariffKnowledge
         created_at: now,
         updated_at: now,
       }
-    end
-
-    def scope_metadata(goods_nomenclature)
-      chapter_scope_codes = chapter_scope_codes(goods_nomenclature)
-      chapter_scope_codes.any? ? { 'chapter_scope_codes' => chapter_scope_codes } : {}
-    end
-
-    def chapter_scope_codes(goods_nomenclature)
-      descriptions = (goods_nomenclature.ancestors + [goods_nomenclature]).map do |item|
-        item.description_plain.presence || item.description.presence
-      end
-      content = descriptions.compact.join(' ')
-      codes = CHAPTER_SCOPE_CODE_PATTERNS.flat_map { |pattern| content.scan(pattern).flatten }
-      codes += CHAPTER_SCOPE_RANGE_PATTERNS.flat_map do |pattern|
-        content.scan(pattern).flat_map { |from_chapter, to_chapter| (from_chapter.to_i..to_chapter.to_i).to_a }
-      end
-      codes.map { |code| sprintf('%02d', code.to_i) }.uniq
     end
 
     def update_values

--- a/app/services/tariff_knowledge/declarable_node_loader.rb
+++ b/app/services/tariff_knowledge/declarable_node_loader.rb
@@ -16,10 +16,17 @@ module TariffKnowledge
                          .each_slice(BATCH_SIZE) do |goods_nomenclatures|
           upsert_goods_nomenclature_nodes(goods_nomenclatures.map(&:sti_cast))
         end
+        remove_hidden_goods_nomenclature_nodes
       end
     end
 
   private
+
+    def remove_hidden_goods_nomenclature_nodes
+      Node.goods_nomenclatures
+          .where(goods_nomenclature_item_id: HiddenGoodsNomenclature.codes)
+          .delete
+    end
 
     def upsert_goods_nomenclature_nodes(goods_nomenclatures)
       rows = goods_nomenclatures.map { |goods_nomenclature| node_row(goods_nomenclature) }

--- a/app/services/tariff_knowledge/relevant_note_fragment_selector.rb
+++ b/app/services/tariff_knowledge/relevant_note_fragment_selector.rb
@@ -1,0 +1,206 @@
+module TariffKnowledge
+  class RelevantNoteFragmentSelector
+    # The classifier prompt needs source evidence, not complete compressed notes.
+    # These caps keep one broad chapter/section note from dominating the prompt:
+    # at most two fragments may come from one compressed note, and at most eight
+    # fragments are emitted for the whole candidate set.
+    MAX_FRAGMENTS_PER_NOTE = 2
+    MAX_TOTAL_FRAGMENTS = 8
+
+    # A fragment must show more than generic relevance before it is emitted.
+    # For example, an exclusion fragment starts at 3 points, so it still needs
+    # a candidate-range match or query-term overlap to pass this threshold.
+    MIN_SCORE = 6
+    MAX_FRAGMENT_CHARS = 700
+    CONTEXT_TYPE_SCORES = {
+      'exclusion' => 3,
+      'inclusion' => 2,
+      'reference' => 1,
+    }.freeze
+    RANGE_MATCH_SCORE = 8
+    MENTIONED_RANGE_SCORE = 4
+    MAX_MENTIONED_RANGE_SCORE = 12
+    QUERY_TERM_SCORE = 2
+    MAX_QUERY_TERM_SCORE = 10
+    SAME_CHAPTER_SCORE = 1
+    MAX_REASON_CODES = 4
+    MAX_REASON_TERMS = 5
+
+    # Rules are evaluated in this order so range evidence wins first, then text
+    # mentions of retrieved chapters/headings, then query-language overlap, with
+    # same-chapter evidence acting only as a small tie-breaker.
+    SCORING_RULES = [
+      ->(evidence_record, _text) { range_match_rule(evidence_record) },
+      ->(_evidence, text) { mentioned_range_rule(text) },
+      ->(_evidence, text) { query_term_rule(text) },
+      ->(evidence_record, _text) { same_chapter_rule(evidence_record) },
+    ].freeze
+    STOP_WORDS = %w[above an and are article articles as at be by chapter chapters code codes for from goods has have heading headings in into is it its kind made nomenclature of on or other purposes than that the this to use used with without].to_set.freeze
+
+    def self.call(...) = new(...).call
+
+    def initialize(query:, search_results:, notes_by_item_id:)
+      @query = query.to_s
+      @search_results = search_results
+      @notes_by_item_id = notes_by_item_id
+    end
+
+    def call
+      contexts = notes_by_item_id.each_with_object({}) do |(item_id, note), grouped|
+        group = grouped[note.context_hash] ||= { key: note.context_hash, commodity_codes: [], fragments: {} }
+        group[:commodity_codes] << item_id
+        scored_fragments(note).each do |fragment|
+          current = group[:fragments][fragment[:key]]
+          group[:fragments][fragment[:key]] = fragment if current.nil? || fragment[:score] > current[:score]
+        end
+      end
+
+      cap_total_fragments(contexts.values.filter_map { |context| selected_context(context) })
+    end
+
+  private
+
+    attr_reader :query, :search_results, :notes_by_item_id
+
+    def selected_context(context)
+      fragments = context[:fragments].values.select { |fragment| fragment[:score] >= MIN_SCORE }
+        .sort_by { |fragment| [-fragment[:score], fragment[:source].to_s, fragment[:key].to_s] }.first(MAX_FRAGMENTS_PER_NOTE)
+        .map { |fragment| fragment.except(:key) }
+      { key: context[:key], commodity_codes: context[:commodity_codes].uniq, fragments: } if fragments.any?
+    end
+
+    def cap_total_fragments(contexts)
+      remaining = MAX_TOTAL_FRAGMENTS
+      contexts
+        .sort_by { |context| [-context[:fragments].first[:score], context[:key].to_s] }
+        .filter_map do |context|
+          fragments = context[:fragments].first(remaining)
+          remaining -= fragments.size
+          context.merge(fragments:) if fragments.any?
+        end
+    end
+
+    def scored_fragments(note)
+      # Each record is compressed-note metadata pointing to a source fragment and
+      # explaining the relationship that made that fragment evidence for a code.
+      fragment_evidence_records(note).filter_map do |evidence_record|
+        fragment_node = fragment_nodes_by_key[evidence_record['source_node_key']]
+        text = (evidence_record['source_context'].presence || fragment_node&.content).to_s.squish
+        next if text.blank?
+
+        score, reasons = score_fragment(evidence_record, text)
+        {
+          key: evidence_record['source_node_key'],
+          source: evidence_record['source_title'] || fragment_node&.title,
+          type: evidence_record['context_type'],
+          text: text.truncate(MAX_FRAGMENT_CHARS, omission: '...'),
+          score:,
+          why_relevant: reasons.join('; '),
+        }
+      end
+    end
+
+    def score_fragment(evidence_record, text)
+      # Scoring is intentionally simple and explainable because the selected
+      # fragments are shown to an LLM as legal/source evidence.
+      #
+      # Base weight reflects rule usefulness:
+      # - exclusions are often decisive boundary rules, so +3
+      # - inclusions are useful positive scope evidence, so +2
+      # - references are weaker context, so +1
+      #
+      # Relevance then comes from links to the current classification problem:
+      # - +8 when the evidence range directly matches a candidate chapter/heading
+      # - up to +12 when the text mentions candidate chapter/heading ranges
+      # - up to +10 when legal text overlaps with meaningful query terms
+      # - +1 as a small same-chapter tie-breaker for chapter-note evidence only
+      #
+      # The score is not a legal ranking. It is a prompt-selection heuristic for
+      # choosing small, auditable fragments that are likely to help classify the
+      # candidate set without sending whole compressed notes.
+      score = CONTEXT_TYPE_SCORES.fetch(evidence_record['context_type'], 0)
+      reasons = ["#{evidence_record['context_type']} evidence"].select { score.positive? }
+
+      SCORING_RULES.each do |rule|
+        rule_result = instance_exec(evidence_record, text, &rule)
+        score, reasons = add_score(score, reasons, *rule_result) if rule_result
+      end
+
+      [score, reasons]
+    end
+
+    def add_score(score, reasons, points, reason) = [score + points, reasons + [reason]]
+
+    def range_match_rule(evidence_record)
+      return unless range_match?(evidence_record)
+
+      [RANGE_MATCH_SCORE, "references retrieved #{evidence_record['range_type']} #{evidence_record['range_code']}"]
+    end
+
+    def mentioned_range_rule(text)
+      # Match explicit legal range phrases only. A bare "9506" in prose is too
+      # ambiguous; "heading 9506" or "chapter 95" is useful classification context.
+      mentioned_codes = candidate_ranges.select { |code| text.match?(/\b(?:chapter|chapters|heading|headings)\s+#{Regexp.escape(code)}\b/i) }
+      return if mentioned_codes.empty?
+
+      [
+        [mentioned_codes.size * MENTIONED_RANGE_SCORE, MAX_MENTIONED_RANGE_SCORE].min,
+        "mentions retrieved ranges #{mentioned_codes.first(MAX_REASON_CODES).join(', ')}",
+      ]
+    end
+
+    def query_term_rule(text)
+      overlap = relevance_tokens.intersection(tokenize(text)).to_a
+      return if overlap.empty?
+
+      [
+        [overlap.size * QUERY_TERM_SCORE, MAX_QUERY_TERM_SCORE].min,
+        "matches query terms #{overlap.first(MAX_REASON_TERMS).join(', ')}",
+      ]
+    end
+
+    def same_chapter_rule(evidence_record)
+      return unless evidence_record['source_node_key'].to_s.include?(':customs_tariff_chapter_note:')
+      return unless candidate_chapters.include?(evidence_record['source_id'].to_s.rjust(2, '0'))
+
+      [SAME_CHAPTER_SCORE, 'same chapter as retrieved candidate']
+    end
+
+    def range_match?(evidence_record)
+      code = evidence_record['range_code'].to_s
+      case evidence_record['range_type']
+      when 'chapter'
+        # Range metadata is created only when the source fragment positively
+        # references a chapter. If that chapter is in the retrieved candidates,
+        # the fragment earns the direct range-match boost even when the rendered
+        # context text does not repeat the code or uses non-padded wording.
+        candidate_chapters.include?(code.rjust(2, '0'))
+      when 'heading'
+        candidate_headings.include?(code)
+      else
+        false
+      end
+    end
+
+    def fragment_nodes_by_key
+      @fragment_nodes_by_key ||= Node.note_fragments.where(key: notes_by_item_id.values.flat_map { |note| fragment_evidence_records(note).pluck('source_node_key') }.compact.uniq).all.index_by(&:key)
+    end
+
+    def fragment_evidence_records(note) = Array(note.metadata.to_h['evidence'])
+
+    def relevance_tokens = @relevance_tokens ||= tokenize(query)
+
+    # Keep token matching intentionally coarse: legal fragments and trader
+    # queries use different grammar, so this only rewards shared meaningful
+    # words/numbers after dropping common tariff/search glue words.
+    def tokenize(text) = text.to_s.downcase.scan(/[a-z0-9]{3,}/).reject { |token| STOP_WORDS.include?(token) }.to_set
+
+    def candidate_chapters = @candidate_chapters ||= candidate_item_ids.map { |item_id| item_id.first(2) }.uniq
+
+    def candidate_headings = @candidate_headings ||= candidate_item_ids.map { |item_id| item_id.first(4) }.uniq
+
+    def candidate_ranges = @candidate_ranges ||= (candidate_chapters + candidate_headings).uniq
+
+    def candidate_item_ids = @candidate_item_ids ||= search_results.map(&:goods_nomenclature_item_id).compact_blank.uniq
+  end
+end

--- a/app/services/tariff_knowledge/source_graph_loader.rb
+++ b/app/services/tariff_knowledge/source_graph_loader.rb
@@ -264,24 +264,8 @@ module TariffKnowledge
       chapter_codes = normalize_chapter_codes(chapter_codes)
       return [] if chapter_codes.empty?
 
-      # Most declarables are scoped by their own item-id chapter prefix. Some
-      # special/proxy codes live outside the CN chapter they represent, so the
-      # declarable loader stores explicit chapter-scope metadata for them.
       direct_conditions = chapter_codes.map { |code| Sequel.like(:goods_nomenclature_item_id, "#{code}%") }
-      (Node.goods_nomenclatures.where(Sequel.|(*direct_conditions)).all + proxy_declarable_nodes)
-        .select { |node| chapter_codes.intersect?([node.goods_nomenclature_item_id.first(2)] + referenced_chapter_codes(node)) }
-        .uniq(&:id)
-    end
-
-    def proxy_declarable_nodes
-      @proxy_declarable_nodes ||= Node.goods_nomenclatures
-                                      .where(Sequel.lit("metadata ? 'chapter_scope_codes'"))
-                                      .all
-    end
-
-    def referenced_chapter_codes(node)
-      @referenced_chapter_codes_by_node_id ||= {}
-      @referenced_chapter_codes_by_node_id[node.id] ||= normalize_chapter_codes(Array(node.metadata.to_h['chapter_scope_codes']))
+      Node.goods_nomenclatures.where(Sequel.|(*direct_conditions)).all
     end
 
     def chapter_codes_for_section(section_id)

--- a/app/services/tariff_knowledge/source_graph_loader.rb
+++ b/app/services/tariff_knowledge/source_graph_loader.rb
@@ -127,7 +127,7 @@ module TariffKnowledge
       delete_stale_edges(
         source_node: fragment_node,
         relationship_type: Edge::APPLIES_TO,
-        current_target_node_ids: scoped_declarable_nodes.map(&:id),
+        current_target_node_dataset: scoped_declarable_nodes,
       )
 
       fragment_node
@@ -227,9 +227,7 @@ module TariffKnowledge
     end
 
     def expand_range(range_node, reference)
-      matching_declarable_nodes(reference).paged_each(rows_per_fetch: BATCH_SIZE) do |declarable_node|
-        upsert_edge(range_node, declarable_node, Edge::EXPANDS_TO)
-      end
+      upsert_edges(range_node, matching_declarable_nodes(reference), Edge::EXPANDS_TO)
     end
 
     def matching_declarable_nodes(reference)
@@ -251,21 +249,25 @@ module TariffKnowledge
       when 'customs_tariff_general_rule'
         general_rule_declarable_nodes
       else
-        []
+        empty_declarable_node_dataset
       end
+    end
+
+    def empty_declarable_node_dataset
+      Node.non_hidden_goods_nomenclatures.where(Sequel.lit('1 = 0'))
     end
 
     def general_rule_declarable_nodes
       # GIRs apply across the tariff, so this is intentionally the full declarable set.
-      @general_rule_declarable_nodes ||= Node.goods_nomenclatures.all
+      @general_rule_declarable_nodes ||= Node.non_hidden_goods_nomenclatures
     end
 
     def scoped_chapter_declarable_nodes(chapter_codes)
       chapter_codes = normalize_chapter_codes(chapter_codes)
-      return [] if chapter_codes.empty?
+      return empty_declarable_node_dataset if chapter_codes.empty?
 
       direct_conditions = chapter_codes.map { |code| Sequel.like(:goods_nomenclature_item_id, "#{code}%") }
-      Node.goods_nomenclatures.where(Sequel.|(*direct_conditions)).all
+      Node.non_hidden_goods_nomenclatures.where(Sequel.|(*direct_conditions))
     end
 
     def chapter_codes_for_section(section_id)
@@ -319,7 +321,7 @@ module TariffKnowledge
     end
 
     def upsert_edges(source_node, target_nodes, relationship_type)
-      target_nodes.each_slice(BATCH_SIZE) do |nodes|
+      target_node_batches(target_nodes).each do |nodes|
         now = Time.zone.now
         rows = nodes.map do |target_node|
           {
@@ -338,12 +340,32 @@ module TariffKnowledge
       end
     end
 
-    def delete_stale_edges(source_node:, relationship_type:, current_target_node_ids:)
+    def target_node_batches(target_nodes)
+      return target_nodes.each_slice(BATCH_SIZE) unless target_nodes.respond_to?(:paged_each)
+
+      Enumerator.new do |yielder|
+        batch = []
+        target_nodes.paged_each(rows_per_fetch: BATCH_SIZE) do |target_node|
+          batch << target_node
+          next unless batch.size == BATCH_SIZE
+
+          yielder << batch
+          batch = []
+        end
+        yielder << batch if batch.any?
+      end
+    end
+
+    def delete_stale_edges(source_node:, relationship_type:, current_target_node_ids: [], current_target_node_dataset: nil)
       dataset = Edge.where(
         source_node_id: source_node.id,
         relationship_type:,
       )
-      dataset = dataset.exclude(target_node_id: current_target_node_ids) if current_target_node_ids.any?
+      if current_target_node_dataset
+        dataset = dataset.exclude(target_node_id: current_target_node_dataset.select(:id))
+      elsif current_target_node_ids.any?
+        dataset = dataset.exclude(target_node_id: current_target_node_ids)
+      end
       dataset.delete
     end
 

--- a/app/services/tariff_knowledge/source_graph_loader.rb
+++ b/app/services/tariff_knowledge/source_graph_loader.rb
@@ -231,7 +231,7 @@ module TariffKnowledge
     end
 
     def matching_declarable_nodes(reference)
-      Node.goods_nomenclatures
+      Node.non_hidden_goods_nomenclatures
           .where(Sequel.like(:goods_nomenclature_item_id, "#{reference.code}%"))
     end
 

--- a/app/services/tariff_knowledge/source_graph_loader.rb
+++ b/app/services/tariff_knowledge/source_graph_loader.rb
@@ -2,6 +2,16 @@ module TariffKnowledge
   class SourceGraphLoader
     BATCH_SIZE = 500
 
+    # Tariff notes often use nested list markers such as "a.", "ii.", "ij.",
+    # and "1.". These patterns identify standalone markers and markers stranded
+    # at the end of a split fragment so we can merge them back into the following
+    # legal text. They intentionally anchor to the whole fragment to avoid
+    # treating ordinary prose as a list marker.
+    LIST_MARKER_PATTERN = /\A(?:ij|\(?[a-z]\)?|[ivx]+|\d+)\.\z/i
+    TRAILING_LIST_MARKER_PATTERN = /\A(.+?)\s+((?:ij|\(?[a-z]\)?|[ivx]+|\d+)\.)\z/im
+    USABLE_UPDATE_STATUSES = [CustomsTariffUpdate::APPROVED].freeze
+    USABLE_SOURCE_STATUSES = %w[approved].freeze
+
     RangeReference = Data.define(:type, :code)
     SourceAssociation = Data.define(:association, :label, :identifier, :title)
 
@@ -44,33 +54,26 @@ module TariffKnowledge
   private
 
     def latest_approved_update
-      if TimeMachine.date_is_set?
-        latest_approved_update_at_time_machine_date
-      else
-        TimeMachine.now { latest_approved_update_at_time_machine_date }
+      # The graph represents the tariff source set we are prepared to expose to
+      # generated classification context. Use one approved update snapshot only;
+      # mixing pending files or older approved files would make note provenance
+      # hard to reason about and could surface source text that is not current.
+      TimeMachine.at(@time_machine_date ||= Time.current) do
+        CustomsTariffUpdate
+          .actual
+          .where(status: USABLE_UPDATE_STATUSES)
+          .order(Sequel.desc(:validity_start_date))
+          .first
       end
-    end
-
-    def latest_approved_update_at_time_machine_date
-      CustomsTariffUpdate
-        .actual
-        .approved
-        .order(Sequel.desc(:validity_start_date))
-        .first
     end
 
     def sources_for(source_association, update)
-      if TimeMachine.date_is_set?
-        sources_for_at_time_machine_date(source_association, update)
-      else
-        TimeMachine.now { sources_for_at_time_machine_date(source_association, update) }
-      end
+      TimeMachine.at(@time_machine_date ||= Time.current) { approved_sources_for_update(source_association, update) }
     end
 
-    def sources_for_at_time_machine_date(source_association, update)
-      update
-        .public_send(:"#{source_association.association}_dataset")
-        .approved
+    def approved_sources_for_update(source_association, update)
+      update.public_send(:"#{source_association.association}_dataset")
+            .where(status: USABLE_SOURCE_STATUSES)
     end
 
     def load_source(source_association, source)
@@ -113,24 +116,90 @@ module TariffKnowledge
         expand_range(range_node, reference)
         range_node
       end
+      scoped_declarable_nodes = scoped_declarable_nodes_for(source_association, source)
+      upsert_edges(fragment_node, scoped_declarable_nodes, Edge::APPLIES_TO)
 
       delete_stale_edges(
         source_node: fragment_node,
         relationship_type: Edge::REFERENCES,
         current_target_node_ids: range_nodes.map(&:id),
       )
+      delete_stale_edges(
+        source_node: fragment_node,
+        relationship_type: Edge::APPLIES_TO,
+        current_target_node_ids: scoped_declarable_nodes.map(&:id),
+      )
 
       fragment_node
     end
 
     def fragments(content)
-      content.to_s.split(/\n{2,}|(?<=[.!?])\s+/).map(&:strip).reject(&:blank?)
+      content
+        .to_s
+        .split(/\n{2,}|(?<=[.!?])\s+/)
+        .map(&:strip)
+        .reject(&:blank?)
+        .then { |split_fragments| merge_orphaned_list_markers(split_fragments) }
+        .then { |split_fragments| merge_dangling_numeric_references(split_fragments) }
+    end
+
+    def merge_orphaned_list_markers(split_fragments)
+      split_fragments.each_with_object([]) do |fragment, merged|
+        fragment = "#{merged.pop} #{fragment}" if list_marker_sequence?(merged.last)
+        match = fragment.match(TRAILING_LIST_MARKER_PATTERN)
+        text, marker = match&.captures
+
+        if match && !list_marker_sequence?(text.strip)
+          merged.push(text.strip, marker)
+        else
+          merged << (match ? "#{text.strip} #{marker}" : fragment)
+        end
+      end
+    end
+
+    def list_marker_sequence?(fragment)
+      fragment.present? && fragment.split.all? { |part| part.match?(LIST_MARKER_PATTERN) }
+    end
+
+    def merge_dangling_numeric_references(split_fragments)
+      split_fragments.each_with_object([]) do |fragment, merged|
+        # Sentence splitting can detach references such as "heading 8481." or
+        # "C." from the text that introduces them. Reattach only when the
+        # previous fragment ends in wording that normally introduces a legal
+        # chapter/heading/rule reference, a digit, or a known year-style number.
+        if merged.last && (
+          numeric_reference_context?(merged.last, fragment) ||
+            (fragment.match?(/\AC\.(?:\s+.+)?\z/i) && merged.last.match?(/\d\z/))
+        )
+          attach_reference_fragment(fragment, merged)
+        else
+          merged << fragment
+        end
+      end
+    end
+
+    def attach_reference_fragment(fragment, merged)
+      reference, remaining_fragment = fragment.match(/\A((?:\d{1,4}|C)\.)\s*(.*)\z/i).captures
+      merged[-1] = "#{merged.last} #{reference}"
+      merged << remaining_fragment.strip if remaining_fragment.present?
+    end
+
+    def numeric_reference_context?(previous_fragment, fragment)
+      fragment.match?(/\A\d{1,4}\.(?:\s+.+)?\z/) &&
+        (
+          previous_fragment.match?(/\b(?:heading|headings|chapter|chapters|rule|rules|and|or|to)\z/i) ||
+            previous_fragment.match?(/\d\z/) ||
+            fragment.match?(/\A(?:19|20)\d{2}\.(?:\s+.+)?\z/)
+        )
     end
 
     def range_references(content)
       references = reference_clauses(content).flat_map do |clause|
         next [] if negated_reference?(clause)
 
+        # Only positive chapter/heading references become range nodes. Negated
+        # clauses such as "excluding chapter 39" are classification evidence but
+        # should not expand the fragment to every commodity in the excluded range.
         clause.scan(/\b(chapter|heading)\s+(\d{2}|\d{4})\b/i).map do |type, code|
           RangeReference.new(type: type.downcase, code:)
         end
@@ -168,6 +237,66 @@ module TariffKnowledge
           .where(Sequel.like(:goods_nomenclature_item_id, "#{reference.code}%"))
     end
 
+    def scoped_declarable_nodes_for(source_association, source)
+      @scoped_declarable_nodes_by_key ||= {}
+      @scoped_declarable_nodes_by_key[[source_association.label, source.public_send(source_association.identifier)]] ||= uncached_scoped_declarable_nodes_for(source_association, source)
+    end
+
+    def uncached_scoped_declarable_nodes_for(source_association, source)
+      case source_association.label
+      when 'customs_tariff_chapter_note'
+        scoped_chapter_declarable_nodes([source.chapter_id])
+      when 'customs_tariff_section_note'
+        scoped_chapter_declarable_nodes(chapter_codes_for_section(source.section_id))
+      when 'customs_tariff_general_rule'
+        general_rule_declarable_nodes
+      else
+        []
+      end
+    end
+
+    def general_rule_declarable_nodes
+      # GIRs apply across the tariff, so this is intentionally the full declarable set.
+      @general_rule_declarable_nodes ||= Node.goods_nomenclatures.all
+    end
+
+    def scoped_chapter_declarable_nodes(chapter_codes)
+      chapter_codes = normalize_chapter_codes(chapter_codes)
+      return [] if chapter_codes.empty?
+
+      # Most declarables are scoped by their own item-id chapter prefix. Some
+      # special/proxy codes live outside the CN chapter they represent, so the
+      # declarable loader stores explicit chapter-scope metadata for them.
+      direct_conditions = chapter_codes.map { |code| Sequel.like(:goods_nomenclature_item_id, "#{code}%") }
+      (Node.goods_nomenclatures.where(Sequel.|(*direct_conditions)).all + proxy_declarable_nodes)
+        .select { |node| chapter_codes.intersect?([node.goods_nomenclature_item_id.first(2)] + referenced_chapter_codes(node)) }
+        .uniq(&:id)
+    end
+
+    def proxy_declarable_nodes
+      @proxy_declarable_nodes ||= Node.goods_nomenclatures
+                                      .where(Sequel.lit("metadata ? 'chapter_scope_codes'"))
+                                      .all
+    end
+
+    def referenced_chapter_codes(node)
+      @referenced_chapter_codes_by_node_id ||= {}
+      @referenced_chapter_codes_by_node_id[node.id] ||= normalize_chapter_codes(Array(node.metadata.to_h['chapter_scope_codes']))
+    end
+
+    def chapter_codes_for_section(section_id)
+      Chapter
+        .association_join(:sections)
+        .where(sections__id: section_id)
+        .select_map(:goods_nomenclature_item_id)
+        .map { |item_id| item_id.first(2) }
+        .uniq
+    end
+
+    def normalize_chapter_codes(chapter_codes)
+      chapter_codes.map { |code| sprintf('%02d', code.to_i) }.uniq
+    end
+
     def source_key(source_association, source)
       identifier = source.public_send(source_association.identifier)
       "note_source:#{source_association.label}:#{source.customs_tariff_update_version}:#{identifier}"
@@ -203,6 +332,26 @@ module TariffKnowledge
       Edge.dataset
           .insert_conflict(target: %i[source_node_id target_node_id relationship_type], update: edge_update_values)
           .insert(values)
+    end
+
+    def upsert_edges(source_node, target_nodes, relationship_type)
+      target_nodes.each_slice(BATCH_SIZE) do |nodes|
+        now = Time.zone.now
+        rows = nodes.map do |target_node|
+          {
+            source_node_id: source_node.id,
+            target_node_id: target_node.id,
+            relationship_type:,
+            metadata: Sequel.pg_jsonb({ 'loader' => self.class.name }),
+            created_at: now,
+            updated_at: now,
+          }
+        end
+
+        Edge.dataset
+            .insert_conflict(target: %i[source_node_id target_node_id relationship_type], update: edge_update_values)
+            .multi_insert(rows)
+      end
     end
 
     def delete_stale_edges(source_node:, relationship_type:, current_target_node_ids:)

--- a/lib/tasks/admin_configurations.rake
+++ b/lib/tasks/admin_configurations.rake
@@ -140,6 +140,9 @@ module AdminConfigurationSeeder
       -----------EXPANDED_QUERY-----------------
       %{expanded_query}
       -----------END EXPANDED_QUERY-------------
+      -----------RELEVANT_COMPRESSED_NOTES-------
+      %{compressed_notes}
+      -----------END RELEVANT_COMPRESSED_NOTES---
 
       -----------ANSWERS_OPENSEARCH-------------
       %{answers_opensearch}

--- a/spec/models/tariff_knowledge/compressed_note_spec.rb
+++ b/spec/models/tariff_knowledge/compressed_note_spec.rb
@@ -52,5 +52,15 @@ RSpec.describe TariffKnowledge::CompressedNote do
       expect(described_class.by_sids([123]).all).to contain_exactly(note)
       expect(described_class.by_item_ids(%w[0101210000]).all).to contain_exactly(note)
     end
+
+    it 'returns current generated notes that are usable by search' do
+      generated_note = create(:tariff_knowledge_compressed_note, approved: false, needs_review: false)
+      approved_note = create(:tariff_knowledge_compressed_note, approved: true, needs_review: false)
+      create(:tariff_knowledge_compressed_note, approved: false, needs_review: true)
+      create(:tariff_knowledge_compressed_note, stale: true, needs_review: false)
+      create(:tariff_knowledge_compressed_note, expired: true, needs_review: false)
+
+      expect(described_class.usable_for_search.all).to contain_exactly(generated_note, approved_note)
+    end
   end
 end

--- a/spec/services/interactive_search_service_spec.rb
+++ b/spec/services/interactive_search_service_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe InteractiveSearchService do
     <<~CONTEXT
       You are a UK trade tariff classification assistant.
       Search query: %{search_input}
+      Relevant compressed notes: %{compressed_notes}
       OpenSearch results: %{answers_opensearch}
       Previous Q&A: %{questions}
       Respond with JSON containing either "questions" or "answers".
@@ -427,6 +428,52 @@ RSpec.describe InteractiveSearchService do
 
     context 'when compressed note context is enabled' do
       before do
+        create(
+          :tariff_knowledge_node,
+          :note_fragment,
+          key: 'note_fragment:customs_tariff_chapter_note:1.31:42:0001',
+          content: 'Heading 4202 includes handbags with outer surface of leather.',
+          source_type: 'customs_tariff_chapter_note',
+          source_id: '42',
+        )
+        metadata = {
+          'evidence' => [
+            {
+              'source_node_key' => 'note_fragment:customs_tariff_chapter_note:1.31:42:0001',
+              'source_type' => 'customs_tariff_chapter_note',
+              'source_id' => '42',
+              'source_title' => 'Chapter 42 notes fragment 1',
+              'source_context' => 'Heading 4202 includes handbags with outer surface of leather.',
+              'context_type' => 'inclusion',
+              'range_type' => 'heading',
+              'range_code' => '4202',
+              'relationships' => [TariffKnowledge::Edge::APPLIES_TO],
+            },
+          ],
+        }
+        create(
+          :tariff_knowledge_node,
+          :note_fragment,
+          key: 'note_fragment:customs_tariff_chapter_note:1.30:42:0001',
+          content: 'Historic heading 4202 evidence should not be used.',
+          source_type: 'customs_tariff_chapter_note',
+          source_id: '42',
+        )
+        historic_metadata = {
+          'evidence' => [
+            {
+              'source_node_key' => 'note_fragment:customs_tariff_chapter_note:1.30:42:0001',
+              'source_type' => 'customs_tariff_chapter_note',
+              'source_id' => '42',
+              'source_title' => 'Historic Chapter 42 notes fragment 1',
+              'source_context' => 'Historic heading 4202 evidence should not be used.',
+              'context_type' => 'inclusion',
+              'range_type' => 'heading',
+              'range_code' => '4202',
+              'relationships' => [TariffKnowledge::Edge::APPLIES_TO],
+            },
+          ],
+        }
         create(:admin_configuration,
                :boolean,
                name: 'search_compressed_notes_enabled',
@@ -434,7 +481,26 @@ RSpec.describe InteractiveSearchService do
                area: 'classification')
         create(:tariff_knowledge_compressed_note,
                goods_nomenclature_item_id: '4202210000',
+               content: 'Historic approved note.',
+               context_hash: Digest::SHA256.hexdigest('Historic approved note.'),
+               metadata: Sequel.pg_jsonb_wrap(historic_metadata),
+               approved: true,
+               stale: false,
+               expired: false,
+               generated_at: 2.days.ago)
+        create(:tariff_knowledge_compressed_note,
+               goods_nomenclature_item_id: '4202210000',
                content: 'Includes handbags with outer surface of leather. Excludes plastic sheeting.',
+               context_hash: Digest::SHA256.hexdigest('Includes handbags with outer surface of leather. Excludes plastic sheeting.'),
+               metadata: Sequel.pg_jsonb_wrap(metadata),
+               approved: true,
+               stale: false,
+               expired: false)
+        create(:tariff_knowledge_compressed_note,
+               goods_nomenclature_item_id: '4202290000',
+               content: 'Includes handbags with outer surface of leather. Excludes plastic sheeting.',
+               context_hash: Digest::SHA256.hexdigest('Includes handbags with outer surface of leather. Excludes plastic sheeting.'),
+               metadata: Sequel.pg_jsonb_wrap(metadata),
                approved: true,
                stale: false,
                expired: false)
@@ -446,7 +512,7 @@ RSpec.describe InteractiveSearchService do
                expired: false)
       end
 
-      it 'adds current approved compressed notes to matching OpenSearch results' do
+      it 'adds current approved compressed notes once and references them from matching OpenSearch results' do
         result
 
         context_arg = nil
@@ -454,12 +520,56 @@ RSpec.describe InteractiveSearchService do
           context_arg = context
         end
 
+        parsed_notes = JSON.parse(context_arg.match(/Relevant compressed notes: (.+?)OpenSearch/m)[1])
         parsed_results = JSON.parse(context_arg.match(/OpenSearch results: (.+?)Previous/m)[1])
+        expect(parsed_notes).to contain_exactly(
+          include(
+            'note_ref' => 'compressed_note_1',
+            'commodity_codes' => contain_exactly('4202210000', '4202290000'),
+            'fragments' => contain_exactly(
+              include(
+                'source' => 'Chapter 42 notes fragment 1',
+                'type' => 'inclusion',
+                'text' => 'Heading 4202 includes handbags with outer surface of leather.',
+              ),
+            ),
+          ),
+        )
         expect(parsed_results.first).to include(
           'commodity_code' => '4202210000',
-          'compressed_note' => 'Includes handbags with outer surface of leather. Excludes plastic sheeting.',
+          'compressed_note_refs' => %w[compressed_note_1],
         )
         expect(parsed_results.second).not_to include('compressed_note')
+        expect(parsed_results.second).not_to include('compressed_note_refs')
+        expect(parsed_results.third).to include(
+          'commodity_code' => '4202290000',
+          'compressed_note_refs' => %w[compressed_note_1],
+        )
+        expect(context_arg).not_to include('Includes handbags with outer surface of leather. Excludes plastic sheeting.')
+        expect(context_arg).not_to include('Historic heading 4202 evidence should not be used.')
+        expect(context_arg.scan('Heading 4202 includes handbags with outer surface of leather.').size).to eq(1)
+      end
+
+      context 'when the configured prompt has no compressed notes placeholder' do
+        let(:default_search_context) do
+          <<~CONTEXT
+            Search query: %{search_input}
+            OpenSearch results: %{answers_opensearch}
+            Previous Q&A: %{questions}
+          CONTEXT
+        end
+
+        it 'inserts the deduplicated notes before OpenSearch results' do
+          result
+
+          context_arg = nil
+          expect(OpenaiClient).to have_received(:call) do |context, **_opts|
+            context_arg = context
+          end
+
+          expect(context_arg).to match(/Relevant compressed notes: .+\nOpenSearch results:/)
+          expect(context_arg.scan('Heading 4202 includes handbags with outer surface of leather.').size).to eq(1)
+        end
       end
     end
 

--- a/spec/services/interactive_search_service_spec.rb
+++ b/spec/services/interactive_search_service_spec.rb
@@ -506,7 +506,16 @@ RSpec.describe InteractiveSearchService do
                content: 'Includes handbags with outer surface of leather. Excludes plastic sheeting.',
                context_hash: Digest::SHA256.hexdigest('Includes handbags with outer surface of leather. Excludes plastic sheeting.'),
                metadata: Sequel.pg_jsonb_wrap(metadata),
-               approved: true,
+               approved: false,
+               needs_review: false,
+               stale: false,
+               expired: false)
+        create(:tariff_knowledge_compressed_note,
+               goods_nomenclature_item_id: '4202220000',
+               content: 'Rejected notes should not be consumed.',
+               metadata: Sequel.pg_jsonb_wrap(metadata),
+               approved: false,
+               needs_review: true,
                stale: false,
                expired: false)
         create(:tariff_knowledge_compressed_note,
@@ -514,13 +523,15 @@ RSpec.describe InteractiveSearchService do
                content: 'Includes handbags with outer surface of leather. Excludes plastic sheeting.',
                context_hash: Digest::SHA256.hexdigest('Includes handbags with outer surface of leather. Excludes plastic sheeting.'),
                metadata: Sequel.pg_jsonb_wrap(metadata),
-               approved: true,
+               approved: false,
+               needs_review: false,
                stale: false,
                expired: false)
         create(:tariff_knowledge_compressed_note,
                goods_nomenclature_item_id: '4202220000',
                content: 'Stale notes should not be consumed.',
                approved: true,
+               needs_review: false,
                stale: true,
                expired: false)
       end
@@ -582,6 +593,7 @@ RSpec.describe InteractiveSearchService do
         )
         expect(context_arg).not_to include('Includes handbags with outer surface of leather. Excludes plastic sheeting.')
         expect(context_arg).not_to include('Historic heading 4202 evidence should not be used.')
+        expect(context_arg).not_to include('Rejected notes should not be consumed.')
         expect(context_arg.scan('Heading 4202 includes handbags with outer surface of leather.').size).to eq(1)
       end
 

--- a/spec/services/interactive_search_service_spec.rb
+++ b/spec/services/interactive_search_service_spec.rb
@@ -439,6 +439,31 @@ RSpec.describe InteractiveSearchService do
       expect(context_arg).to include('OpenSearch results:')
     end
 
+    context 'when the configured prompt wraps compressed notes in marker lines' do
+      let(:default_search_context) do
+        <<~CONTEXT
+          Search query: %{search_input}
+          -----------RELEVANT_COMPRESSED_NOTES-------
+          %{compressed_notes}
+          -----------END RELEVANT_COMPRESSED_NOTES---
+          OpenSearch results: %{answers_opensearch}
+          Previous Q&A: %{questions}
+        CONTEXT
+      end
+
+      it 'removes the whole compressed notes marker section when no contexts are selected' do
+        result
+
+        context_arg = nil
+        expect(OpenaiClient).to have_received(:call) do |context, **_opts|
+          context_arg = context
+        end
+
+        expect(context_arg).not_to include('RELEVANT_COMPRESSED_NOTES')
+        expect(context_arg).to include('OpenSearch results:')
+      end
+    end
+
     context 'when compressed note context is enabled' do
       before do
         create(

--- a/spec/services/interactive_search_service_spec.rb
+++ b/spec/services/interactive_search_service_spec.rb
@@ -426,6 +426,19 @@ RSpec.describe InteractiveSearchService do
       allow(OpenaiClient).to receive(:call).and_return(ai_response)
     end
 
+    it 'removes the compressed notes line when no compressed note contexts are selected' do
+      result
+
+      context_arg = nil
+      expect(OpenaiClient).to have_received(:call) do |context, **_opts|
+        context_arg = context
+      end
+
+      expect(context_arg).not_to include('Relevant compressed notes')
+      expect(context_arg).not_to include('Relevant compressed notes: []')
+      expect(context_arg).to include('OpenSearch results:')
+    end
+
     context 'when compressed note context is enabled' do
       before do
         create(
@@ -510,6 +523,28 @@ RSpec.describe InteractiveSearchService do
                approved: true,
                stale: true,
                expired: false)
+      end
+
+      context 'when no compressed notes qualify' do
+        let(:opensearch_results) do
+          [
+            build_result('4202230000', 'Handbags with outer surface of textile materials', 7.1),
+            build_result('4202240000', 'Other handbags', 6.8),
+          ]
+        end
+
+        it 'removes the compressed notes line instead of sending an empty array' do
+          result
+
+          context_arg = nil
+          expect(OpenaiClient).to have_received(:call) do |context, **_opts|
+            context_arg = context
+          end
+
+          expect(context_arg).not_to include('Relevant compressed notes')
+          expect(context_arg).not_to include('Relevant compressed notes: []')
+          expect(context_arg).to include('OpenSearch results:')
+        end
       end
 
       it 'adds current approved compressed notes once and references them from matching OpenSearch results' do

--- a/spec/services/tariff_knowledge/compressed_note_generator_spec.rb
+++ b/spec/services/tariff_knowledge/compressed_note_generator_spec.rb
@@ -196,58 +196,6 @@ RSpec.describe TariffKnowledge::CompressedNoteGenerator do
       )
     end
 
-    it 'summarises broad proxy chapter-range fragments while retaining provenance' do
-      declarable_node.update(
-        goods_nomenclature_item_id: '9930240000',
-        content: nil,
-        metadata: Sequel.pg_jsonb_wrap('chapter_scope_codes' => ('01'..'24').to_a),
-      )
-      chapter_two_fragment_node = create(
-        :tariff_knowledge_node,
-        :note_fragment,
-        key: 'note_fragment:customs_tariff_chapter_note:1.31:02:0001',
-        title: 'Chapter 02 notes fragment 1',
-        content: 'This chapter covers meat and edible meat offal.',
-        source_type: 'customs_tariff_chapter_note',
-        source_id: '02',
-      )
-      create(
-        :tariff_knowledge_edge,
-        source_node: chapter_two_fragment_node,
-        target_node: declarable_node,
-        relationship_type: TariffKnowledge::Edge::APPLIES_TO,
-      )
-
-      described_class.call(goods_nomenclature_sids: [123])
-
-      note = TariffKnowledge::CompressedNote[123]
-      expect(note.content).to include('Chapter note provenance for CN chapters 01 to 02 applies')
-      expect(note.content).not_to include('Commodity context')
-      expect(note.content).not_to include('9930240000: Goods from CN chapters 1 to 24')
-      expect(note.content).not_to include('Heading 0101 covers live horses.')
-      expect(note.content).not_to include('This chapter covers meat and edible meat offal.')
-      expect(note.metadata.to_hash).to include(
-        'source_node_keys' => [
-          'note_fragment:customs_tariff_chapter_note:1.31:01:0002',
-          'note_fragment:customs_tariff_chapter_note:1.31:02:0001',
-        ],
-      )
-    end
-
-    it 'uses singular chapter wording for one broad proxy chapter note' do
-      declarable_node.update(
-        goods_nomenclature_item_id: '9930240000',
-        content: nil,
-        metadata: Sequel.pg_jsonb_wrap('chapter_scope_codes' => ('01'..'24').to_a),
-      )
-
-      described_class.call(goods_nomenclature_sids: [123])
-
-      note = TariffKnowledge::CompressedNote[123]
-      expect(note.content).to include('Chapter note provenance for CN chapter 01 applies')
-      expect(note.content).not_to include('chapters 01 to 01')
-    end
-
     it 'does not include referenced fragments that do not directly apply to the declarable' do
       TariffKnowledge::Edge
         .where(

--- a/spec/services/tariff_knowledge/compressed_note_generator_spec.rb
+++ b/spec/services/tariff_knowledge/compressed_note_generator_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe TariffKnowledge::CompressedNoteGenerator do
         key: 'goods_nomenclature:123',
         goods_nomenclature_sid: 123,
         goods_nomenclature_item_id: '0101210000',
+        content: '0100000000: Live animals > 0101000000: Live horses, asses, mules and hinnies > 0101210000: Pure-bred breeding animals',
       )
     end
     let(:range_node) do
@@ -18,19 +19,54 @@ RSpec.describe TariffKnowledge::CompressedNoteGenerator do
         goods_nomenclature_item_id: nil,
         producline_suffix: nil,
         goods_nomenclature_type: nil,
+        metadata: Sequel.pg_jsonb_wrap({ 'range_type' => 'heading', 'code' => '0101' }),
+      )
+    end
+    let(:source_node) do
+      create(
+        :tariff_knowledge_node,
+        node_type: TariffKnowledge::Node::NOTE_SOURCE,
+        key: 'note_source:customs_tariff_chapter_note:1.31:01',
+        title: 'Chapter 01 notes',
+        content: "1. This chapter includes:\n\nHeading 0101 covers live horses.",
+        goods_nomenclature_sid: nil,
+        goods_nomenclature_item_id: nil,
+        producline_suffix: nil,
+        goods_nomenclature_type: nil,
+      )
+    end
+    let(:lead_in_fragment_node) do
+      create(
+        :tariff_knowledge_node,
+        :note_fragment,
+        key: 'note_fragment:customs_tariff_chapter_note:1.31:01:0001',
+        title: 'Chapter 01 notes fragment 1',
+        content: '1. This chapter includes:',
       )
     end
     let(:fragment_node) do
       create(
         :tariff_knowledge_node,
         :note_fragment,
-        key: 'note_fragment:customs_tariff_chapter_note:1.31:01:0001',
-        title: 'Chapter 01 notes fragment 1',
+        key: 'note_fragment:customs_tariff_chapter_note:1.31:01:0002',
+        title: 'Chapter 01 notes fragment 2',
         content: 'Heading 0101 covers live horses.',
       )
     end
 
     before do
+      create(
+        :tariff_knowledge_edge,
+        source_node:,
+        target_node: lead_in_fragment_node,
+        relationship_type: TariffKnowledge::Edge::CONTAINS,
+      )
+      create(
+        :tariff_knowledge_edge,
+        source_node:,
+        target_node: fragment_node,
+        relationship_type: TariffKnowledge::Edge::CONTAINS,
+      )
       create(
         :tariff_knowledge_edge,
         source_node: fragment_node,
@@ -43,24 +79,220 @@ RSpec.describe TariffKnowledge::CompressedNoteGenerator do
         target_node: declarable_node,
         relationship_type: TariffKnowledge::Edge::EXPANDS_TO,
       )
+      create(
+        :tariff_knowledge_edge,
+        source_node: fragment_node,
+        target_node: declarable_node,
+        relationship_type: TariffKnowledge::Edge::APPLIES_TO,
+      )
     end
 
-    it 'creates reviewable compressed notes from source-evidenced graph fragments' do
+    it 'creates compressed notes from directly applicable source-evidenced graph fragments' do
       described_class.call(goods_nomenclature_sids: [123])
 
       note = TariffKnowledge::CompressedNote[123]
       expect(note).to have_attributes(
         goods_nomenclature_item_id: '0101210000',
-        content: "Chapter 01 notes fragment 1\nHeading 0101 covers live horses.",
-        needs_review: true,
+        content: "Chapter 01 notes fragment 2\nHeading 0101 covers live horses.",
+        needs_review: false,
         approved: false,
         stale: false,
       )
       expect(note.metadata.to_hash).to include(
-        'source_node_keys' => ['note_fragment:customs_tariff_chapter_note:1.31:01:0001'],
+        'source_node_keys' => ['note_fragment:customs_tariff_chapter_note:1.31:01:0002'],
         'range_node_keys' => ['range:heading:0101'],
       )
+      expect(note.metadata.to_hash['evidence'].size).to eq(1)
+      evidence = note.metadata.to_hash['evidence'].first
+      expect(evidence).to include(
+        'source_node_key' => 'note_fragment:customs_tariff_chapter_note:1.31:01:0002',
+        'source_type' => 'customs_tariff_chapter_note',
+        'source_id' => '01',
+        'source_version' => '1.31',
+        'source_title' => 'Chapter 01 notes fragment 2',
+        'parent_source_node_key' => 'note_source:customs_tariff_chapter_note:1.31:01',
+        'parent_source_title' => 'Chapter 01 notes',
+        'source_context' => '1. This chapter includes: Heading 0101 covers live horses.',
+        'context_type' => 'inclusion',
+        'range_node_key' => 'range:heading:0101',
+        'range_title' => 'Heading 0101',
+      )
+      expect(evidence['relationships']).to contain_exactly(
+        TariffKnowledge::Edge::REFERENCES,
+        TariffKnowledge::Edge::EXPANDS_TO,
+        TariffKnowledge::Edge::APPLIES_TO,
+      )
       expect(note.context_hash).to eq(Digest::SHA256.hexdigest(note.content))
+    end
+
+    it 'includes fragments that directly apply to the declarable without an explicit range reference' do
+      scoped_fragment_node = create(
+        :tariff_knowledge_node,
+        :note_fragment,
+        key: 'note_fragment:customs_tariff_chapter_note:1.31:01:0003',
+        title: 'Chapter 01 notes fragment 3',
+        content: 'Live animals are classified in this chapter.',
+      )
+      create(
+        :tariff_knowledge_edge,
+        source_node: scoped_fragment_node,
+        target_node: declarable_node,
+        relationship_type: TariffKnowledge::Edge::APPLIES_TO,
+      )
+
+      described_class.call(goods_nomenclature_sids: [123])
+
+      note = TariffKnowledge::CompressedNote[123]
+      expect(note.content).to include('Chapter 01 notes fragment 2')
+      expect(note.content).to include('Heading 0101 covers live horses.')
+      expect(note.content).to include('Chapter 01 notes fragment 3')
+      expect(note.content).to include('Live animals are classified in this chapter.')
+      expect(note.metadata.to_hash).to include(
+        'source_node_keys' => [
+          'note_fragment:customs_tariff_chapter_note:1.31:01:0002',
+          'note_fragment:customs_tariff_chapter_note:1.31:01:0003',
+        ],
+      )
+      direct_evidence = note.metadata.to_hash['evidence'].find do |evidence|
+        evidence['source_node_key'] == 'note_fragment:customs_tariff_chapter_note:1.31:01:0003'
+      end
+      expect(direct_evidence).to include(
+        'range_node_key' => nil,
+        'relationships' => [TariffKnowledge::Edge::APPLIES_TO],
+      )
+    end
+
+    it 'summarises directly applicable general rules while retaining provenance' do
+      general_rule_fragment_node = create(
+        :tariff_knowledge_node,
+        :note_fragment,
+        key: 'note_fragment:customs_tariff_general_rule:1.31:1:0001',
+        title: 'General Interpretive Rule 1 fragment 1',
+        content: 'Classification shall be determined according to the terms of the headings and any relative section or chapter notes.',
+        source_type: 'customs_tariff_general_rule',
+        source_id: '1',
+      )
+      create(
+        :tariff_knowledge_edge,
+        source_node: general_rule_fragment_node,
+        target_node: declarable_node,
+        relationship_type: TariffKnowledge::Edge::APPLIES_TO,
+      )
+
+      described_class.call(goods_nomenclature_sids: [123])
+
+      note = TariffKnowledge::CompressedNote[123]
+      expect(note.content).to include('Chapter 01 notes fragment 2')
+      expect(note.content).to include('Heading 0101 covers live horses.')
+      expect(note.content).to include('General Interpretive Rules 1 apply when classifying goods.')
+      expect(note.content).not_to include('Commodity context')
+      expect(note.content).not_to include('0101210000: Pure-bred breeding animals')
+      expect(note.content).not_to include('Classification shall be determined according to the terms of the headings')
+      expect(note.metadata.to_hash).to include(
+        'source_node_keys' => [
+          'note_fragment:customs_tariff_chapter_note:1.31:01:0002',
+          'note_fragment:customs_tariff_general_rule:1.31:1:0001',
+        ],
+      )
+    end
+
+    it 'summarises broad proxy chapter-range fragments while retaining provenance' do
+      declarable_node.update(
+        goods_nomenclature_item_id: '9930240000',
+        content: nil,
+        metadata: Sequel.pg_jsonb_wrap('chapter_scope_codes' => ('01'..'24').to_a),
+      )
+      chapter_two_fragment_node = create(
+        :tariff_knowledge_node,
+        :note_fragment,
+        key: 'note_fragment:customs_tariff_chapter_note:1.31:02:0001',
+        title: 'Chapter 02 notes fragment 1',
+        content: 'This chapter covers meat and edible meat offal.',
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '02',
+      )
+      create(
+        :tariff_knowledge_edge,
+        source_node: chapter_two_fragment_node,
+        target_node: declarable_node,
+        relationship_type: TariffKnowledge::Edge::APPLIES_TO,
+      )
+
+      described_class.call(goods_nomenclature_sids: [123])
+
+      note = TariffKnowledge::CompressedNote[123]
+      expect(note.content).to include('Chapter note provenance for CN chapters 01 to 02 applies')
+      expect(note.content).not_to include('Commodity context')
+      expect(note.content).not_to include('9930240000: Goods from CN chapters 1 to 24')
+      expect(note.content).not_to include('Heading 0101 covers live horses.')
+      expect(note.content).not_to include('This chapter covers meat and edible meat offal.')
+      expect(note.metadata.to_hash).to include(
+        'source_node_keys' => [
+          'note_fragment:customs_tariff_chapter_note:1.31:01:0002',
+          'note_fragment:customs_tariff_chapter_note:1.31:02:0001',
+        ],
+      )
+    end
+
+    it 'uses singular chapter wording for one broad proxy chapter note' do
+      declarable_node.update(
+        goods_nomenclature_item_id: '9930240000',
+        content: nil,
+        metadata: Sequel.pg_jsonb_wrap('chapter_scope_codes' => ('01'..'24').to_a),
+      )
+
+      described_class.call(goods_nomenclature_sids: [123])
+
+      note = TariffKnowledge::CompressedNote[123]
+      expect(note.content).to include('Chapter note provenance for CN chapter 01 applies')
+      expect(note.content).not_to include('chapters 01 to 01')
+    end
+
+    it 'does not include referenced fragments that do not directly apply to the declarable' do
+      TariffKnowledge::Edge
+        .where(
+          source_node_id: fragment_node.id,
+          target_node_id: range_node.id,
+          relationship_type: TariffKnowledge::Edge::REFERENCES,
+        )
+        .delete
+      TariffKnowledge::Edge
+        .where(
+          source_node_id: range_node.id,
+          target_node_id: declarable_node.id,
+          relationship_type: TariffKnowledge::Edge::EXPANDS_TO,
+        )
+        .delete
+      TariffKnowledge::Edge
+        .where(
+          source_node_id: fragment_node.id,
+          target_node_id: declarable_node.id,
+          relationship_type: TariffKnowledge::Edge::APPLIES_TO,
+        )
+        .delete
+      non_applicable_fragment_node = create(
+        :tariff_knowledge_node,
+        :note_fragment,
+        key: 'note_fragment:customs_tariff_section_note:1.31:16:0001',
+        title: 'Section XVI notes fragment 1',
+        content: 'This section does not cover articles of chapter 39.',
+      )
+      create(
+        :tariff_knowledge_edge,
+        source_node: non_applicable_fragment_node,
+        target_node: range_node,
+        relationship_type: TariffKnowledge::Edge::REFERENCES,
+      )
+      create(
+        :tariff_knowledge_edge,
+        source_node: range_node,
+        target_node: declarable_node,
+        relationship_type: TariffKnowledge::Edge::EXPANDS_TO,
+      )
+
+      described_class.call(goods_nomenclature_sids: [123])
+
+      expect(TariffKnowledge::CompressedNote[123]).to be_nil
     end
 
     it 'updates generated notes when the graph context changes' do
@@ -87,5 +319,69 @@ RSpec.describe TariffKnowledge::CompressedNoteGenerator do
       expect(TariffKnowledge::CompressedNote[123].content)
         .to eq('Reviewed human content')
     end
+
+    it 'preloads graph evidence for the requested goods nomenclatures' do
+      second_declarable_node = create(
+        :tariff_knowledge_node,
+        key: 'goods_nomenclature:456',
+        goods_nomenclature_sid: 456,
+        goods_nomenclature_item_id: '0101290000',
+      )
+      create(
+        :tariff_knowledge_edge,
+        source_node: range_node,
+        target_node: second_declarable_node,
+        relationship_type: TariffKnowledge::Edge::EXPANDS_TO,
+      )
+      create(
+        :tariff_knowledge_edge,
+        source_node: fragment_node,
+        target_node: second_declarable_node,
+        relationship_type: TariffKnowledge::Edge::APPLIES_TO,
+      )
+
+      queries = sql_queries do
+        described_class.call(goods_nomenclature_sids: [123, 456])
+      end
+
+      expect(queries.grep(/FROM "tariff_knowledge_edges"/).size).to be <= 5
+    end
+
+    it 'uses source note context to identify exclusion evidence' do
+      source_node.update(content: "1. This chapter does not cover:\n\nHeading 0101 covers live horses.")
+      lead_in_fragment_node.update(content: '1. This chapter does not cover:')
+
+      described_class.call(goods_nomenclature_sids: [123])
+
+      evidence = TariffKnowledge::CompressedNote[123].metadata['evidence'].first
+      expect(evidence['source_context']).to eq('1. This chapter does not cover: Heading 0101 covers live horses.')
+      expect(evidence['context_type']).to eq('exclusion')
+    end
+
+    it 'derives source context from graph fragment order when content has been merged' do
+      source_node.update(content: "1. This chapter includes:\n\nii.\n\nHeading 0101 covers live horses.")
+      fragment_node.update(content: 'ii. Heading 0101 covers live horses.')
+
+      described_class.call(goods_nomenclature_sids: [123])
+
+      evidence = TariffKnowledge::CompressedNote[123].metadata['evidence'].first
+      expect(evidence['source_context']).to eq('1. This chapter includes: ii. Heading 0101 covers live horses.')
+      expect(evidence['context_type']).to eq('inclusion')
+    end
+  end
+
+  def sql_queries
+    queries = []
+    logger = Logger.new(StringIO.new)
+    logger.formatter = proc do |_severity, _datetime, _progname, message|
+      queries << message
+      nil
+    end
+
+    Sequel::Model.db.loggers << logger
+    yield
+    queries
+  ensure
+    Sequel::Model.db.loggers.delete(logger)
   end
 end

--- a/spec/services/tariff_knowledge/compressed_note_refresh_spec.rb
+++ b/spec/services/tariff_knowledge/compressed_note_refresh_spec.rb
@@ -39,6 +39,25 @@ RSpec.describe TariffKnowledge::CompressedNoteRefresh do
       )
     end
 
+    it 'does not regenerate hidden declarables and expires their existing notes' do
+      create(:commodity, parent: heading, goods_nomenclature_sid: 123, goods_nomenclature_item_id: '0101210000')
+      hidden_commodity = create(:commodity, parent: heading, goods_nomenclature_sid: 124, goods_nomenclature_item_id: '0101900000')
+      create(:hidden_goods_nomenclature, goods_nomenclature_item_id: hidden_commodity.goods_nomenclature_item_id)
+      create(
+        :tariff_knowledge_compressed_note,
+        goods_nomenclature_sid: hidden_commodity.goods_nomenclature_sid,
+        goods_nomenclature_item_id: hidden_commodity.goods_nomenclature_item_id,
+        expired: false,
+      )
+      GoodsNomenclatures::TreeNode.refresh!
+
+      described_class.call
+
+      expect(TariffKnowledge::CompressedNoteGenerator)
+        .to have_received(:call).with(goods_nomenclature_sids: [123]).ordered
+      expect(TariffKnowledge::CompressedNote[hidden_commodity.goods_nomenclature_sid].expired).to be(true)
+    end
+
     it 'processes current declarables in batches' do
       stub_const("#{described_class}::BATCH_SIZE", 1)
       create(:commodity, parent: heading, goods_nomenclature_sid: 123, goods_nomenclature_item_id: '0101210000')

--- a/spec/services/tariff_knowledge/declarable_node_loader_spec.rb
+++ b/spec/services/tariff_knowledge/declarable_node_loader_spec.rb
@@ -39,5 +39,37 @@ RSpec.describe TariffKnowledge::DeclarableNodeLoader do
                                   .first
       expect(node.goods_nomenclature_item_id).to eq('0101210000')
     end
+
+    it 'stores explicit chapter scope metadata for proxy declarables' do
+      chapter = create(
+        :chapter,
+        :with_description,
+        goods_nomenclature_item_id: '9900000000',
+        description: 'Special combined nomenclature codes',
+      )
+      heading = create(
+        :heading,
+        :with_description,
+        parent: chapter,
+        goods_nomenclature_item_id: '9930000000',
+        description: 'Goods from CN chapters 1 to 24',
+      )
+      commodity = create(
+        :commodity,
+        :with_description,
+        parent: heading,
+        goods_nomenclature_item_id: '9930240000',
+        description: 'Other',
+      )
+      GoodsNomenclatures::TreeNode.refresh!
+
+      described_class.call
+
+      node = TariffKnowledge::Node.goods_nomenclatures
+                                  .where(goods_nomenclature_sid: commodity.goods_nomenclature_sid)
+                                  .first
+      expect(node.content).to be_nil
+      expect(node.metadata.to_hash).to include('chapter_scope_codes' => ('01'..'24').to_a)
+    end
   end
 end

--- a/spec/services/tariff_knowledge/declarable_node_loader_spec.rb
+++ b/spec/services/tariff_knowledge/declarable_node_loader_spec.rb
@@ -40,36 +40,19 @@ RSpec.describe TariffKnowledge::DeclarableNodeLoader do
       expect(node.goods_nomenclature_item_id).to eq('0101210000')
     end
 
-    it 'stores explicit chapter scope metadata for proxy declarables' do
-      chapter = create(
-        :chapter,
-        :with_description,
-        goods_nomenclature_item_id: '9900000000',
-        description: 'Special combined nomenclature codes',
-      )
-      heading = create(
-        :heading,
-        :with_description,
-        parent: chapter,
-        goods_nomenclature_item_id: '9930000000',
-        description: 'Goods from CN chapters 1 to 24',
-      )
+    it 'does not create goods nomenclature nodes for hidden declarables' do
       commodity = create(
         :commodity,
-        :with_description,
         parent: heading,
         goods_nomenclature_item_id: '9930240000',
-        description: 'Other',
       )
+      create(:hidden_goods_nomenclature, goods_nomenclature_item_id: commodity.goods_nomenclature_item_id)
       GoodsNomenclatures::TreeNode.refresh!
 
       described_class.call
 
-      node = TariffKnowledge::Node.goods_nomenclatures
-                                  .where(goods_nomenclature_sid: commodity.goods_nomenclature_sid)
-                                  .first
-      expect(node.content).to be_nil
-      expect(node.metadata.to_hash).to include('chapter_scope_codes' => ('01'..'24').to_a)
+      expect(TariffKnowledge::Node.goods_nomenclatures.where(goods_nomenclature_sid: commodity.goods_nomenclature_sid))
+        .to be_empty
     end
   end
 end

--- a/spec/services/tariff_knowledge/declarable_node_loader_spec.rb
+++ b/spec/services/tariff_knowledge/declarable_node_loader_spec.rb
@@ -54,5 +54,26 @@ RSpec.describe TariffKnowledge::DeclarableNodeLoader do
       expect(TariffKnowledge::Node.goods_nomenclatures.where(goods_nomenclature_sid: commodity.goods_nomenclature_sid))
         .to be_empty
     end
+
+    it 'removes existing goods nomenclature nodes when their code is now hidden' do
+      commodity = create(
+        :commodity,
+        parent: heading,
+        goods_nomenclature_item_id: '9930240000',
+      )
+      create(
+        :tariff_knowledge_node,
+        key: "goods_nomenclature:#{commodity.goods_nomenclature_sid}",
+        goods_nomenclature_sid: commodity.goods_nomenclature_sid,
+        goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
+      )
+      create(:hidden_goods_nomenclature, goods_nomenclature_item_id: commodity.goods_nomenclature_item_id)
+      GoodsNomenclatures::TreeNode.refresh!
+
+      described_class.call
+
+      expect(TariffKnowledge::Node.goods_nomenclatures.where(goods_nomenclature_sid: commodity.goods_nomenclature_sid))
+        .to be_empty
+    end
   end
 end

--- a/spec/services/tariff_knowledge/relevant_note_fragment_selector_spec.rb
+++ b/spec/services/tariff_knowledge/relevant_note_fragment_selector_spec.rb
@@ -1,0 +1,246 @@
+RSpec.describe TariffKnowledge::RelevantNoteFragmentSelector do
+  let(:search_result_class) { Data.define(:goods_nomenclature_item_id, :description, :full_description, :score) }
+  let(:search_results) do
+    [
+      search_result_class.new(
+        goods_nomenclature_item_id: '9506911000',
+        description: 'Exercising apparatus with adjustable resistance mechanisms',
+        full_description: nil,
+        score: 10,
+      ),
+      search_result_class.new(
+        goods_nomenclature_item_id: '6403999110',
+        description: 'Sports footwear with outer soles of rubber',
+        full_description: nil,
+        score: 6,
+      ),
+    ]
+  end
+  let(:query) { 'children exercise stepper with adjustable resistance' }
+  let(:note_content) { 'Full Chapter 95 note content should not be emitted by the selector.' }
+  let(:context_hash) { Digest::SHA256.hexdigest(note_content) }
+  let(:note) do
+    create(
+      :tariff_knowledge_compressed_note,
+      goods_nomenclature_item_id: '9506911000',
+      content: note_content,
+      context_hash:,
+      metadata: Sequel.pg_jsonb_wrap(
+        'evidence' => [
+          evidence_for(
+            'note_fragment:customs_tariff_chapter_note:1.31:95:0002',
+            'candles (heading 3406);',
+            'exclusion',
+          ),
+          evidence_for(
+            'note_fragment:customs_tariff_chapter_note:1.31:95:0008',
+            'sports footwear (other than skating boots with ice or roller skates attached) of Chapter 64',
+            'exclusion',
+          ),
+          evidence_for(
+            'note_fragment:customs_tariff_chapter_note:1.31:95:0032',
+            'Heading 9506 includes articles and equipment for general physical exercise',
+            'inclusion',
+            range_type: 'heading',
+            range_code: '9506',
+          ),
+        ],
+      ),
+    )
+  end
+
+  before do
+    create_fragment('note_fragment:customs_tariff_chapter_note:1.31:95:0002', 'candles (heading 3406);')
+    create_fragment(
+      'note_fragment:customs_tariff_chapter_note:1.31:95:0008',
+      'sports footwear (other than skating boots with ice or roller skates attached) of Chapter 64',
+    )
+    create_fragment(
+      'note_fragment:customs_tariff_chapter_note:1.31:95:0032',
+      'Heading 9506 includes articles and equipment for general physical exercise',
+    )
+  end
+
+  it 'selects fragments that discriminate between retrieved candidate ranges' do
+    contexts = described_class.call(
+      query:,
+      search_results:,
+      notes_by_item_id: { '9506911000' => note },
+    )
+
+    expect(contexts.size).to eq(1)
+    fragment_texts = contexts.first[:fragments].pluck(:text)
+    expect(fragment_texts).to include(
+      a_string_including('sports footwear'),
+      a_string_including('general physical exercise'),
+    )
+    expect(fragment_texts).not_to include(a_string_including('candles'))
+  end
+
+  it 'does not emit full compressed note content' do
+    contexts = described_class.call(
+      query:,
+      search_results:,
+      notes_by_item_id: { '9506911000' => note },
+    )
+
+    emitted_text = contexts.first[:fragments].pluck(:text).join("\n")
+    expect(emitted_text).not_to include(note_content)
+  end
+
+  it 'uses range metadata even when context text does not repeat the candidate code' do
+    range_note = create_note_with_evidence(
+      '9506911000',
+      evidence_for(
+        'note_fragment:customs_tariff_chapter_note:1.31:95:range',
+        'This includes articles and equipment for general physical exercise.',
+        'reference',
+        range_type: 'heading',
+        range_code: '9506',
+      ),
+    )
+    create_fragment(
+      'note_fragment:customs_tariff_chapter_note:1.31:95:range',
+      'This includes articles and equipment for general physical exercise.',
+    )
+
+    contexts = described_class.call(
+      query: 'unrelated query',
+      search_results: [
+        search_result_class.new(
+          goods_nomenclature_item_id: '9506911000',
+          description: 'Articles and equipment for general physical exercise',
+          full_description: nil,
+          score: 10,
+        ),
+      ],
+      notes_by_item_id: { '9506911000' => range_note },
+    )
+
+    expect(contexts.first[:fragments].first[:why_relevant]).to include('references retrieved heading 9506')
+  end
+
+  it 'caps total emitted fragments across all selected notes' do
+    contexts = described_class.call(
+      query: 'plastic exercise article',
+      search_results: Array.new(5) do |index|
+        search_result_class.new(
+          goods_nomenclature_item_id: "95069110#{index.to_s.rjust(2, '0')}",
+          description: 'Articles and equipment for general physical exercise',
+          full_description: nil,
+          score: 10,
+        )
+      end,
+      notes_by_item_id: 5.times.to_h do |note_index|
+        item_id = "95069110#{note_index.to_s.rjust(2, '0')}"
+        [item_id, create_note_with_fragments(item_id, note_index)]
+      end,
+    )
+
+    expect(contexts.sum { |context| context[:fragments].size }).to eq(described_class::MAX_TOTAL_FRAGMENTS)
+  end
+
+  it 'applies the global fragment cap to the highest scoring notes first' do
+    high_score_note = create_note_with_fragments('9506911000', 1)
+    low_score_notes = 8.times.to_h do |index|
+      item_id = "95069120#{index.to_s.rjust(2, '0')}"
+      key = "note_fragment:customs_tariff_chapter_note:1.31:95:low#{index}"
+      text = "Chapter 95 includes exercise goods #{index}."
+      create_fragment(key, text)
+      [item_id, create_note_with_evidence(item_id, evidence_for(key, text, 'inclusion'))]
+    end
+
+    contexts = described_class.call(
+      query: 'exercise article',
+      search_results: [
+        search_result_class.new(
+          goods_nomenclature_item_id: '9506911000',
+          description: 'Articles and equipment for general physical exercise',
+          full_description: nil,
+          score: 10,
+        ),
+      ],
+      notes_by_item_id: low_score_notes.merge('9506911000' => high_score_note),
+    )
+
+    expect(contexts.pluck(:key)).to include(high_score_note.context_hash)
+  end
+
+  it 'does not apply the same-chapter bonus to section evidence source ids' do
+    section_note = create_note_with_evidence(
+      '9506911000',
+      evidence_for(
+        'note_fragment:customs_tariff_section_note:1.31:95:0001',
+        'This section excludes exercise goods.',
+        'exclusion',
+        source_type: 'customs_tariff_section_note',
+      ),
+    )
+    create_fragment('note_fragment:customs_tariff_section_note:1.31:95:0001', 'This section excludes exercise goods.')
+
+    contexts = described_class.call(
+      query:,
+      search_results:,
+      notes_by_item_id: { '9506911000' => section_note },
+    )
+
+    expect(contexts).to be_empty
+  end
+
+  def evidence_for(key, text, context_type, range_type: nil, range_code: nil, source_type: 'customs_tariff_chapter_note')
+    {
+      'source_node_key' => key,
+      'source_type' => source_type,
+      'source_id' => '95',
+      'source_title' => key.split(':').last,
+      'source_context' => text,
+      'context_type' => context_type,
+      'range_type' => range_type,
+      'range_code' => range_code,
+      'relationships' => [TariffKnowledge::Edge::APPLIES_TO],
+    }
+  end
+
+  def create_note_with_fragments(item_id, note_index)
+    evidence = Array.new(6) do |fragment_index|
+      key = "note_fragment:customs_tariff_chapter_note:1.31:95:#{note_index}#{fragment_index}"
+      text = "Heading 9506 includes plastic exercise article #{note_index}-#{fragment_index}"
+      create_fragment(key, text)
+      evidence_for(key, text, 'inclusion', range_type: 'heading', range_code: '9506')
+    end
+    content = "compressed note #{note_index}"
+
+    create(
+      :tariff_knowledge_compressed_note,
+      goods_nomenclature_item_id: item_id,
+      content:,
+      context_hash: Digest::SHA256.hexdigest(content),
+      metadata: Sequel.pg_jsonb_wrap('evidence' => evidence),
+    )
+  end
+
+  def create_note_with_evidence(item_id, evidence)
+    content = "compressed note #{item_id}"
+
+    create(
+      :tariff_knowledge_compressed_note,
+      goods_nomenclature_item_id: item_id,
+      content:,
+      context_hash: Digest::SHA256.hexdigest(content),
+      metadata: Sequel.pg_jsonb_wrap('evidence' => [evidence]),
+    )
+  end
+
+  def create_fragment(key, content)
+    _node_type, source_type, _version, source_id, _sequence = key.split(':')
+
+    create(
+      :tariff_knowledge_node,
+      :note_fragment,
+      key:,
+      content:,
+      source_type:,
+      source_id:,
+    )
+  end
+end

--- a/spec/services/tariff_knowledge/source_graph_loader_spec.rb
+++ b/spec/services/tariff_knowledge/source_graph_loader_spec.rb
@@ -85,6 +85,29 @@ RSpec.describe TariffKnowledge::SourceGraphLoader do
       expect(TariffKnowledge::Node.where(node_type: TariffKnowledge::Node::RANGE).count).to be_zero
     end
 
+    it 'does not apply chapter note fragments to stale hidden goods nomenclature nodes' do
+      hidden_node = create(
+        :tariff_knowledge_node,
+        key: 'goods_nomenclature:99001',
+        goods_nomenclature_sid: 99_001,
+        goods_nomenclature_item_id: '0101900000',
+      )
+      create(:hidden_goods_nomenclature, goods_nomenclature_item_id: hidden_node.goods_nomenclature_item_id)
+      create(
+        :customs_tariff_chapter_note,
+        :approved,
+        customs_tariff_update: update,
+        chapter_id: '01',
+        content: 'Live animals are classified in this chapter.',
+      )
+
+      described_class.call
+
+      fragment_node = TariffKnowledge::Node.by_key('note_fragment:customs_tariff_chapter_note:1.31:01:0001').first
+
+      expect(edge_exists?(fragment_node, hidden_node, TariffKnowledge::Edge::APPLIES_TO)).to be(false)
+    end
+
     it 'keeps list markers attached to the note text they introduce' do
       create(
         :customs_tariff_chapter_note,

--- a/spec/services/tariff_knowledge/source_graph_loader_spec.rb
+++ b/spec/services/tariff_knowledge/source_graph_loader_spec.rb
@@ -163,29 +163,6 @@ RSpec.describe TariffKnowledge::SourceGraphLoader do
       ])
     end
 
-    it 'applies chapter note fragments to proxy declarables classified in that chapter' do
-      proxy_declarable_node = create(
-        :tariff_knowledge_node,
-        key: 'goods_nomenclature:9880010000',
-        goods_nomenclature_sid: 99_001,
-        goods_nomenclature_item_id: '9880010000',
-        metadata: Sequel.pg_jsonb_wrap('chapter_scope_codes' => %w[01]),
-      )
-      create(
-        :customs_tariff_chapter_note,
-        :approved,
-        customs_tariff_update: update,
-        chapter_id: '01',
-        content: 'Live animals are classified in this chapter.',
-      )
-
-      described_class.call
-
-      fragment_node = TariffKnowledge::Node.by_key('note_fragment:customs_tariff_chapter_note:1.31:01:0001').first
-
-      expect(edge_exists?(fragment_node, proxy_declarable_node, TariffKnowledge::Edge::APPLIES_TO)).to be(true)
-    end
-
     it 'applies section note fragments to declarables in the section chapters' do
       section = create(:section, id: 1)
       chapter.add_section(section)
@@ -208,32 +185,6 @@ RSpec.describe TariffKnowledge::SourceGraphLoader do
         .select_map(Sequel[:target_node][:goods_nomenclature_item_id])
 
       expect(applied_codes).to contain_exactly('0101210000', '0101290000')
-    end
-
-    it 'applies section note fragments to proxy declarables classified in one of the section chapters' do
-      section = create(:section, id: 1)
-      chapter.add_section(section)
-      chapter.save
-      proxy_declarable_node = create(
-        :tariff_knowledge_node,
-        key: 'goods_nomenclature:9930240000',
-        goods_nomenclature_sid: 99_302,
-        goods_nomenclature_item_id: '9930240000',
-        metadata: Sequel.pg_jsonb_wrap('chapter_scope_codes' => ('01'..'24').to_a),
-      )
-      create(
-        :customs_tariff_section_note,
-        :approved,
-        customs_tariff_update: update,
-        section_id: section.id,
-        content: 'Section I covers live animals and animal products.',
-      )
-
-      described_class.call
-
-      fragment_node = TariffKnowledge::Node.by_key('note_fragment:customs_tariff_section_note:1.31:1:0001').first
-
-      expect(edge_exists?(fragment_node, proxy_declarable_node, TariffKnowledge::Edge::APPLIES_TO)).to be(true)
     end
 
     it 'loads general rules from an approved update and applies them to every declarable' do

--- a/spec/services/tariff_knowledge/source_graph_loader_spec.rb
+++ b/spec/services/tariff_knowledge/source_graph_loader_spec.rb
@@ -108,6 +108,29 @@ RSpec.describe TariffKnowledge::SourceGraphLoader do
       expect(edge_exists?(fragment_node, hidden_node, TariffKnowledge::Edge::APPLIES_TO)).to be(false)
     end
 
+    it 'does not expand explicit range references to stale hidden goods nomenclature nodes' do
+      hidden_node = create(
+        :tariff_knowledge_node,
+        key: 'goods_nomenclature:99002',
+        goods_nomenclature_sid: 99_002,
+        goods_nomenclature_item_id: '0101900000',
+      )
+      create(:hidden_goods_nomenclature, goods_nomenclature_item_id: hidden_node.goods_nomenclature_item_id)
+      create(
+        :customs_tariff_chapter_note,
+        :approved,
+        customs_tariff_update: update,
+        chapter_id: '01',
+        content: 'Heading 0101 covers live horses.',
+      )
+
+      described_class.call
+
+      range_node = TariffKnowledge::Node.by_key('range:heading:0101').first
+
+      expect(edge_exists?(range_node, hidden_node, TariffKnowledge::Edge::EXPANDS_TO)).to be(false)
+    end
+
     it 'keeps list markers attached to the note text they introduce' do
       create(
         :customs_tariff_chapter_note,

--- a/spec/services/tariff_knowledge/source_graph_loader_spec.rb
+++ b/spec/services/tariff_knowledge/source_graph_loader_spec.rb
@@ -41,6 +41,8 @@ RSpec.describe TariffKnowledge::SourceGraphLoader do
       )
 
       expect(edge_exists?(source_node, fragment_node, TariffKnowledge::Edge::CONTAINS)).to be(true)
+      expect(edge_exists?(fragment_node, TariffKnowledge::Node.goods_nomenclatures.where(goods_nomenclature_item_id: '0101210000').first, TariffKnowledge::Edge::APPLIES_TO)).to be(true)
+      expect(edge_exists?(fragment_node, TariffKnowledge::Node.goods_nomenclatures.where(goods_nomenclature_item_id: '0101290000').first, TariffKnowledge::Edge::APPLIES_TO)).to be(true)
       expect(edge_exists?(fragment_node, range_node, TariffKnowledge::Edge::REFERENCES)).to be(true)
 
       expanded_codes = TariffKnowledge::Edge
@@ -52,8 +54,207 @@ RSpec.describe TariffKnowledge::SourceGraphLoader do
       expect(expanded_codes).to contain_exactly('0101210000', '0101290000')
       expect(TariffKnowledge::Node.where(node_type: TariffKnowledge::Node::RANGE).map(:key))
         .not_to include('range:chapter:02')
-      expect(TariffKnowledge::Edge.by_relationship(TariffKnowledge::Edge::APPLIES_TO).count)
-        .to be_zero
+      applied_codes = TariffKnowledge::Edge
+        .by_relationship(TariffKnowledge::Edge::APPLIES_TO)
+        .where(source_node_id: fragment_node.id)
+        .association_join(:target_node)
+        .select_map(Sequel[:target_node][:goods_nomenclature_item_id])
+
+      expect(applied_codes).to contain_exactly('0101210000', '0101290000')
+    end
+
+    it 'applies chapter note fragments to all declarables in the chapter even without explicit references' do
+      create(
+        :customs_tariff_chapter_note,
+        :approved,
+        customs_tariff_update: update,
+        chapter_id: '01',
+        content: 'Live animals are classified in this chapter.',
+      )
+
+      described_class.call
+
+      fragment_node = TariffKnowledge::Node.by_key('note_fragment:customs_tariff_chapter_note:1.31:01:0001').first
+      applied_codes = TariffKnowledge::Edge
+        .by_relationship(TariffKnowledge::Edge::APPLIES_TO)
+        .where(source_node_id: fragment_node.id)
+        .association_join(:target_node)
+        .select_map(Sequel[:target_node][:goods_nomenclature_item_id])
+
+      expect(applied_codes).to contain_exactly('0101210000', '0101290000')
+      expect(TariffKnowledge::Node.where(node_type: TariffKnowledge::Node::RANGE).count).to be_zero
+    end
+
+    it 'keeps list markers attached to the note text they introduce' do
+      create(
+        :customs_tariff_chapter_note,
+        :approved,
+        customs_tariff_update: update,
+        chapter_id: '01',
+        content: '1. This chapter covers live animals. a. Pure-bred breeding animals are defined here.',
+      )
+
+      described_class.call
+
+      fragment_contents = TariffKnowledge::Node
+        .note_fragments
+        .order(:key)
+        .select_map(:content)
+
+      expect(fragment_contents).to eq([
+        '1. This chapter covers live animals.',
+        'a. Pure-bred breeding animals are defined here.',
+      ])
+    end
+
+    it 'moves trailing list markers onto the following note text' do
+      create(
+        :customs_tariff_chapter_note,
+        :approved,
+        customs_tariff_update: update,
+        chapter_id: '01',
+        content: "m. abrasive paper is excluded; n. cellulose wadding is excluded. For these goods: (a). pure-bred animals; ii. other animals; ij. arms. 1. A. The following expressions have the meanings assigned to them.\n\n— the goods comply with the Cereal Seeds Regulations 1974 or\n— it is established that the goods are actually intended for sowing\n6. The duty rate applicable to mixtures falling in Chapter 10 can be found in Part Four.",
+      )
+
+      described_class.call
+
+      fragment_contents = TariffKnowledge::Node
+        .note_fragments
+        .order(:key)
+        .select_map(:content)
+
+      expect(fragment_contents).to eq([
+        'm. abrasive paper is excluded;',
+        'n. cellulose wadding is excluded.',
+        'For these goods:',
+        '(a). pure-bred animals;',
+        'ii. other animals;',
+        'ij. arms.',
+        '1. A. The following expressions have the meanings assigned to them.',
+        "— the goods comply with the Cereal Seeds Regulations 1974 or\n— it is established that the goods are actually intended for sowing",
+        '6. The duty rate applicable to mixtures falling in Chapter 10 can be found in Part Four.',
+      ])
+    end
+
+    it 'keeps dangling numeric tariff references attached to the preceding text' do
+      create(
+        :customs_tariff_chapter_note,
+        :approved,
+        customs_tariff_update: update,
+        chapter_id: '01',
+        content: 'The headings do not apply to other preparations of headings 3207, 3208, 3209, 3210, 3212, 3213 and 3215. Subheading 8481 20 takes precedence over all other subheadings of heading 8481. Textile garments means garments of headings 6201 to 6211. Oceanic sharks are of codes 0304 88 29. The goods comply with The Seed Potatoes Regulations 1991. Temperature is measured at 20 C. Classification follows Rule 3.',
+      )
+
+      described_class.call
+
+      fragment_contents = TariffKnowledge::Node
+        .note_fragments
+        .order(:key)
+        .select_map(:content)
+
+      expect(fragment_contents).to eq([
+        'The headings do not apply to other preparations of headings 3207, 3208, 3209, 3210, 3212, 3213 and 3215.',
+        'Subheading 8481 20 takes precedence over all other subheadings of heading 8481.',
+        'Textile garments means garments of headings 6201 to 6211.',
+        'Oceanic sharks are of codes 0304 88 29.',
+        'The goods comply with The Seed Potatoes Regulations 1991.',
+        'Temperature is measured at 20 C.',
+        'Classification follows Rule 3.',
+      ])
+    end
+
+    it 'applies chapter note fragments to proxy declarables classified in that chapter' do
+      proxy_declarable_node = create(
+        :tariff_knowledge_node,
+        key: 'goods_nomenclature:9880010000',
+        goods_nomenclature_sid: 99_001,
+        goods_nomenclature_item_id: '9880010000',
+        metadata: Sequel.pg_jsonb_wrap('chapter_scope_codes' => %w[01]),
+      )
+      create(
+        :customs_tariff_chapter_note,
+        :approved,
+        customs_tariff_update: update,
+        chapter_id: '01',
+        content: 'Live animals are classified in this chapter.',
+      )
+
+      described_class.call
+
+      fragment_node = TariffKnowledge::Node.by_key('note_fragment:customs_tariff_chapter_note:1.31:01:0001').first
+
+      expect(edge_exists?(fragment_node, proxy_declarable_node, TariffKnowledge::Edge::APPLIES_TO)).to be(true)
+    end
+
+    it 'applies section note fragments to declarables in the section chapters' do
+      section = create(:section, id: 1)
+      chapter.add_section(section)
+      chapter.save
+      create(
+        :customs_tariff_section_note,
+        :approved,
+        customs_tariff_update: update,
+        section_id: section.id,
+        content: 'Section I covers live animals and animal products.',
+      )
+
+      described_class.call
+
+      fragment_node = TariffKnowledge::Node.by_key('note_fragment:customs_tariff_section_note:1.31:1:0001').first
+      applied_codes = TariffKnowledge::Edge
+        .by_relationship(TariffKnowledge::Edge::APPLIES_TO)
+        .where(source_node_id: fragment_node.id)
+        .association_join(:target_node)
+        .select_map(Sequel[:target_node][:goods_nomenclature_item_id])
+
+      expect(applied_codes).to contain_exactly('0101210000', '0101290000')
+    end
+
+    it 'applies section note fragments to proxy declarables classified in one of the section chapters' do
+      section = create(:section, id: 1)
+      chapter.add_section(section)
+      chapter.save
+      proxy_declarable_node = create(
+        :tariff_knowledge_node,
+        key: 'goods_nomenclature:9930240000',
+        goods_nomenclature_sid: 99_302,
+        goods_nomenclature_item_id: '9930240000',
+        metadata: Sequel.pg_jsonb_wrap('chapter_scope_codes' => ('01'..'24').to_a),
+      )
+      create(
+        :customs_tariff_section_note,
+        :approved,
+        customs_tariff_update: update,
+        section_id: section.id,
+        content: 'Section I covers live animals and animal products.',
+      )
+
+      described_class.call
+
+      fragment_node = TariffKnowledge::Node.by_key('note_fragment:customs_tariff_section_note:1.31:1:0001').first
+
+      expect(edge_exists?(fragment_node, proxy_declarable_node, TariffKnowledge::Edge::APPLIES_TO)).to be(true)
+    end
+
+    it 'loads general rules from an approved update and applies them to every declarable' do
+      create(
+        :customs_tariff_general_rule,
+        :approved,
+        customs_tariff_update: update,
+        rule_label: '1',
+        content: 'Classification shall be determined according to the terms of the headings.',
+      )
+
+      described_class.call
+
+      fragment_node = TariffKnowledge::Node.by_key('note_fragment:customs_tariff_general_rule:1.31:1:0001').first
+      applied_codes = TariffKnowledge::Edge
+        .by_relationship(TariffKnowledge::Edge::APPLIES_TO)
+        .where(source_node_id: fragment_node.id)
+        .association_join(:target_node)
+        .select_map(Sequel[:target_node][:goods_nomenclature_item_id])
+
+      expect(applied_codes).to contain_exactly('0101210000', '0101290000', '0200000000')
     end
 
     it 'is idempotent' do
@@ -75,7 +276,7 @@ RSpec.describe TariffKnowledge::SourceGraphLoader do
       expect(TariffKnowledge::Edge.count).to eq(edge_count)
     end
 
-    it 'loads approved chapter, section, and general rule source associations from the latest approved update' do
+    it 'loads chapter, section, and general rule source associations from the latest approved update' do
       create(
         :customs_tariff_chapter_note,
         :approved,
@@ -99,9 +300,10 @@ RSpec.describe TariffKnowledge::SourceGraphLoader do
       )
       create(
         :customs_tariff_chapter_note,
+        :approved,
         customs_tariff_update: update,
         chapter_id: '02',
-        content: 'Heading 0201 is pending.',
+        content: 'Heading 0201 is approved.',
       )
 
       described_class.call
@@ -109,6 +311,7 @@ RSpec.describe TariffKnowledge::SourceGraphLoader do
       expect(TariffKnowledge::Node.where(node_type: TariffKnowledge::Node::NOTE_SOURCE).select_order_map(:key))
         .to contain_exactly(
           'note_source:customs_tariff_chapter_note:1.31:01',
+          'note_source:customs_tariff_chapter_note:1.31:02',
           'note_source:customs_tariff_general_rule:1.31:1',
           'note_source:customs_tariff_section_note:1.31:1',
         )
@@ -120,7 +323,7 @@ RSpec.describe TariffKnowledge::SourceGraphLoader do
         .to eq('GIR 1')
     end
 
-    it 'only loads notes from the latest approved update that is actual in TimeMachine' do
+    it 'loads notes from the latest current approved update and ignores newer future approved updates' do
       older_update = create(
         :customs_tariff_update,
         :approved,
@@ -141,7 +344,7 @@ RSpec.describe TariffKnowledge::SourceGraphLoader do
         chapter_id: '01',
         content: 'Heading 0101 covers older horses.',
       )
-      current_note = create(
+      create(
         :customs_tariff_chapter_note,
         :approved,
         customs_tariff_update: update,
@@ -153,7 +356,7 @@ RSpec.describe TariffKnowledge::SourceGraphLoader do
         :approved,
         customs_tariff_update: future_update,
         chapter_id: '01',
-        content: 'Heading 0101 covers future horses.',
+        content: 'Heading 0101 covers approved future horses.',
       )
 
       described_class.call
@@ -161,10 +364,80 @@ RSpec.describe TariffKnowledge::SourceGraphLoader do
       expect(TariffKnowledge::Node.where(node_type: TariffKnowledge::Node::NOTE_SOURCE).select_map(:source_version))
         .to contain_exactly(update.version)
       expect(TariffKnowledge::Node.by_key('note_source:customs_tariff_chapter_note:1.31:01').first.content)
-        .to eq(current_note.content)
+        .to eq('Heading 0101 covers current horses.')
     end
 
-    it 'honours an existing TimeMachine date when choosing the latest approved update and its source associations' do
+    it 'does not use non-approved updates as the source graph version' do
+      rejected_update = create(
+        :customs_tariff_update,
+        :rejected,
+        version: '1.32',
+        validity_start_date: 1.month.from_now,
+      )
+      pending_update = create(
+        :customs_tariff_update,
+        version: '1.33',
+        validity_start_date: 2.months.from_now,
+      )
+      create(
+        :customs_tariff_chapter_note,
+        :approved,
+        customs_tariff_update: update,
+        chapter_id: '01',
+        content: 'Heading 0101 covers approved update horses.',
+      )
+      create(
+        :customs_tariff_chapter_note,
+        :approved,
+        customs_tariff_update: rejected_update,
+        chapter_id: '01',
+        content: 'Heading 0101 covers rejected update horses.',
+      )
+      create(
+        :customs_tariff_chapter_note,
+        :approved,
+        customs_tariff_update: pending_update,
+        chapter_id: '01',
+        content: 'Heading 0101 covers pending update horses.',
+      )
+
+      described_class.call
+
+      expect(TariffKnowledge::Node.where(node_type: TariffKnowledge::Node::NOTE_SOURCE).select_map(:source_version))
+        .to contain_exactly(update.version)
+      expect(TariffKnowledge::Node.by_key('note_source:customs_tariff_chapter_note:1.31:01').first.content)
+        .to eq('Heading 0101 covers approved update horses.')
+    end
+
+    it 'does not load non-approved note sources from the selected update' do
+      create(
+        :customs_tariff_chapter_note,
+        :approved,
+        customs_tariff_update: update,
+        chapter_id: '01',
+        content: 'Heading 0101 covers approved source horses.',
+      )
+      create(
+        :customs_tariff_chapter_note,
+        customs_tariff_update: update,
+        chapter_id: '02',
+        content: 'Heading 0201 covers pending source cattle.',
+      )
+      create(
+        :customs_tariff_chapter_note,
+        :rejected,
+        customs_tariff_update: update,
+        chapter_id: '03',
+        content: 'Heading 0201 covers rejected source cattle.',
+      )
+
+      described_class.call
+
+      expect(TariffKnowledge::Node.where(node_type: TariffKnowledge::Node::NOTE_SOURCE).select_order_map(:key))
+        .to contain_exactly('note_source:customs_tariff_chapter_note:1.31:01')
+    end
+
+    it 'uses the latest approved update even inside an existing TimeMachine date' do
       old_update = create(
         :customs_tariff_update,
         :approved,
@@ -178,7 +451,7 @@ RSpec.describe TariffKnowledge::SourceGraphLoader do
         version: '1.31',
         validity_start_date: Date.new(2021, 1, 1),
       )
-      old_note = create(
+      create(
         :customs_tariff_chapter_note,
         :approved,
         customs_tariff_update: old_update,
@@ -196,9 +469,9 @@ RSpec.describe TariffKnowledge::SourceGraphLoader do
       TimeMachine.at(Date.new(2020, 6, 1)) { described_class.call }
 
       expect(TariffKnowledge::Node.where(node_type: TariffKnowledge::Node::NOTE_SOURCE).select_map(:source_version))
-        .to contain_exactly(old_update.version)
-      expect(TariffKnowledge::Node.by_key('note_source:customs_tariff_chapter_note:1.29:01').first.content)
-        .to eq(old_note.content)
+        .to contain_exactly(current_update.version)
+      expect(TariffKnowledge::Node.by_key('note_source:customs_tariff_chapter_note:1.31:01').first.content)
+        .to eq('Heading 0101 covers current horses.')
     end
 
     it 'sets TimeMachine.now when called outside an existing TimeMachine context' do


### PR DESCRIPTION
### Jira link

BAU

### What?

- [x] Deduplicate compressed-note context before adding it to classification prompts.
- [x] Target relevant note fragments instead of sending whole compressed notes.
- [x] Add deterministic fragment scoring so selected note relevance is explainable and stable.
- [x] Build compressed notes only from the latest approved tariff source data.
- [x] Preserve provenance and fragment metadata for auditability.

### Why?

Compressed notes should help the classifier LLM understand relevant legal/source rules without flooding the prompt with duplicated or irrelevant chapter and section note text.

The prompt payload gets much smaller as the context becomes more targeted:

| Payload shape | p50 chars | p90 chars | max chars |
|---|---:|---:|---:|
| Per-result whole notes | `569,463` | `1,126,410` | `1,486,517` |
| Deduplicated whole notes | `55,378` | `129,292` | `267,617` |
| Selected fragments | `<= 5,600` | `<= 5,600` | `<= 5,600` |

On the current ATAR overlap, the selected note context was rated useful for classification in `71.6%` of cases (`34.9%` directly helpful, `36.7%` somewhat helpful). The main weak area is chapters `84-97`, where broad chapter-level exclusions are often less specific for machinery, electrical, vehicle, optical, toy, and miscellaneous goods.

### Risk

**Risk level:** 🟢

**Reason for rating:** Low risk. This is not used by a live trader-facing journey, and the change affects internal generated classification context rather than authoritative tariff data, measures, duties, or public API behaviour.

### Flow diagrams

Compressed note generation:

```mermaid
flowchart TD
    SOURCES[Approved tariff notes and GIRs]
    GRAPH[Knowledge graph fragments]
    NOTE[Compressed note row]
    META[Evidence metadata]
    LIFECYCLE[Generated-content lifecycle]

    SOURCES --> GRAPH
    GRAPH --> NOTE
    NOTE --> META
    NOTE --> LIFECYCLE

    classDef source stroke:#2f6f9f,stroke-width:2px
    classDef persisted stroke:#4f7d45,stroke-width:2px
    classDef lifecycle stroke:#9a6a2f,stroke-width:2px

    class SOURCES,GRAPH source
    class NOTE,META persisted
    class LIFECYCLE lifecycle
```

Search-time augmentation:

```mermaid
flowchart TD
    RESULTS[Search results]
    NOTES[Usable persisted notes]
    SCORING[Score evidence fragments]
    SELECTED[Selected fragments]
    PROMPT[Augmented prompt]

    RESULTS --> NOTES
    NOTES --> SCORING
    SCORING --> SELECTED
    SELECTED --> PROMPT

    classDef retrieval stroke:#2f6f9f,stroke-width:2px
    classDef persisted stroke:#4f7d45,stroke-width:2px
    classDef prompt stroke:#6f4fa3,stroke-width:2px

    class RESULTS retrieval
    class NOTES,SCORING,SELECTED persisted
    class PROMPT prompt
```
