### PR TITLE
AI-516: Fix notes extractor dropping additional, subheading and numbered chapter notes

### DIFF
--- a/app/lib/customs_tariff_importer/notes_extractor.rb
+++ b/app/lib/customs_tariff_importer/notes_extractor.rb
@@ -2,15 +2,17 @@ module CustomsTariffImporter
   class NotesExtractor
     WORD_NS = { 'w' => 'http://schemas.openxmlformats.org/wordprocessingml/2006/main' }.freeze
 
-    SECTION_PATTERN          = /\ASECTION\s+([IVX]+)/i
-    CHAPTER_PATTERN          = /\ACHAPTER\s+(\d+)/i
+    SECTION_PATTERN          = /\ASECTION\s+([IVX]+)\z/i
+    CHAPTER_PATTERN          = /\ACHAPTER\s+(\d+)\z/
     CHAPTER_NOTES_PATTERN    = /\AChapter\s+[Nn]otes?\z/i
     ADDITIONAL_NOTES_PATTERN = /\AAdditional\s+[Cc]hapter\s+[Nn]otes?\z/i
+    SUBHEADING_NOTES_PATTERN = /\ASubheading\s+[Nn]otes?\z/i
     SECTION_NOTES_PATTERN    = /\ASection\s+[Nn]otes?\z/i
     GENERAL_RULES_PATTERN    = /\AGeneral\s+Interpretive\s+Rules?\z/i
     RULE_PATTERN             = /\ARule\s+(\d+)\z/i
     COMMODITY_CODE_PATTERN   = /\A\d{10}\z/
     PART_BOUNDARY_PATTERN    = /\APART\s+\w+/i
+    NUMBERED_NOTE_PATTERN    = /\A1\.\s*[A-Za-z(]/
 
     Result = Data.define(:chapters, :sections, :general_rules)
 
@@ -177,6 +179,15 @@ module CustomsTariffImporter
       elsif text.match?(CHAPTER_NOTES_PATTERN)
         @note_lines = []
         @state = :collecting_chapter
+      elsif text.match?(ADDITIONAL_NOTES_PATTERN)
+        @note_lines = [text]
+        @state = :collecting_chapter
+      elsif text.match?(SUBHEADING_NOTES_PATTERN)
+        @note_lines = [text]
+        @state = :collecting_chapter
+      elsif text.match?(NUMBERED_NOTE_PATTERN)
+        @note_lines = [text]
+        @state = :collecting_chapter
       elsif (m = text.match(CHAPTER_PATTERN))
         finalize_chapter_note
         @current_chapter = sprintf('%02d', m[1].to_i)
@@ -195,7 +206,7 @@ module CustomsTariffImporter
         @note_lines = []
         @state = :skipping
       elsif text.match?(ADDITIONAL_NOTES_PATTERN)
-        # continue accumulating — additional chapter notes belong to the same chapter
+        @note_lines << text
       elsif (m = text.match(CHAPTER_PATTERN))
         finalize_chapter_note
         @current_chapter = sprintf('%02d', m[1].to_i)

--- a/spec/lib/customs_tariff_importer/notes_extractor_spec.rb
+++ b/spec/lib/customs_tariff_importer/notes_extractor_spec.rb
@@ -159,6 +159,7 @@ RSpec.describe CustomsTariffImporter::NotesExtractor do
         ])
 
         expect(result.chapters['01']).to include('Primary note.')
+        expect(result.chapters['01']).to include('Additional Chapter Notes')
         expect(result.chapters['01']).to include('Extra note.')
       end
 
@@ -178,6 +179,98 @@ RSpec.describe CustomsTariffImporter::NotesExtractor do
       it 'does not save a chapter with no notes' do
         result = parse(['CHAPTER 1', 'CHAPTER 2'])
         expect(result.chapters).to be_empty
+      end
+    end
+
+    describe 'boundary pattern anchoring' do
+      it 'does not treat an inline chapter reference within note text as a chapter boundary' do
+        result = parse([
+          'CHAPTER 72',
+          'Chapter Notes',
+          '1. Some definition.',
+          'Chapter 72 does not include products of heading 7301 or 7302.',
+          'More note text.',
+          'CHAPTER 73',
+          'Chapter Notes',
+          'Steel content.',
+        ])
+
+        expect(result.chapters['72']).to include('More note text.')
+        expect(result.chapters['73']).to include('Steel content.')
+      end
+
+      it 'does not treat an inline section reference within note text as a section boundary' do
+        result = parse([
+          'CHAPTER 5',
+          'Chapter Notes',
+          '1. Some definition.',
+          'Section II also covers related products.',
+          'More note text.',
+          'CHAPTER 6',
+          'Chapter Notes',
+          'Next chapter content.',
+        ])
+
+        expect(result.chapters['05']).to include('More note text.')
+        expect(result.chapters['06']).to include('Next chapter content.')
+      end
+    end
+
+    describe 'chapter notes without a "Chapter Notes" heading' do
+      it 'starts collecting from "Additional chapter notes" when it is the first heading' do
+        result = parse([
+          'CHAPTER 53',
+          'OTHER VEGETABLE TEXTILE FIBRES; PAPER YARN AND WOVEN FABRICS OF PAPER YARN',
+          'Additional chapter notes',
+          '1. (A) For the purposes of code 5306 10 90, the expression "put up for retail sale" means goods put up:',
+          '5306100000',
+        ])
+
+        expect(result.chapters['53']).to start_with('Additional chapter notes')
+        expect(result.chapters['53']).to include('1. (A) For the purposes of code 5306 10 90')
+        expect(result.chapters['53']).not_to include('5306100000')
+      end
+
+      it 'starts collecting from "Subheading note" when it is the first heading' do
+        result = parse([
+          'CHAPTER 52',
+          'COTTON',
+          'Subheading note',
+          "For the purposes of subheadings 5209.42 and 5211.42, the expression 'denim' means fabrics of yarns.",
+          '5201000000',
+        ])
+
+        expect(result.chapters['52']).to start_with('Subheading note')
+        expect(result.chapters['52']).to include("the expression 'denim' means fabrics of yarns.")
+        expect(result.chapters['52']).not_to include('5201000000')
+      end
+
+      it 'starts collecting from the first numbered note when there is no heading' do
+        result = parse([
+          'CHAPTER 30',
+          'PHARMACEUTICAL PRODUCTS',
+          '1. This chapter does not cover:',
+          '(a) foods or beverages (such as dietetic, diabetic or fortified foods).',
+          '3001000000',
+        ])
+
+        expect(result.chapters['30']).to start_with('1. This chapter does not cover:')
+        expect(result.chapters['30']).to include('(a) foods or beverages')
+        expect(result.chapters['30']).not_to include('3001000000')
+      end
+
+      it 'does not mistake a duty-rate percentage for a numbered note' do
+        result = parse([
+          'CHAPTER 1',
+          'LIVE ANIMALS',
+          '0.00%',
+          'CHAPTER 2',
+          'Chapter Notes',
+          'Meat content.',
+        ])
+
+        expect(result.chapters['01']).to be_nil
+        expect(result.chapters['02']).to include('Meat content.')
       end
     end
 


### PR DESCRIPTION
## What:

This PR tidies up how the **NotesExtractor** reads chapter notes out of the source DOCX, so we stop accidentally losing some of them along the way. While digging into the chapter-notes output I noticed a few note blocks weren't making it through, and it traced back to a couple of patterns the extractor wasn't recognising.

Here's what changed in **`app/lib/customs_tariff_importer/notes_extractor.rb`**:

- Anchored `SECTION_PATTERN` and `CHAPTER_PATTERN` with `\z` so a heading like "CHAPTER 1 NOTES" is no longer mistaken for a plain chapter boundary. Previously that false match would close off the note we were busy collecting too early.
- Taught the extractor to recognise three note openers it used to skip past:
  - **"Additional chapter note(s)"** — now starts (or carries on) collecting chapter notes, and the heading itself is kept in the output
  - **"Subheading note(s)"** (new `SUBHEADING_NOTES_PATTERN`) — now starts collecting chapter notes
  - **Bare numbered notes** like "1. ..." (new `NUMBERED_NOTE_PATTERN`) — now start collecting chapter notes

I've also added spec coverage in **`spec/lib/customs_tariff_importer/notes_extractor_spec.rb`** for each of these cases.

## Why:

The downstream notes formatter can only do its job if it receives the complete note blocks, and right now the extractor is quietly dropping some of them, so the extracted chapter notes don't match what's actually in the source document.

A couple of small things worth flagging for review:
- The `\z` anchors are the key fix — without them, note headings that happen to contain the word "CHAPTER" or "SECTION" were being treated as section/chapter boundaries.
- "Additional chapter notes" now appends to the current chapter rather than being treated as a fresh block, since they belong to the same chapter.

Happy to walk through any of it if it's easier — thanks for taking a look! 🙏

## Ticket:

[AI-516](https://transformuk.atlassian.net/browse/AI-516)

## Risk:
**Risk level:** 🟢

**Reason for rating:** Tightly scoped change to a single import/extraction class with full spec coverage and no behaviour change to existing endpoints, measures, or sync. It only affects how chapter notes are parsed out of the source document.

───────────────────────────────────────────────────

Rate the overall risk of deploying this change:

🟢 Green  – Low risk. Good to go, standard review applies.

🟠 Amber  – Medium risk. Socialise with the team before merging.

🔴 Red    – High risk. Requires explicit approval from Thor or Neil before merging.