### PR TITLE
BAU: Schedule search analytics snapshots daily

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -46,7 +46,7 @@
       cron: "0 18 * * *"
       description: "Populates search suggestions which are used in the frontend"
     SearchAnalyticsSnapshotWorker:
-      cron: "0 6 * * 6"
+      cron: "0 4 * * *"
       queue: within_1_day
       description: "Refreshes cached aggregate search analytics snapshots"
     ReportWorker:

--- a/spec/config/sidekiq_schedule_spec.rb
+++ b/spec/config/sidekiq_schedule_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe 'config/sidekiq.yml' do
     [uk_schedule, xi_schedule].each do |schedule|
       expect(schedule).to include(
         'SearchAnalyticsSnapshotWorker' => include(
-          'cron' => '0 6 * * 6',
+          'cron' => '0 4 * * *',
           'queue' => 'within_1_day',
           'description' => 'Refreshes cached aggregate search analytics snapshots',
         ),


### PR DESCRIPTION
## What:

- Changes `SearchAnalyticsSnapshotWorker` from weekly Saturday 06:00 to daily 04:00.
- Updates the Sidekiq schedule spec to assert the daily 04:00 cron expression for both UK and XI services.

## Why:

Search analytics snapshots need to be generated every morning so the cached admin analytics view has a daily refresh cadence.

## Ticket:

N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:**
Small Sidekiq scheduler configuration change for cached search analytics snapshots. It does not alter tariff data, public APIs, search indexing, sync behaviour, or trader-facing regulatory content.
