### PR TITLE
HMRC-2366 Fix CC incorrectly marked as invalid

### DIFF
--- a/app/services/api/user/active_commodities_service.rb
+++ b/app/services/api/user/active_commodities_service.rb
@@ -56,9 +56,13 @@ module Api
 
         # Find commodities that had children at their creation date
         commodities_with_creation_children = had_children_at_creation(expired_sids)
+        # For commodities that started with children, keep those that became declarable later
+        commodities_ever_declarable = ever_declarable_since_creation(
+          expired_sids.select { |sid| commodities_with_creation_children[sid] },
+        )
 
         expired_candidates
-          .reject { |sid, _| commodities_with_creation_children[sid] }
+          .reject { |sid, _| commodities_with_creation_children[sid] && !commodities_ever_declarable[sid] }
           .map { |sid, code| [sid, code] }
       end
 
@@ -69,7 +73,7 @@ module Api
           .where(goods_nomenclature_sid: goods_nomenclature_sids)
           .select(:goods_nomenclature_sid, :validity_start_date)
           .all
-          .map { |gn| [gn.goods_nomenclature_sid, gn.validity_start_date] }
+          .map { |gn| [gn.goods_nomenclature_sid, gn.validity_start_date.to_date] }
 
         results = {}
 
@@ -92,6 +96,52 @@ module Api
         end
 
         results
+      end
+
+      def self.ever_declarable_since_creation(goods_nomenclature_sids)
+        return {} if goods_nomenclature_sids.empty?
+
+        parents = GoodsNomenclature
+          .where(goods_nomenclature_sid: goods_nomenclature_sids)
+          .eager(:historical_children)
+          .all
+
+        parents.each_with_object({}) do |parent, results|
+          child_periods = parent.historical_children
+                               .map { |child| [child.validity_start_date.to_date, child.validity_end_date&.to_date] }
+                               .uniq
+                               .sort_by(&:first)
+
+          results[parent.goods_nomenclature_sid] = declarable_period_exists?(
+            parent.validity_start_date.to_date,
+            parent.validity_end_date&.to_date,
+            child_periods,
+          )
+        end
+      end
+
+      # A commodity was declarable if there is any day in its validity window not covered by a child.
+      def self.declarable_period_exists?(parent_start_date, parent_end_date, child_periods)
+        return true if child_periods.empty?
+
+        covered_until = parent_start_date
+
+        child_periods.each do |child_start_date, child_end_date|
+          return true if child_start_date > covered_until
+
+          if child_end_date.nil?
+            # Open-ended child covers everything from child_start_date onwards
+            return false
+          end
+
+          covered_until = [covered_until, child_end_date + 1].max
+        end
+
+        if parent_end_date
+          covered_until <= parent_end_date
+        else
+          child_periods.last.last.present?
+        end
       end
 
       def initialize(subscription)

--- a/spec/services/api/user/active_commodities_service_spec.rb
+++ b/spec/services/api/user/active_commodities_service_spec.rb
@@ -184,6 +184,64 @@ RSpec.describe Api::User::ActiveCommoditiesService do
       expired_sids = result.map(&:first)
       expect(expired_sids).not_to include(666)
     end
+
+    it 'excludes commodities covered by an open-ended child from creation even if a later child also exists' do
+      start_date = 2.years.ago.beginning_of_day
+
+      parent_commodity = create(:commodity, :non_grouping,
+                                goods_nomenclature_item_id: '2233333333',
+                                goods_nomenclature_sid: 663,
+                                validity_start_date: start_date,
+                                validity_end_date: nil)
+
+      create(:commodity, :non_grouping,
+             goods_nomenclature_item_id: '2233333334',
+             goods_nomenclature_sid: 662,
+             validity_start_date: start_date,
+             validity_end_date: nil,
+             parent: parent_commodity)
+
+      create(:commodity, :non_grouping,
+             goods_nomenclature_item_id: '2233333335',
+             goods_nomenclature_sid: 661,
+             validity_start_date: 1.year.ago.beginning_of_day,
+             validity_end_date: nil,
+             parent: parent_commodity)
+
+      result = described_class.all_expired_commodities(target_sids: [663])
+
+      expired_sids = result.map(&:first)
+      expect(expired_sids).not_to include(663)
+    end
+
+    it 'includes commodities that started as subheading, became declarable, then became subheading again' do
+      parent_start_date = 3.years.ago.beginning_of_day
+
+      parent_commodity = create(:commodity, :non_grouping,
+                                goods_nomenclature_item_id: '3333333333',
+                                goods_nomenclature_sid: 333,
+                                validity_start_date: parent_start_date,
+                                validity_end_date: nil)
+
+      create(:commodity, :non_grouping,
+             goods_nomenclature_item_id: '3333333334',
+             goods_nomenclature_sid: 334,
+             validity_start_date: parent_start_date,
+             validity_end_date: 2.years.ago.beginning_of_day,
+             parent: parent_commodity)
+
+      create(:commodity, :non_grouping,
+             goods_nomenclature_item_id: '3333333335',
+             goods_nomenclature_sid: 335,
+             validity_start_date: 1.year.ago.beginning_of_day,
+             validity_end_date: nil,
+             parent: parent_commodity)
+
+      result = described_class.all_expired_commodities
+
+      expired_sids = result.map(&:first)
+      expect(expired_sids).to include(333)
+    end
   end
 
   describe '#initialize' do


### PR DESCRIPTION
## What:
Commodity Code 9403208000 has recently had children added. It is being incorrectly identified as invalid for CCWL when it should be expired.
The issue is that an assumption was made that a declarable CC would have started in that state, but this one originally had children, later became declarable and now has children again.

A check has been added when finding expired candidates to check whether it was ever declarable in its lifetime.

## Why:
Correctly bucket CCs as active, expired and invalid for CCWL.

## Ticket:
[<!-- Link to the relevant Jira/ticket, or 'N/A' if not applicable -->](https://transformuk.atlassian.net/browse/HMRC-2366)

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Fixes a bug so makes data better.
