### PR TITLE
Migrate backend to maintained Excel gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem 'sidekiq-scheduler'
 gem 'opensearch-ruby'
 
 # Reporting
-gem 'fast_excel', git: 'https://github.com/willfish/fast_excel.git', branch: 'HMRC-1866-write-rich-string'
+gem 'uber_fast_excel', git: 'https://github.com/willfish/fast_excel.git', branch: 'master', require: 'fast_excel'
 
 # Diffing
 gem 'diff-lcs'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/willfish/fast_excel.git
-  revision: 1c5fa76c13c75e2962aca6ec5fff509cb85e6acc
+  revision: 21b71a2a9b90a1c73c4b934d6d186edf59b65506
   branch: master
   specs:
     uber_fast_excel (0.6.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/willfish/fast_excel.git
-  revision: b63426e3d056c77bb9df56f25bbe40c6d1e2092b
-  branch: HMRC-1866-write-rich-string
+  revision: 1c5fa76c13c75e2962aca6ec5fff509cb85e6acc
+  branch: master
   specs:
-    fast_excel (0.5.0)
+    uber_fast_excel (0.6.0)
       base64 (>= 0.2, < 2)
       ffi (> 1.17, < 2)
 
@@ -522,7 +522,6 @@ DEPENDENCIES
   dotenv-rails
   engtagger
   factory_bot_rails
-  fast_excel!
   foreman
   forgery
   get_process_mem
@@ -566,6 +565,7 @@ DEPENDENCIES
   sidekiq-scheduler
   simplecov
   slack-notifier
+  uber_fast_excel!
   webmock
 
 RUBY VERSION


### PR DESCRIPTION
## What

Migrate the backend from the abandoned `fast_excel` branch dependency to the maintained `uber_fast_excel` gem source on `willfish/fast_excel` `master`.

The gem is still required as `fast_excel`, so existing `FastExcel` call sites continue to load without application code changes.

## Why

I'm kicking this gem into shape and will migrate it to trade-tariff assuming that's what we want. Basically what I found was its the best gem just unmaintained/with some gaps in test coverage/best practices

The backend was pinned to the `HMRC-1866-write-rich-string` branch of the old gem name. The maintained fork has been promoted under the `uber_fast_excel` gem name and the rich-string changes are now on the main branch.

🟢 Low risk

**Reason for rating:**

Dependency migration only. The backend continues to require the library as `fast_excel`, so existing `FastExcel` call sites are unchanged. The lockfile now points at the maintained `uber_fast_excel` gem source on `willfish/fast_excel` `master`.