### PR TITLE
Auto-apply low-risk label to all dependabot PRs

### DIFF
--- a/.github/workflows/risk-label.yml
+++ b/.github/workflows/risk-label.yml
@@ -6,7 +6,48 @@ on:
 
 jobs:
   risk-label:
+    if: github.actor != 'dependabot[bot]'
     uses: trade-tariff/trade-tariff-tools/.github/workflows/risk-label-reusable.yml@main
     permissions:
       contents: read
       pull-requests: write
+
+  risk-label-dependabot:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Apply low-risk label to dependabot PR
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const RISK_LABELS = ['low-risk', 'medium-risk', 'high-risk'];
+            const prNumber = context.payload.pull_request.number;
+
+            const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            for (const label of currentLabels) {
+              if (RISK_LABELS.includes(label.name) && label.name !== 'low-risk') {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  name: label.name,
+                });
+              }
+            }
+
+            if (!currentLabels.find(l => l.name === 'low-risk')) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                labels: ['low-risk'],
+              });
+            }


### PR DESCRIPTION
## What:
Add a dedicated `risk-label-dependabot` job to the Risk Label workflow that automatically applies the `low-risk` label to any PR opened by `dependabot[bot]`, and skip the existing reusable workflow job for those PRs.

## Why:
Dependabot PRs are dependency bumps with no API changes — they fall squarely in the 🟢 low-risk category per our own template. Running the standard risk-label check against them fails because dependabot PRs don't have a PR body with the required risk emoji, causing the check to error unnecessarily.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
CI/CD workflow change that only affects label assignment on dependabot PRs. No production code or infrastructure is touched.