### PR TITLE
AI-516: Extract source note structure as markdown

### DIFF
--- a/app/controllers/api/admin/customs_tariff_updates/chapter_notes_controller.rb
+++ b/app/controllers/api/admin/customs_tariff_updates/chapter_notes_controller.rb
@@ -138,7 +138,7 @@ module Api
 
         def customs_tariff_chapter_note
           @customs_tariff_chapter_note ||= CustomsTariffChapterNote
-            .where(id: params[:id], customs_tariff_update_version: customs_tariff_update.version)
+            .where(chapter_id: params[:id], customs_tariff_update_version: customs_tariff_update.version)
             .first.tap { |n| raise Sequel::RecordNotFound unless n }
         end
 

--- a/app/controllers/api/admin/customs_tariff_updates/section_notes_controller.rb
+++ b/app/controllers/api/admin/customs_tariff_updates/section_notes_controller.rb
@@ -127,7 +127,7 @@ module Api
 
         def customs_tariff_section_note
           @customs_tariff_section_note ||= CustomsTariffSectionNote
-            .where(id: params[:id], customs_tariff_update_version: customs_tariff_update.version)
+            .where(section_id: params[:id], customs_tariff_update_version: customs_tariff_update.version)
             .first.tap { |n| raise Sequel::RecordNotFound unless n }
         end
 

--- a/app/lib/customs_tariff_importer/notes_extractor.rb
+++ b/app/lib/customs_tariff_importer/notes_extractor.rb
@@ -110,7 +110,7 @@ module CustomsTariffImporter
       plain_text = paragraph_plain_text(para)
       return plain_text if structural_marker?(plain_text)
 
-      para.xpath('./w:r', WORD_NS).map { |run|
+      para.xpath('.//w:r', WORD_NS).map { |run|
         text = run.xpath('.//w:t', WORD_NS).map(&:text).join
         next if text.empty?
 
@@ -532,6 +532,7 @@ module CustomsTariffImporter
       @in_nested_numbered_subnote = false
       @last_top_level_note_number = nil
       @previous_markdown_bullet_indent = nil
+      @numbering_counters.clear
     end
 
     def numbered_note?(text)

--- a/app/lib/customs_tariff_importer/notes_extractor.rb
+++ b/app/lib/customs_tariff_importer/notes_extractor.rb
@@ -15,6 +15,7 @@ module CustomsTariffImporter
     COMMODITY_CODE_PATTERN   = /\A\d{10}\z/
     PART_BOUNDARY_PATTERN    = /\APART\s+\w+/i
     NUMBERED_NOTE_PATTERN    = /\A1\.\s*[A-Za-z(]/
+    SINGLETON_EXPRESSION_WRAPPER_CHAPTERS = %w[74 78 80].freeze
 
     Result = Data.define(:chapters, :sections, :general_rules)
 
@@ -69,11 +70,200 @@ module CustomsTariffImporter
 
     def extract_paragraphs(xml)
       doc = Nokogiri::XML(xml)
-      doc.xpath('//w:p', WORD_NS).map do |para|
-        style = para.at_xpath('.//w:pStyle', WORD_NS)&.attr('w:val').to_s
-        text = para.xpath('.//w:t', WORD_NS).map(&:text).join.strip
-        { style:, text: }
+      doc.xpath('/w:document/w:body/*', WORD_NS).flat_map do |node|
+        case node.name
+        when 'p'
+          [paragraph_block(node)]
+        when 'tbl'
+          table_markdown_lines(node).map { |text| { style: '', text: } }
+        else
+          []
+        end
       end
+    end
+
+    def paragraph_block(para)
+      style = para.at_xpath('./w:pPr/w:pStyle', WORD_NS)&.attr('w:val').to_s
+      {
+        style:,
+        text: paragraph_text(para),
+        indent: paragraph_indent(para),
+        numbering: paragraph_numbering(para),
+      }
+    end
+
+    def paragraph_indent(para)
+      para.at_xpath('./w:pPr/w:ind', WORD_NS)&.attr('w:left').to_i
+    end
+
+    def paragraph_numbering(para)
+      num_pr = para.at_xpath('./w:pPr/w:numPr', WORD_NS)
+      return unless num_pr
+
+      {
+        id: num_pr.at_xpath('./w:numId', WORD_NS)&.attr('w:val').to_i,
+        level: num_pr.at_xpath('./w:ilvl', WORD_NS)&.attr('w:val').to_i,
+      }
+    end
+
+    def paragraph_text(para)
+      plain_text = paragraph_plain_text(para)
+      return plain_text if structural_marker?(plain_text)
+
+      para.xpath('./w:r', WORD_NS).map { |run|
+        text = run.xpath('.//w:t', WORD_NS).map(&:text).join
+        next if text.empty?
+
+        bold?(run.at_xpath('./w:rPr/w:b', WORD_NS)) ? bold_markdown(text) : text
+      }.compact.join.strip
+    end
+
+    def bold_markdown(text)
+      return text.sub(/\A([1-9]\d*\.\s+)(.+)\z/, '\1**\2**') if text.match?(/\A[1-9]\d*\.(?!\d)\s+\S/)
+
+      "**#{text}**"
+    end
+
+    def paragraph_plain_text(para)
+      para.xpath('.//w:t', WORD_NS).map(&:text).join.strip
+    end
+
+    def structural_marker?(text)
+      text.match?(SECTION_PATTERN) ||
+        text.match?(CHAPTER_PATTERN) ||
+        text.match?(CHAPTER_NOTES_PATTERN) ||
+        text.match?(ADDITIONAL_NOTES_PATTERN) ||
+        text.match?(SUBHEADING_NOTES_PATTERN) ||
+        text.match?(SECTION_NOTES_PATTERN) ||
+        text.match?(GENERAL_RULES_PATTERN) ||
+        text.match?(RULE_PATTERN) ||
+        text.match?(PART_BOUNDARY_PATTERN)
+    end
+
+    def bold?(node)
+      return false unless node
+
+      !%w[0 false off].include?(node.attr('w:val').to_s.downcase)
+    end
+
+    def table_markdown_lines(table)
+      rows = table.xpath('./w:tr', WORD_NS).map { |row| table_row_cells(row) }
+      rows.reject!(&:empty?)
+      return [] if rows.empty?
+      return [rows.flatten.find(&:present?)] if commodity_table?(rows)
+      return grouped_table_markdown_lines(rows) if grouped_table_header?(rows)
+
+      header, body_rows = table_header_and_body(rows)
+      body = body_rows.map { |row| normalize_table_row(row, header.length) }
+      ['', markdown_table_row(header), markdown_table_separator(header.length), *body.map { |row| markdown_table_row(row) }, '']
+    end
+
+    def table_row_cells(row)
+      row.xpath('./w:tc', WORD_NS).flat_map do |cell|
+        text = cell.xpath('./w:p', WORD_NS)
+          .map { |para| paragraph_plain_text(para) }
+          .reject(&:blank?)
+          .join(' ')
+
+        Array.new(table_cell_span(cell), text)
+      end
+    end
+
+    def table_cell_span(cell)
+      cell.at_xpath('./w:tcPr/w:gridSpan', WORD_NS)&.attr('w:val').to_i.then { |span| span.positive? ? span : 1 }
+    end
+
+    def commodity_table?(rows)
+      rows.flatten.find(&:present?).to_s.match?(COMMODITY_CODE_PATTERN)
+    end
+
+    def table_header_and_body(rows)
+      header_rows = table_header_rows(rows)
+      header = combine_table_header_rows(header_rows)
+
+      [header, rows.drop(header_rows.length)]
+    end
+
+    def grouped_table_markdown_lines(rows)
+      columns = rows.map(&:length).max
+      header = collapse_spanned_cells(normalize_table_row(rows.first, columns))
+      markers = collapse_spanned_cells(normalize_table_row(rows.second, columns))
+      subheader = normalize_table_row(rows.third, columns)
+      body = rows.drop(3).map { |row| normalize_table_row(row, columns) }
+
+      [
+        '',
+        markdown_table_row(header),
+        markdown_table_separator(columns),
+        markdown_table_row(markers),
+        markdown_table_row(subheader),
+        *body.map { |row| markdown_table_row(row) },
+        '',
+      ]
+    end
+
+    def collapse_spanned_cells(row)
+      previous = nil
+      row.map do |cell|
+        collapsed = cell == previous ? '' : cell
+        previous = cell
+        collapsed
+      end
+    end
+
+    def grouped_table_header?(rows)
+      return false if rows.length < 4
+      return false unless rows.first.length == rows.third.length
+      return false unless rows.first.chunk_while { |left, right| left == right }.any? { |chunk| chunk.length > 1 }
+      return false unless rows.second.compact_blank.all? { |cell| cell.match?(/\A\(\d+\)\z/) }
+
+      rows.third.any?(&:blank?) && rows.third.any?(&:present?)
+    end
+
+    def table_header_rows(rows)
+      return rows.first(2) if multi_row_header?(rows)
+
+      [collapse_duplicate_header_cells(rows.first)]
+    end
+
+    def collapse_duplicate_header_cells(row)
+      row.chunk_while { |left, right| left == right }.map(&:first)
+    end
+
+    def multi_row_header?(rows)
+      return false if rows.length < 3
+      return false unless rows.second.any?(&:blank?)
+
+      rows.first.zip(rows.second).any? { |top, lower| top.present? && lower.present? }
+    end
+
+    def combine_table_header_rows(rows)
+      columns = rows.map(&:length).max
+      normalized = rows.map { |row| normalize_table_row(row, columns) }
+
+      Array.new(columns) do |index|
+        normalized.map { |row| row[index] }.reject(&:blank?).uniq.join(' ')
+      end
+    end
+
+    def normalize_table_row(row, columns)
+      if columns == 2 && row.length == 3
+        [row.first(2).reject(&:blank?).join(' '), row.last]
+      else
+        row.first(columns).fill('', row.length...columns)
+      end
+    end
+
+    def markdown_table_row(cells)
+      "| #{cells.map { |cell| markdown_table_cell(cell) }.join(' | ')} |"
+    end
+
+    def markdown_table_separator(columns)
+      markdown_table_row(Array.new(columns, '---'))
+    end
+
+    def markdown_table_cell(text)
+      text.to_s.strip.gsub(/[\\|]/) { |character| "\\#{character}" }
     end
 
     def parse_notes(paragraphs)
@@ -85,8 +275,15 @@ module CustomsTariffImporter
       @chapters        = {}
       @sections        = {}
       @general_rules   = {}
+      @in_numbered_note = false
+      @in_nested_numbered_subnote = false
+      @last_top_level_note_number = nil
+      @previous_markdown_bullet_indent = nil
+      @current_paragraph = nil
+      @numbering_counters = {}
 
       paragraphs.each do |para|
+        @current_paragraph = para
         send(:"handle_#{@state}", para[:text])
       end
 
@@ -136,7 +333,7 @@ module CustomsTariffImporter
         @note_lines = []
         @state = :in_section
       elsif text.present? || (@note_lines.any? && @note_lines.last.present?)
-        @note_lines << text
+        append_note_line(text)
       end
     end
 
@@ -170,7 +367,7 @@ module CustomsTariffImporter
         finalize_section_note
         @state = :skipping
       elsif text.present? || (@note_lines.any? && @note_lines.last.present?)
-        @note_lines << text
+        append_note_line(text)
       end
     end
 
@@ -182,13 +379,16 @@ module CustomsTariffImporter
         @note_lines = []
         @state = :collecting_chapter
       elsif text.match?(ADDITIONAL_NOTES_PATTERN)
-        @note_lines = [text]
+        @note_lines = []
+        append_note_line(text)
         @state = :collecting_chapter
       elsif text.match?(SUBHEADING_NOTES_PATTERN)
-        @note_lines = [text]
+        @note_lines = []
+        append_note_line(text)
         @state = :collecting_chapter
       elsif text.match?(NUMBERED_NOTE_PATTERN)
-        @note_lines = [text]
+        @note_lines = []
+        append_note_line(text)
         @state = :collecting_chapter
       elsif (m = text.match(CHAPTER_PATTERN))
         finalize_chapter_note
@@ -208,7 +408,7 @@ module CustomsTariffImporter
         @note_lines = []
         @state = :skipping
       elsif text.match?(ADDITIONAL_NOTES_PATTERN)
-        @note_lines << text
+        append_note_line(text)
       elsif (m = text.match(CHAPTER_PATTERN))
         finalize_chapter_note
         @current_chapter = sprintf('%02d', m[1].to_i)
@@ -220,7 +420,7 @@ module CustomsTariffImporter
         @note_lines = []
         @state = :in_section
       elsif text.present? || (@note_lines.any? && @note_lines.last.present?)
-        @note_lines << text
+        append_note_line(text)
       end
     end
 
@@ -239,19 +439,21 @@ module CustomsTariffImporter
     def finalize_chapter_note
       return if @current_chapter.nil?
 
-      content = @note_lines.join("\n").strip
+      content = normalize_note_lines(@note_lines, chapter: true).join("\n").strip
       @chapters[@current_chapter] = content if content.present?
       @current_chapter = nil
       @note_lines = []
+      reset_note_formatting_context
     end
 
     def finalize_section_note
       return if @current_section.nil?
 
-      content = @note_lines.join("\n").strip
+      content = normalize_note_lines(@note_lines, section: true).join("\n").strip
       @sections[RomanNumerals::Converter.to_decimal(@current_section)] = content if content.present?
       @current_section = nil
       @note_lines = []
+      reset_note_formatting_context
     end
 
     def finalize_rule
@@ -261,6 +463,428 @@ module CustomsTariffImporter
       @general_rules[@current_rule] = content if content.present?
       @current_rule = nil
       @note_lines = []
+    end
+
+    def append_note_line(text)
+      formatted = formatted_note_line(text)
+      @note_lines << '' if blank_line_needed_before?(formatted)
+      @note_lines << formatted
+      update_note_formatting_context(text, formatted)
+    end
+
+    def formatted_note_line(text)
+      return text if text.blank?
+
+      if @previous_markdown_bullet_indent && bullet_continuation_line?(text)
+        return "#{' ' * (@previous_markdown_bullet_indent + 4)}#{text.sub(/\A\s*/, '')}"
+      end
+
+      text = normalize_dotless_numbered_note(text)
+      text = normalize_visual_numbering(text)
+      return markdown_note_section_heading(text) if note_section_heading?(text)
+      return nested_numbered_subnote_start(text) if nested_numbered_subnote_start?(text)
+      return indented_marker_line(text) if indented_marker?(text)
+      return "    #{text}" if nested_numbered_note?(text)
+      return text if numbered_note?(text)
+      return markdown_bullet_line(text) if source_bullet_line?(text)
+      return "    #{text.sub(/\A\s*/, '')}" if @in_numbered_note
+
+      text
+    end
+
+    def update_note_formatting_context(text, formatted)
+      return if text.blank?
+
+      if note_section_heading?(text)
+        reset_note_formatting_context
+        return
+      end
+
+      if nested_numbered_subnote_start?(text)
+        @in_numbered_note = true
+        @in_nested_numbered_subnote = true
+        @previous_markdown_bullet_indent = nil
+        return
+      end
+
+      if nested_numbered_subnote?(formatted)
+        @in_numbered_note = true
+        @in_nested_numbered_subnote = true
+        @previous_markdown_bullet_indent = nil
+        return
+      end
+
+      @in_nested_numbered_subnote = false if @in_nested_numbered_subnote && !numbered_note?(formatted)
+      if numbered_note?(formatted)
+        @in_numbered_note = true
+        @last_top_level_note_number = formatted[/\A([1-9]\d*)\./, 1].to_i unless @in_nested_numbered_subnote
+      end
+      @previous_markdown_bullet_indent =
+        if markdown_bullet?(formatted)
+          formatted[/\A */].length
+        elsif @previous_markdown_bullet_indent && bullet_continuation_line?(text)
+          formatted[/\A */].length - 4
+        end
+    end
+
+    def reset_note_formatting_context
+      @in_numbered_note = false
+      @in_nested_numbered_subnote = false
+      @last_top_level_note_number = nil
+      @previous_markdown_bullet_indent = nil
+    end
+
+    def numbered_note?(text)
+      text.match?(/\A[1-9]\d*\.(?!\d)/)
+    end
+
+    def nested_numbered_note?(text)
+      return false unless numbered_note?(text)
+      return true if @in_nested_numbered_subnote
+      return false unless @in_numbered_note && @last_top_level_note_number
+
+      text[/\A([1-9]\d*)\./, 1].to_i <= @last_top_level_note_number
+    end
+
+    def dotless_numbered_note?(text)
+      return false unless (match = text.match(/\A([1-9]\d*)\s+(?:[A-Z]|\u201C|\()/))
+
+      note_number = match[1].to_i
+      return note_number == 1 if @last_top_level_note_number.nil?
+
+      note_number == @last_top_level_note_number + 1
+    end
+
+    def normalize_dotless_numbered_note(text)
+      return text unless dotless_numbered_note?(text)
+
+      text.sub(/\A([1-9]\d*)\s+/, '\1. ')
+    end
+
+    def normalize_visual_numbering(text)
+      numbering = @current_paragraph&.fetch(:numbering, nil)
+      return text unless numbering && numbering[:id].positive? && numbering[:level].zero?
+      return text if numbered_note?(text)
+
+      number = next_visual_number(numbering)
+      "#{number}. #{text}"
+    end
+
+    def next_visual_number(numbering)
+      key = [numbering[:id], numbering[:level]]
+      @numbering_counters[key] = @numbering_counters.fetch(key, 0) + 1
+    end
+
+    def nested_numbered_subnote_start?(text)
+      text.match?(/\A\([a-z]\)\s+1\.(?!\d)\s+\S/)
+    end
+
+    def nested_numbered_subnote_start(text)
+      marker, nested_note = text.match(/\A(\([a-z]\))\s+(1\.(?!\d)\s+.+)\z/).captures
+
+      "    #{marker}\n\n    #{nested_note}"
+    end
+
+    def markdown_bullet?(text)
+      text.match?(/\A\s*-\s+\S/)
+    end
+
+    def source_bullet_line?(text)
+      text.match?(/\A\s*(?:-|•|—)\s+\S/)
+    end
+
+    def markdown_bullet_line(text)
+      bullet_text = text.sub(/\A\s*(?:-|•|—)\s+/, '')
+      "#{'    ' if @in_numbered_note}- #{bullet_text}"
+    end
+
+    def indented_marker?(text)
+      paragraph_indent_level.positive? && indented_marker_text?(text)
+    end
+
+    def indented_marker_line(text)
+      indent_level = @in_numbered_note ? indented_marker_indent_level(text) : paragraph_indent_level - 1
+      "#{'    ' * indent_level}#{indented_marker_prefix(text)}#{text}"
+    end
+
+    def indented_marker_indent_level(text)
+      return 1 if alphabetic_marker_text?(text) && !roman_marker_text?(text)
+      return 1 if numeric_bracket_marker_text?(text)
+      return 1 if roman_bracket_marker_text?(text)
+
+      paragraph_indent_level
+    end
+
+    def indented_marker_prefix(text)
+      bullet_marker_text?(text) ? '- ' : ''
+    end
+
+    def paragraph_indent_level
+      (@current_paragraph&.fetch(:indent, 0).to_i / 720).clamp(0, 3)
+    end
+
+    def indented_marker_text?(text)
+      text.match?(/\A(?:[a-z]\.|\([A-Z]\)|\([ivxlcdm]+\)|[ivxlcdm]+\.|\(\d+\))\s+\S/i)
+    end
+
+    def alphabetic_marker_text?(text)
+      text.match?(/\A[a-z]\.\s+\S/i)
+    end
+
+    def roman_marker_text?(text)
+      text.match?(/\A(?:i{1,3}|iv|v|vi{0,3}|ix)\.\s+\S/i)
+    end
+
+    def numeric_bracket_marker_text?(text)
+      text.match?(/\A\(\d+\)\s+\S/)
+    end
+
+    def roman_bracket_marker_text?(text)
+      text.match?(/\A\((?:i{1,3}|iv|v|vi{0,3}|ix)\)\s+\S/i)
+    end
+
+    def bullet_marker_text?(text)
+      text.match?(/\A\([A-Z]\)\s+\S/) || roman_marker_text?(text)
+    end
+
+    def bullet_continuation_line?(text)
+      text.match?(/\A(?:and|or|(?:not\s+)?less than|more than|\d+(?:[.,]\d+)?\s*(?:%|W|mm|cm|g|kg)(?=\s|$))/i)
+    end
+
+    def note_section_heading?(text)
+      plain_note_section_heading?(text) || markdown_note_section_heading?(text)
+    end
+
+    def plain_note_section_heading?(text)
+      text.match?(ADDITIONAL_NOTES_PATTERN) || text.match?(SUBHEADING_NOTES_PATTERN)
+    end
+
+    def markdown_note_section_heading?(text)
+      text.match?(/\A###\s+(?:Additional\s+[Cc]hapter\s+[Nn]otes?|Subheading\s+[Nn]otes?)\z/i)
+    end
+
+    def markdown_note_section_heading(text)
+      "### #{text}"
+    end
+
+    def blank_line_needed_before?(formatted)
+      formatted.present? &&
+        @note_lines.last.present? &&
+        (markdown_bullet?(@note_lines.last) ||
+         markdown_bullet?(formatted) ||
+         source_indented_marker_line?(formatted) ||
+         source_indented_marker_continuation?(formatted) ||
+         nested_numbered_subnote?(formatted) ||
+         numbered_note?(formatted) ||
+         standalone_bold_line?(formatted) ||
+         consecutive_variable_definition_paragraphs?(formatted))
+    end
+
+    def consecutive_variable_definition_paragraphs?(formatted)
+      variable_definition_paragraph?(@note_lines.last) && variable_definition_paragraph?(formatted)
+    end
+
+    def source_indented_marker_line?(formatted)
+      paragraph_indent_level.positive? &&
+        formatted.match?(/\A\s+(?:-\s+)?(?:[a-z]\.|\([A-Z]\)|[ivxlcdm]+\.|\(\d+\))\s+\S/i)
+    end
+
+    def source_indented_marker_continuation?(formatted)
+      return false unless paragraph_indent_level.positive?
+
+      @note_lines.last.to_s.match?(/\A\s+(?:[a-z]\.|\([A-Z]\)|\([ivxlcdm]+\)|[ivxlcdm]+\.|\(\d+\))\s+\S/i) &&
+        formatted.match?(/\A\s+\S/)
+    end
+
+    def variable_definition_paragraph?(text)
+      text.match?(/\A {4}[“"]?[A-Z][”"]?\s+is\b/)
+    end
+
+    def standalone_bold_line?(text)
+      text.match?(/\A\s*\*\*[^*].*[^*]\*\*\z/)
+    end
+
+    def nested_numbered_subnote?(text)
+      text.match?(/\A {4}[1-9]\d*\.(?!\d)\s+\S/)
+    end
+
+    def normalize_note_lines(lines, chapter: false, section: false)
+      lines = lines.dup
+      start_index = 0
+
+      remove_section_note_preamble(lines) if section
+
+      if chapter
+        loop do
+          next_heading_index = next_note_section_heading_index(lines, start_index)
+          normalize_singleton_expression_section(lines, next_content_line_index(lines, start_index), next_heading_index)
+          break unless next_heading_index
+
+          start_index = next_heading_index + 1
+        end
+
+        normalize_omitted_additional_chapter_note_one(lines)
+      end
+
+      normalize_compact_numbered_letter_markers(lines)
+      normalize_indented_marker_spacing(lines) if section
+      normalize_lettered_paragraph_lists(lines)
+      join_split_paragraph_continuations(lines)
+
+      lines
+    end
+
+    def remove_section_note_preamble(lines)
+      lines.delete_if { |line| section_note_preamble?(line) }
+      lines.shift while lines.any? && lines.first.blank?
+    end
+
+    def section_note_preamble?(line)
+      line.to_s
+        .strip
+        .delete_prefix('**')
+        .delete_suffix('**')
+        .match?(/\AThere are important section (?:note|noted|notes) for this part of the tariff:?\z/i)
+    end
+
+    def normalize_indented_marker_spacing(lines)
+      index = 1
+      while index < lines.length
+        if indented_marker_spacing_needed?(lines, index)
+          lines.insert(index, '')
+          index += 1
+        end
+
+        index += 1
+      end
+    end
+
+    def indented_marker_spacing_needed?(lines, index)
+      lines[index - 1].present? && final_indented_marker_line?(lines[index])
+    end
+
+    def final_indented_marker_line?(line)
+      line.to_s.match?(/\A {4}(?:[a-z]{1,4}[.)]|\([a-z]\)|\([A-Z]\)|\([1-9]\d*\)|[ivxlcdm]+\.)\s+\S/i)
+    end
+
+    def normalize_omitted_additional_chapter_note_one(lines)
+      additional_heading_index = lines.index { |line| additional_chapter_notes_heading?(line) }
+      return unless additional_heading_index
+
+      first_line_index = next_content_line_index(lines, additional_heading_index.to_i + 1)
+      return unless first_line_index
+      return if numbered_note?(lines[first_line_index])
+
+      next_heading_index = next_note_section_heading_index(lines, additional_heading_index) || lines.length
+      return unless lines[(first_line_index + 1)...next_heading_index].any? { |line| line.match?(/\A2\.\s?[A-Z]\./) }
+
+      lines[first_line_index] = "1. #{lines[first_line_index]}"
+      ((first_line_index + 1)...next_heading_index).each do |index|
+        next if lines[index].blank? || numbered_note?(lines[index])
+
+        lines[index] = "    #{lines[index].sub(/\A\s*/, '')}"
+      end
+
+      if lines[first_line_index - 1].present?
+        lines.insert(first_line_index, '')
+        first_line_index += 1
+      end
+
+      lines.insert(first_line_index + 1, '') if lines[first_line_index + 1].present?
+    end
+
+    def additional_chapter_notes_heading?(line)
+      plain_note_section_heading?(line) && line.match?(ADDITIONAL_NOTES_PATTERN) ||
+        line.match?(/\A###\s+Additional\s+[Cc]hapter\s+[Nn]otes?\z/i)
+    end
+
+    def normalize_compact_numbered_letter_markers(lines)
+      lines.map! { |line| line.sub(/\A([1-9]\d*)\.([A-Z]\.)/, '\1. \2') }
+      lines.map! { |line| line.sub(/\A([1-9]\d*)\.(?=[A-Z][a-z])/, '\1. ') }
+    end
+
+    def normalize_lettered_paragraph_lists(lines)
+      index = 1
+      while index < lines.length
+        if lettered_paragraph_list_start?(lines, index)
+          index = normalize_lettered_paragraph_list(lines, index)
+        else
+          index += 1
+        end
+      end
+    end
+
+    def lettered_paragraph_list_start?(lines, index)
+      lettered_list_lead_in?(lines[index - 1]) && lettered_paragraph_item?(lines[index], 'a')
+    end
+
+    def lettered_list_lead_in?(line)
+      line.to_s.match?(/(?:applies only to|does not apply to):\z/)
+    end
+
+    def normalize_lettered_paragraph_list(lines, index)
+      expected_letter = 'a'
+
+      while index < lines.length && lettered_paragraph_item?(lines[index], expected_letter)
+        lines.insert(index, '') if lines[index - 1].present?
+        index += 1
+
+        lines[index] = lines[index].sub(/\A {4}/, '    - ')
+        expected_letter = expected_letter.next
+        index += 1
+      end
+
+      lines.insert(index, '') if lines[index].present?
+      index
+    end
+
+    def lettered_paragraph_item?(line, expected_letter)
+      line.match?(/\A {4}(?:#{expected_letter}\.|\(#{expected_letter}\))\s+\S/)
+    end
+
+    def join_split_paragraph_continuations(lines)
+      index = 1
+      while index < lines.length
+        if split_paragraph_continuation?(lines[index - 1], lines[index])
+          lines[index - 1] = "#{lines[index - 1]} #{lines[index].strip}"
+          lines.delete_at(index)
+        else
+          index += 1
+        end
+      end
+    end
+
+    def split_paragraph_continuation?(previous, current)
+      previous.to_s.match?(/\b(?:a|an|and|by|for|in|of|or|the|to|with)\z/i) &&
+        current.to_s.match?(/\A {4}[a-z]/)
+    end
+
+    def normalize_singleton_expression_section(lines, start_index, end_index)
+      end_index ||= lines.length
+      return unless start_index
+      return unless singleton_expression_section?(lines, start_index, end_index)
+
+      lines[start_index] = lines[start_index].sub(/\A1\.\s*/, '')
+      (start_index...end_index).each do |index|
+        lines[index] = lines[index].sub(/\A {4}/, '')
+      end
+    end
+
+    def singleton_expression_section?(lines, start_index, end_index)
+      return false unless SINGLETON_EXPRESSION_WRAPPER_CHAPTERS.include?(@current_chapter)
+      return false unless lines[start_index]&.match?(
+        /\A1\.\s+In this chapter, the following expressions? (?:has|have) the meanings? hereby assigned to (?:it|them):\z/i,
+      )
+
+      lines[start_index...end_index].grep(/\A[2-9]\d*\.(?!\d)/).empty?
+    end
+
+    def next_note_section_heading_index(lines, start_index)
+      ((start_index + 1)...lines.length).find { |index| note_section_heading?(lines[index]) }
+    end
+
+    def next_content_line_index(lines, start_index)
+      (start_index...lines.length).find { |index| lines[index].present? }
     end
   end
 end

--- a/app/serializers/api/admin/customs_tariff_updates/chapter_note_serializer.rb
+++ b/app/serializers/api/admin/customs_tariff_updates/chapter_note_serializer.rb
@@ -5,7 +5,7 @@ module Api
         include JSONAPI::Serializer
 
         set_type :customs_tariff_chapter_note
-        set_id   :id
+        set_id   :chapter_id
 
         attributes :chapter_id, :content, :customs_tariff_update_version
 

--- a/app/serializers/api/admin/customs_tariff_updates/section_note_serializer.rb
+++ b/app/serializers/api/admin/customs_tariff_updates/section_note_serializer.rb
@@ -5,7 +5,7 @@ module Api
         include JSONAPI::Serializer
 
         set_type :customs_tariff_section_note
-        set_id   :id
+        set_id   :section_id
 
         attributes :section_id, :content, :customs_tariff_update_version
 

--- a/spec/lib/customs_tariff_importer/notes_extractor_spec.rb
+++ b/spec/lib/customs_tariff_importer/notes_extractor_spec.rb
@@ -38,6 +38,22 @@ RSpec.describe CustomsTariffImporter::NotesExtractor do
     "<w:p><w:r>#{run_properties}<w:t>#{escaped}</w:t></w:r></w:p>"
   end
 
+  def hyperlink_paragraph_xml(prefix, linked_text, suffix)
+    escaped_prefix = prefix.gsub('&', '&amp;').gsub('<', '&lt;').gsub('>', '&gt;')
+    escaped_linked_text = linked_text.gsub('&', '&amp;').gsub('<', '&lt;').gsub('>', '&gt;')
+    escaped_suffix = suffix.gsub('&', '&amp;').gsub('<', '&lt;').gsub('>', '&gt;')
+
+    <<~XML
+      <w:p>
+        <w:r><w:t>#{escaped_prefix}</w:t></w:r>
+        <w:hyperlink w:anchor="target">
+          <w:r><w:t>#{escaped_linked_text}</w:t></w:r>
+        </w:hyperlink>
+        <w:r><w:t>#{escaped_suffix}</w:t></w:r>
+      </w:p>
+    XML
+  end
+
   def indented_paragraph_xml(text, left:)
     escaped = text.gsub('&', '&amp;').gsub('<', '&lt;').gsub('>', '&gt;')
 
@@ -1101,6 +1117,34 @@ RSpec.describe CustomsTariffImporter::NotesExtractor do
         result = described_class.new('1.30', docx_content).call
 
         expect(result.chapters['07']).to eq('5. Heading 0711 applies to preserved vegetables.')
+      end
+
+      it 'preserves visible text inside hyperlink-wrapped runs' do
+        docx_content = build_docx_from_body_xml([
+          paragraph_xml('CHAPTER 20', bold: true),
+          paragraph_xml('Chapter Notes', bold: true),
+          hyperlink_paragraph_xml('1. Products of heading ', '2009', ' are covered by this chapter.'),
+        ].join("\n"))
+
+        result = described_class.new('1.30', docx_content).call
+
+        expect(result.chapters['20']).to eq('1. Products of heading 2009 are covered by this chapter.')
+      end
+
+      it 'resets visual numbering counters between chapter notes sharing a Word numId' do
+        docx_content = build_docx_from_body_xml([
+          paragraph_xml('CHAPTER 84', bold: true),
+          paragraph_xml('Chapter Notes', bold: true),
+          numbered_paragraph_xml('This chapter does not cover:', num_id: 23),
+          paragraph_xml('CHAPTER 85', bold: true),
+          paragraph_xml('Chapter Notes', bold: true),
+          numbered_paragraph_xml('This chapter does not cover:', num_id: 23),
+        ].join("\n"))
+
+        result = described_class.new('1.30', docx_content).call
+
+        expect(result.chapters['84']).to eq('1. This chapter does not cover:')
+        expect(result.chapters['85']).to eq('1. This chapter does not cover:')
       end
 
       it 'uses commodity tables as note boundaries instead of note markdown' do

--- a/spec/lib/customs_tariff_importer/notes_extractor_spec.rb
+++ b/spec/lib/customs_tariff_importer/notes_extractor_spec.rb
@@ -5,16 +5,20 @@ RSpec.describe CustomsTariffImporter::NotesExtractor do
 
   # Builds a minimal .docx (ZIP containing word/document.xml) from a flat list of paragraph strings
   def build_docx(paragraphs)
-    ns = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main'
     para_xml = paragraphs.map { |text|
       escaped = text.gsub('&', '&amp;').gsub('<', '&lt;').gsub('>', '&gt;')
       "<w:p><w:r><w:t>#{escaped}</w:t></w:r></w:p>"
     }.join("\n")
 
+    build_docx_from_body_xml(para_xml)
+  end
+
+  def build_docx_from_body_xml(body_xml)
+    ns = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main'
     xml = <<~XML
       <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
       <w:document xmlns:w="#{ns}">
-        <w:body>#{para_xml}</w:body>
+        <w:body>#{body_xml}</w:body>
       </w:document>
     XML
 
@@ -25,6 +29,51 @@ RSpec.describe CustomsTariffImporter::NotesExtractor do
       zip.write(xml)
     end
     buffer.string
+  end
+
+  def paragraph_xml(text, bold: false)
+    escaped = text.gsub('&', '&amp;').gsub('<', '&lt;').gsub('>', '&gt;')
+    run_properties = bold ? '<w:rPr><w:b/></w:rPr>' : ''
+
+    "<w:p><w:r>#{run_properties}<w:t>#{escaped}</w:t></w:r></w:p>"
+  end
+
+  def indented_paragraph_xml(text, left:)
+    escaped = text.gsub('&', '&amp;').gsub('<', '&lt;').gsub('>', '&gt;')
+
+    <<~XML
+      <w:p>
+        <w:pPr><w:ind w:left="#{left}"/></w:pPr>
+        <w:r><w:t>#{escaped}</w:t></w:r>
+      </w:p>
+    XML
+  end
+
+  def numbered_paragraph_xml(text, num_id: 1, level: 0)
+    escaped = text.gsub('&', '&amp;').gsub('<', '&lt;').gsub('>', '&gt;')
+
+    <<~XML
+      <w:p>
+        <w:pPr>
+          <w:numPr>
+            <w:ilvl w:val="#{level}"/>
+            <w:numId w:val="#{num_id}"/>
+          </w:numPr>
+        </w:pPr>
+        <w:r><w:t>#{escaped}</w:t></w:r>
+      </w:p>
+    XML
+  end
+
+  def paragraph_xml_with_paragraph_bold_only(text)
+    escaped = text.gsub('&', '&amp;').gsub('<', '&lt;').gsub('>', '&gt;')
+
+    <<~XML
+      <w:p>
+        <w:pPr><w:rPr><w:b/></w:rPr></w:pPr>
+        <w:r><w:t>#{escaped}</w:t></w:r>
+      </w:p>
+    XML
   end
 
   # Unit tests for the state machine via parse_notes (private)
@@ -96,6 +145,40 @@ RSpec.describe CustomsTariffImporter::NotesExtractor do
       it 'converts the section key to an integer' do
         result = parse(['SECTION iv', 'Section Notes', 'Some content.'])
         expect(result.sections.keys).to contain_exactly(4)
+      end
+
+      it 'normalises compact numbering and indented marker paragraphs' do
+        [
+          '**There are important section noted for this part of the tariff:**',
+          'There are important section noted for this part of the tariff:',
+          '**There are important section notes for this part of the tariff**',
+        ].each do |preamble|
+          result = parse([
+            'SECTION XV',
+            'Section Notes',
+            preamble,
+            '1.This section does not cover:',
+            '    a. prepared paints;',
+            '    b. ferro-cerium;',
+            '2.Throughout the nomenclature, the expression means:',
+            '    a. articles of heading 7307;',
+          ])
+
+          expect(result.sections[15]).not_to include('There are important section')
+          expect(result.sections[15]).to include(
+            [
+              '1. This section does not cover:',
+              '',
+              '    a. prepared paints;',
+              '',
+              '    b. ferro-cerium;',
+              '',
+              '2. Throughout the nomenclature, the expression means:',
+              '',
+              '    a. articles of heading 7307;',
+            ].join("\n"),
+          )
+        end
       end
 
       it 'does not save a section with no notes' do
@@ -226,7 +309,7 @@ RSpec.describe CustomsTariffImporter::NotesExtractor do
           '5306100000',
         ])
 
-        expect(result.chapters['53']).to start_with('Additional chapter notes')
+        expect(result.chapters['53']).to start_with('### Additional chapter notes')
         expect(result.chapters['53']).to include('1. (A) For the purposes of code 5306 10 90')
         expect(result.chapters['53']).not_to include('5306100000')
       end
@@ -240,7 +323,7 @@ RSpec.describe CustomsTariffImporter::NotesExtractor do
           '5201000000',
         ])
 
-        expect(result.chapters['52']).to start_with('Subheading note')
+        expect(result.chapters['52']).to start_with('### Subheading note')
         expect(result.chapters['52']).to include("the expression 'denim' means fabrics of yarns.")
         expect(result.chapters['52']).not_to include('5201000000')
       end
@@ -330,6 +413,352 @@ RSpec.describe CustomsTariffImporter::NotesExtractor do
         expect(result.chapters['01']).to include("Line one.\n\nLine two.")
       end
     end
+
+    describe 'recoverable markdown list signal' do
+      it 'drops a singleton opening expression-note number and unindents its content' do
+        result = parse([
+          'CHAPTER 74',
+          'Chapter Notes',
+          '1. In this chapter, the following expressions have the meanings hereby assigned to them:',
+          '',
+          'a. Refined copper:',
+          '',
+          'Metal containing copper.',
+          'Subheading note',
+          '',
+          '1. In this chapter, the following expressions have the meanings hereby assigned to them:',
+          '',
+          'a. Copper-zinc base alloys (brasses):',
+        ])
+
+        expect(result.chapters['74']).to eq(
+          [
+            'In this chapter, the following expressions have the meanings hereby assigned to them:',
+            '',
+            'a. Refined copper:',
+            '',
+            'Metal containing copper.',
+            '### Subheading note',
+            '',
+            'In this chapter, the following expressions have the meanings hereby assigned to them:',
+            '',
+            'a. Copper-zinc base alloys (brasses):',
+          ].join("\n"),
+        )
+      end
+
+      it 'keeps an opening expression-note number when the section has later numbered notes' do
+        result = parse([
+          'CHAPTER 72',
+          'Chapter Notes',
+          '1. In this chapter, the following expressions have the meanings hereby assigned to them:',
+          'a. pig iron',
+          'Iron-carbon alloys.',
+          '2. Ferrous metals clad with another ferrous metal are to be classified elsewhere.',
+        ])
+
+        expect(result.chapters['72']).to include('1. In this chapter')
+        expect(result.chapters['72']).to include('2. Ferrous metals clad')
+        expect(result.chapters['72']).to include('    a. pig iron')
+      end
+
+      it 'keeps numbered-note content indented before rendering' do
+        result = parse([
+          'CHAPTER 72',
+          'Chapter Notes',
+          '1. In this chapter, the following expressions have the meanings hereby assigned to them:',
+          'a. pig iron',
+          'Iron-carbon alloys not usefully malleable, containing one or more of the following:',
+          '- not more than 10 % of chromium',
+          '- not more than 6 % of manganese',
+          'b. spiegeleisen',
+          'Additional chapter note',
+          '1. For the purposes of code 7201 50 10:',
+          '- ferro-alloys contain 4 % or more of iron',
+        ])
+
+        expect(result.chapters['72']).to include(
+          [
+            '1. In this chapter, the following expressions have the meanings hereby assigned to them:',
+            '    a. pig iron',
+            '    Iron-carbon alloys not usefully malleable, containing one or more of the following:',
+            '',
+            '    - not more than 10 % of chromium',
+            '',
+            '    - not more than 6 % of manganese',
+            '',
+            '    b. spiegeleisen',
+            '### Additional chapter note',
+            '',
+            '1. For the purposes of code 7201 50 10:',
+            '',
+            '    - ferro-alloys contain 4 % or more of iron',
+          ].join("\n"),
+        )
+      end
+
+      it 'keeps explicit hyphen bullets nested under their numbered note' do
+        result = parse([
+          'CHAPTER 72',
+          'Chapter Notes',
+          '1. In this chapter, the following expressions have the meanings hereby assigned to them:',
+          'f. other alloy steel',
+          'Steels containing one or more of the following elements:',
+          '- 0.3 % or more of aluminium',
+          '- 0.0008 % or more of boron',
+          'g. remelting scrap ingots of iron or steel',
+        ])
+
+        expect(result.chapters['72']).to include(
+          [
+            '    Steels containing one or more of the following elements:',
+            '',
+            '    - 0.3 % or more of aluminium',
+            '',
+            '    - 0.0008 % or more of boron',
+            '',
+            '    g. remelting scrap ingots of iron or steel',
+          ].join("\n"),
+        )
+      end
+
+      it 'keeps unmarked continuation lines inside the previous bullet item' do
+        result = parse([
+          'CHAPTER 72',
+          'Chapter Notes',
+          'Additional chapter note',
+          "- 'Tool steel': containing one of the following compositions:",
+          '- less than 0.6 % of carbon',
+          'and 0.7 % or more of silicon and 0.05 % or more of vanadium',
+          'or',
+          '4 % or more of tungsten;',
+          '- 0.8 % or more of carbon',
+        ])
+
+        expect(result.chapters['72']).to include(
+          [
+            '- less than 0.6 % of carbon',
+            '',
+            '    and 0.7 % or more of silicon and 0.05 % or more of vanadium',
+            '    or',
+            '    4 % or more of tungsten;',
+            '',
+            '- 0.8 % or more of carbon',
+          ].join("\n"),
+        )
+      end
+
+      it 'converts source em dash bullets and keeps following paragraphs outside the bullet' do
+        result = parse([
+          'CHAPTER 2',
+          'Chapter Notes',
+          '1. A. The following expressions have the meanings hereby assigned to them:',
+          '(c) portions composed of either:',
+          '— forequarters comprising all the bones and the scrag;',
+          'The forequarters and the hindquarters constituting compensated quarters must be presented together;',
+          '(d) unseparated forequarters:',
+        ])
+
+        expect(result.chapters['02']).to include(
+          [
+            '    (c) portions composed of either:',
+            '',
+            '    - forequarters comprising all the bones and the scrag;',
+            '',
+            '    The forequarters and the hindquarters constituting compensated quarters must be presented together;',
+            '    (d) unseparated forequarters:',
+          ].join("\n"),
+        )
+      end
+
+      it 'splits a lettered item with an inline nested number into a nested numbered list' do
+        result = parse([
+          'CHAPTER 2',
+          'Chapter Notes',
+          '1. A. The following expressions have the meanings hereby assigned to them:',
+          "(h) 1. 'crop' and 'chuck and blade' cuts, for the purposes of code 0202 30 50: the dorsal part;",
+          "2. 'brisket' cut, for the purposes of code 0202 30 50: the lower part.",
+          'B. Products covered by additional chapter notes may be presented with or without the vertebral column.',
+        ])
+
+        expect(result.chapters['02']).to include(
+          [
+            '    (h)',
+            '',
+            "    1. 'crop' and 'chuck and blade' cuts, for the purposes of code 0202 30 50: the dorsal part;",
+            '',
+            "    2. 'brisket' cut, for the purposes of code 0202 30 50: the lower part.",
+            '    B. Products covered by additional chapter notes may be presented with or without the vertebral column.',
+          ].join("\n"),
+        )
+      end
+
+      it 'normalises dotless numbered notes before nested bullets and tables' do
+        result = parse([
+          'CHAPTER 4',
+          'Chapter Notes',
+          '3. Previous note.',
+          '4 The term “unfit for human consumption” applies when:',
+          '• the goods are homogeneously mixed',
+          '| Denaturant | Minimum quantity |',
+          '| --- | --- |',
+          '| Spirit of turpentine | 500 |',
+          '5. The duty rate applies.',
+        ])
+
+        expect(result.chapters['04']).to include(
+          [
+            '4. The term “unfit for human consumption” applies when:',
+            '',
+            '    - the goods are homogeneously mixed',
+            '',
+            '    | Denaturant | Minimum quantity |',
+            '    | --- | --- |',
+            '    | Spirit of turpentine | 500 |',
+            '',
+            '5. The duty rate applies.',
+          ].join("\n"),
+        )
+      end
+
+      it 'restores an omitted first additional chapter note marker when later notes continue the sequence' do
+        result = parse([
+          'CHAPTER 15',
+          'Chapter Notes',
+          'Additional chapter notes',
+          'For the purposes of subheadings/codes 1507 10 and 1518 00 31:',
+          '(a) fixed vegetable oils obtained by pressure are crude if:',
+          '— decantation within the normal time limits,',
+          '(b) fixed vegetable oils obtained by extraction are crude when indistinguishable;',
+          '2.A. Headings 1509 and 1510 cover only oils derived solely from olives.',
+          'B. Codes 1509 20 00, 1509 30 00 and 1509 40 00 cover only points 1, 2 and 3 below.',
+          '1. For the purposes of code 1509 20 00, extra virgin olive oil means category 1 oil.',
+          '2. Code 1509 30 00 covers category 2 oil.',
+          '3. Code 1509 40 00 covers category 3 oil.',
+          'C. Code 1509 90 00 covers other olive oil.',
+          '3. Codes 1522 00 31 and 1522 00 39 do not cover residues.',
+        ])
+
+        expect(result.chapters['15']).to include(
+          [
+            '### Additional chapter notes',
+            '',
+            '1. For the purposes of subheadings/codes 1507 10 and 1518 00 31:',
+            '',
+            '    (a) fixed vegetable oils obtained by pressure are crude if:',
+            '',
+            '    - decantation within the normal time limits,',
+            '',
+            '    (b) fixed vegetable oils obtained by extraction are crude when indistinguishable;',
+            '',
+            '2. A. Headings 1509 and 1510 cover only oils derived solely from olives.',
+            '    B. Codes 1509 20 00, 1509 30 00 and 1509 40 00 cover only points 1, 2 and 3 below.',
+            '',
+            '    1. For the purposes of code 1509 20 00, extra virgin olive oil means category 1 oil.',
+            '',
+            '    2. Code 1509 30 00 covers category 2 oil.',
+            '',
+            '    3. Code 1509 40 00 covers category 3 oil.',
+            '    C. Code 1509 90 00 covers other olive oil.',
+            '',
+            '3. Codes 1522 00 31 and 1522 00 39 do not cover residues.',
+          ].join("\n"),
+        )
+      end
+
+      it 'joins same-note paragraph continuations split mid-phrase by the source document' do
+        result = parse([
+          'CHAPTER 15',
+          'Chapter Notes',
+          '5. Food preparations are excluded by their specific form of',
+          'presentation revealing their function.',
+        ])
+
+        expect(result.chapters['15']).to eq(
+          '5. Food preparations are excluded by their specific form of presentation revealing their function.',
+        )
+      end
+
+      it 'keeps consecutive indented source paragraphs separate under a numbered note' do
+        result = parse([
+          'CHAPTER 17',
+          'Chapter Notes',
+          '3. For products of codes 1702 2010, the sugar content is determined using the following formula:',
+          'S + 0,95 x (F + G) + M',
+          'where:',
+          '“S” is the sucrose content determined by the HPLC method;',
+          '“F” is the fructose content determined by the HPLC method;',
+          '“G” is the glucose content determined by the HPLC method;',
+          '“M” is the maltose content determined by the HPLC method.',
+        ])
+
+        expect(result.chapters['17']).to include(
+          [
+            '    “S” is the sucrose content determined by the HPLC method;',
+            '',
+            '    “F” is the fructose content determined by the HPLC method;',
+            '',
+            '    “G” is the glucose content determined by the HPLC method;',
+            '',
+            '    “M” is the maltose content determined by the HPLC method.',
+          ].join("\n"),
+        )
+      end
+
+      it 'normalises compact note markers and lettered paragraph lists after colon lead-ins' do
+        result = parse([
+          'CHAPTER 34',
+          'Chapter Notes',
+          '5.In heading 3404, artificial waxes and prepared waxes applies only to:',
+          'a. chemically produced organic products of a waxy character;',
+          'b. products obtained by mixing different waxes;',
+          'c. products of a waxy character with a basis of one or more waxes.',
+          'The heading does not apply to:',
+          '(a) products of heading 1516;',
+          '(b) unmixed animal waxes;',
+          '(c) mineral waxes; or',
+          '(d) waxes mixed with a liquid medium.',
+        ])
+
+        expect(result.chapters['34']).to include(
+          [
+            '5. In heading 3404, artificial waxes and prepared waxes applies only to:',
+            '',
+            '    - a. chemically produced organic products of a waxy character;',
+            '',
+            '    - b. products obtained by mixing different waxes;',
+            '',
+            '    - c. products of a waxy character with a basis of one or more waxes.',
+            '',
+            '    The heading does not apply to:',
+            '',
+            '    - (a) products of heading 1516;',
+            '',
+            '    - (b) unmixed animal waxes;',
+            '',
+            '    - (c) mineral waxes; or',
+            '',
+            '    - (d) waxes mixed with a liquid medium.',
+          ].join("\n"),
+        )
+      end
+
+      it 'does not normalise a dotless number unless it continues the top-level note sequence' do
+        result = parse([
+          'CHAPTER 4',
+          'Chapter Notes',
+          '1. Previous note.',
+          '4 The goods are put up in containers.',
+        ])
+
+        expect(result.chapters['04']).to include(
+          [
+            '1. Previous note.',
+            '    4 The goods are put up in containers.',
+          ].join("\n"),
+        )
+      end
+    end
   end
 
   # Integration tests — full call through read_document_xml → extract_paragraphs → parse_notes
@@ -388,6 +817,313 @@ RSpec.describe CustomsTariffImporter::NotesExtractor do
           rules: 1,
           duration_ms: a_kind_of(Float),
         )
+      end
+    end
+
+    context 'with source formatting in the .docx' do
+      it 'converts Word tables to markdown before storing chapter notes' do
+        table_xml = <<~XML
+          <w:tbl>
+            <w:tr>
+              <w:tc>
+                <w:tcPr><w:gridSpan w:val="2"/></w:tcPr>
+                <w:p><w:r><w:t>Element</w:t></w:r></w:p>
+              </w:tc>
+              <w:tc><w:p><w:r><w:t>Limiting content % by weight</w:t></w:r></w:p></w:tc>
+            </w:tr>
+            <w:tr>
+              <w:tc><w:p><w:r><w:t>Ag</w:t></w:r></w:p></w:tc>
+              <w:tc><w:p><w:r><w:t>Silver | gold \\ alloy</w:t></w:r></w:p></w:tc>
+              <w:tc><w:p><w:r><w:t>0,25</w:t></w:r></w:p></w:tc>
+            </w:tr>
+            <w:tr>
+              <w:tc><w:p><w:r><w:t>Other elements are, for example, Al, Be, Co, Fe, Mn, Ni, Si.</w:t></w:r></w:p></w:tc>
+              <w:tc><w:p/></w:tc>
+              <w:tc><w:p><w:r><w:t>0.3</w:t></w:r></w:p></w:tc>
+            </w:tr>
+          </w:tbl>
+        XML
+
+        docx_content = build_docx_from_body_xml([
+          paragraph_xml('CHAPTER 74', bold: true),
+          paragraph_xml('Chapter Notes', bold: true),
+          paragraph_xml('1. In this chapter, the following expressions have the meanings hereby assigned to them:'),
+          paragraph_xml('Other elements', bold: true),
+          table_xml,
+          paragraph_xml('b. Copper alloys:'),
+        ].join("\n"))
+
+        result = described_class.new('1.30', docx_content).call
+
+        expect(result.chapters['74']).to include(<<~MARKDOWN.strip)
+          **Other elements**
+
+          | Element | Limiting content % by weight |
+          | --- | --- |
+          | Ag Silver \\| gold \\\\ alloy | 0,25 |
+          | Other elements are, for example, Al, Be, Co, Fe, Mn, Ni, Si. | 0.3 |
+        MARKDOWN
+        expect(result.chapters['74']).not_to include("Ag\n    Silver\n    0,25")
+      end
+
+      it 'preserves table columns from spanned multi-row headers' do
+        table_xml = <<~XML
+          <w:tbl>
+            <w:tr>
+              <w:tc><w:p><w:r><w:t>Cereal</w:t></w:r></w:p></w:tc>
+              <w:tc><w:p><w:r><w:t>Starch content</w:t></w:r></w:p></w:tc>
+              <w:tc><w:p><w:r><w:t>Ash content</w:t></w:r></w:p></w:tc>
+              <w:tc>
+                <w:tcPr><w:gridSpan w:val="2"/></w:tcPr>
+                <w:p><w:r><w:t>Rate of passage through a sieve with an aperture of</w:t></w:r></w:p>
+              </w:tc>
+            </w:tr>
+            <w:tr>
+              <w:tc><w:p><w:r><w:t> </w:t></w:r></w:p></w:tc>
+              <w:tc><w:p><w:r><w:t> </w:t></w:r></w:p></w:tc>
+              <w:tc><w:p><w:r><w:t> </w:t></w:r></w:p></w:tc>
+              <w:tc><w:p><w:r><w:t>315 micrometres (microns)</w:t></w:r></w:p></w:tc>
+              <w:tc><w:p><w:r><w:t>500 micrometres (microns)</w:t></w:r></w:p></w:tc>
+            </w:tr>
+            <w:tr>
+              <w:tc><w:p><w:r><w:t>(1)</w:t></w:r></w:p></w:tc>
+              <w:tc><w:p><w:r><w:t>(2)</w:t></w:r></w:p></w:tc>
+              <w:tc><w:p><w:r><w:t>(3)</w:t></w:r></w:p></w:tc>
+              <w:tc><w:p><w:r><w:t>(4)</w:t></w:r></w:p></w:tc>
+              <w:tc><w:p><w:r><w:t>(5)</w:t></w:r></w:p></w:tc>
+            </w:tr>
+            <w:tr>
+              <w:tc><w:p><w:r><w:t>Maize (corn) and grain sorghum</w:t></w:r></w:p></w:tc>
+              <w:tc><w:p><w:r><w:t>45 %</w:t></w:r></w:p></w:tc>
+              <w:tc><w:p><w:r><w:t>2 %</w:t></w:r></w:p></w:tc>
+              <w:tc><w:p><w:r><w:t>—</w:t></w:r></w:p></w:tc>
+              <w:tc><w:p><w:r><w:t>90 %</w:t></w:r></w:p></w:tc>
+            </w:tr>
+          </w:tbl>
+        XML
+
+        docx_content = build_docx_from_body_xml([
+          paragraph_xml('CHAPTER 11', bold: true),
+          paragraph_xml('Chapter Notes', bold: true),
+          paragraph_xml('2. Products are classified according to the table:'),
+          table_xml,
+        ].join("\n"))
+
+        result = described_class.new('1.30', docx_content).call
+
+        expect(result.chapters['11']).to include(
+          [
+            '    | Cereal | Starch content | Ash content | Rate of passage through a sieve with an aperture of 315 micrometres (microns) | Rate of passage through a sieve with an aperture of 500 micrometres (microns) |',
+            '    | --- | --- | --- | --- | --- |',
+            '    | (1) | (2) | (3) | (4) | (5) |',
+            '    | Maize (corn) and grain sorghum | 45 % | 2 % | — | 90 % |',
+          ].join("\n"),
+        )
+      end
+
+      it 'preserves grouped table columns when a top header spans several subcolumns' do
+        table_xml = <<~XML
+          <w:tbl>
+            <w:tr>
+              <w:tc>
+                <w:tcPr><w:gridSpan w:val="3"/></w:tcPr>
+                <w:p><w:r><w:t>Denaturant</w:t></w:r></w:p>
+              </w:tc>
+              <w:tc><w:p><w:r><w:t>Minimum quantity to be used (in g) per 100 kg of denatured product</w:t></w:r></w:p></w:tc>
+            </w:tr>
+            <w:tr>
+              <w:tc>
+                <w:tcPr><w:gridSpan w:val="3"/></w:tcPr>
+                <w:p><w:r><w:t>(1)</w:t></w:r></w:p>
+              </w:tc>
+              <w:tc><w:p><w:r><w:t>(2)</w:t></w:r></w:p></w:tc>
+            </w:tr>
+            <w:tr>
+              <w:tc><w:p><w:r><w:t>Chemical name or description</w:t></w:r></w:p></w:tc>
+              <w:tc><w:p><w:r><w:t>Common name</w:t></w:r></w:p></w:tc>
+              <w:tc><w:p><w:r><w:t>Colour index</w:t></w:r></w:p></w:tc>
+              <w:tc><w:p/></w:tc>
+            </w:tr>
+            <w:tr>
+              <w:tc><w:p><w:r><w:t>Sodium salt of 4-sulphobenzeneazo-resorcinol</w:t></w:r></w:p></w:tc>
+              <w:tc><w:p><w:r><w:t>Chrysoine S</w:t></w:r></w:p></w:tc>
+              <w:tc><w:p><w:r><w:t>14270</w:t></w:r></w:p></w:tc>
+              <w:tc><w:p><w:r><w:t>6</w:t></w:r></w:p></w:tc>
+            </w:tr>
+          </w:tbl>
+        XML
+
+        docx_content = build_docx_from_body_xml([
+          paragraph_xml('CHAPTER 25', bold: true),
+          paragraph_xml('Chapter Notes', bold: true),
+          paragraph_xml('2. The term denatured applies when:'),
+          table_xml,
+        ].join("\n"))
+
+        result = described_class.new('1.30', docx_content).call
+
+        expect(result.chapters['25']).to include(
+          [
+            '    | Denaturant |  |  | Minimum quantity to be used (in g) per 100 kg of denatured product |',
+            '    | --- | --- | --- | --- |',
+            '    | (1) |  |  | (2) |',
+            '    | Chemical name or description | Common name | Colour index |  |',
+            '    | Sodium salt of 4-sulphobenzeneazo-resorcinol | Chrysoine S | 14270 | 6 |',
+          ].join("\n"),
+        )
+      end
+
+      it 'uses source indentation to recover nested marker lists' do
+        docx_content = build_docx_from_body_xml([
+          paragraph_xml('CHAPTER 84', bold: true),
+          paragraph_xml('Chapter Notes', bold: true),
+          numbered_paragraph_xml('This chapter does not cover:', num_id: 23),
+          indented_paragraph_xml('a. millstones, grindstones or other articles of Chapter 68;', left: 720),
+          indented_paragraph_xml('b. machinery or appliances of ceramic material;', left: 720),
+          numbered_paragraph_xml('Subject to the operation of note 3 to Section XVI, a machine is to be classified under the former group.', num_id: 23),
+          indented_paragraph_xml('(A) Heading 8419 does not, however, cover:', left: 1080),
+          indented_paragraph_xml('i. germination plant, incubators or brooders (heading 8436);', left: 1800),
+          indented_paragraph_xml('ii. grain dampening machines (heading 8437);', left: 1800),
+          indented_paragraph_xml('(B) Heading 8422 does not cover:', left: 1080),
+          indented_paragraph_xml('i. sewing machines for closing bags or similar containers (heading 8452); or', left: 1800),
+          indented_paragraph_xml('ii. office machinery of heading 8472.', left: 1800),
+          numbered_paragraph_xml('Heading 8457 applies only to machine tools for working metal either:', num_id: 23),
+          indented_paragraph_xml('a. by automatic tool change from a magazine;', left: 1800),
+          indented_paragraph_xml('b. by the automatic use of different unit heads;', left: 1800),
+          numbered_paragraph_xml('For the purposes of heading 8471, automatic data-processing machines means machines, capable of', num_id: 23),
+          indented_paragraph_xml('(1) storing the processing program;', left: 1800),
+          indented_paragraph_xml('(2) being freely programmed;', left: 1080),
+        ].join("\n"))
+
+        result = described_class.new('1.30', docx_content).call
+
+        expect(result.chapters['84']).to include(
+          [
+            '1. This chapter does not cover:',
+            '',
+            '    a. millstones, grindstones or other articles of Chapter 68;',
+            '',
+            '    b. machinery or appliances of ceramic material;',
+            '',
+            '2. Subject to the operation of note 3 to Section XVI, a machine is to be classified under the former group.',
+            '',
+            '    - (A) Heading 8419 does not, however, cover:',
+            '',
+            '        - i. germination plant, incubators or brooders (heading 8436);',
+            '',
+            '        - ii. grain dampening machines (heading 8437);',
+            '',
+            '    - (B) Heading 8422 does not cover:',
+            '',
+            '        - i. sewing machines for closing bags or similar containers (heading 8452); or',
+            '',
+            '        - ii. office machinery of heading 8472.',
+            '',
+            '3. Heading 8457 applies only to machine tools for working metal either:',
+            '',
+            '    a. by automatic tool change from a magazine;',
+            '',
+            '    b. by the automatic use of different unit heads;',
+            '',
+            '4. For the purposes of heading 8471, automatic data-processing machines means machines, capable of',
+            '',
+            '    (1) storing the processing program;',
+            '',
+            '    (2) being freely programmed;',
+          ].join("\n"),
+        )
+      end
+
+      it 'keeps source-indented definition paragraphs and roman bracket conditions out of code blocks' do
+        docx_content = build_docx_from_body_xml([
+          paragraph_xml('CHAPTER 75', bold: true),
+          paragraph_xml('Subheading notes', bold: true),
+          numbered_paragraph_xml('In this chapter, the following expressions have the meanings hereby assigned to them:', num_id: 24),
+          indented_paragraph_xml('a. nickel, not alloyed:', left: 720),
+          indented_paragraph_xml('Metal containing by weight at least 99 % of nickel plus cobalt, provided that:', left: 720),
+          indented_paragraph_xml('(i) the cobalt content by weight does not exceed 1.5 %, and', left: 1800),
+          indented_paragraph_xml('(ii) the content by weight of any other element does not exceed the limit specified in the following table:', left: 1800),
+        ].join("\n"))
+
+        result = described_class.new('1.30', docx_content).call
+
+        expect(result.chapters['75']).to include(
+          [
+            '### Subheading notes',
+            '',
+            '1. In this chapter, the following expressions have the meanings hereby assigned to them:',
+            '',
+            '    a. nickel, not alloyed:',
+            '',
+            '    Metal containing by weight at least 99 % of nickel plus cobalt, provided that:',
+            '',
+            '    (i) the cobalt content by weight does not exceed 1.5 %, and',
+            '',
+            '    (ii) the content by weight of any other element does not exceed the limit specified in the following table:',
+          ].join("\n"),
+        )
+      end
+
+      it 'preserves source bold without inventing bold for plain paragraphs' do
+        docx_content = build_docx_from_body_xml([
+          paragraph_xml('CHAPTER 74', bold: true),
+          paragraph_xml('Chapter Notes', bold: true),
+          paragraph_xml('1. In this chapter, the following expressions have the meanings hereby assigned to them:'),
+          paragraph_xml('a. Refined copper:'),
+          paragraph_xml('Actually bold source text', bold: true),
+        ].join("\n"))
+
+        result = described_class.new('1.30', docx_content).call
+
+        expect(result.chapters['74']).to include("a. Refined copper:\n\n**Actually bold source text**")
+        expect(result.chapters['74']).not_to include('**a. Refined copper:**')
+      end
+
+      it 'keeps numbered note markers outside source paragraph bold markdown' do
+        docx_content = build_docx_from_body_xml([
+          paragraph_xml('CHAPTER 7', bold: true),
+          paragraph_xml('Chapter Notes', bold: true),
+          paragraph_xml('5. Heading 0711 applies to preserved vegetables.', bold: true),
+        ].join("\n"))
+
+        result = described_class.new('1.30', docx_content).call
+
+        expect(result.chapters['07']).to eq('5. **Heading 0711 applies to preserved vegetables.**')
+      end
+
+      it 'does not treat paragraph property bold as visible text bold' do
+        docx_content = build_docx_from_body_xml([
+          paragraph_xml('CHAPTER 7', bold: true),
+          paragraph_xml('Chapter Notes', bold: true),
+          paragraph_xml_with_paragraph_bold_only('5. Heading 0711 applies to preserved vegetables.'),
+        ].join("\n"))
+
+        result = described_class.new('1.30', docx_content).call
+
+        expect(result.chapters['07']).to eq('5. Heading 0711 applies to preserved vegetables.')
+      end
+
+      it 'uses commodity tables as note boundaries instead of note markdown' do
+        commodity_table_xml = <<~XML
+          <w:tbl>
+            <w:tr>
+              <w:tc><w:p><w:r><w:t>7401000000</w:t></w:r></w:p></w:tc>
+              <w:tc><w:p><w:r><w:t>Copper mattes</w:t></w:r></w:p></w:tc>
+            </w:tr>
+          </w:tbl>
+        XML
+
+        docx_content = build_docx_from_body_xml([
+          paragraph_xml('CHAPTER 74'),
+          paragraph_xml('Chapter Notes'),
+          paragraph_xml('1. Note content.'),
+          commodity_table_xml,
+          paragraph_xml('This commodity description should not be captured.'),
+        ].join("\n"))
+
+        result = described_class.new('1.30', docx_content).call
+
+        expect(result.chapters['74']).to eq('1. Note content.')
       end
     end
 

--- a/spec/requests/api/admin/customs_tariff_updates/chapter_notes_controller_spec.rb
+++ b/spec/requests/api/admin/customs_tariff_updates/chapter_notes_controller_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Api::Admin::CustomsTariffUpdates::ChapterNotesController do
 
       expect(response.status).to eq(200)
       note = JSON.parse(response.body)['data'].find { |n| n.dig('attributes', 'chapter_id') == '01' }
+      expect(note['id']).to eq('01')
       expect(note.dig('attributes', 'file_diff', 'changed_fields')).to include('content')
     end
 
@@ -200,6 +201,20 @@ RSpec.describe Api::Admin::CustomsTariffUpdates::ChapterNotesController do
 
       expect(response.status).to eq(200)
       expect(note.reload.content).to eq('Updated content')
+    end
+
+    it 'updates when following the JSON:API id from the index response' do
+      get "/uk/admin/customs_tariff_updates/#{update.version}/chapter_notes.json",
+          headers: request_headers(format: :json)
+
+      response_id = JSON.parse(response.body).dig('data', 0, 'id')
+
+      patch "/uk/admin/customs_tariff_updates/#{update.version}/chapter_notes/#{response_id}.json",
+            params: { data: { type: 'customs_tariff_chapter_note', attributes: { content: 'Updated via response id' } } },
+            headers: request_headers(format: :json), as: :json
+
+      expect(response.status).to eq(200)
+      expect(note.reload.content).to eq('Updated via response id')
     end
 
     it 'returns 422 when the parent update is rejected' do

--- a/spec/requests/api/admin/customs_tariff_updates/chapter_notes_controller_spec.rb
+++ b/spec/requests/api/admin/customs_tariff_updates/chapter_notes_controller_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Api::Admin::CustomsTariffUpdates::ChapterNotesController do
     let!(:note)   { create(:customs_tariff_chapter_note, customs_tariff_update: update) }
 
     it 'returns the note with a versions array' do
-      get "/uk/admin/customs_tariff_updates/#{update.version}/chapter_notes/#{note.id}.json",
+      get "/uk/admin/customs_tariff_updates/#{update.version}/chapter_notes/#{note.chapter_id}.json",
           headers: request_headers(format: :json)
 
       expect(response.status).to eq(200)
@@ -113,7 +113,7 @@ RSpec.describe Api::Admin::CustomsTariffUpdates::ChapterNotesController do
       end
 
       it 'returns file_diff instead of versions' do
-        get "/uk/admin/customs_tariff_updates/#{update.version}/chapter_notes/#{note.id}.json",
+        get "/uk/admin/customs_tariff_updates/#{update.version}/chapter_notes/#{note.chapter_id}.json",
             params: { compare_version: compare_update.version },
             headers: request_headers(format: :json)
 
@@ -130,7 +130,7 @@ RSpec.describe Api::Admin::CustomsTariffUpdates::ChapterNotesController do
     let!(:note)   { create(:customs_tariff_chapter_note, customs_tariff_update: update) }
 
     it 'destroys the note and returns 204' do
-      delete "/uk/admin/customs_tariff_updates/#{update.version}/chapter_notes/#{note.id}.json",
+      delete "/uk/admin/customs_tariff_updates/#{update.version}/chapter_notes/#{note.chapter_id}.json",
              headers: request_headers(format: :json)
 
       expect(response.status).to eq(204)
@@ -140,7 +140,7 @@ RSpec.describe Api::Admin::CustomsTariffUpdates::ChapterNotesController do
     it 'returns 422 and does not destroy when the parent update is rejected' do
       update.update(status: CustomsTariffUpdate::REJECTED)
 
-      delete "/uk/admin/customs_tariff_updates/#{update.version}/chapter_notes/#{note.id}.json",
+      delete "/uk/admin/customs_tariff_updates/#{update.version}/chapter_notes/#{note.chapter_id}.json",
              headers: request_headers(format: :json)
 
       expect(response.status).to eq(422)
@@ -150,7 +150,7 @@ RSpec.describe Api::Admin::CustomsTariffUpdates::ChapterNotesController do
     it 'returns 404 when the note does not belong to the update' do
       other_update = create(:customs_tariff_update)
 
-      delete "/uk/admin/customs_tariff_updates/#{other_update.version}/chapter_notes/#{note.id}.json",
+      delete "/uk/admin/customs_tariff_updates/#{other_update.version}/chapter_notes/#{note.chapter_id}.json",
              headers: request_headers(format: :json)
 
       expect(response.status).to eq(404)
@@ -194,7 +194,7 @@ RSpec.describe Api::Admin::CustomsTariffUpdates::ChapterNotesController do
     let!(:note)   { create(:customs_tariff_chapter_note, customs_tariff_update: update) }
 
     it 'updates the content' do
-      patch "/uk/admin/customs_tariff_updates/#{update.version}/chapter_notes/#{note.id}.json",
+      patch "/uk/admin/customs_tariff_updates/#{update.version}/chapter_notes/#{note.chapter_id}.json",
             params: { data: { type: 'customs_tariff_chapter_note', attributes: { content: 'Updated content' } } },
             headers: request_headers(format: :json), as: :json
 
@@ -205,7 +205,7 @@ RSpec.describe Api::Admin::CustomsTariffUpdates::ChapterNotesController do
     it 'returns 422 when the parent update is rejected' do
       update.update(status: CustomsTariffUpdate::REJECTED)
 
-      patch "/uk/admin/customs_tariff_updates/#{update.version}/chapter_notes/#{note.id}.json",
+      patch "/uk/admin/customs_tariff_updates/#{update.version}/chapter_notes/#{note.chapter_id}.json",
             params: { data: { type: 'customs_tariff_chapter_note', attributes: { content: 'Updated' } } },
             headers: request_headers(format: :json), as: :json
 
@@ -214,7 +214,7 @@ RSpec.describe Api::Admin::CustomsTariffUpdates::ChapterNotesController do
 
     it 'creates a Version record on successful save' do
       expect {
-        patch "/uk/admin/customs_tariff_updates/#{update.version}/chapter_notes/#{note.id}.json",
+        patch "/uk/admin/customs_tariff_updates/#{update.version}/chapter_notes/#{note.chapter_id}.json",
               params: { data: { type: 'customs_tariff_chapter_note', attributes: { content: 'Versioned' } } },
               headers: request_headers(format: :json), as: :json
       }.to change { Version.where(item_type: 'CustomsTariffChapterNote', item_id: note.id.to_s).count }.by(1)

--- a/spec/requests/api/admin/customs_tariff_updates/section_notes_controller_spec.rb
+++ b/spec/requests/api/admin/customs_tariff_updates/section_notes_controller_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Api::Admin::CustomsTariffUpdates::SectionNotesController do
 
       expect(response.status).to eq(200)
       note = JSON.parse(response.body)['data'].find { |n| n.dig('attributes', 'section_id') == 1 }
+      expect(note['id']).to eq('1')
       expect(note.dig('attributes', 'file_diff', 'changed_fields')).to include('content')
     end
 
@@ -167,6 +168,20 @@ RSpec.describe Api::Admin::CustomsTariffUpdates::SectionNotesController do
         note_id: note.id,
         whodunnit: 'operator-1',
       )
+    end
+
+    it 'updates when following the JSON:API id from the index response' do
+      get "/uk/admin/customs_tariff_updates/#{update.version}/section_notes.json",
+          headers: request_headers(format: :json)
+
+      response_id = JSON.parse(response.body).dig('data', 0, 'id')
+
+      patch "/uk/admin/customs_tariff_updates/#{update.version}/section_notes/#{response_id}.json",
+            params: { data: { type: 'customs_tariff_section_note', attributes: { content: 'Updated via response id' } } },
+            headers: request_headers(format: :json), as: :json
+
+      expect(response.status).to eq(200)
+      expect(note.reload.content).to eq('Updated via response id')
     end
 
     it 'returns 422 when the parent update is rejected' do

--- a/spec/requests/api/admin/customs_tariff_updates/section_notes_controller_spec.rb
+++ b/spec/requests/api/admin/customs_tariff_updates/section_notes_controller_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Api::Admin::CustomsTariffUpdates::SectionNotesController do
     let!(:note)   { create(:customs_tariff_section_note, customs_tariff_update: update) }
 
     it 'returns the note with a versions array' do
-      get "/uk/admin/customs_tariff_updates/#{update.version}/section_notes/#{note.id}.json",
+      get "/uk/admin/customs_tariff_updates/#{update.version}/section_notes/#{note.section_id}.json",
           headers: request_headers(format: :json)
 
       expect(response.status).to eq(200)
@@ -116,7 +116,7 @@ RSpec.describe Api::Admin::CustomsTariffUpdates::SectionNotesController do
         end
 
         it 'returns file_diff instead of versions' do
-          get "/uk/admin/customs_tariff_updates/#{update.version}/section_notes/#{note.id}.json",
+          get "/uk/admin/customs_tariff_updates/#{update.version}/section_notes/#{note.section_id}.json",
               params: { compare_version: compare_update.version },
               headers: request_headers(format: :json)
 
@@ -135,7 +135,7 @@ RSpec.describe Api::Admin::CustomsTariffUpdates::SectionNotesController do
                                customs_tariff_update: other_update,
                                section_id: 99)
 
-          get "/uk/admin/customs_tariff_updates/#{other_update.version}/section_notes/#{orphan_note.id}.json",
+          get "/uk/admin/customs_tariff_updates/#{other_update.version}/section_notes/#{orphan_note.section_id}.json",
               params: { compare_version: compare_update.version },
               headers: request_headers(format: :json)
 
@@ -155,7 +155,7 @@ RSpec.describe Api::Admin::CustomsTariffUpdates::SectionNotesController do
     end
 
     it 'updates the content' do
-      patch "/uk/admin/customs_tariff_updates/#{update.version}/section_notes/#{note.id}.json",
+      patch "/uk/admin/customs_tariff_updates/#{update.version}/section_notes/#{note.section_id}.json",
             params: { data: { type: 'customs_tariff_section_note', attributes: { content: 'Updated content' } } },
             headers: request_headers({ 'X-Whodunnit' => 'operator-1' }, format: :json), as: :json
 
@@ -172,7 +172,7 @@ RSpec.describe Api::Admin::CustomsTariffUpdates::SectionNotesController do
     it 'returns 422 when the parent update is rejected' do
       update.update(status: CustomsTariffUpdate::REJECTED)
 
-      patch "/uk/admin/customs_tariff_updates/#{update.version}/section_notes/#{note.id}.json",
+      patch "/uk/admin/customs_tariff_updates/#{update.version}/section_notes/#{note.section_id}.json",
             params: { data: { type: 'customs_tariff_section_note', attributes: { content: 'Updated' } } },
             headers: request_headers(format: :json), as: :json
 
@@ -182,7 +182,7 @@ RSpec.describe Api::Admin::CustomsTariffUpdates::SectionNotesController do
 
     it 'creates a Version record on successful save' do
       expect {
-        patch "/uk/admin/customs_tariff_updates/#{update.version}/section_notes/#{note.id}.json",
+        patch "/uk/admin/customs_tariff_updates/#{update.version}/section_notes/#{note.section_id}.json",
               params: { data: { type: 'customs_tariff_section_note', attributes: { content: 'Versioned content' } } },
               headers: request_headers(format: :json), as: :json
       }.to change { Version.where(item_type: 'CustomsTariffSectionNote', item_id: note.id.to_s).count }.by(1)
@@ -194,7 +194,7 @@ RSpec.describe Api::Admin::CustomsTariffUpdates::SectionNotesController do
     let!(:note)   { create(:customs_tariff_section_note, customs_tariff_update: update) }
 
     it 'destroys the note and returns 204' do
-      delete "/uk/admin/customs_tariff_updates/#{update.version}/section_notes/#{note.id}.json",
+      delete "/uk/admin/customs_tariff_updates/#{update.version}/section_notes/#{note.section_id}.json",
              headers: request_headers(format: :json)
 
       expect(response.status).to eq(204)
@@ -204,7 +204,7 @@ RSpec.describe Api::Admin::CustomsTariffUpdates::SectionNotesController do
     it 'returns 422 and does not destroy when the parent update is rejected' do
       update.update(status: CustomsTariffUpdate::REJECTED)
 
-      delete "/uk/admin/customs_tariff_updates/#{update.version}/section_notes/#{note.id}.json",
+      delete "/uk/admin/customs_tariff_updates/#{update.version}/section_notes/#{note.section_id}.json",
              headers: request_headers(format: :json)
 
       expect(response.status).to eq(422)
@@ -214,7 +214,7 @@ RSpec.describe Api::Admin::CustomsTariffUpdates::SectionNotesController do
     it 'returns 404 when the note does not belong to the update' do
       other_update = create(:customs_tariff_update)
 
-      delete "/uk/admin/customs_tariff_updates/#{other_update.version}/section_notes/#{note.id}.json",
+      delete "/uk/admin/customs_tariff_updates/#{other_update.version}/section_notes/#{note.section_id}.json",
              headers: request_headers(format: :json)
 
       expect(response.status).to eq(404)


### PR DESCRIPTION
### Jira link

[AI-516](https://transformuk.atlassian.net/browse/AI-516)

### What?

- [x] Extract Word tables into markdown tables before storing chapter note content.
- [x] Preserve source signal from the DOCX, including run-level bold, hyperlink-wrapped runs, paragraph indentation, visual numbering, source bullets, and grouped table headers.
- [x] Reset visual numbering between logical note blocks so reused Word numbering definitions do not bleed across chapters or sections.
- [x] Normalise known note-shape issues such as compact numbered notes, split paragraph continuations, singleton expression-note wrappers, and omitted additional chapter note numbering.
- [x] Normalise section notes through the same markdown path where appropriate, including removal of the stale Section 15 preamble that is not part of the production note.
- [x] Use stable chapter and section identifiers for admin note lookup endpoints and JSON:API IDs so regenerated notes can be checked without knowing internal row IDs.
- [x] Add regression coverage for representative chapter tables, denaturant tables, source indentation, bold handling, hyperlink text, section-note preambles, stable note lookup paths, and reused numbering identifiers.

### Why?

Without these changes the section/chapter notes do not present properly in the admin UI (and nor will they in the frontend when we come to use them)

The source document contains useful presentation signal that was previously flattened into plain text. Once that signal is lost, admin has to reconstruct tables, lists, emphasis, and indentation from heuristics far away from the original document, which is brittle and difficult to review.

This stores richer markdown at import time, while the source document is still available, so downstream admin previews can render the parsed note content directly.

### Risk

**Risk level:** 🟢

**Reason for rating:** Low risk because this only affects the tariff notes extraction feature that is currently available in staging and is not live in production. It does not change current production journeys or trader-facing behaviour, and the change is covered by focused parser, request, reimport, and rendered-preview checks.

