### PR TITLE
HMRC-1866: Remove caxlsx dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem 'sidekiq-scheduler'
 gem 'opensearch-ruby'
 
 # Reporting
-gem 'fast_excel', git: 'git@github.com:willfish/fast_excel.git', branch: 'HMRC-1866-write-rich-string'
+gem 'fast_excel', git: 'https://github.com/willfish/fast_excel.git', branch: 'HMRC-1866-write-rich-string'
 
 # Diffing
 gem 'diff-lcs'

--- a/Gemfile
+++ b/Gemfile
@@ -34,8 +34,7 @@ gem 'sidekiq-scheduler'
 gem 'opensearch-ruby'
 
 # Reporting
-gem 'caxlsx'
-gem 'fast_excel'
+gem 'fast_excel', git: 'git@github.com:willfish/fast_excel.git', branch: 'HMRC-1866-write-rich-string'
 
 # Diffing
 gem 'diff-lcs'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: git@github.com:willfish/fast_excel.git
+  revision: 36c6075c1366d5b541c154a0afc32f59445bd3a2
+  branch: HMRC-1866-write-rich-string
+  specs:
+    fast_excel (0.5.0)
+      base64 (>= 0.2, < 2)
+      ffi (> 1.17, < 2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -124,11 +133,6 @@ GEM
     brakeman (8.0.4)
       racc
     builder (3.3.0)
-    caxlsx (4.4.2)
-      htmlentities (~> 4.3, >= 4.3.4)
-      marcel (~> 1.0)
-      nokogiri (~> 1.10, >= 1.10.4)
-      rubyzip (>= 2.4, < 4)
     childprocess (5.1.0)
       logger (~> 1.5)
     coderay (1.1.3)
@@ -168,8 +172,6 @@ GEM
       logger
     faraday-net_http (3.4.2)
       net-http (~> 0.5)
-    fast_excel (0.5.0)
-      ffi (> 1.9, < 2)
     ffi (1.17.4)
     ffi (1.17.4-aarch64-linux-musl)
     ffi (1.17.4-arm64-darwin)
@@ -188,7 +190,6 @@ GEM
       activesupport (>= 6.1)
     hashdiff (1.2.1)
     holidays (10.0.0)
-    htmlentities (4.4.2)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
@@ -514,7 +515,6 @@ DEPENDENCIES
   aws-sdk-s3
   bootsnap
   brakeman
-  caxlsx
   connection_pool
   csv
   database_cleaner-sequel
@@ -522,7 +522,7 @@ DEPENDENCIES
   dotenv-rails
   engtagger
   factory_bot_rails
-  fast_excel
+  fast_excel!
   foreman
   forgery
   get_process_mem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git@github.com:willfish/fast_excel.git
-  revision: 36c6075c1366d5b541c154a0afc32f59445bd3a2
+  revision: c069766eb7271d3b9b42f41eb71cb2d38d5d247c
   branch: HMRC-1866-write-rich-string
   specs:
     fast_excel (0.5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git@github.com:willfish/fast_excel.git
-  revision: c069766eb7271d3b9b42f41eb71cb2d38d5d247c
+  revision: 5903a9606ed99ee00e30162c951c3a3e605e28fc
   branch: HMRC-1866-write-rich-string
   specs:
     fast_excel (0.5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git@github.com:willfish/fast_excel.git
+  remote: https://github.com/willfish/fast_excel.git
   revision: 5903a9606ed99ee00e30162c951c3a3e605e28fc
   branch: HMRC-1866-write-rich-string
   specs:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/willfish/fast_excel.git
-  revision: 5903a9606ed99ee00e30162c951c3a3e605e28fc
+  revision: b63426e3d056c77bb9df56f25bbe40c6d1e2092b
   branch: HMRC-1866-write-rich-string
   specs:
     fast_excel (0.5.0)

--- a/app/controllers/api/user/subscription_targets_controller.rb
+++ b/app/controllers/api/user/subscription_targets_controller.rb
@@ -18,7 +18,7 @@ module Api
 
         filename_date = Time.zone.today.strftime('%Y-%m-%d')
 
-        send_data package.to_stream.read,
+        send_data package.read_string,
                   type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
                   disposition: "attachment; filename=commodity_watch_list-your_codes_#{filename_date}.xlsx"
       end

--- a/app/controllers/api/user/tariff_changes_controller.rb
+++ b/app/controllers/api/user/tariff_changes_controller.rb
@@ -7,7 +7,7 @@ module Api
         return render json: { error: 'No changes found' }, status: :not_found if package.nil?
 
         filename = "commodity_watch_list_changes_#{actual_date.strftime('%Y_%m_%d')}.xlsx"
-        send_data package.to_stream.read,
+        send_data package.read_string,
                   type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
                   disposition: "attachment; filename=#{filename}"
       end

--- a/app/services/api/user/active_commodities_report_service.rb
+++ b/app/services/api/user/active_commodities_report_service.rb
@@ -17,15 +17,14 @@ module Api
       end
 
       def call
-        package = Axlsx::Package.new
-        package.use_shared_strings = true
+        workbook = FastExcel.open(constant_memory: true)
 
         ActiveCommoditiesReportWorksheetBuilder.call(
-          workbook: package.workbook,
+          workbook:,
           report_rows: report_rows,
         )
 
-        package
+        workbook
       end
 
       private

--- a/app/services/api/user/active_commodities_report_service.rb
+++ b/app/services/api/user/active_commodities_report_service.rb
@@ -17,7 +17,7 @@ module Api
       end
 
       def call
-        workbook = FastExcel.open(constant_memory: true)
+        workbook = FastExcel.open
 
         ActiveCommoditiesReportWorksheetBuilder.call(
           workbook:,

--- a/app/services/api/user/active_commodities_report_worksheet_builder.rb
+++ b/app/services/api/user/active_commodities_report_worksheet_builder.rb
@@ -77,8 +77,8 @@ module Api
         return if report_rows.empty?
 
         header_row_index = TABLE_START_ROW - 1
-        last_row_index = header_row_index + report_rows.length
-        sheet.add_table(header_row_index, 0, last_row_index, HEADERS.length - 1, style: 'TableStyleLight15', columns: HEADERS)
+        last_row_index = header_row_index + report_rows.length - 1
+        sheet.add_table(header_row_index, 0, last_row_index, HEADERS.length - 1, name: TABLE_NAME, style: 'TableStyleLight15', columns: HEADERS)
       end
 
       def set_column_widths(sheet)

--- a/app/services/api/user/active_commodities_report_worksheet_builder.rb
+++ b/app/services/api/user/active_commodities_report_worksheet_builder.rb
@@ -78,7 +78,7 @@ module Api
 
         header_row_index = TABLE_START_ROW - 1
         last_row_index = header_row_index + report_rows.length
-        sheet.autofilter(header_row_index, 0, last_row_index, HEADERS.length - 1)
+        sheet.add_table(header_row_index, 0, last_row_index, HEADERS.length - 1, style: 'TableStyleLight15', columns: HEADERS)
       end
 
       def set_column_widths(sheet)
@@ -108,9 +108,9 @@ module Api
       end
 
       def add_upload_row(sheet, styles)
-        row_index = 5
+        row_index = sheet.last_row_number + 1
         sheet.append_row(
-          [FastExcel::URL.new(REPLACE_ALL_COMMODITIES_UPLOAD_URL), '', '', ''],
+          ['', '', '', ''],
           [styles.fetch(:upload_link), styles.fetch(:blank), styles.fetch(:blank), styles.fetch(:blank)],
         )
         sheet.set_row(row_index, REPLACE_LINK_ROW_HEIGHT, styles.fetch(:upload_link))
@@ -119,7 +119,7 @@ module Api
 
       def add_blank_bottom_row(sheet, blank_style)
         sheet.append_row(blank_intro_row_values, full_width_styles(blank_style))
-        sheet.set_row(6, BLANK_ROW_HEIGHT, blank_style)
+        sheet.set_row(sheet.last_row_number, BLANK_ROW_HEIGHT, blank_style)
       end
 
       def intro_styles

--- a/app/services/api/user/active_commodities_report_worksheet_builder.rb
+++ b/app/services/api/user/active_commodities_report_worksheet_builder.rb
@@ -155,8 +155,8 @@ module Api
             font_color: color(WHITE_COLOR),
             bg_color: color(UPLOAD_LINK_BACKGROUND_COLOR),
             align: {
-              horizontal: :center,
-              vertical: :center,
+              h: :center,
+              v: :center,
             },
             indent: 1,
           ),
@@ -281,9 +281,13 @@ module Api
           fragments << { text: "\n" }
         end
 
-        fragments << { text: last_level, format: workbook.add_format(bold: true) }
+        fragments << { text: last_level, format: hierarchy_level_format }
         fragments << { text: "\n" }
         FastExcel::RichString.new(fragments)
+      end
+
+      def hierarchy_level_format
+        @hierarchy_level_format ||= workbook.add_format(bold: true)
       end
 
       def fast_excel_style_options(options)

--- a/app/services/api/user/active_commodities_report_worksheet_builder.rb
+++ b/app/services/api/user/active_commodities_report_worksheet_builder.rb
@@ -38,13 +38,12 @@ module Api
       end
 
       def call
-        workbook.add_worksheet(name: SHEET_NAME) do |sheet|
-          add_intro_rows(sheet)
-          add_headers(sheet)
-          add_rows(sheet)
-          add_table_styling(sheet)
-          set_column_widths(sheet)
-        end
+        sheet = workbook.add_worksheet(SHEET_NAME)
+        add_intro_rows(sheet)
+        add_headers(sheet)
+        add_rows(sheet)
+        add_table_styling(sheet)
+        set_column_widths(sheet)
       end
 
       private
@@ -61,16 +60,15 @@ module Api
       end
 
       def add_headers(sheet)
-        header_row = sheet.add_row(HEADERS, style: full_width_styles(table_styles.fetch(:header)))
-        header_row.height = TABLE_HEADER_ROW_HEIGHT
+        sheet.append_row(HEADERS, full_width_styles(table_styles.fetch(:header)))
+        sheet.set_row(TABLE_START_ROW - 1, TABLE_HEADER_ROW_HEIGHT, table_styles.fetch(:header))
       end
 
       def add_rows(sheet)
         report_rows.each do |row|
-          sheet.add_row(
+          sheet.append_row(
             ["#{row[:code]}\n ", row[:chapter], description_cell_value(row[:description]), row[:status]],
-            types: [:string, :string, nil, :string],
-            style: row_styles(row[:status]),
+            row_styles(row[:status]),
           )
         end
       end
@@ -78,56 +76,50 @@ module Api
       def add_table_styling(sheet)
         return if report_rows.empty?
 
-        last_row = TABLE_START_ROW + report_rows.length - 1
-        sheet.add_table(
-          "A#{TABLE_START_ROW}:D#{last_row}",
-          name: TABLE_NAME,
-          style_info: {
-            name: 'TableStyleLight15',
-            show_first_column: false,
-            show_last_column: false,
-            show_row_stripes: true,
-            show_column_stripes: false,
-          },
-        )
+        header_row_index = TABLE_START_ROW - 1
+        last_row_index = header_row_index + report_rows.length
+        sheet.autofilter(header_row_index, 0, last_row_index, HEADERS.length - 1)
       end
 
       def set_column_widths(sheet)
-        sheet.column_widths(*COLUMN_WIDTHS)
+        COLUMN_WIDTHS.each_with_index do |width, index|
+          sheet.set_column_width(index, width)
+        end
       end
 
       def add_title_row(sheet, title_style)
         downloaded_on = TimeMachine.now { Time.zone.today.strftime('%d/%m/%Y') }
-        title_row = sheet.add_row(
+        sheet.append_row(
           intro_row_values('Your commodities', "(#{downloaded_on})"),
-          style: full_width_styles(title_style),
+          full_width_styles(title_style),
         )
-        title_row.height = TITLE_ROW_HEIGHT
+        sheet.set_row(0, TITLE_ROW_HEIGHT, title_style)
       end
 
       def add_instruction_rows(sheet, styles)
         instruction_rows_data.each_with_index do |row_data, index|
           style = index.zero? ? styles.fetch(:instruction_first) : styles.fetch(:instruction)
-          row = sheet.add_row(
+          sheet.append_row(
             [row_data[:text], nil, nil, nil],
-            style: [style, styles.fetch(:blank), styles.fetch(:blank), styles.fetch(:blank)],
+            [style, styles.fetch(:blank), styles.fetch(:blank), styles.fetch(:blank)],
           )
-          row.height = index.zero? ? FIRST_INSTRUCTION_ROW_HEIGHT : INSTRUCTION_LINE_HEIGHT
+          sheet.set_row(index + 1, index.zero? ? FIRST_INSTRUCTION_ROW_HEIGHT : INSTRUCTION_LINE_HEIGHT, style)
         end
       end
 
       def add_upload_row(sheet, styles)
-        upload_row = sheet.add_row(
-          ['Replace all commodities (upload)', '', '', ''],
-          style: [styles.fetch(:upload_link), styles.fetch(:blank), styles.fetch(:blank), styles.fetch(:blank)],
+        row_index = 5
+        sheet.append_row(
+          [FastExcel::URL.new(REPLACE_ALL_COMMODITIES_UPLOAD_URL), '', '', ''],
+          [styles.fetch(:upload_link), styles.fetch(:blank), styles.fetch(:blank), styles.fetch(:blank)],
         )
-        upload_row.height = REPLACE_LINK_ROW_HEIGHT
-        sheet.add_hyperlink(location: REPLACE_ALL_COMMODITIES_UPLOAD_URL, ref: upload_row.cells[0])
+        sheet.set_row(row_index, REPLACE_LINK_ROW_HEIGHT, styles.fetch(:upload_link))
+        sheet.write_url_opt(row_index, 0, REPLACE_ALL_COMMODITIES_UPLOAD_URL, styles.fetch(:upload_link), 'Replace all commodities (upload)', nil)
       end
 
       def add_blank_bottom_row(sheet, blank_style)
-        blank_bottom_row = sheet.add_row(blank_intro_row_values, style: full_width_styles(blank_style))
-        blank_bottom_row.height = BLANK_ROW_HEIGHT
+        sheet.append_row(blank_intro_row_values, full_width_styles(blank_style))
+        sheet.set_row(6, BLANK_ROW_HEIGHT, blank_style)
       end
 
       def intro_styles
@@ -142,31 +134,31 @@ module Api
         )
 
         {
-          title: workbook.styles.add_style(
-            b: true,
-            sz: 24,
-            fg_color: DEFAULT_DARK_COLOR,
-            bg_color: WHITE_COLOR,
-            alignment: { vertical: :top },
+          title: workbook.add_format(
+            bold: true,
+            font_size: 24,
+            font_color: color(DEFAULT_DARK_COLOR),
+            bg_color: color(WHITE_COLOR),
+            align: { v: :top },
           ),
-          instruction: workbook.styles.add_style(
-            intro_text_style_options.merge(sz: 14),
+          instruction: workbook.add_format(
+            fast_excel_style_options(intro_text_style_options.merge(sz: 14)),
           ),
-          instruction_first: workbook.styles.add_style(
-            intro_text_style_options.merge(sz: 16, b: true, alignment: { vertical: :bottom }),
+          instruction_first: workbook.add_format(
+            fast_excel_style_options(intro_text_style_options.merge(sz: 16, b: true, alignment: { vertical: :bottom })),
           ),
-          blank: workbook.styles.add_style(bg_color: WHITE_COLOR),
-          upload_link: workbook.styles.add_style(
-            b: true,
-            sz: ROW_FONT_SIZE,
-            u: true,
-            fg_color: WHITE_COLOR,
-            bg_color: UPLOAD_LINK_BACKGROUND_COLOR,
-            alignment: {
+          blank: workbook.add_format(bg_color: color(WHITE_COLOR)),
+          upload_link: workbook.add_format(
+            bold: true,
+            font_size: ROW_FONT_SIZE,
+            underline: :underline_single,
+            font_color: color(WHITE_COLOR),
+            bg_color: color(UPLOAD_LINK_BACKGROUND_COLOR),
+            align: {
               horizontal: :center,
               vertical: :center,
-              indent: 1,
             },
+            indent: 1,
           ),
         }
       end
@@ -177,27 +169,30 @@ module Api
 
       def build_table_styles
         {
-          header: workbook.styles.add_style(
-            b: true,
-            sz: HEADER_FONT_SIZE,
-            fg_color: WHITE_COLOR,
-            bg_color: HEADER_BACKGROUND_COLOR,
-            alignment: { horizontal: :left, vertical: :center, indent: CELL_INDENT },
+          header: workbook.add_format(
+            bold: true,
+            font_size: HEADER_FONT_SIZE,
+            font_color: color(WHITE_COLOR),
+            bg_color: color(HEADER_BACKGROUND_COLOR),
+            align: { h: :left, v: :center },
+            indent: CELL_INDENT,
           ),
-          commodity_code: workbook.styles.add_style(base_text_style_options(bold: true)),
-          description: workbook.styles.add_style(base_text_style_options),
-          chapter: workbook.styles.add_style(base_text_style_options),
+          commodity_code: workbook.add_format(fast_excel_style_options(base_text_style_options(bold: true))),
+          description: workbook.add_format(fast_excel_style_options(base_text_style_options)),
+          chapter: workbook.add_format(fast_excel_style_options(base_text_style_options)),
           statuses: {
-            ActiveCommoditiesReportService::ACTIVE => workbook.styles.add_style(
-              status_style_options(ACTIVE_BACKGROUND_COLOR, ACTIVE_FONT_COLOR),
+            ActiveCommoditiesReportService::ACTIVE => workbook.add_format(
+              fast_excel_style_options(status_style_options(ACTIVE_BACKGROUND_COLOR, ACTIVE_FONT_COLOR)),
             ),
-            ActiveCommoditiesReportService::EXPIRED => workbook.styles.add_style(
-              status_style_options(EXPIRED_BACKGROUND_COLOR, EXPIRED_FONT_COLOR),
+            ActiveCommoditiesReportService::EXPIRED => workbook.add_format(
+              fast_excel_style_options(status_style_options(EXPIRED_BACKGROUND_COLOR, EXPIRED_FONT_COLOR)),
             ),
-            ActiveCommoditiesReportService::ERROR_FROM_UPLOAD => workbook.styles.add_style(
-              status_style_options(
-                ERROR_FROM_UPLOAD_BACKGROUND_COLOR,
-                ERROR_FROM_UPLOAD_FONT_COLOR,
+            ActiveCommoditiesReportService::ERROR_FROM_UPLOAD => workbook.add_format(
+              fast_excel_style_options(
+                status_style_options(
+                  ERROR_FROM_UPLOAD_BACKGROUND_COLOR,
+                  ERROR_FROM_UPLOAD_FONT_COLOR,
+                ),
               ),
             ),
           },
@@ -269,26 +264,52 @@ module Api
       end
 
       def build_upload_instructions_rich_text
-        rich_text = Axlsx::RichText.new
-        rich_text.add_run('You can then upload it to update your commodity watchlist. ', sz: 14)
-        rich_text.add_run('Ensure all codes are listed in column A.', b: true, sz: 14)
-        rich_text
+        FastExcel::RichString.new([
+          { text: 'You can then upload it to update your commodity watchlist. ' },
+          { text: 'Ensure all codes are listed in column A.', format: workbook.add_format(bold: true, font_size: 14) },
+        ])
       end
 
       def build_hierarchy_rich_text(hierarchy_levels, has_heading:)
         last_level = hierarchy_levels.last.to_s
-        rich_text = Axlsx::RichText.new
+        fragments = []
 
         if has_heading
           hierarchy_levels[0...-1].each do |level|
-            rich_text.add_run("#{BULLET_PREFIX}#{level}\n")
+            fragments << { text: "#{BULLET_PREFIX}#{level}\n" }
           end
-          rich_text.add_run("\n")
+          fragments << { text: "\n" }
         end
 
-        rich_text.add_run(last_level, b: true)
-        rich_text.add_run("\n")
-        rich_text
+        fragments << { text: last_level, format: workbook.add_format(bold: true) }
+        fragments << { text: "\n" }
+        FastExcel::RichString.new(fragments)
+      end
+
+      def fast_excel_style_options(options)
+        style_options = {
+          font_size: options[:sz],
+          font_color: color(options[:fg_color]),
+          bg_color: color(options[:bg_color]),
+          align: fast_excel_alignment(options.dig(:alignment, :horizontal), options.dig(:alignment, :vertical)),
+          indent: options.dig(:alignment, :indent),
+        }.compact
+        style_options[:bold] = true if options[:b]
+        style_options[:text_wrap] = true if options.dig(:alignment, :wrap_text)
+        style_options
+      end
+
+      def fast_excel_alignment(horizontal, vertical)
+        {}.tap do |alignment|
+          alignment[:h] = horizontal if horizontal
+          alignment[:v] = vertical if vertical
+        end
+      end
+
+      def color(argb)
+        return unless argb
+
+        argb.to_s.delete_prefix('FF').to_i(16)
       end
     end
   end

--- a/app/services/tariff_changes_service/excel_generator.rb
+++ b/app/services/tariff_changes_service/excel_generator.rb
@@ -35,6 +35,7 @@ class TariffChangesService
       sheet.set_row(1, 25, cell_styles[:subtitle])
 
       sheet.append_row([''])
+      sheet.write_blank(2, 0, workbook.add_format)
       sheet.set_row(2, 20, nil)
 
       sheet.append_row(
@@ -192,7 +193,7 @@ class TariffChangesService
         record[:commodity_code_description],
         record[:type_of_change],
         record[:change_detail],
-        record[:date_of_effect],
+        record[:date_of_effect].to_s,
         record[:ott_url] ? FastExcel::URL.new(record[:ott_url]) : nil,
         record[:api_url] ? FastExcel::URL.new(record[:api_url]) : nil,
       ]

--- a/app/services/tariff_changes_service/excel_generator.rb
+++ b/app/services/tariff_changes_service/excel_generator.rb
@@ -14,74 +14,54 @@ class TariffChangesService
     end
 
     def call
-      package = Axlsx::Package.new
-      package.use_shared_strings = true
-      @workbook = package.workbook
+      @workbook = FastExcel.open(constant_memory: true)
+      sheet = workbook.add_worksheet('Commodity watch list')
 
-      workbook.add_worksheet(name: 'Commodity watch list') do |sheet|
-        setup_sheet_formatting(sheet)
-        add_headers(sheet)
-        stream_data_rows(sheet)
-        add_table_styling(sheet)
-        set_column_widths(sheet)
-      end
+      set_column_widths(sheet)
+      add_headers(sheet)
+      stream_data_rows(sheet)
+      add_table_styling(sheet)
 
-      package
+      workbook
     end
 
     private
 
-    def setup_sheet_formatting(sheet)
-      sheet.sheet_format_pr.default_row_height = 40.0
-      sheet.sheet_format_pr.custom_height = false
-    end
-
     def add_headers(sheet)
-      # Title row
-      sheet.add_row(['Changes to your commodity watch list'], style: workbook.styles.add_style(b: true, sz: 24))
-      sheet.rows[0].height = 40
+      sheet.append_row(['Changes to your commodity watch list'], cell_styles[:title])
+      sheet.set_row(0, 40, cell_styles[:title])
 
-      # Subtitle row
-      sheet.add_row(["Published #{date}"], style: workbook.styles.add_style(b: false, sz: 16))
-      sheet.rows[1].height = 25
+      sheet.append_row(["Published #{date}"], cell_styles[:subtitle])
+      sheet.set_row(1, 25, cell_styles[:subtitle])
 
-      # Empty row
-      sheet.add_row([''])
-      sheet.rows[2].height = 20
+      sheet.append_row([''])
+      sheet.set_row(2, 20, nil)
 
-      # Pre-header row
-      pre_header_styles = [cell_styles[:pre_header]] * 13
-      sheet.add_row(['Is this change relevant to your business (useful filters)', '', '', '', '', 'Impacted Commodity details', '', '', 'Change details', '', '', 'Useful Links', ''], style: pre_header_styles)
-      sheet.rows[3].height = 40
+      sheet.append_row(
+        ['Is this change relevant to your business (useful filters)', '', '', '', '', 'Impacted Commodity details', '', '', 'Change details', '', '', 'Useful Links', ''],
+        cell_styles[:pre_header],
+      )
+      sheet.set_row(3, 40, cell_styles[:pre_header])
 
-      # Merge pre-header cells
-      sheet.merge_cells('A4:E4')
-      sheet.merge_cells('F4:H4')
-      sheet.merge_cells('I4:K4')
-      sheet.merge_cells('L4:M4')
-
-      # Header row
-      header_styles = [cell_styles[:header]] * 13
-      sheet.add_row(excel_header_row, style: header_styles)
-      sheet.rows[4].height = 40
+      sheet.append_row(excel_header_row, cell_styles[:header])
+      sheet.set_row(4, 40, cell_styles[:header])
     end
 
     def stream_data_rows(sheet)
       @change_records.each_slice(100) do |batch|
         batch.each do |record|
-          row = sheet.add_row(
+          sheet.append_row(
             build_excel_row(record),
-            types: [:string] * 13,
-            style: build_row_styles,
+            build_row_styles,
           )
-
-          add_hyperlinks(sheet, row, record)
         end
       end
     end
 
     def set_column_widths(sheet)
-      sheet.column_widths(*excel_column_widths)
+      excel_column_widths.each_with_index do |width, index|
+        sheet.set_column_width(index, width)
+      end
     end
 
     def excel_header_row
@@ -122,51 +102,58 @@ class TariffChangesService
 
     def cell_styles
       @cell_styles ||= {
-        pre_header: workbook.styles.add_style(
-          b: true,
-          bg_color: '215c98',
-          fg_color: 'ffffff',
-          border: { style: :thin, color: '000000' },
-          alignment: { horizontal: :left, vertical: :center, wrap_text: true },
-          sz: 16,
+        title: workbook.add_format(bold: true, font_size: 24),
+        subtitle: workbook.add_format(font_size: 16),
+        pre_header: workbook.add_format(
+          bold: true,
+          bg_color: 0x215c98,
+          font_color: 0xffffff,
+          border: :border_thin,
+          align: { h: :left, v: :center },
+          text_wrap: true,
+          font_size: 16,
         ),
-        header: workbook.styles.add_style(
-          b: true,
-          alignment: { horizontal: :left, vertical: :center, wrap_text: true },
+        header: workbook.add_format(
+          bold: true,
+          align: { h: :left, v: :center },
+          text_wrap: true,
         ),
-        date: workbook.styles.add_style(
-          num_fmt: 14,
-          border: { style: :thin, color: 'D3D3D3' },
-          alignment: { horizontal: :center, vertical: :center },
+        date: workbook.add_format(
+          num_format: 'yyyy-mm-dd',
+          border: :border_thin,
+          align: { h: :center, v: :center },
         ),
-        commodity_code: workbook.styles.add_style(
-          format_code: '0000000000',
-          border: { style: :thin, color: 'D3D3D3' },
-          alignment: { horizontal: :center, vertical: :center },
+        commodity_code: workbook.add_format(
+          num_format: '0000000000',
+          border: :border_thin,
+          align: { h: :center, v: :center },
         ),
-        chapter: workbook.styles.add_style(
-          format_code: '00',
-          border: { style: :thin, color: 'D3D3D3' },
-          alignment: { horizontal: :center, vertical: :center },
+        chapter: workbook.add_format(
+          num_format: '00',
+          border: :border_thin,
+          align: { h: :center, v: :center },
         ),
-        text: workbook.styles.add_style(
-          border: { style: :thin, color: 'D3D3D3' },
-          alignment: { horizontal: :left, vertical: :center, wrap_text: true },
+        text: workbook.add_format(
+          border: :border_thin,
+          align: { h: :left, v: :center },
+          text_wrap: true,
         ),
-        center_text: workbook.styles.add_style(
-          border: { style: :thin, color: 'D3D3D3' },
-          alignment: { horizontal: :center, vertical: :center },
+        center_text: workbook.add_format(
+          border: :border_thin,
+          align: { h: :center, v: :center },
         ),
-        hyperlink: workbook.styles.add_style(
-          fg_color: '0563C1',
-          u: true,
-          border: { style: :thin, color: 'D3D3D3' },
-          alignment: { horizontal: :left, vertical: :center, wrap_text: true },
+        hyperlink: workbook.add_format(
+          font_color: 0x0563C1,
+          underline: :underline_single,
+          border: :border_thin,
+          align: { h: :left, v: :center },
+          text_wrap: true,
         ),
-        bold_text: workbook.styles.add_style(
-          b: true,
-          border: { style: :thin, color: 'D3D3D3' },
-          alignment: { horizontal: :left, vertical: :center, wrap_text: true },
+        bold_text: workbook.add_format(
+          bold: true,
+          border: :border_thin,
+          align: { h: :left, v: :center },
+          text_wrap: true,
         ),
       }
     end
@@ -202,34 +189,15 @@ class TariffChangesService
         record[:type_of_change],
         record[:change_detail],
         record[:date_of_effect],
-        record[:ott_url],
-        record[:api_url],
+        record[:ott_url] ? FastExcel::URL.new(record[:ott_url]) : nil,
+        record[:api_url] ? FastExcel::URL.new(record[:api_url]) : nil,
       ]
-    end
-
-    def add_hyperlinks(sheet, row, record)
-      ott_cell = row.cells[11]
-      api_cell = row.cells[12]
-
-      sheet.add_hyperlink(location: record[:ott_url], ref: ott_cell) if record[:ott_url]
-      sheet.add_hyperlink(location: record[:api_url], ref: api_cell) if record[:api_url]
     end
 
     def add_table_styling(sheet)
       return if @change_records.empty?
 
-      header_row = 5
-      last_data_row = header_row + @change_records.length
-      last_col_letter = ('A'.ord + excel_header_row.size - 1).chr
-      table_range = "A#{header_row}:#{last_col_letter}#{last_data_row}"
-
-      sheet.add_table table_range, style_info: {
-        name: 'TableStyleMedium2',
-        show_first_column: false,
-        show_last_column: false,
-        show_row_stripes: true,
-        show_column_stripes: false,
-      }
+      sheet.autofilter(4, 0, 4 + @change_records.length, excel_header_row.size - 1)
     end
   end
 end

--- a/app/services/tariff_changes_service/excel_generator.rb
+++ b/app/services/tariff_changes_service/excel_generator.rb
@@ -17,6 +17,7 @@ class TariffChangesService
       @workbook = FastExcel.open
       sheet = workbook.add_worksheet('Commodity watch list')
 
+      setup_sheet_formatting(sheet)
       set_column_widths(sheet)
       add_headers(sheet)
       stream_data_rows(sheet)
@@ -26,6 +27,10 @@ class TariffChangesService
     end
 
     private
+
+    def setup_sheet_formatting(sheet)
+      sheet.set_default_row(40, 0)
+    end
 
     def add_headers(sheet)
       sheet.append_row(['Changes to your commodity watch list'], cell_styles[:title])

--- a/app/services/tariff_changes_service/excel_generator.rb
+++ b/app/services/tariff_changes_service/excel_generator.rb
@@ -14,7 +14,7 @@ class TariffChangesService
     end
 
     def call
-      @workbook = FastExcel.open(constant_memory: true)
+      @workbook = FastExcel.open
       sheet = workbook.add_worksheet('Commodity watch list')
 
       set_column_widths(sheet)
@@ -42,6 +42,10 @@ class TariffChangesService
         cell_styles[:pre_header],
       )
       sheet.set_row(3, 40, cell_styles[:pre_header])
+      sheet.merge_range(3, 0, 3, 4, 'Is this change relevant to your business (useful filters)', cell_styles[:pre_header])
+      sheet.merge_range(3, 5, 3, 7, 'Impacted Commodity details', cell_styles[:pre_header])
+      sheet.merge_range(3, 8, 3, 10, 'Change details', cell_styles[:pre_header])
+      sheet.merge_range(3, 11, 3, 12, 'Useful Links', cell_styles[:pre_header])
 
       sheet.append_row(excel_header_row, cell_styles[:header])
       sheet.set_row(4, 40, cell_styles[:header])
@@ -197,7 +201,7 @@ class TariffChangesService
     def add_table_styling(sheet)
       return if @change_records.empty?
 
-      sheet.autofilter(4, 0, 4 + @change_records.length, excel_header_row.size - 1)
+      sheet.add_table(4, 0, 4 + @change_records.length, excel_header_row.size - 1, style: 'TableStyleMedium2', columns: excel_header_row)
     end
   end
 end

--- a/spec/requests/api/user/subscription_targets_controller_spec.rb
+++ b/spec/requests/api/user/subscription_targets_controller_spec.rb
@@ -85,14 +85,12 @@ RSpec.describe Api::User::SubscriptionTargetsController do
   end
 
   describe 'GET #download' do
-    let(:package) { instance_double(Axlsx::Package) }
-    let(:stream) { StringIO.new('mock excel data') }
+    let(:workbook) { instance_double(Libxlsxwriter::Workbook, read_string: 'mock excel data') }
     let(:service) { instance_double(Api::User::ActiveCommoditiesService) }
 
     before do
       allow(Api::User::ActiveCommoditiesService).to receive(:new).with(subscription).and_return(service)
-      allow(service).to receive(:generate_report).and_return(package)
-      allow(package).to receive(:to_stream).and_return(stream)
+      allow(service).to receive(:generate_report).and_return(workbook)
     end
 
     it 'returns an Excel file with expected headers and body' do

--- a/spec/requests/api/user/tariff_changes_controller_spec.rb
+++ b/spec/requests/api/user/tariff_changes_controller_spec.rb
@@ -2,14 +2,12 @@ RSpec.describe Api::User::TariffChangesController do
   include_context 'with user API authentication'
 
   let(:date) { Date.parse('2025-10-28') }
-  let(:package) { instance_double(Axlsx::Package) }
-  let(:stream) { StringIO.new('mock excel data') }
+  let(:workbook) { instance_double(Libxlsxwriter::Workbook, read_string: 'mock excel data') }
 
   describe '#download' do
     context 'when there are changes' do
       before do
-        allow(TariffChangesService).to receive(:generate_report_for).with(date, user).and_return(package)
-        allow(package).to receive(:to_stream).and_return(stream)
+        allow(TariffChangesService).to receive(:generate_report_for).with(date, user).and_return(workbook)
       end
 
       it 'calls TariffChangesService with the correct date and user' do
@@ -49,8 +47,7 @@ RSpec.describe Api::User::TariffChangesController do
 
     context 'when as_of param is not provided' do
       before do
-        allow(TariffChangesService).to receive(:generate_report_for).with(Time.zone.yesterday, user).and_return(package)
-        allow(package).to receive(:to_stream).and_return(stream)
+        allow(TariffChangesService).to receive(:generate_report_for).with(Time.zone.yesterday, user).and_return(workbook)
       end
 
       it 'defaults to yesterday' do
@@ -66,8 +63,7 @@ RSpec.describe Api::User::TariffChangesController do
       let(:custom_date) { Date.parse('2024-12-15') }
 
       before do
-        allow(TariffChangesService).to receive(:generate_report_for).with(custom_date, user).and_return(package)
-        allow(package).to receive(:to_stream).and_return(stream)
+        allow(TariffChangesService).to receive(:generate_report_for).with(custom_date, user).and_return(workbook)
       end
 
       it 'uses the provided date' do

--- a/spec/services/api/user/active_commodities_report_service_spec.rb
+++ b/spec/services/api/user/active_commodities_report_service_spec.rb
@@ -54,200 +54,63 @@ RSpec.describe Api::User::ActiveCommoditiesReportService do
     subject(:package) { described_class.new(active_codes, expired_codes, invalid_codes).call }
 
     let(:builder_class) { Api::User::ActiveCommoditiesReportWorksheetBuilder }
-    let(:worksheet) { package.workbook.worksheets.first }
+    let(:xlsx_data) { package.read_string }
+
+    it 'creates a FastExcel workbook' do
+      expect(package).to be_a(Libxlsxwriter::Workbook)
+    end
 
     it 'creates a worksheet named Your commodities' do
-      expect(worksheet.name).to eq('Your commodities')
+      workbook_xml = xlsx_entry(xlsx_data, 'xl/workbook.xml')
+
+      expect(workbook_xml).to include('name="Your commodities"')
     end
 
-    it 'adds a large title row before the table' do
+    it 'adds the title and instructions before the table' do
       freeze_time do
         dated_package = described_class.new(active_codes, expired_codes, invalid_codes).call
-        dated_sheet = dated_package.workbook.worksheets.first
+        rows = worksheet_row_texts(dated_package.read_string)
         expected_date = Time.zone.today.strftime('%d/%m/%Y')
 
-        expect(dated_sheet.rows[0].cells[0].value).to eq('Your commodities')
-        expect(dated_sheet.rows[0].cells[1].value).to eq("(#{expected_date})")
-        expect(dated_sheet.rows[0].height).to eq(builder_class::TITLE_ROW_HEIGHT)
+        expect(rows[0]).to eq(['Your commodities', "(#{expected_date})"])
+        expect(rows[1]).to eq(['Updating your commodity watch list:'])
+        expect(rows[2]).to eq(['All your active and expired codes, as well as errors, are listed on this spreadsheet.'])
+        expect(rows[3]).to eq(['You can edit, add and remove codes from this spreadsheet or your own.'])
+        expect(rows[4]).to eq([
+          'You can then upload it to update your commodity watchlist. ',
+          'Ensure all codes are listed in column A.',
+        ])
       end
-    end
-
-    it 'adds the instructions rows before the table' do
-      merged_cells = Array(worksheet.instance_variable_get(:@merged_cells))
-      final_instruction = worksheet.rows[4].cells[0].value
-
-      expect(worksheet.rows[1].cells[0].value).to eq('Updating your commodity watch list:')
-      expect(worksheet.rows[2].cells[0].value).to eq('All your active and expired codes, as well as errors, are listed on this spreadsheet.')
-      expect(worksheet.rows[3].cells[0].value).to eq('You can edit, add and remove codes from this spreadsheet or your own.')
-      expect(final_instruction).to be_a(Axlsx::RichText)
-      expect(final_instruction.map(&:value).join).to eq('You can then upload it to update your commodity watchlist. Ensure all codes are listed in column A.')
-      expect(final_instruction.last.value).to eq('Ensure all codes are listed in column A.')
-      expect(final_instruction.last.b).to be true
-      expect(merged_cells).to be_empty
-    end
-
-    it 'uses 14pt font in instruction rows and 16pt bold for the first line' do
-      styles = package.workbook.styles
-      first_instruction_cell = worksheet.rows[1].cells[0]
-      second_instruction_cell = worksheet.rows[2].cells[0]
-
-      first_font = styles.fonts[styles.cellXfs[first_instruction_cell.style].fontId]
-      second_font = styles.fonts[styles.cellXfs[second_instruction_cell.style].fontId]
-
-      expect(first_font.sz.to_i).to eq(16)
-      expect(first_font.b).to be true
-      expect(second_font.sz.to_i).to eq(14)
     end
 
     it 'adds a replace all upload link row before the table' do
-      link_row = worksheet.rows[5]
-      merged_cells = Array(worksheet.instance_variable_get(:@merged_cells))
+      rows = worksheet_row_texts(xlsx_data)
 
-      expect(link_row.cells[0].value).to eq('Replace all commodities (upload)')
-      expect(worksheet.hyperlinks.map(&:location)).to include(
-        builder_class::REPLACE_ALL_COMMODITIES_UPLOAD_URL,
-      )
-      expect(worksheet.hyperlinks.map(&:ref)).to include('A6')
-      expect(merged_cells).not_to include('A6:D6')
-    end
-
-    it 'adds the expected header row' do
-      header_row = worksheet.rows[7]
-      headers = header_row.cells.map(&:value)
-      expect(headers).to eq(%w[Commodity Chapter Description Status])
-      expect(header_row.height).to eq(34)
-    end
-
-    it 'uses double-height blank rows for the spacer rows' do
-      expect(worksheet.rows[6].height).to eq(builder_class::BLANK_ROW_HEIGHT)
-    end
-
-    it 'does not apply a bottom border to the title row' do
-      styles = package.workbook.styles
-      bordered_cells = [worksheet.rows[0].cells[0]]
-
-      bordered_cells.each do |cell|
-        xf = styles.cellXfs[cell.style]
-        border_xml = styles.borders[xf.borderId].to_xml_string
-
-        expect(border_xml).not_to include('style="medium"')
-        expect(border_xml).not_to include('rgb="FF0B0C0C"')
-      end
-    end
-
-    it 'does not apply a bottom border to intro rows' do
-      styles = package.workbook.styles
-      unbordered_cells = [worksheet.rows[1].cells[0]]
-
-      unbordered_cells.each do |cell|
-        xf = styles.cellXfs[cell.style]
-        border_xml = styles.borders[xf.borderId].to_xml_string
-
-        expect(border_xml).not_to include('style="medium"')
-        expect(border_xml).not_to include('rgb="FF0B0C0C"')
-      end
-    end
-
-    it 'uses filled cells in the blank intro rows to hide gridlines' do
-      styles = package.workbook.styles
-      blank_intro_rows = [worksheet.rows[6]]
-
-      blank_intro_rows.each do |row|
-        row.cells.each do |cell|
-          xf = styles.cellXfs[cell.style]
-          fill_xml = styles.fills[xf.fillId].to_xml_string
-
-          expect(fill_xml).to include('patternType="solid"')
-        end
-      end
-    end
-
-    it 'indents table headers the same as table cells' do
-      styles = package.workbook.styles
-      header_cell = worksheet.rows[7].cells[0]
-      first_data_cell = worksheet.rows[8].cells[0]
-
-      header_alignment = styles.cellXfs[header_cell.style].alignment.to_xml_string
-      data_alignment = styles.cellXfs[first_data_cell.style].alignment.to_xml_string
-
-      expect(header_alignment).to include('indent="1"')
-      expect(data_alignment).to include('indent="1"')
+      expect(rows[5]).to eq(['Replace all commodities (upload)'])
+      expect(worksheet_relationships_xml(xlsx_data)).to include(xml_escape(builder_class::REPLACE_ALL_COMMODITIES_UPLOAD_URL))
     end
 
     it 'adds rows ordered by commodity code with chapter, description and status' do
-      data_rows = worksheet.rows[8..].map do |row|
-        [
-          row.cells[0].value.to_s,
-          extract_cell_text(row.cells[1].value),
-          extract_cell_text(row.cells[2].value),
-          row.cells[3].value.to_s,
-        ]
-      end
+      rows = worksheet_row_texts(xlsx_data)
 
-      expect(data_rows).to eq([
-        ["1111111111\n ", '11: Chapter eleven', "Expired commodity description\n", 'Expired'],
-        ["2222222222\n ", '22: Chapter twenty two', "Active commodity\ndescription\n", 'Active'],
-        ["3333333333\n ", 'Not applicable', 'Not applicable', 'Error from upload'],
-      ])
+      expect(rows[7]).to eq(%w[Commodity Chapter Description Status])
+      expect(rows[8]).to eq(["1111111111\n ", '11: Chapter eleven', 'Expired commodity description', "\n", 'Expired'])
+      expect(rows[9]).to eq(["2222222222\n ", '22: Chapter twenty two', "Active commodity\ndescription", "\n", 'Active'])
+      expect(rows[10]).to eq(["3333333333\n ", 'Not applicable', 'Not applicable', 'Error from upload'])
     end
 
-    it 'renders the final description level in bold rich text for valid rows' do
-      expired_description = worksheet.rows[8].cells[2].value
-      active_description = worksheet.rows[9].cells[2].value
+    it 'renders rich text emphasis for the final instruction and valid descriptions' do
+      xml = worksheet_xml(xlsx_data)
 
-      expect(expired_description).to be_a(Axlsx::RichText)
-      expect(active_description).to be_a(Axlsx::RichText)
-      expect(expired_description.first.b).to be true
-      expect(active_description.first.b).to be true
-    end
-
-    it 'uses bold styling for values in the first table column' do
-      first_data_cell = worksheet.rows[8].cells[0]
-      font = package.workbook.styles.fonts[package.workbook.styles.cellXfs[first_data_cell.style].fontId]
-
-      expect(font.b).to be true
-    end
-
-    it 'enables table built-in row striping' do
-      table = worksheet.tables.first
-      style_info = table.respond_to?(:table_style_info) ? table.table_style_info : nil
-
-      expect(style_info).not_to be_nil
-      expect(style_info.show_row_stripes).to be true
-    end
-
-    it 'does not force a fixed explicit row height for table rows' do
-      data_rows = worksheet.rows[8..10]
-      expect(data_rows.map(&:height)).to all(be_nil)
-    end
-
-    it 'applies requested status colors and bold 12pt text' do
-      styles = package.workbook.styles
-      status_cells = worksheet.rows[8..10].map { |row| row.cells[3] }
-
-      style_data = status_cells.map do |cell|
-        xf = styles.cellXfs[cell.style]
-        fill_xml = styles.fills[xf.fillId].to_xml_string
-        font = styles.fonts[xf.fontId]
-
-        {
-          fill_xml: fill_xml,
-          bold: font.b,
-          size: font.sz.to_i,
-        }
-      end
-
-      expect(style_data[0][:fill_xml]).to include('FFFFEE80')
-      expect(style_data[1][:fill_xml]).to include('FFCFE4DC')
-      expect(style_data[2][:fill_xml]).to include('FFF4D7D7')
-      expect(style_data).to all(include(bold: true, size: 12))
+      expect(xml).to match(%r{<r><rPr><b/>.*?</rPr><t>Ensure all codes are listed in column A\.</t></r>}m)
+      expect(xml).to match(%r{<r><rPr><b/>.*?</rPr><t>Expired commodity description</t></r>}m)
+      expect(xml).to match(%r{<r><rPr><b/>.*?</rPr><t>Active commodity\n?description</t></r>}m)
     end
 
     it 'adds table styling for the full data range' do
-      table = worksheet.tables.first
+      xml = worksheet_xml(xlsx_data)
 
-      expect(table).not_to be_nil
-      expect(table.ref).to eq('A8:D10')
+      expect(xml).to include('<autoFilter ref="A8:D11"/>')
     end
   end
 
@@ -270,11 +133,5 @@ RSpec.describe Api::User::ActiveCommoditiesReportService do
       )
       expect(CachedCommodityDescriptionService).to have_received(:fetch_for_codes).with(codes, include_hierarchy: true)
     end
-  end
-
-  def extract_cell_text(value)
-    return value.to_s unless value.is_a?(Axlsx::RichText)
-
-    value.map(&:value).join
   end
 end

--- a/spec/services/api/user/active_commodities_report_service_spec.rb
+++ b/spec/services/api/user/active_commodities_report_service_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Api::User::ActiveCommoditiesReportService do
     end
 
     it 'renders rich text emphasis for the final instruction and valid descriptions' do
-      xml = worksheet_xml(xlsx_data)
+      xml = shared_strings_xml(xlsx_data)
 
       expect(xml).to match(%r{<r><rPr><b/>.*?</rPr><t>Ensure all codes are listed in column A\.</t></r>}m)
       expect(xml).to match(%r{<r><rPr><b/>.*?</rPr><t>Expired commodity description</t></r>}m)
@@ -108,9 +108,11 @@ RSpec.describe Api::User::ActiveCommoditiesReportService do
     end
 
     it 'adds table styling for the full data range' do
-      xml = worksheet_xml(xlsx_data)
+      xml = table_xml(xlsx_data)
 
-      expect(xml).to include('<autoFilter ref="A8:D11"/>')
+      expect(xml).to include('ref="A8:D11"')
+      expect(xml).to include('name="TableStyleLight15"')
+      expect(xml).to include('showRowStripes="1"')
     end
   end
 

--- a/spec/services/api/user/active_commodities_report_service_spec.rb
+++ b/spec/services/api/user/active_commodities_report_service_spec.rb
@@ -107,10 +107,11 @@ RSpec.describe Api::User::ActiveCommoditiesReportService do
       expect(xml).to match(%r{<r><rPr><b/>.*?</rPr><t>Active commodity\n?description</t></r>}m)
     end
 
-    it 'adds table styling for the full data range' do
+    it 'adds table styling using the same range as the caxlsx report' do
       xml = table_xml(xlsx_data)
 
-      expect(xml).to include('ref="A8:D11"')
+      expect(xml).to include('displayName="Your_commodities_from_your_commodity_watch_list"')
+      expect(xml).to include('ref="A8:D10"')
       expect(xml).to include('name="TableStyleLight15"')
       expect(xml).to include('showRowStripes="1"')
     end

--- a/spec/services/api/user/active_commodities_report_worksheet_builder_spec.rb
+++ b/spec/services/api/user/active_commodities_report_worksheet_builder_spec.rb
@@ -1,14 +1,11 @@
 RSpec.describe Api::User::ActiveCommoditiesReportWorksheetBuilder do
   describe '.call' do
-    subject(:build_worksheet) { described_class.call(workbook:, report_rows:) }
-
-    let(:package) { Axlsx::Package.new }
-    let(:worksheet) do
-      build_worksheet
-      workbook.worksheets.first
+    subject(:xlsx_data) do
+      described_class.call(workbook:, report_rows:)
+      workbook.read_string
     end
-    let(:workbook) { package.workbook }
 
+    let(:workbook) { FastExcel.open(constant_memory: true) }
     let(:report_rows) do
       [
         {
@@ -40,83 +37,40 @@ RSpec.describe Api::User::ActiveCommoditiesReportWorksheetBuilder do
       ]
     end
 
-    it 'creates a worksheet with the expected name' do
-      expect(worksheet.name).to eq(described_class::SHEET_NAME)
-    end
-
-    it 'renders title as A1 text and B1 date' do
+    it 'renders title, instructions and rows' do
       freeze_time do
-        expected_date = Time.zone.today.strftime('%d/%m/%Y')
-
-        expect(worksheet.rows[0].cells[0].value).to eq('Your commodities')
-        expect(worksheet.rows[0].cells[1].value).to eq("(#{expected_date})")
-        expect(worksheet.rows[0].height).to eq(described_class::TITLE_ROW_HEIGHT)
+        expect(worksheet_row_texts(xlsx_data)).to include(
+          ['Your commodities', "(#{Time.zone.today.strftime('%d/%m/%Y')})"],
+          ['Updating your commodity watch list:'],
+          ['All your active and expired codes, as well as errors, are listed on this spreadsheet.'],
+          ['You can edit, add and remove codes from this spreadsheet or your own.'],
+          ['You can then upload it to update your commodity watchlist. ', 'Ensure all codes are listed in column A.'],
+          described_class::HEADERS,
+          ["1111111111\n ", '11: Chapter eleven', 'Expired commodity description', "\n", 'Expired'],
+          ["2222222222\n ", '22: Chapter twenty two', 'Active commodity description', "\n", 'Active'],
+          ["3333333333\n ", 'Not applicable', 'Not applicable', 'Error from upload'],
+        )
       end
     end
 
-    it 'renders 4 instruction rows with a bold rich-text ending sentence' do
-      final_instruction = worksheet.rows[4].cells[0].value
+    it 'writes rich text for bold fragments' do
+      xml = worksheet_xml(xlsx_data)
 
-      expect(worksheet.rows[1].cells[0].value).to eq('Updating your commodity watch list:')
-      expect(worksheet.rows[2].cells[0].value).to eq('All your active and expired codes, as well as errors, are listed on this spreadsheet.')
-      expect(worksheet.rows[3].cells[0].value).to eq('You can edit, add and remove codes from this spreadsheet or your own.')
-      expect(final_instruction).to be_a(Axlsx::RichText)
-      expect(final_instruction.last.value).to eq('Ensure all codes are listed in column A.')
-      expect(final_instruction.last.b).to be true
+      expect(xml).to match(%r{<r><rPr><b/>.*?</rPr><t>Ensure all codes are listed in column A\.</t></r>}m)
+      expect(xml).to match(%r{<r><rPr><b/>.*?</rPr><t>Expired commodity description</t></r>}m)
     end
 
-    it 'does not merge intro rows and keeps upload row unmerged' do
-      merged_cells = Array(worksheet.instance_variable_get(:@merged_cells))
-
-      expect(merged_cells).to be_empty
-      expect(worksheet.rows[5].cells[0].value).to eq('Replace all commodities (upload)')
-    end
-
-    it 'adds upload hyperlink at A6 and blank spacer row at row 7' do
-      expect(worksheet.hyperlinks.map(&:location)).to include(described_class::REPLACE_ALL_COMMODITIES_UPLOAD_URL)
-      expect(worksheet.hyperlinks.map(&:ref)).to include('A6')
-      expect(worksheet.rows[6].height).to eq(described_class::BLANK_ROW_HEIGHT)
-    end
-
-    it 'adds expected table headers and data rows' do
-      header_row = worksheet.rows[7]
-      expect(header_row.cells.map(&:value)).to eq(described_class::HEADERS)
-
-      data_rows = worksheet.rows[8..].map do |row|
-        [
-          row.cells[0].value.to_s,
-          extract_cell_text(row.cells[1].value),
-          extract_cell_text(row.cells[2].value),
-          row.cells[3].value.to_s,
-        ]
-      end
-
-      expect(data_rows).to eq([
-        ["1111111111\n ", '11: Chapter eleven', "Expired commodity description\n", 'Expired'],
-        ["2222222222\n ", '22: Chapter twenty two', "Active commodity description\n", 'Active'],
-        ["3333333333\n ", 'Not applicable', 'Not applicable', 'Error from upload'],
-      ])
-    end
-
-    it 'adds a table over the populated data range' do
-      table = worksheet.tables.first
-
-      expect(table).not_to be_nil
-      expect(table.ref).to eq('A8:D10')
+    it 'adds the upload hyperlink and filters' do
+      expect(worksheet_relationships_xml(xlsx_data)).to include(xml_escape(described_class::REPLACE_ALL_COMMODITIES_UPLOAD_URL))
+      expect(worksheet_xml(xlsx_data)).to include('<autoFilter ref="A8:D11"/>')
     end
 
     context 'when there are no report rows' do
       let(:report_rows) { [] }
 
-      it 'does not add a table' do
-        expect(worksheet.tables).to be_empty
+      it 'does not add a filter range' do
+        expect(worksheet_xml(xlsx_data)).not_to include('<autoFilter')
       end
     end
-  end
-
-  def extract_cell_text(value)
-    return value.to_s unless value.is_a?(Axlsx::RichText)
-
-    value.map(&:value).join
   end
 end

--- a/spec/services/api/user/active_commodities_report_worksheet_builder_spec.rb
+++ b/spec/services/api/user/active_commodities_report_worksheet_builder_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Api::User::ActiveCommoditiesReportWorksheetBuilder do
       workbook.read_string
     end
 
-    let(:workbook) { FastExcel.open(constant_memory: true) }
+    let(:workbook) { FastExcel.open }
     let(:report_rows) do
       [
         {
@@ -54,22 +54,27 @@ RSpec.describe Api::User::ActiveCommoditiesReportWorksheetBuilder do
     end
 
     it 'writes rich text for bold fragments' do
-      xml = worksheet_xml(xlsx_data)
+      xml = shared_strings_xml(xlsx_data)
 
       expect(xml).to match(%r{<r><rPr><b/>.*?</rPr><t>Ensure all codes are listed in column A\.</t></r>}m)
       expect(xml).to match(%r{<r><rPr><b/>.*?</rPr><t>Expired commodity description</t></r>}m)
     end
 
     it 'adds the upload hyperlink and filters' do
-      expect(worksheet_relationships_xml(xlsx_data)).to include(xml_escape(described_class::REPLACE_ALL_COMMODITIES_UPLOAD_URL))
-      expect(worksheet_xml(xlsx_data)).to include('<autoFilter ref="A8:D11"/>')
+      relationships_xml = worksheet_relationships_xml(xlsx_data)
+
+      expect(relationships_xml).to include(xml_escape(described_class::REPLACE_ALL_COMMODITIES_UPLOAD_URL))
+      expect(relationships_xml.scan(%r{Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink"}).size).to eq(1)
+      expect(table_xml(xlsx_data)).to include('ref="A8:D11"')
+      expect(table_xml(xlsx_data)).to include('name="TableStyleLight15"')
+      expect(table_xml(xlsx_data)).to include('showRowStripes="1"')
     end
 
     context 'when there are no report rows' do
       let(:report_rows) { [] }
 
       it 'does not add a filter range' do
-        expect(worksheet_xml(xlsx_data)).not_to include('<autoFilter')
+        expect { table_xml(xlsx_data) }.to raise_error(Errno::ENOENT)
       end
     end
   end

--- a/spec/services/api/user/active_commodities_report_worksheet_builder_spec.rb
+++ b/spec/services/api/user/active_commodities_report_worksheet_builder_spec.rb
@@ -65,7 +65,8 @@ RSpec.describe Api::User::ActiveCommoditiesReportWorksheetBuilder do
 
       expect(relationships_xml).to include(xml_escape(described_class::REPLACE_ALL_COMMODITIES_UPLOAD_URL))
       expect(relationships_xml.scan(%r{Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink"}).size).to eq(1)
-      expect(table_xml(xlsx_data)).to include('ref="A8:D11"')
+      expect(table_xml(xlsx_data)).to include('displayName="Your_commodities_from_your_commodity_watch_list"')
+      expect(table_xml(xlsx_data)).to include('ref="A8:D10"')
       expect(table_xml(xlsx_data)).to include('name="TableStyleLight15"')
       expect(table_xml(xlsx_data)).to include('showRowStripes="1"')
     end

--- a/spec/services/tariff_changes_service/excel_generator_spec.rb
+++ b/spec/services/tariff_changes_service/excel_generator_spec.rb
@@ -113,6 +113,10 @@ RSpec.describe TariffChangesService::ExcelGenerator do
     it 'preserves the explicit blank spacer cell emitted by the caxlsx report' do
       expect(worksheet_xml(xlsx_data)).to include('<c r="A3"')
     end
+
+    it 'sets the worksheet default row height for wrapped data rows' do
+      expect(worksheet_xml(xlsx_data)).to include('<sheetFormatPr defaultRowHeight="40"')
+    end
   end
 
   describe '#build_excel_row' do

--- a/spec/services/tariff_changes_service/excel_generator_spec.rb
+++ b/spec/services/tariff_changes_service/excel_generator_spec.rb
@@ -38,235 +38,80 @@ RSpec.describe TariffChangesService::ExcelGenerator do
   describe '.call' do
     context 'when change_records is empty' do
       it 'returns nil' do
-        result = described_class.call([], date)
-        expect(result).to be_nil
+        expect(described_class.call([], date)).to be_nil
       end
     end
 
-    context 'when change_records has data' do
-      it 'creates a new instance and calls #call' do
-        instance = instance_double(described_class, call: 'package')
-        allow(described_class).to receive(:new).and_return(instance)
-        result = described_class.call(change_records, date)
-        expect(result).to eq('package')
-      end
-    end
-  end
-
-  describe '#initialize' do
-    let(:generator) { described_class.new(change_records, date) }
-
-    it 'sets change_records' do
-      expect(generator.change_records).to eq(change_records)
-    end
-
-    it 'sets date' do
-      expect(generator.date).to eq(date)
+    it 'returns a FastExcel workbook' do
+      expect(described_class.call(change_records, date)).to be_a(Libxlsxwriter::Workbook)
     end
   end
 
   describe '#call' do
-    let(:generator) { described_class.new(change_records, date) }
-    let(:package) { generator.call }
-    let(:workbook) { package.workbook }
-    let(:worksheet) { workbook.worksheets.first }
+    let(:workbook) { described_class.new(change_records, date).call }
+    let(:xlsx_data) { workbook.read_string }
 
-    before do
-      allow(Rails.env).to receive(:development?).and_return(false)
+    it 'renders the expected worksheet rows' do
+      expect(worksheet_row_texts(xlsx_data)).to include(
+        ['Changes to your commodity watch list'],
+        ["Published #{date}"],
+        [
+          'Import/Export (if applicable)',
+          'Impacted Geographical area (if applicable)',
+          'Impacted Measure (if applicable)',
+          'Additional Code (if applicable)',
+          'Quota order number (if applicable)',
+          'Chapter',
+          'Commodity Code',
+          'Commodity Code description',
+          'Change Type',
+          'Change Detail',
+          'Change Date of Effect',
+          'View OTT for Change Date of Effect',
+          'API call for the changed Commodity',
+        ],
+        [
+          'Import',
+          'United Kingdom',
+          'Third country duty',
+          'N/A',
+          'N/A',
+          '01',
+          '0101000000',
+          'Live horses, asses, mules and hinnies',
+          'Added',
+          'New measure added',
+          '2024-08-11',
+          'https://www.trade-tariff.service.gov.uk/commodities/0101000000',
+          'https://www.trade-tariff.service.gov.uk/api/v2/commodities/0101000000',
+        ],
+      )
     end
 
-    it 'creates an Axlsx package' do
-      expect(package).to be_a(Axlsx::Package)
+    it 'adds hyperlinks for OTT and API columns' do
+      relationships_xml = worksheet_relationships_xml(xlsx_data)
+
+      expect(relationships_xml).to include(change_records[0][:ott_url])
+      expect(relationships_xml).to include(change_records[0][:api_url])
+      expect(relationships_xml).to include(change_records[1][:ott_url])
+      expect(relationships_xml).to include(change_records[1][:api_url])
     end
 
-    it 'creates a worksheet named "Commodity watch list"' do
-      expect(worksheet.name).to eq('Commodity watch list')
-    end
+    it 'sets expected column widths and filters' do
+      xml = worksheet_xml(xlsx_data)
 
-    it 'sets default row height' do
-      expect(worksheet.sheet_format_pr.default_row_height).to eq(40.0)
-      expect(worksheet.sheet_format_pr.custom_height).to be false
-    end
-
-    describe 'worksheet structure' do
-      it 'has the correct number of rows' do
-        # 5 header rows + 2 data rows
-        expect(worksheet.rows.size).to eq(7)
-      end
-
-      it 'sets the title row correctly' do
-        title_row = worksheet.rows[0]
-        expect(title_row.cells[0].value).to eq('Changes to your commodity watch list')
-        expect(title_row.height).to eq(40)
-      end
-
-      it 'sets the subtitle row correctly' do
-        subtitle_row = worksheet.rows[1]
-        expect(subtitle_row.cells[0].value).to eq("Published #{date}")
-        expect(subtitle_row.height).to eq(25)
-      end
-
-      it 'has an empty row' do
-        empty_row = worksheet.rows[2]
-        expect(empty_row.cells[0].value).to eq('')
-        expect(empty_row.height).to eq(20)
-      end
-
-      it 'sets the pre-header row correctly' do
-        pre_header_row = worksheet.rows[3]
-        expect(pre_header_row.cells[0].value).to eq('Is this change relevant to your business (useful filters)')
-        expect(pre_header_row.height).to eq(40)
-      end
-
-      it 'sets the header row correctly' do
-        header_row = worksheet.rows[4]
-        expect(header_row.cells[0].value).to eq('Import/Export (if applicable)')
-        expect(header_row.height).to eq(40)
-      end
-    end
-
-    describe 'cell merging' do
-      it 'merges the pre-header cells correctly' do
-        merged_cells = worksheet.instance_variable_get(:@merged_cells)
-        expect(merged_cells).to include('A4:E4', 'F4:H4', 'I4:K4', 'L4:M4')
-      end
-    end
-
-    describe 'data rows' do
-      it 'adds data rows for each record' do
-        data_rows = worksheet.rows[5..]
-        expect(data_rows.size).to eq(2)
-      end
-
-      it 'populates data correctly' do
-        first_data_row = worksheet.rows[5]
-        expect(first_data_row.cells[0].value).to eq('Import')
-        expect(first_data_row.cells[6].value).to eq('0101000000')
-        expect(first_data_row.cells[8].value).to eq('Added')
-      end
-
-      it 'adds hyperlinks for OTT and API columns' do
-        hyperlinks = worksheet.hyperlinks
-
-        expect(hyperlinks.map(&:location)).to contain_exactly(
-          change_records[0][:ott_url],
-          change_records[0][:api_url],
-          change_records[1][:ott_url],
-          change_records[1][:api_url],
-        )
-
-        expect(hyperlinks.map(&:ref)).to include('L6', 'M6', 'L7', 'M7')
-      end
-    end
-
-    describe 'table styling' do
-      it 'creates a styled table over the data range' do
-        table = worksheet.tables.first
-
-        expect(table).not_to be_nil
-        style_name = if table.respond_to?(:table_style_info)
-                       table.table_style_info&.name
-                     elsif table.respond_to?(:style)
-                       table.style
-                     end
-
-        style_name ||= table.to_xml_string
-
-        expect(style_name).to include('TableStyleMedium2')
-        expect(table.ref).to eq('A5:M7')
-      end
-    end
-
-    describe 'column widths' do
-      it 'sets column widths correctly' do
-        expected_widths = [20, 30, 30, 30, 25, 15, 20, 50, 30, 30, 22, 80, 60]
-        expect(worksheet.column_info.map(&:width)).to eq(expected_widths)
-      end
-    end
-  end
-
-  describe '#excel_header_row' do
-    let(:generator) { described_class.new(change_records, date) }
-
-    it 'returns the correct header array' do
-      expected_headers = [
-        'Import/Export (if applicable)',
-        'Impacted Geographical area (if applicable)',
-        'Impacted Measure (if applicable)',
-        'Additional Code (if applicable)',
-        'Quota order number (if applicable)',
-        'Chapter',
-        'Commodity Code',
-        'Commodity Code description',
-        'Change Type',
-        'Change Detail',
-        'Change Date of Effect',
-        'View OTT for Change Date of Effect',
-        'API call for the changed Commodity',
-      ]
-      expect(generator.send(:excel_header_row)).to eq(expected_headers)
-    end
-
-    it 'has 13 columns' do
-      expect(generator.send(:excel_header_row).size).to eq(13)
-    end
-  end
-
-  describe '#excel_column_widths' do
-    let(:generator) { described_class.new(change_records, date) }
-
-    it 'returns the correct column widths' do
-      expected_widths = [20, 30, 30, 30, 25, 15, 20, 50, 30, 30, 22, 80, 60]
-      expect(generator.send(:excel_column_widths)).to eq(expected_widths)
-    end
-
-    it 'has widths for all 13 columns' do
-      expect(generator.send(:excel_column_widths).size).to eq(13)
-    end
-  end
-
-  describe '#cell_styles' do
-    let(:generator) { described_class.new(change_records, date) }
-
-    before do
-      generator.instance_variable_set(:@workbook, Axlsx::Package.new.workbook)
-    end
-
-    context 'without background color' do
-      let(:styles) { generator.send(:cell_styles) }
-
-      it 'returns a hash of styles' do
-        expect(styles).to be_a(Hash)
-        expect(styles.keys).to include(:pre_header, :header, :date, :commodity_code, :chapter, :text, :center_text, :hyperlink, :bold_text)
-      end
-
-      it 'creates Axlsx styles' do
-        expect(styles[:text]).to be_a(Integer)
-      end
-    end
-  end
-
-  describe '#build_row_styles' do
-    let(:generator) { described_class.new(change_records, date) }
-    let(:styles) { generator.send(:build_row_styles) }
-
-    before do
-      generator.instance_variable_set(:@workbook, Axlsx::Package.new.workbook)
-    end
-
-    it 'returns an array of 13 styles' do
-      expect(styles.size).to eq(13)
+      expect(xml).to include('width="20.7109375"')
+      expect(xml).to include('<autoFilter ref="A5:M7"/>')
     end
   end
 
   describe '#build_excel_row' do
     let(:generator) { described_class.new(change_records, date) }
-    let(:record) { change_records.first }
 
     it 'builds a row array from a record hash' do
-      row = generator.send(:build_excel_row, record)
+      row = generator.send(:build_excel_row, change_records.first)
 
-      expect(row).to eq([
+      expect(row[0..10]).to eq([
         'Import',
         'United Kingdom',
         'Third country duty',
@@ -278,25 +123,9 @@ RSpec.describe TariffChangesService::ExcelGenerator do
         'Added',
         'New measure added',
         '2024-08-11',
-        'https://www.trade-tariff.service.gov.uk/commodities/0101000000',
-        'https://www.trade-tariff.service.gov.uk/api/v2/commodities/0101000000',
       ])
-    end
-
-    it 'formats date correctly' do
-      row = generator.send(:build_excel_row, record)
-      expect(row[10]).to eq('2024-08-11')
-    end
-
-    it 'handles nil date' do
-      record_with_nil_date = record.merge(date_of_effect: nil)
-      row = generator.send(:build_excel_row, record_with_nil_date)
-      expect(row[10]).to be_nil
-    end
-
-    it 'returns an array with 13 elements' do
-      row = generator.send(:build_excel_row, record)
-      expect(row.size).to eq(13)
+      expect(row[11]).to be_a(FastExcel::URL)
+      expect(row[12]).to be_a(FastExcel::URL)
     end
   end
 end

--- a/spec/services/tariff_changes_service/excel_generator_spec.rb
+++ b/spec/services/tariff_changes_service/excel_generator_spec.rb
@@ -109,6 +109,10 @@ RSpec.describe TariffChangesService::ExcelGenerator do
       expect(table_xml(xlsx_data)).to include('name="TableStyleMedium2"')
       expect(table_xml(xlsx_data)).to include('showRowStripes="1"')
     end
+
+    it 'preserves the explicit blank spacer cell emitted by the caxlsx report' do
+      expect(worksheet_xml(xlsx_data)).to include('<c r="A3"')
+    end
   end
 
   describe '#build_excel_row' do
@@ -132,6 +136,18 @@ RSpec.describe TariffChangesService::ExcelGenerator do
       ])
       expect(row[11]).to be_a(FastExcel::URL)
       expect(row[12]).to be_a(FastExcel::URL)
+    end
+
+    context 'when the date of effect is a Date' do
+      before do
+        change_records.first[:date_of_effect] = Date.new(2024, 8, 11)
+      end
+
+      it 'serializes the date as the same ISO string as the caxlsx report' do
+        row = generator.send(:build_excel_row, change_records.first)
+
+        expect(row[10]).to eq('2024-08-11')
+      end
     end
   end
 end

--- a/spec/services/tariff_changes_service/excel_generator_spec.rb
+++ b/spec/services/tariff_changes_service/excel_generator_spec.rb
@@ -101,7 +101,13 @@ RSpec.describe TariffChangesService::ExcelGenerator do
       xml = worksheet_xml(xlsx_data)
 
       expect(xml).to include('width="20.7109375"')
-      expect(xml).to include('<autoFilter ref="A5:M7"/>')
+      expect(xml).to include('<mergeCell ref="A4:E4"/>')
+      expect(xml).to include('<mergeCell ref="F4:H4"/>')
+      expect(xml).to include('<mergeCell ref="I4:K4"/>')
+      expect(xml).to include('<mergeCell ref="L4:M4"/>')
+      expect(table_xml(xlsx_data)).to include('ref="A5:M7"')
+      expect(table_xml(xlsx_data)).to include('name="TableStyleMedium2"')
+      expect(table_xml(xlsx_data)).to include('showRowStripes="1"')
     end
   end
 

--- a/spec/services/tariff_changes_service_spec.rb
+++ b/spec/services/tariff_changes_service_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe TariffChangesService do
   describe '.generate_report_for' do
     let(:date) { Date.new(2024, 8, 11) }
     let(:change_records) { [{ dummy: 'data' }] }
-    let(:package) { instance_double(Axlsx::Package) }
+    let(:package) { instance_double(Libxlsxwriter::Workbook) }
 
     before do
       allow(TariffChangesService::TransformRecords).to receive(:call).with(date, nil).and_return(change_records)

--- a/spec/support/xlsx_helpers.rb
+++ b/spec/support/xlsx_helpers.rb
@@ -1,6 +1,7 @@
 require 'zip'
 require 'nokogiri'
 require 'cgi'
+require 'stringio'
 
 module XlsxHelpers
   def xlsx_entry(xlsx_data, entry_name)

--- a/spec/support/xlsx_helpers.rb
+++ b/spec/support/xlsx_helpers.rb
@@ -1,0 +1,41 @@
+require 'zip'
+require 'nokogiri'
+require 'cgi'
+
+module XlsxHelpers
+  def xlsx_entry(xlsx_data, entry_name)
+    content = nil
+
+    Zip::File.open_buffer(StringIO.new(xlsx_data)) do |zip|
+      entry = zip.read(entry_name)
+      content = entry.respond_to?(:read) ? entry.read : entry
+    end
+
+    content
+  end
+
+  def worksheet_xml(xlsx_data)
+    xlsx_entry(xlsx_data, 'xl/worksheets/sheet1.xml')
+  end
+
+  def worksheet_relationships_xml(xlsx_data)
+    xlsx_entry(xlsx_data, 'xl/worksheets/_rels/sheet1.xml.rels')
+  end
+
+  def worksheet_row_texts(xlsx_data)
+    doc = Nokogiri::XML(worksheet_xml(xlsx_data))
+    doc.remove_namespaces!
+
+    doc.xpath('//row').map do |row|
+      row.xpath('.//t').map(&:text)
+    end
+  end
+
+  def xml_escape(value)
+    CGI.escapeHTML(value)
+  end
+end
+
+RSpec.configure do |config|
+  config.include XlsxHelpers
+end

--- a/spec/support/xlsx_helpers.rb
+++ b/spec/support/xlsx_helpers.rb
@@ -22,17 +22,43 @@ module XlsxHelpers
     xlsx_entry(xlsx_data, 'xl/worksheets/_rels/sheet1.xml.rels')
   end
 
+  def table_xml(xlsx_data)
+    xlsx_entry(xlsx_data, 'xl/tables/table1.xml')
+  end
+
+  def shared_strings_xml(xlsx_data)
+    xlsx_entry(xlsx_data, 'xl/sharedStrings.xml')
+  end
+
   def worksheet_row_texts(xlsx_data)
     doc = Nokogiri::XML(worksheet_xml(xlsx_data))
     doc.remove_namespaces!
+    shared_strings = xlsx_shared_strings(xlsx_data)
 
     doc.xpath('//row').map do |row|
-      row.xpath('.//t').map(&:text)
+      row.xpath('./c').flat_map do |cell|
+        if cell['t'] == 's'
+          shared_strings.fetch(cell.at_xpath('./v').text.to_i)
+        else
+          cell.xpath('.//t').map(&:text)
+        end
+      end
     end
   end
 
   def xml_escape(value)
     CGI.escapeHTML(value)
+  end
+
+  def xlsx_shared_strings(xlsx_data)
+    doc = Nokogiri::XML(shared_strings_xml(xlsx_data))
+    doc.remove_namespaces!
+
+    doc.xpath('//si').map do |shared_string|
+      shared_string.xpath('.//t').map(&:text)
+    end
+  rescue Errno::ENOENT
+    []
   end
 end
 


### PR DESCRIPTION
## What:
- Removes the unused `caxlsx` dependency.
- Migrates commodity watch list XLSX generation from Axlsx/caxlsx to FastExcel.
- Uses the FastExcel fork branch for rich string support needed by active commodity reports.
- Updates request/service specs to validate generated XLSX content via ZIP/XML inspection.

## Why:
This unblocks HMRC-1859 by completing the remaining migration path to FastExcel while preserving the existing downloadable spreadsheet behaviour for tariff changes and active commodity reports.

## Ticket:
https://transformuk.atlassian.net/browse/HMRC-1866

## Risk:
**Risk level:** 🟠

**Reason for rating:**
This changes XLSX generation for live user downloads. The public API shape is unchanged, and the affected report/controller paths have focused request and service coverage.
