### PR TITLE
AI-516 Fix Notes Extractor

### DIFF
--- a/app/lib/customs_tariff_importer/notes_extractor.rb
+++ b/app/lib/customs_tariff_importer/notes_extractor.rb
@@ -1,3 +1,5 @@
+require 'zip'
+
 module CustomsTariffImporter
   class NotesExtractor
     WORD_NS = { 'w' => 'http://schemas.openxmlformats.org/wordprocessingml/2006/main' }.freeze


### PR DESCRIPTION
## What:
Fixes an issue with `bundle exec rake importer:customs_tariff:reimport`

## Why:
Rake task Failed Requiring 'zip' gem.

## Ticket:
[AI-516](https://transformuk.atlassian.net/browse/AI-516)

## Risk:
**Risk level:** 🟢 

**Reason for rating:**
Low risk just a require file for a rake task