### PR TITLE
Add Link header pointing to API docs llms.txt on all responses

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,6 +13,7 @@ class ApplicationController < ActionController::API
   before_action :maintenance_mode_if_active
   around_action :configure_time_machine
   after_action  :check_query_count, if: -> { TradeTariffBackend.check_query_count? }
+  after_action  :set_api_docs_link_header
 
   def nothing
     head :ok
@@ -69,6 +70,10 @@ class ApplicationController < ActionController::API
 
   def set_trade_tariff_request_id
     TradeTariffRequest.request_id = params[:request_id].presence || request.request_id
+  end
+
+  def set_api_docs_link_header
+    response.set_header('Link', '<https://api-docs.trade-tariff.service.gov.uk/llms.txt>; rel="describedby"')
   end
 
   def logged_request_id

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -69,6 +69,14 @@ RSpec.describe ApplicationController, type: :request do
       end
     end
 
+    context 'with Link header' do
+      it 'includes the API docs link header on every response' do
+        api_get('/uk/api/healthcheck')
+
+        expect(response.headers['Link']).to eq('<https://api-docs.trade-tariff.service.gov.uk/llms.txt>; rel="describedby"')
+      end
+    end
+
     context 'with request logging payload' do
       def process_action_payload_for(params:)
         events = []


### PR DESCRIPTION
## Summary

- Adds an `after_action` to `ApplicationController` that sets a `Link: <https://api-docs.trade-tariff.service.gov.uk/llms.txt>; rel="describedby"` header on every API response
- Covers all controllers (public API, admin, internal, user) since they all inherit from `ApplicationController`
- Adds a request spec asserting the header is present

## Why

LLM consumers hitting the API have no way to discover the API documentation without already knowing the docs site exists. The `Link` header with `rel="describedby"` (RFC 8288) is a machine-readable pointer that LLM tooling checks at the point of first contact — surfacing the `llms.txt` index immediately.

## Risk

low-risk — additive response header, no behaviour change, no data change, read-only observability.