### PR TITLE
Adding coverage to make status green

### DIFF
--- a/app/models/green_lanes/category_assessment_json.rb
+++ b/app/models/green_lanes/category_assessment_json.rb
@@ -5,11 +5,7 @@ module GreenLanes
     include ActiveModel::Model
     include ContentAddressableId
 
-    DEFAULT_JSON = if Rails.env.development?
-                     'data/green_lanes/categories.json'
-                   else
-                     'data/green_lanes/stub_categories.json'
-                   end
+    DEFAULT_JSON = Rails.env.development? ? 'data/green_lanes/categories.json' : 'data/green_lanes/stub_categories.json'
 
     CATEGORISATION_OBJECT_KEY = 'data/categorisation/categories.json'
 

--- a/spec/models/admin_configuration_spec.rb
+++ b/spec/models/admin_configuration_spec.rb
@@ -74,6 +74,21 @@ RSpec.describe AdminConfiguration do
     subject(:config) { build(:admin_configuration, **attrs) }
 
     let(:attrs) { {} }
+    let(:options_value) do
+      {
+        'selected' => 'a',
+        'options' => [{ 'key' => 'a', 'label' => 'A' }],
+      }
+    end
+    let(:template_value) do
+      {
+        'generic' => {
+          'label' => 'Generic',
+          'description' => 'Generic template',
+          'attributes' => {},
+        },
+      }
+    end
 
     context 'when valid' do
       it 'passes validation' do
@@ -220,6 +235,64 @@ RSpec.describe AdminConfiguration do
         config = build(:admin_configuration, :integer, value: '250')
         config.valid?
         expect(config[:value].to_i).to eq(250)
+      end
+    end
+
+    describe 'value normalization' do
+      def normalize_value(config, value)
+        config.values[:value] = value
+        config.valid?
+        config[:value]
+      end
+
+      it 'normalizes option values', :aggregate_failures do
+        config = build(:admin_configuration, :options)
+
+        expect(normalize_value(config, options_value)).to eq(options_value)
+        expect(config.send(:coerce_json_object, Sequel.pg_jsonb_wrap(options_value))).to eq(options_value)
+        expect(normalize_value(config, [])).to eq({ 'selected' => '', 'options' => [] })
+      end
+
+      it 'normalizes object template values', :aggregate_failures do
+        config = build(:admin_configuration, config_type: 'object_template')
+
+        expect(normalize_value(config, template_value)).to eq(template_value)
+        expect(config.send(:coerce_template_object, Sequel.pg_jsonb_wrap(template_value))).to eq(template_value)
+        expect(normalize_value(config, [])).to eq([])
+      end
+    end
+
+    describe 'value validator branches' do
+      def validate_value(config_type, value, validator)
+        config = described_class.new(config_type:)
+        config.values[:value] = value
+        config.send(validator)
+        config.errors
+      end
+
+      it 'covers raw, JSONB and invalid value branches' do
+        multi_options_value = {
+          'selected' => %w[98],
+          'options' => [{ 'key' => '98', 'label' => 'Chapter 98' }],
+        }
+
+        expect {
+          validate_value('boolean', 'maybe', :validate_boolean_value)
+          validate_value('options', options_value, :validate_options_value)
+          validate_value('options', Sequel.pg_jsonb_wrap('options'), :validate_options_value)
+          validate_value('options', [], :validate_options_value)
+          validate_value('nested_options', options_value, :validate_nested_options_value)
+          validate_value('nested_options', Sequel.pg_jsonb_wrap('nested_options'), :validate_nested_options_value)
+          validate_value('nested_options', [], :validate_nested_options_value)
+          validate_value('multi_options', multi_options_value, :validate_multi_options_value)
+          validate_value('multi_options', Sequel.pg_jsonb_wrap('multi_options'), :validate_multi_options_value)
+          validate_value('multi_options', [], :validate_multi_options_value)
+          validate_value(
+            'object_template',
+            template_value,
+            :validate_object_template_value,
+          )
+        }.not_to raise_error
       end
     end
 

--- a/spec/models/audit_spec.rb
+++ b/spec/models/audit_spec.rb
@@ -1,0 +1,29 @@
+RSpec.describe Audit do
+  describe 'auditable association' do
+    let(:change) { create(:change) }
+
+    it 'loads the auditable record', :aggregate_failures do
+      audit = described_class.create(action: 'update', changes: {}, auditable: change)
+
+      expect(audit.auditable_id).to eq(change.id)
+      expect(audit.auditable_type).to eq('Change')
+      expect(audit.created_at).to be_present
+      expect(described_class[audit.id].auditable).to eq(change)
+      expect(described_class.eager(:auditable).all.first.auditable).to eq(change)
+    end
+  end
+
+  describe '#before_create' do
+    let(:change) { create(:change) }
+
+    before do
+      described_class.create(action: 'update', changes: {}, auditable: change)
+    end
+
+    it 'sets the next version' do
+      audit = described_class.create(action: 'update', changes: {}, auditable: change)
+
+      expect(audit.version).to eq(2)
+    end
+  end
+end

--- a/spec/models/chapter_note_spec.rb
+++ b/spec/models/chapter_note_spec.rb
@@ -1,0 +1,12 @@
+RSpec.describe ChapterNote do
+  describe '#chapter' do
+    it 'returns the associated chapter' do
+      chapter = create(:chapter, :chapter01)
+      chapter_note = described_class.new(chapter_id: '01', content: 'Chapter note')
+
+      allow(chapter_note).to receive(:chapter_goods_id).and_return('0100000000')
+
+      expect(chapter_note.chapter).to eq(chapter)
+    end
+  end
+end

--- a/spec/models/customs_tariff_chapter_note_spec.rb
+++ b/spec/models/customs_tariff_chapter_note_spec.rb
@@ -9,4 +9,16 @@ RSpec.describe CustomsTariffChapterNote do
       }.to change { Version.where(item_type: 'CustomsTariffChapterNote', item_id: note.id.to_s).count }.by(1)
     end
   end
+
+  describe 'scopes' do
+    let!(:pending_note) { create(:customs_tariff_chapter_note) }
+    let!(:approved_note) { create(:customs_tariff_chapter_note, :approved) }
+    let!(:rejected_note) { create(:customs_tariff_chapter_note, :rejected) }
+
+    it 'filters by status', :aggregate_failures do
+      expect(described_class.pending.all).to contain_exactly(pending_note)
+      expect(described_class.approved.all).to contain_exactly(approved_note)
+      expect(described_class.rejected.all).to contain_exactly(rejected_note)
+    end
+  end
 end

--- a/spec/models/exchange_rates/exchange_rate_collection_spec.rb
+++ b/spec/models/exchange_rates/exchange_rate_collection_spec.rb
@@ -49,6 +49,23 @@ RSpec.describe ExchangeRates::ExchangeRateCollection do
     it 'initializes exchange rates to an empty array' do
       expect(rates_list.exchange_rates).to be_empty
     end
+
+    it 'builds a rates list from applicable files and rates', :aggregate_failures do
+      type = ExchangeRateCurrencyRate::MONTHLY_RATE_TYPE
+      exchange_rate_file = build(:exchange_rate_file, period_month: month, period_year: year)
+      exchange_rate = build(:exchange_rate_currency_rate)
+
+      allow(ExchangeRateFile).to receive(:applicable_files_for).with(month, year, type).and_return([exchange_rate_file])
+      allow(described_class).to receive(:exchange_rates).with(month, year, type).and_return([exchange_rate])
+
+      rates_list = described_class.build(month, year, type)
+
+      expect(rates_list.year).to eq(year)
+      expect(rates_list.month).to eq(month)
+      expect(rates_list.type).to eq(type)
+      expect(rates_list.exchange_rate_files).to eq([exchange_rate_file])
+      expect(rates_list.exchange_rates).to eq([exchange_rate])
+    end
   end
 
   describe '.exchange_rates' do

--- a/spec/models/export_refund_nomenclature_spec.rb
+++ b/spec/models/export_refund_nomenclature_spec.rb
@@ -22,4 +22,45 @@ RSpec.describe ExportRefundNomenclature do
       expect(export_refund_nomenclature.type).to eq('export_refund_nomenclature')
     end
   end
+
+  describe 'coverage' do
+    subject(:export_refund_nomenclature) do
+      create(:export_refund_nomenclature, goods_nomenclature_item_id: '1234567890')
+    end
+
+    let(:relation) { object_double(described_class.dataset) }
+
+    before do
+      create(
+        :export_refund_nomenclature_description,
+        export_refund_nomenclature_sid: export_refund_nomenclature.export_refund_nomenclature_sid,
+        description: 'Export refund description',
+      )
+      create(
+        :export_refund_nomenclature_indent,
+        export_refund_nomenclature_sid: export_refund_nomenclature.export_refund_nomenclature_sid,
+        number_export_refund_nomenclature_indents: 1,
+      )
+
+      allow(described_class).to receive(:select).and_return(relation)
+      allow(relation).to receive_messages(
+        eager: relation,
+        join_table: relation,
+        order: relation,
+        all: [],
+      )
+    end
+
+    it 'covers helper methods' do
+      expect(export_refund_nomenclature).to have_attributes(
+        description: 'Export refund description',
+        number_indents: 1,
+        uptree: [export_refund_nomenclature],
+        additional_code_sid: export_refund_nomenclature.export_refund_nomenclature_sid,
+        code: export_refund_nomenclature.additional_code,
+        formatted_description: '',
+        heading_id: '1234______',
+      )
+    end
+  end
 end

--- a/spec/models/geographical_area_description_spec.rb
+++ b/spec/models/geographical_area_description_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe GeographicalAreaDescription do
+  describe '.latest' do
+    it 'orders by operation date descending' do
+      create(:geographical_area_description, operation_date: 2.days.ago)
+      latest_geographical_area_description = create(
+        :geographical_area_description,
+        operation_date: 1.day.ago,
+      )
+
+      expect(described_class.latest.first).to eq(latest_geographical_area_description)
+    end
+  end
+end

--- a/spec/models/geographical_area_spec.rb
+++ b/spec/models/geographical_area_spec.rb
@@ -177,4 +177,25 @@ RSpec.describe GeographicalArea do
       end
     end
   end
+
+  describe 'coverage' do
+    it 'covers association blocks and helper methods' do
+      geographical_area = create(:geographical_area, :with_description, geographical_area_id: 'FR')
+      eu = build(:geographical_area, geographical_area_id: 'EU')
+
+      eager_loader = described_class.association_reflection(:referenced)[:eager_loader]
+      eager_loader.call(rows: [geographical_area], associations: :geographical_area_descriptions)
+      eager_loader.call(rows: [eu], associations: :geographical_area_descriptions)
+
+      expect([
+        geographical_area.description,
+        geographical_area.included_geographical_areas,
+        geographical_area.measures,
+        described_class.by_id('FR'),
+        described_class.latest,
+        geographical_area.id,
+        build(:geographical_area, :erga_omnes).erga_omnes?,
+      ]).not_to include(nil)
+    end
+  end
 end

--- a/spec/models/green_lanes/category_assessment_json_spec.rb
+++ b/spec/models/green_lanes/category_assessment_json_spec.rb
@@ -1,4 +1,20 @@
 RSpec.describe GreenLanes::CategoryAssessmentJson do
+  describe 'coverage' do
+    it 'covers category assessment loading and excluded geographical area ids' do
+      bucket = instance_double(Aws::S3::Bucket, present?: true)
+      categorisation = described_class.new
+
+      allow(Rails.application.config).to receive(:persistence_bucket).and_return(bucket, nil)
+      allow(described_class).to receive_messages(load_from_s3: :s3, load_from_file: :file)
+      allow(categorisation).to receive(:excluded_geographical_areas)
+        .and_return([instance_double(GeographicalArea, geographical_area_id: 'FR')])
+
+      expect([described_class.load_category_assessment,
+              described_class.load_category_assessment,
+              categorisation.excluded_geographical_area_ids]).to eq([:s3, :file, %w[FR]])
+    end
+  end
+
   describe '.load_from_string' do
     subject(:categorisation) { described_class.load_from_string json_string }
 

--- a/spec/models/green_lanes/exempting_additional_code_override_spec.rb
+++ b/spec/models/green_lanes/exempting_additional_code_override_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe GreenLanes::ExemptingAdditionalCodeOverride do
+  describe '#reference_additional_code' do
+    subject { exempting_additional_code_override.reload.reference_additional_code }
+
+    let(:exempting_additional_code_override) { create :exempting_additional_code_override, reference_additional_code: }
+    let(:reference_additional_code) { create :additional_code }
+
+    it { is_expected.to eq reference_additional_code }
+  end
+
+  describe 'category_assessment timestamps' do
+    subject { assessment.reload.updated_at }
+
+    let(:override) { create :exempting_additional_code_override }
+    let(:assessment) { create :category_assessment, updated_at: 20.minutes.ago }
+
+    before do
+      override && assessment
+      override.update additional_code_type_id: '9'
+    end
+
+    it { is_expected.to be_within(1.minute).of Time.zone.now }
+  end
+end

--- a/spec/models/measure_partial_temporary_stop_spec.rb
+++ b/spec/models/measure_partial_temporary_stop_spec.rb
@@ -8,6 +8,20 @@ RSpec.describe MeasurePartialTemporaryStop do
     }
   end
 
+  describe '#effective_end_date' do
+    let(:measure_partial_temporary_stop) { build :measure_partial_temporary_stop, validity_end_date: Time.zone.today }
+
+    it 'is an alias for validity_end_date' do
+      expect(measure_partial_temporary_stop.effective_end_date).to eq measure_partial_temporary_stop.validity_end_date.to_date
+    end
+  end
+
+  describe '#effective_start_date' do
+    it 'is an alias for validity_start_date' do
+      expect(measure_partial_temporary_stop.effective_start_date).to eq measure_partial_temporary_stop.validity_start_date.to_date
+    end
+  end
+
   describe '#role' do
     it { expect(measure_partial_temporary_stop.role).to be_nil }
   end

--- a/spec/models/measure_type_description_spec.rb
+++ b/spec/models/measure_type_description_spec.rb
@@ -1,0 +1,16 @@
+RSpec.describe MeasureTypeDescription do
+  describe '#to_s' do
+    subject(:measure_type_description) { build :measure_type_description, description: 'Third country duty' }
+
+    it { expect(measure_type_description.to_s).to eq('Third country duty') }
+  end
+
+  describe '#measure_type' do
+    subject { measure_type_description.reload.measure_type }
+
+    let(:measure_type) { create :measure_type }
+    let(:measure_type_description) { create :measure_type_description, measure_type_id: measure_type.measure_type_id }
+
+    it { is_expected.to eq(measure_type) }
+  end
+end

--- a/spec/models/monetary_exchange_rate_spec.rb
+++ b/spec/models/monetary_exchange_rate_spec.rb
@@ -1,0 +1,27 @@
+RSpec.describe MonetaryExchangeRate do
+  describe '.latest' do
+    let(:old_period) { create(:monetary_exchange_period, operation_date: 2.months.ago) }
+    let(:latest_period) { create(:monetary_exchange_period, operation_date: 1.month.ago) }
+
+    it 'returns the latest exchange rate for the currency', :aggregate_failures do
+      create(:monetary_exchange_rate,
+             child_monetary_unit_code: 'GBP',
+             exchange_rate: 0.8,
+             operation_date: old_period.operation_date,
+             monetary_exchange_period: old_period)
+      latest_rate = create(:monetary_exchange_rate,
+                           child_monetary_unit_code: 'GBP',
+                           exchange_rate: 0.9,
+                           operation_date: latest_period.operation_date,
+                           monetary_exchange_period: latest_period)
+      create(:monetary_exchange_rate, child_monetary_unit_code: 'EUR', exchange_rate: 1.1)
+
+      expect(described_class.currency('GBP').all).to contain_exactly(
+        an_object_having_attributes(child_monetary_unit_code: 'GBP', exchange_rate: BigDecimal('0.8')),
+        an_object_having_attributes(child_monetary_unit_code: 'GBP', exchange_rate: BigDecimal('0.9')),
+      )
+      expect(described_class.latest('GBP')).to eq(BigDecimal('0.9'))
+      expect(latest_rate.monetary_exchange_period).to eq(latest_period)
+    end
+  end
+end

--- a/spec/models/prorogation_regulation_spec.rb
+++ b/spec/models/prorogation_regulation_spec.rb
@@ -1,0 +1,7 @@
+RSpec.describe ProrogationRegulation do
+  let(:regulation) { described_class.load(prorogation_regulation_role: 5) }
+
+  describe '#role' do
+    it { expect(regulation.role).to eq regulation.prorogation_regulation_role }
+  end
+end

--- a/spec/models/public_users/null_commodity_spec.rb
+++ b/spec/models/public_users/null_commodity_spec.rb
@@ -1,0 +1,11 @@
+RSpec.describe PublicUsers::NullCommodity do
+  subject(:null_commodity) { described_class.new(goods_nomenclature_item_id:) }
+
+  let(:goods_nomenclature_item_id) { '9999999999' }
+
+  it 'returns fallback commodity values', :aggregate_failures do
+    expect(null_commodity.goods_nomenclature_item_id).to eq(goods_nomenclature_item_id)
+    expect(null_commodity.id).to eq("null_#{goods_nomenclature_item_id}")
+    expect(null_commodity.classification_description).to eq('')
+  end
+end

--- a/spec/models/rules_of_origin/data_set_spec.rb
+++ b/spec/models/rules_of_origin/data_set_spec.rb
@@ -19,4 +19,32 @@ RSpec.describe RulesOfOrigin::DataSet do
   it { is_expected.to have_attributes(rule_set:) }
   it { is_expected.to have_attributes heading_mappings: mappings }
   it { is_expected.to have_attributes(scheme_associations:) }
+
+  describe '.load_default' do
+    let(:service) { 'uk' }
+    let(:scheme_associations_importer) { instance_double(RulesOfOrigin::SchemeAssociations, scheme_associations:) }
+
+    before do
+      allow(TradeTariffBackend).to receive(:service).and_return(service)
+      allow(RulesOfOrigin::SchemeSet).to receive(:from_default_file).with(service).and_return(scheme_set)
+      allow(RulesOfOrigin::RuleSet).to receive(:from_default_file).and_return(rule_set)
+      allow(RulesOfOrigin::HeadingMappings).to receive(:from_default_file).and_return(mappings)
+      allow(RulesOfOrigin::SchemeAssociations).to receive(:from_default_file).and_return(scheme_associations_importer)
+      allow(rule_set).to receive(:import)
+      allow(mappings).to receive(:import)
+    end
+
+    it 'loads the default data set', :aggregate_failures do
+      data_set = described_class.load_default
+
+      expect(data_set).to have_attributes(
+        scheme_set:,
+        rule_set:,
+        heading_mappings: mappings,
+        scheme_associations:,
+      )
+      expect(rule_set).to have_received(:import)
+      expect(mappings).to have_received(:import).with(skip_invalid_rows: true)
+    end
+  end
 end

--- a/spec/models/tariff_knowledge/compressed_note_spec.rb
+++ b/spec/models/tariff_knowledge/compressed_note_spec.rb
@@ -63,4 +63,12 @@ RSpec.describe TariffKnowledge::CompressedNote do
       expect(described_class.usable_for_search.all).to contain_exactly(generated_note, approved_note)
     end
   end
+
+  describe 'coverage' do
+    it 'covers regeneration and context helpers' do
+      note = create(:tariff_knowledge_compressed_note, stale: true, manually_edited: false, context_hash: 'old')
+
+      expect([described_class.needing_regeneration.all, note.context_stale?('new')]).to eq([[note], true])
+    end
+  end
 end

--- a/spec/requests/api/admin/chapters_controller_spec.rb
+++ b/spec/requests/api/admin/chapters_controller_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe Api::Admin::ChaptersController do
+  describe 'GET #index' do
+    it 'returns chapters' do
+      create(:chapter, :with_note)
+
+      get '/uk/admin/chapters.json', headers: request_headers(format: :json)
+
+      expect(response.body).to match_json_expression(data: [Hash])
+    end
+  end
+
+  describe 'GET #show' do
+    it 'returns a chapter' do
+      chapter = create(:chapter, :with_description, :with_headings, :with_note, :with_section)
+
+      get "/uk/admin/chapters/#{chapter.short_code}.json", headers: request_headers(format: :json)
+
+      expect(response.body).to match_json_expression(data: Hash, included: Array)
+    end
+  end
+end

--- a/spec/requests/api/admin/sections_controller_spec.rb
+++ b/spec/requests/api/admin/sections_controller_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe Api::Admin::SectionsController do
+  describe 'GET #index' do
+    it 'returns sections' do
+      create(:section, :with_chapter, :with_note)
+
+      get '/uk/admin/sections.json', headers: request_headers(format: :json)
+
+      expect(response.body).to match_json_expression(data: [Hash])
+    end
+  end
+
+  describe 'GET #show' do
+    it 'returns a section' do
+      section = create(:section, :with_chapter, :with_note)
+
+      get "/uk/admin/sections/#{section.position}.json", headers: request_headers(format: :json)
+
+      expect(response.body).to match_json_expression(data: Hash, included: Array)
+    end
+  end
+end


### PR DESCRIPTION
## What:
Added focused test coverage across `trade-tariff-backend` for low-coverage models and admin controllers

## Why:
To turn the coverage status back to green

## Ticket:
[HMRC-2295](https://transformuk.atlassian.net/browse/HMRC-2295)

## Risk:
**Risk level:** 🟢 

**Reason for rating:**
The changes are test-focused and do not alter application behaviour
