### PR TITLE
AI-868: Fix tariff knowledge graph gaps

### DIFF
--- a/app/services/tariff_knowledge/compressed_note_generator.rb
+++ b/app/services/tariff_knowledge/compressed_note_generator.rb
@@ -106,9 +106,9 @@ module TariffKnowledge
     end
 
     def current_fragment_nodes(ids)
-      nodes_by_id(ids, Node.note_fragments).select do |_id, node|
-        current_source_version.blank? || node.source_version == current_source_version
-      end
+      dataset = Node.note_fragments
+      dataset = dataset.where(source_version: current_source_version) if current_source_version.present?
+      nodes_by_id(ids, dataset)
     end
 
     def current_source_version

--- a/app/services/tariff_knowledge/compressed_note_generator.rb
+++ b/app/services/tariff_knowledge/compressed_note_generator.rb
@@ -28,7 +28,7 @@ module TariffKnowledge
     end
 
     def generate_for(declarable_node, evidence)
-      return if evidence.empty?
+      return mark_existing_note_stale(declarable_node) if evidence.empty?
 
       content = content_for(declarable_node, evidence)
       attributes = {
@@ -66,7 +66,7 @@ module TariffKnowledge
       range_nodes = nodes_by_id(expansion_edges.map(&:source_node_id), Node.where(node_type: Node::RANGE))
       reference_edges = Edge.by_relationship(Edge::REFERENCES).where(target_node_id: range_nodes.keys).all
       apply_edges = Edge.by_relationship(Edge::APPLIES_TO).where(target_node_id: declarable_node_ids).all
-      fragment_nodes = nodes_by_id((reference_edges + apply_edges).map(&:source_node_id), Node.note_fragments)
+      fragment_nodes = current_fragment_nodes((reference_edges + apply_edges).map(&:source_node_id))
       expansion_edges_by_target_id = expansion_edges.group_by(&:target_node_id)
       reference_edges_by_range_id = reference_edges.group_by(&:target_node_id)
       apply_edges_by_target_id = apply_edges.group_by(&:target_node_id)
@@ -103,6 +103,24 @@ module TariffKnowledge
     def nodes_by_id(ids, dataset)
       ids = ids.compact.uniq
       ids.empty? ? {} : dataset.where(id: ids).all.index_by(&:id)
+    end
+
+    def current_fragment_nodes(ids)
+      nodes_by_id(ids, Node.note_fragments).select do |_id, node|
+        current_source_version.blank? || node.source_version == current_source_version
+      end
+    end
+
+    def current_source_version
+      return @current_source_version if defined?(@current_source_version)
+
+      @current_source_version = TimeMachine.at(@time_machine_date ||= Time.current) do
+        CustomsTariffUpdate
+          .actual
+          .where(status: SourceGraphLoader::USABLE_UPDATE_STATUSES)
+          .order(Sequel.desc(:validity_start_date))
+          .get(:version)
+      end
     end
 
     def source_nodes_by_fragment_node_id(fragment_nodes)
@@ -216,13 +234,23 @@ module TariffKnowledge
 
     def upsert_note(declarable_node, attributes)
       note = CompressedNote[declarable_node.goods_nomenclature_sid]
-      return note if note&.manually_edited
+      return mark_note_stale_if_context_changed(note, attributes[:context_hash]) if note&.manually_edited
 
       if note
         note.update(attributes)
       else
         CompressedNote.create(attributes.merge(goods_nomenclature_sid: declarable_node.goods_nomenclature_sid))
       end
+    end
+
+    def mark_existing_note_stale(declarable_node)
+      CompressedNote[declarable_node.goods_nomenclature_sid]&.mark_stale!
+      nil
+    end
+
+    def mark_note_stale_if_context_changed(note, current_hash)
+      note.mark_stale! if note.context_stale?(current_hash)
+      note
     end
   end
 end

--- a/app/services/tariff_knowledge/relevant_note_fragment_selector.rb
+++ b/app/services/tariff_knowledge/relevant_note_fragment_selector.rb
@@ -84,7 +84,7 @@ module TariffKnowledge
       # Each record is compressed-note metadata pointing to a source fragment and
       # explaining the relationship that made that fragment evidence for a code.
       fragment_evidence_records(note).filter_map do |evidence_record|
-        fragment_node = fragment_nodes_by_key[evidence_record['source_node_key']]
+        fragment_node = fragment_node_for(evidence_record)
         text = (evidence_record['source_context'].presence || fragment_node&.content).to_s.squish
         next if text.blank?
 
@@ -98,6 +98,12 @@ module TariffKnowledge
           why_relevant: reasons.join('; '),
         }
       end
+    end
+
+    def fragment_node_for(evidence_record)
+      return if evidence_record['source_context'].present? && evidence_record['source_title'].present?
+
+      fragment_nodes_by_key[evidence_record['source_node_key']]
     end
 
     def score_fragment(evidence_record, text)
@@ -183,10 +189,19 @@ module TariffKnowledge
     end
 
     def fragment_nodes_by_key
-      @fragment_nodes_by_key ||= Node.note_fragments.where(key: notes_by_item_id.values.flat_map { |note| fragment_evidence_records(note).pluck('source_node_key') }.compact.uniq).all.index_by(&:key)
+      @fragment_nodes_by_key ||= begin
+        keys = notes_by_item_id.values.flat_map { |note| fallback_fragment_keys(note) }.compact.uniq
+        keys.empty? ? {} : Node.note_fragments.where(key: keys).all.index_by(&:key)
+      end
     end
 
     def fragment_evidence_records(note) = Array(note.metadata.to_h['evidence'])
+
+    def fallback_fragment_keys(note)
+      fragment_evidence_records(note).filter_map do |evidence_record|
+        evidence_record['source_node_key'] if evidence_record['source_context'].blank? || evidence_record['source_title'].blank?
+      end
+    end
 
     def relevance_tokens = @relevance_tokens ||= tokenize(query)
 

--- a/app/services/tariff_knowledge/source_graph_loader.rb
+++ b/app/services/tariff_knowledge/source_graph_loader.rb
@@ -44,11 +44,13 @@ module TariffKnowledge
       update = latest_approved_update
       return unless update
 
-      prune_non_current_source_nodes(update.version)
+      Node.db.transaction do
+        prune_non_current_source_nodes(update.version)
 
-      SOURCE_ASSOCIATIONS.each do |source_association|
-        sources_for(source_association, update).each do |source|
-          load_source(source_association, source)
+        SOURCE_ASSOCIATIONS.each do |source_association|
+          sources_for(source_association, update).each do |source|
+            load_source(source_association, source)
+          end
         end
       end
     end

--- a/app/services/tariff_knowledge/source_graph_loader.rb
+++ b/app/services/tariff_knowledge/source_graph_loader.rb
@@ -44,6 +44,8 @@ module TariffKnowledge
       update = latest_approved_update
       return unless update
 
+      prune_non_current_source_nodes(update.version)
+
       SOURCE_ASSOCIATIONS.each do |source_association|
         sources_for(source_association, update).each do |source|
           load_source(source_association, source)
@@ -227,7 +229,13 @@ module TariffKnowledge
     end
 
     def expand_range(range_node, reference)
-      upsert_edges(range_node, matching_declarable_nodes(reference), Edge::EXPANDS_TO)
+      current_declarable_nodes = matching_declarable_nodes(reference)
+      upsert_edges(range_node, current_declarable_nodes, Edge::EXPANDS_TO)
+      delete_stale_edges(
+        source_node: range_node,
+        relationship_type: Edge::EXPANDS_TO,
+        current_target_node_dataset: current_declarable_nodes,
+      )
     end
 
     def matching_declarable_nodes(reference)
@@ -286,6 +294,14 @@ module TariffKnowledge
     def source_key(source_association, source)
       identifier = source.public_send(source_association.identifier)
       "note_source:#{source_association.label}:#{source.customs_tariff_update_version}:#{identifier}"
+    end
+
+    def prune_non_current_source_nodes(source_version)
+      Node
+        .where(node_type: [Node::NOTE_SOURCE, Node::NOTE_FRAGMENT])
+        .where(source_type: SOURCE_ASSOCIATIONS.map(&:label))
+        .exclude(source_version:)
+        .delete
     end
 
     def upsert_node(attributes)

--- a/spec/services/tariff_knowledge/compressed_note_generator_spec.rb
+++ b/spec/services/tariff_knowledge/compressed_note_generator_spec.rb
@@ -268,6 +268,79 @@ RSpec.describe TariffKnowledge::CompressedNoteGenerator do
         .to eq('Reviewed human content')
     end
 
+    it 'marks manually edited notes stale when graph context changes' do
+      create(
+        :tariff_knowledge_compressed_note,
+        goods_nomenclature_sid: 123,
+        content: 'Reviewed human content',
+        context_hash: Digest::SHA256.hexdigest('Reviewed human content'),
+        manually_edited: true,
+        approved: true,
+        stale: false,
+      )
+
+      described_class.call(goods_nomenclature_sids: [123])
+
+      note = TariffKnowledge::CompressedNote[123]
+      expect(note).to have_attributes(
+        content: 'Reviewed human content',
+        stale: true,
+      )
+    end
+
+    it 'marks existing notes stale when evidence disappears' do
+      create(
+        :tariff_knowledge_compressed_note,
+        goods_nomenclature_sid: 123,
+        goods_nomenclature_item_id: '0101210000',
+        content: 'Old generated context',
+        stale: false,
+        expired: false,
+        needs_review: false,
+      )
+      TariffKnowledge::Edge.where(target_node_id: declarable_node.id).delete
+
+      described_class.call(goods_nomenclature_sids: [123])
+
+      expect(TariffKnowledge::CompressedNote[123]).to have_attributes(stale: true)
+      expect(TariffKnowledge::CompressedNote.usable_for_search.by_sids([123]).all).to be_empty
+    end
+
+    it 'ignores fragments from old source versions' do
+      create(
+        :customs_tariff_update,
+        :approved,
+        version: '1.30',
+        validity_start_date: 2.months.ago,
+        validity_end_date: 1.month.ago,
+      )
+      create(
+        :customs_tariff_update,
+        :approved,
+        version: '1.31',
+        validity_start_date: 1.day.ago,
+      )
+      old_fragment_node = create(
+        :tariff_knowledge_node,
+        :note_fragment,
+        key: 'note_fragment:customs_tariff_chapter_note:1.30:01:0001',
+        title: 'Old Chapter 01 notes fragment 1',
+        content: 'Old version evidence should not be used.',
+        source_version: '1.30',
+      )
+      create(
+        :tariff_knowledge_edge,
+        source_node: old_fragment_node,
+        target_node: declarable_node,
+        relationship_type: TariffKnowledge::Edge::APPLIES_TO,
+      )
+
+      described_class.call(goods_nomenclature_sids: [123])
+
+      expect(TariffKnowledge::CompressedNote[123].content)
+        .not_to include('Old version evidence')
+    end
+
     it 'preloads graph evidence for the requested goods nomenclatures' do
       second_declarable_node = create(
         :tariff_knowledge_node,

--- a/spec/services/tariff_knowledge/relevant_note_fragment_selector_spec.rb
+++ b/spec/services/tariff_knowledge/relevant_note_fragment_selector_spec.rb
@@ -88,6 +88,18 @@ RSpec.describe TariffKnowledge::RelevantNoteFragmentSelector do
     expect(emitted_text).not_to include(note_content)
   end
 
+  it 'does not load fragment nodes when metadata has context' do
+    queries = sql_queries do
+      described_class.call(
+        query:,
+        search_results:,
+        notes_by_item_id: { '9506911000' => note },
+      )
+    end
+
+    expect(queries.grep(/FROM "tariff_knowledge_nodes"/)).to be_empty
+  end
+
   it 'uses range metadata even when context text does not repeat the candidate code' do
     range_note = create_note_with_evidence(
       '9506911000',
@@ -242,5 +254,20 @@ RSpec.describe TariffKnowledge::RelevantNoteFragmentSelector do
       source_type:,
       source_id:,
     )
+  end
+
+  def sql_queries
+    queries = []
+    logger = Logger.new(StringIO.new)
+    logger.formatter = proc do |_severity, _datetime, _progname, message|
+      queries << message
+      nil
+    end
+
+    Sequel::Model.db.loggers << logger
+    yield
+    queries
+  ensure
+    Sequel::Model.db.loggers.delete(logger)
   end
 end

--- a/spec/services/tariff_knowledge/source_graph_loader_spec.rb
+++ b/spec/services/tariff_knowledge/source_graph_loader_spec.rb
@@ -131,6 +131,44 @@ RSpec.describe TariffKnowledge::SourceGraphLoader do
       expect(edge_exists?(range_node, hidden_node, TariffKnowledge::Edge::EXPANDS_TO)).to be(false)
     end
 
+    it 'removes stale range expansion edges' do
+      hidden_node = create(
+        :tariff_knowledge_node,
+        key: 'goods_nomenclature:99003',
+        goods_nomenclature_sid: 99_003,
+        goods_nomenclature_item_id: '0101900000',
+      )
+      create(:hidden_goods_nomenclature, goods_nomenclature_item_id: hidden_node.goods_nomenclature_item_id)
+      range_node = create(
+        :tariff_knowledge_node,
+        node_type: TariffKnowledge::Node::RANGE,
+        key: 'range:heading:0101',
+        title: 'Heading 0101',
+        goods_nomenclature_sid: nil,
+        goods_nomenclature_item_id: nil,
+        producline_suffix: nil,
+        goods_nomenclature_type: nil,
+        metadata: Sequel.pg_jsonb_wrap({ 'range_type' => 'heading', 'code' => '0101' }),
+      )
+      create(
+        :tariff_knowledge_edge,
+        source_node: range_node,
+        target_node: hidden_node,
+        relationship_type: TariffKnowledge::Edge::EXPANDS_TO,
+      )
+      create(
+        :customs_tariff_chapter_note,
+        :approved,
+        customs_tariff_update: update,
+        chapter_id: '01',
+        content: 'Heading 0101 covers live horses.',
+      )
+
+      described_class.call
+
+      expect(edge_exists?(range_node, hidden_node, TariffKnowledge::Edge::EXPANDS_TO)).to be(false)
+    end
+
     it 'keeps list markers attached to the note text they introduce' do
       create(
         :customs_tariff_chapter_note,
@@ -318,6 +356,50 @@ RSpec.describe TariffKnowledge::SourceGraphLoader do
         .to eq('Section 1 notes')
       expect(TariffKnowledge::Node.by_key('note_source:customs_tariff_general_rule:1.31:1').first.title)
         .to eq('GIR 1')
+    end
+
+    it 'prunes note source nodes from older graph snapshots' do
+      old_source_node = create(
+        :tariff_knowledge_node,
+        node_type: TariffKnowledge::Node::NOTE_SOURCE,
+        key: 'note_source:customs_tariff_chapter_note:1.30:01',
+        title: 'Old Chapter 01 notes',
+        content: 'Old source content',
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '01',
+        source_version: '1.30',
+        goods_nomenclature_sid: nil,
+        goods_nomenclature_item_id: nil,
+        producline_suffix: nil,
+        goods_nomenclature_type: nil,
+      )
+      old_fragment_node = create(
+        :tariff_knowledge_node,
+        :note_fragment,
+        key: 'note_fragment:customs_tariff_chapter_note:1.30:01:0001',
+        content: 'Old fragment content',
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '01',
+        source_version: '1.30',
+      )
+      create(
+        :tariff_knowledge_edge,
+        source_node: old_source_node,
+        target_node: old_fragment_node,
+        relationship_type: TariffKnowledge::Edge::CONTAINS,
+      )
+      create(
+        :customs_tariff_chapter_note,
+        :approved,
+        customs_tariff_update: update,
+        chapter_id: '01',
+        content: 'Heading 0101 covers current horses.',
+      )
+
+      described_class.call
+
+      expect(TariffKnowledge::Node.by_key('note_source:customs_tariff_chapter_note:1.30:01').first).to be_nil
+      expect(TariffKnowledge::Node.by_key('note_fragment:customs_tariff_chapter_note:1.30:01:0001').first).to be_nil
     end
 
     it 'loads notes from the latest current approved update and ignores newer future approved updates' do


### PR DESCRIPTION
### Jira link

[AI-868](https://transformuk.atlassian.net/browse/AI-868)

### What?

- [x] Exclude old tariff knowledge source versions when generating compressed notes.
- [x] Prune old source and fragment nodes when loading the current approved graph snapshot.
- [x] Mark existing compressed notes stale when their graph evidence disappears.
- [x] Mark manually edited compressed notes stale when graph context changes without overwriting the manual content.
- [x] Remove stale range expansion edges for hidden or no-longer-matching goods.
- [x] Avoid loading fragment nodes during search-time scoring when note metadata already has the source context.

### Why?

Compressed notes should only be built from the current approved tariff source graph. Old graph edges could otherwise keep obsolete note evidence available to search augmentation, and notes whose evidence disappeared could remain usable even though they no longer matched the graph.

Search-time fragment selection also had an avoidable database lookup. Generated note metadata already stores the source context and title used for scoring, so the selector now only falls back to graph fragments when metadata is incomplete.

### Risk

**Risk level:** 🟢

**Reason for rating:** Low risk. This affects internal generated classification context and adds regression coverage for stale graph data, lifecycle handling, and search-time note selection. It does not change authoritative tariff data, public API behaviour, measures, duties, or trader-facing journeys.
