### PR TITLE
Extract Green Lanes API key auth concern

### DIFF
--- a/app/controllers/api/v2/green_lanes/base_controller.rb
+++ b/app/controllers/api/v2/green_lanes/base_controller.rb
@@ -4,6 +4,7 @@ module Api
       class BaseController < ApiController
         no_caching
 
+        include ApiKeyAuthenticatable
         include ApiTokenAuthenticatable
 
         before_action :check_service, :authenticate, :set_request_scope
@@ -29,42 +30,24 @@ module Api
         end
 
         def authenticate
-          unless Rails.env.development? && TradeTariffBackend.green_lanes_api_keys.blank?
-            authenticated = authenticate_with_api_keys
-          end
+          return if skip_authentication?
 
-          unless Rails.env.development? && TradeTariffBackend.api_tokens.blank?
-            authenticated ||= authenticate_with_api_tokens
-          end
+          authenticated = false
+          authenticated ||= authenticate_with_api_keys
+          authenticated ||= authenticate_with_api_tokens
 
-          unless authenticated || (Rails.env.development? && TradeTariffBackend.green_lanes_api_keys.blank?)
-            render json: { error: 'Invalid API Key' }, status: :bad_request
-          end
+          return if authenticated
+
+          render json: { error: 'Invalid API Key' }, status: :bad_request
         end
 
-        def authenticate_with_api_keys
-          provided_key = request.headers['X-Api-Key']
-          return false if provided_key.blank?
+        def skip_authentication?
+          return false unless Rails.env.development?
 
-          Rails.logger.debug "Provided key: #{provided_key}"
+          no_api_keys = api_keys.blank?
+          no_api_tokens = TradeTariffBackend.api_tokens.blank?
 
-          key, config = api_keys.find do |api_key, _config|
-            ActiveSupport::SecurityUtils.secure_compare(provided_key, api_key)
-          end
-
-          key.present?.tap do |authenticated|
-            @client_id = config['client_id'] if authenticated
-            @auth_type = 'x-api-key' if authenticated
-          end
-        end
-
-        def api_keys
-          @api_keys ||= read_api_keys
-        end
-
-        def read_api_keys
-          api_key_hash = JSON.parse(TradeTariffBackend.green_lanes_api_keys)
-          api_key_hash['api_keys']
+          no_api_keys && no_api_tokens
         end
       end
     end

--- a/app/controllers/concerns/api_key_authenticatable.rb
+++ b/app/controllers/concerns/api_key_authenticatable.rb
@@ -1,0 +1,32 @@
+module ApiKeyAuthenticatable
+  extend ActiveSupport::Concern
+
+  included do
+    private
+
+    def authenticate_with_api_keys
+      provided_key = request.headers['X-Api-Key']
+      return false if provided_key.blank? || api_keys.blank?
+
+      Rails.logger.debug "Provided key: #{provided_key}"
+
+      key, config = api_keys.find do |api_key, _config|
+        ActiveSupport::SecurityUtils.secure_compare(provided_key, api_key)
+      end
+
+      key.present?.tap do |authenticated|
+        @client_id = config['client_id'] if authenticated
+        @auth_type = 'x-api-key' if authenticated
+      end
+    end
+
+    def api_keys
+      @api_keys ||= read_api_keys
+    end
+
+    def read_api_keys
+      api_key_hash = JSON.parse(TradeTariffBackend.green_lanes_api_keys)
+      api_key_hash['api_keys']
+    end
+  end
+end

--- a/spec/requests/api/v2/green_lanes/goods_nomenclatures_controller_spec.rb
+++ b/spec/requests/api/v2/green_lanes/goods_nomenclatures_controller_spec.rb
@@ -122,5 +122,16 @@ RSpec.describe Api::V2::GreenLanes::GoodsNomenclaturesController, :v2 do
 
       it { is_expected.to have_http_status :success }
     end
+
+    context 'when in development mode and green lanes API keys are the default empty JSON object' do
+      let(:authorization) { nil }
+
+      before do
+        allow(Rails.env).to receive(:development?).and_return(true)
+        allow(TradeTariffBackend).to receive_messages(api_tokens: nil, green_lanes_api_keys: '{}')
+      end
+
+      it { is_expected.to have_http_status :success }
+    end
   end
 end


### PR DESCRIPTION
## What:
Extract Green Lanes API key authentication logic into a dedicated ApiKeyAuthenticatable concern and keep the base controller focused on auth orchestration.
This matches an existing pattern used by `ApiTokenAuthenticatable` and `PublicUserAuthenticatable`

Also fixes an issue where the default TradeTariffBackend.green_lanes_api_keys value ('{}') was not being handled correctly in development-mode authentication checks.

## Why:
This improves separation of concerns and readability in the Green Lanes base controller while preserving current authentication behavior.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Controller refactor plus request-spec coverage update with no intended API contract change; focused regression coverage passes.
