### PR TITLE
AI-884: Preserve source-driven tariff note indentation

### DIFF
--- a/app/lib/customs_tariff_importer/notes_extractor.rb
+++ b/app/lib/customs_tariff_importer/notes_extractor.rb
@@ -8,6 +8,7 @@ module CustomsTariffImporter
     CHAPTER_PATTERN          = /\ACHAPTER\s+(\d+)\z/
     CHAPTER_NOTES_PATTERN    = /\AChapter\s+[Nn]otes?\z/i
     ADDITIONAL_NOTES_PATTERN = /\AAdditional\s+[Cc]hapter\s+[Nn]otes?\z/i
+    ADDITIONAL_SECTION_NOTES_PATTERN = /\AAdditional\s+[Ss]ection\s+[Nn]otes?\z/i
     SUBHEADING_NOTES_PATTERN = /\ASubheading\s+[Nn]otes?\z/i
     SECTION_NOTES_PATTERN    = /\ASection\s+[Nn]otes?\z/i
     GENERAL_RULES_PATTERN    = /\AGeneral\s+Interpretive\s+Rules?\z/i
@@ -266,6 +267,7 @@ module CustomsTariffImporter
       @general_rules[@current_rule] = content if content.present?
       @current_rule = nil
       @note_lines = []
+      @formatter.reset_note_formatting_context
     end
 
     def append_note_line(text)

--- a/app/lib/customs_tariff_importer/notes_extractor/formatter.rb
+++ b/app/lib/customs_tariff_importer/notes_extractor/formatter.rb
@@ -30,6 +30,8 @@ module CustomsTariffImporter
       def reset_note_formatting_context
         @in_numbered_note = false
         @in_nested_numbered_subnote = false
+        @in_source_indented_marker_list = false
+        @source_indented_marker_list_closed = false
         @last_top_level_note_number = nil
         @previous_markdown_bullet_indent = nil
         @current_paragraph = nil
@@ -73,12 +75,17 @@ module CustomsTariffImporter
           style:,
           text: paragraph_text(para),
           indent: paragraph_indent(para),
+          first_line_indent: paragraph_first_line_indent(para),
           numbering: paragraph_numbering(para),
         }
       end
 
       def paragraph_indent(para)
         para.at_xpath('./w:pPr/w:ind', WORD_NS)&.attr('w:left').to_i
+      end
+
+      def paragraph_first_line_indent(para)
+        para.at_xpath('./w:pPr/w:ind', WORD_NS)&.attr('w:firstLine').to_i
       end
 
       def paragraph_numbering(para)
@@ -267,6 +274,7 @@ module CustomsTariffImporter
         return "    #{text}" if nested_numbered_note?(text)
         return text if numbered_note?(text)
         return markdown_bullet_line(text) if source_bullet_line?(text)
+        return missing_source_bullet_line(text) if missing_source_bullet_line?(text)
         return "    #{text.sub(/\A\s*/, '')}" if @in_numbered_note
 
         text
@@ -280,9 +288,22 @@ module CustomsTariffImporter
           return
         end
 
+        if source_indented_marker_line?(formatted)
+          @in_source_indented_marker_list = true
+          @source_indented_marker_list_closed = false
+          @previous_markdown_bullet_indent = nil
+          return
+        end
+
+        if source_indented_marker_list_ended?(text)
+          @in_source_indented_marker_list = false
+          @source_indented_marker_list_closed = true
+        end
+
         if nested_numbered_subnote_start?(text)
           @in_numbered_note = true
           @in_nested_numbered_subnote = true
+          @source_indented_marker_list_closed = false
           @previous_markdown_bullet_indent = nil
           return
         end
@@ -297,6 +318,7 @@ module CustomsTariffImporter
         @in_nested_numbered_subnote = false if @in_nested_numbered_subnote && !numbered_note?(formatted)
         if numbered_note?(formatted)
           @in_numbered_note = true
+          @source_indented_marker_list_closed = false
           @last_top_level_note_number = formatted[/\A([1-9]\d*)\./, 1].to_i unless @in_nested_numbered_subnote
         end
         @previous_markdown_bullet_indent =
@@ -371,6 +393,16 @@ module CustomsTariffImporter
         "#{'    ' if @in_numbered_note}- #{bullet_text}"
       end
 
+      def missing_source_bullet_line?(text)
+        @previous_markdown_bullet_indent &&
+          paragraph_first_line_indent_level.positive? &&
+          text.match?(/\A\S/)
+      end
+
+      def missing_source_bullet_line(text)
+        "#{' ' * @previous_markdown_bullet_indent}- #{text.sub(/\A\s*/, '')}"
+      end
+
       def indented_marker?(text)
         paragraph_indent_level.positive? && indented_marker_text?(text)
       end
@@ -394,6 +426,10 @@ module CustomsTariffImporter
 
       def paragraph_indent_level
         (@current_paragraph&.fetch(:indent, 0).to_i / 720).clamp(0, 3)
+      end
+
+      def paragraph_first_line_indent_level
+        (@current_paragraph&.fetch(:first_line_indent, 0).to_i / 720).clamp(0, 3)
       end
 
       def indented_marker_text?(text)
@@ -424,6 +460,16 @@ module CustomsTariffImporter
         text.match?(/\A(?:and|or|(?:not\s+)?less than|more than|\d+(?:[.,]\d+)?\s*(?:%|W|mm|cm|g|kg)(?=\s|$))/i)
       end
 
+      def source_indented_marker_list_ended?(text)
+        @in_source_indented_marker_list &&
+          paragraph_indent_level.zero? &&
+          !indented_marker_text?(text)
+      end
+
+      def in_closed_source_indented_marker_list?
+        @source_indented_marker_list_closed && paragraph_indent_level.zero?
+      end
+
       def note_section_heading?(text)
         plain_note_section_heading?(text) || markdown_note_section_heading?(text)
       end
@@ -448,6 +494,8 @@ module CustomsTariffImporter
           (markdown_bullet?(lines.last) ||
            note_section_heading?(formatted) ||
            markdown_bullet?(formatted) ||
+           source_indented_marker_list_ended?(formatted) ||
+           closed_source_indented_marker_list_paragraph?(formatted) ||
            source_indented_marker_line?(formatted) ||
            source_indented_marker_continuation?(formatted, lines) ||
            nested_numbered_subnote?(formatted) ||
@@ -470,6 +518,12 @@ module CustomsTariffImporter
 
         lines.last.to_s.match?(/\A\s+(?:[a-z]\.|\([A-Z]\)|\([ivxlcdm]+\)|[ivxlcdm]+\.|\(\d+\))\s+\S/i) &&
           formatted.match?(/\A\s+\S/)
+      end
+
+      def closed_source_indented_marker_list_paragraph?(formatted)
+        in_closed_source_indented_marker_list? &&
+          !note_section_heading?(formatted) &&
+          !numbered_note?(formatted)
       end
 
       def variable_definition_paragraph?(text)

--- a/app/lib/customs_tariff_importer/notes_extractor/formatter.rb
+++ b/app/lib/customs_tariff_importer/notes_extractor/formatter.rb
@@ -91,23 +91,23 @@ module CustomsTariffImporter
         end
 
         def observe(formatted, in_numbered_note:, paragraph_indent_level:, paragraph_first_line_indent_level:)
-          if source_child_marker_line?(formatted, paragraph_indent_level:) ||
-              first_line_source_child_marker_line?(formatted, paragraph_indent_level:, paragraph_first_line_indent_level:)
+          if (paragraph_indent_level.positive? && formatted.match?(SOURCE_CHILD_MARKER_LINE_PATTERN)) ||
+              (paragraph_indent_level.zero? && paragraph_first_line_indent_level.positive? && self.class.marker_line?(formatted, :child))
             marker = self.class.marker_from_line(formatted)
             @active_child_family = self.class.child_marker_family(marker) if marker
             @pending_parent_depth
-          elsif source_parent_marker_line?(formatted, paragraph_indent_level:)
-            @pending_parent_depth = formatted_indent_level(formatted)
-            @active_child_family = nil
-          elsif first_line_source_parent_marker_line?(formatted, paragraph_indent_level:, paragraph_first_line_indent_level:)
-            @pending_parent_depth = formatted_indent_level(formatted)
-            @active_child_family = nil
-          elsif logical_parent_marker_line?(formatted, in_numbered_note:)
+          elsif (paragraph_indent_level.positive? && formatted.match?(SOURCE_PARENT_MARKER_LINE_PATTERN)) ||
+              (paragraph_indent_level.zero? && paragraph_first_line_indent_level.positive? && self.class.marker_line?(formatted, :parent)) ||
+              (in_numbered_note && self.class.marker_line?(formatted, :parent))
             @pending_parent_depth = formatted_indent_level(formatted)
             @active_child_family = nil
           else
             reset
           end
+        end
+
+        def self.source_marker_line?(line)
+          line.to_s.match?(SOURCE_MARKER_LINE_PATTERN)
         end
 
         def self.marker_text?(text)
@@ -122,48 +122,10 @@ module CustomsTariffImporter
           text.match?(ROMAN_MARKER_TEXT_PATTERN)
         end
 
-        def self.child_marker_text?(text)
-          text.match?(CHILD_MARKER_TEXT_PATTERN)
-        end
-
-        def self.bullet_marker_text?(text)
-          roman_marker_text?(text)
-        end
-
-        def self.parent_line?(line)
-          parsed_line(line)&.then { |marker| marker[:indent_level].positive? && parent_marker?(marker[:text]) }
-        end
-
-        def self.first_parent_line?(line)
-          parsed_line(line)&.then { |marker| marker[:indent_level].positive? && first_parent_marker?(marker[:text]) }
-        end
-
-        def self.promotable_parent_line?(line)
-          parsed_line(line)&.then { |marker| marker[:indent_level].positive? && promotable_parent_marker?(marker[:text]) }
-        end
-
-        def self.child_line?(line)
-          parsed_line(line)&.then { |marker| marker[:indent_level].positive? && child_marker?(marker[:text]) }
-        end
-
-        def self.first_child_line?(line)
-          parsed_line(line)&.then { |marker| marker[:indent_level].positive? && first_child_marker?(marker[:text]) }
-        end
-
-        def self.source_marker_line?(line)
-          line.to_s.match?(SOURCE_MARKER_LINE_PATTERN)
-        end
-
-        def self.child_line_deeper_than?(line, parent_indent_level)
-          parsed_line(line)&.then { |marker| marker[:indent_level] > parent_indent_level && child_marker?(marker[:text]) }
-        end
-
-        def self.first_child_line_deeper_than?(line, parent_indent_level)
-          parsed_line(line)&.then { |marker| marker[:indent_level] > parent_indent_level && first_child_marker?(marker[:text]) }
-        end
-
-        def self.roman_child_line_deeper_than?(line, parent_indent_level)
-          parsed_line(line)&.then { |marker| marker[:indent_level] > parent_indent_level && roman_child_marker?(marker[:text]) }
+        def self.marker_line?(line, kind, min_indent: 1)
+          parsed_line(line)&.then do |marker|
+            marker[:indent_level] >= min_indent && public_send("#{kind}_marker?", marker[:text])
+          end
         end
 
         def self.indent_level(line)
@@ -220,31 +182,6 @@ module CustomsTariffImporter
         private_class_method :parsed_line
 
         private
-
-        def source_parent_marker_line?(formatted, paragraph_indent_level:)
-          paragraph_indent_level.positive? &&
-            formatted.match?(SOURCE_PARENT_MARKER_LINE_PATTERN)
-        end
-
-        def first_line_source_parent_marker_line?(formatted, paragraph_indent_level:, paragraph_first_line_indent_level:)
-          paragraph_indent_level.zero? &&
-            paragraph_first_line_indent_level.positive? &&
-            self.class.parent_line?(formatted)
-        end
-
-        def logical_parent_marker_line?(formatted, in_numbered_note:)
-          in_numbered_note && self.class.parent_line?(formatted)
-        end
-
-        def source_child_marker_line?(formatted, paragraph_indent_level:)
-          paragraph_indent_level.positive? && formatted.match?(SOURCE_CHILD_MARKER_LINE_PATTERN)
-        end
-
-        def first_line_source_child_marker_line?(formatted, paragraph_indent_level:, paragraph_first_line_indent_level:)
-          paragraph_indent_level.zero? &&
-            paragraph_first_line_indent_level.positive? &&
-            self.class.child_line?(formatted)
-        end
 
         def formatted_indent_level(formatted)
           formatted[/\A */].length / 4
@@ -661,7 +598,7 @@ module CustomsTariffImporter
       def first_line_indented_marker?(text)
         paragraph_indent_level.zero? &&
           paragraph_first_line_indent_level.positive? &&
-          indented_marker_text?(text)
+          MarkerTrie.marker_text?(text)
       end
 
       def first_line_indented_marker_line(text)
@@ -674,7 +611,7 @@ module CustomsTariffImporter
       end
 
       def indented_marker?(text)
-        paragraph_indent_level.positive? && indented_marker_text?(text)
+        paragraph_indent_level.positive? && MarkerTrie.marker_text?(text)
       end
 
       def child_indented_marker?(text)
@@ -687,14 +624,14 @@ module CustomsTariffImporter
       end
 
       def indented_marker_indent_level(text)
-        return 1 if alphabetic_marker_text?(text) && !roman_marker_text?(text)
+        return 1 if MarkerTrie.alphabetic_marker_text?(text) && !MarkerTrie.roman_marker_text?(text)
         return @marker_trie.child_indent_level(text) if @marker_trie.child_indent_level(text)
 
         [paragraph_indent_level, 1].min
       end
 
       def indented_marker_prefix(text)
-        bullet_marker_text?(text) ? '- ' : ''
+        MarkerTrie.roman_marker_text?(text) && @marker_trie.child_indent_level(text) ? '- ' : ''
       end
 
       def paragraph_indent_level
@@ -705,22 +642,6 @@ module CustomsTariffImporter
         (@current_paragraph&.fetch(:first_line_indent, 0).to_i / 720).clamp(0, 3)
       end
 
-      def indented_marker_text?(text)
-        MarkerTrie.marker_text?(text)
-      end
-
-      def alphabetic_marker_text?(text)
-        MarkerTrie.alphabetic_marker_text?(text)
-      end
-
-      def roman_marker_text?(text)
-        MarkerTrie.roman_marker_text?(text)
-      end
-
-      def bullet_marker_text?(text)
-        MarkerTrie.bullet_marker_text?(text)
-      end
-
       def bullet_continuation_line?(text)
         text.match?(/\A(?:and|or|(?:not\s+)?less than|more than|\d+(?:[.,]\d+)?\s*(?:%|W|mm|cm|g|kg)(?=\s|$))/i)
       end
@@ -728,7 +649,7 @@ module CustomsTariffImporter
       def source_indented_marker_list_ended?(text)
         @in_source_indented_marker_list &&
           paragraph_indent_level.zero? &&
-          !indented_marker_text?(text)
+          !MarkerTrie.marker_text?(text)
       end
 
       def in_closed_source_indented_marker_list?
@@ -912,7 +833,7 @@ module CustomsTariffImporter
       def normalize_source_nested_marker_lists(lines)
         index = 0
         while index < lines.length
-          if promotable_parent_marker_line?(lines[index])
+          if MarkerTrie.marker_line?(lines[index], :promotable_parent)
             index = normalize_source_nested_marker_list(lines, index)
           else
             index += 1
@@ -991,8 +912,8 @@ module CustomsTariffImporter
       def normalize_source_nested_marker_list(lines, start_index)
         parent_indices, child_indices, stop_index, parent_indent_level = source_nested_marker_group(lines, start_index)
         return start_index + 1 if child_indices.empty?
-        return start_index + 1 if uppercase_parent_marker_line?(lines[start_index]) &&
-          !roman_child_marker_line?(lines[child_indices.first], parent_indent_level)
+        return start_index + 1 if MarkerTrie.uppercase_parent_marker?(MarkerTrie.marker_from_line(lines[start_index]).to_s) &&
+          !MarkerTrie.marker_line?(lines[child_indices.first], :roman_child, min_indent: parent_indent_level.to_i + 1)
 
         parent_indices.each do |index|
           lines[index] = marker_list_line(lines[index], indent_level: MarkerTrie.indent_level(lines[index]), bullet: true)
@@ -1030,16 +951,21 @@ module CustomsTariffImporter
 
         loop do
           index = next_content_line_index(lines, index)
-          break unless index && parent_marker_line?(lines[index])
+          break unless index && MarkerTrie.marker_line?(lines[index], :parent)
 
           parent_indices << index
           parent_indent_level = MarkerTrie.indent_level(lines[index])
           index += 1
 
           while (index = next_content_line_index(lines, index))
-            break if parent_marker_line?(lines[index])
-            return [parent_indices, child_indices, index, parent_indent_level] unless child_marker_line?(lines[index], parent_indent_level)
-            return [parent_indices, [], index, parent_indent_level] if child_indices.empty? && !first_child_marker_line?(lines[index], parent_indent_level)
+            break if MarkerTrie.marker_line?(lines[index], :parent)
+            unless MarkerTrie.marker_line?(lines[index], :child, min_indent: parent_indent_level.to_i + 1)
+              return [parent_indices, child_indices, index, parent_indent_level]
+            end
+            if child_indices.empty? &&
+                !MarkerTrie.marker_line?(lines[index], :first_child, min_indent: parent_indent_level.to_i + 1)
+              return [parent_indices, [], index, parent_indent_level]
+            end
 
             child_indices << index
             index += 1
@@ -1049,34 +975,6 @@ module CustomsTariffImporter
         end
 
         [parent_indices, child_indices, index || lines.length, parent_indent_level]
-      end
-
-      def parent_marker_line?(line)
-        MarkerTrie.parent_line?(line)
-      end
-
-      def first_parent_marker_line?(line)
-        MarkerTrie.first_parent_line?(line)
-      end
-
-      def promotable_parent_marker_line?(line)
-        MarkerTrie.promotable_parent_line?(line)
-      end
-
-      def uppercase_parent_marker_line?(line)
-        MarkerTrie.uppercase_parent_marker?(MarkerTrie.marker_from_line(line).to_s)
-      end
-
-      def child_marker_line?(line, parent_indent_level = 0)
-        MarkerTrie.child_line_deeper_than?(line, parent_indent_level)
-      end
-
-      def first_child_marker_line?(line, parent_indent_level = 0)
-        MarkerTrie.first_child_line_deeper_than?(line, parent_indent_level)
-      end
-
-      def roman_child_marker_line?(line, parent_indent_level = 0)
-        MarkerTrie.roman_child_line_deeper_than?(line, parent_indent_level)
       end
 
       def normalize_lettered_paragraph_lists(lines)

--- a/app/lib/customs_tariff_importer/notes_extractor/formatter.rb
+++ b/app/lib/customs_tariff_importer/notes_extractor/formatter.rb
@@ -311,6 +311,7 @@ module CustomsTariffImporter
         end
 
         normalize_source_nested_marker_lists(lines)
+        normalize_semantic_numeric_marker_lists(lines)
         normalize_plain_marker_code_block_indents(lines)
         normalize_indented_marker_spacing(lines) if section
         normalize_lettered_paragraph_lists(lines)
@@ -923,6 +924,61 @@ module CustomsTariffImporter
         lines.map! do |line|
           plain_deep_marker_line?(line) ? marker_list_line(line, indent_level: 1, bullet: false) : line
         end
+      end
+
+      def normalize_semantic_numeric_marker_lists(lines)
+        index = 0
+        while index < lines.length
+          if semantic_numeric_marker_list_lead_in?(lines[index])
+            first_item_index = next_content_line_index(lines, index + 1)
+            if first_item_index && first_semantic_numeric_marker_line?(lines[first_item_index], lines[index])
+              normalize_semantic_numeric_marker_list(lines, first_item_index, line_indent_level(lines[index]))
+            end
+          end
+
+          index += 1
+        end
+      end
+
+      def normalize_semantic_numeric_marker_list(lines, start_index, indent_level)
+        index = start_index
+        while index < lines.length
+          index = next_content_line_index(lines, index)
+          break unless index && semantic_numeric_marker_line?(lines[index])
+
+          lines[index] = marker_list_line(lines[index], indent_level:, bullet: true)
+          index += 1
+        end
+      end
+
+      def semantic_numeric_marker_list_lead_in?(line)
+        line_indent_level(line) == 1 &&
+          semantic_numeric_marker_list_lead_in_marker?(line) &&
+          line.to_s.strip.end_with?(':')
+      end
+
+      def semantic_numeric_marker_list_lead_in_marker?(line)
+        marker = MarkerTrie.marker_from_line(line).to_s
+
+        marker.blank? || marker.match?(/\A(?:[a-z]|ij)\.\z/i)
+      end
+
+      def first_semantic_numeric_marker_line?(line, lead_in)
+        lead_in_indent_level = line_indent_level(lead_in)
+
+        semantic_numeric_marker_line?(line) &&
+          [lead_in_indent_level, lead_in_indent_level + 1].include?(MarkerTrie.indent_level(line)) &&
+          MarkerTrie.marker_from_line(line) == '(1)'
+      end
+
+      def semantic_numeric_marker_line?(line)
+        MarkerTrie.indent_level(line).to_i.positive? &&
+          MarkerTrie.marker_from_line(line).to_s.match?(/\A\(\d+\)\z/) &&
+          !markdown_bullet?(line)
+      end
+
+      def line_indent_level(line)
+        line.to_s[/\A */].length / 4
       end
 
       def plain_deep_marker_line?(line)

--- a/app/lib/customs_tariff_importer/notes_extractor/formatter.rb
+++ b/app/lib/customs_tariff_importer/notes_extractor/formatter.rb
@@ -118,6 +118,7 @@ module CustomsTariffImporter
           text.match?(CHAPTER_PATTERN) ||
           text.match?(CHAPTER_NOTES_PATTERN) ||
           text.match?(ADDITIONAL_NOTES_PATTERN) ||
+          text.match?(ADDITIONAL_SECTION_NOTES_PATTERN) ||
           text.match?(SUBHEADING_NOTES_PATTERN) ||
           text.match?(SECTION_NOTES_PATTERN) ||
           text.match?(GENERAL_RULES_PATTERN) ||
@@ -428,11 +429,13 @@ module CustomsTariffImporter
       end
 
       def plain_note_section_heading?(text)
-        text.match?(ADDITIONAL_NOTES_PATTERN) || text.match?(SUBHEADING_NOTES_PATTERN)
+        text.match?(ADDITIONAL_NOTES_PATTERN) ||
+          text.match?(ADDITIONAL_SECTION_NOTES_PATTERN) ||
+          text.match?(SUBHEADING_NOTES_PATTERN)
       end
 
       def markdown_note_section_heading?(text)
-        text.match?(/\A###\s+(?:Additional\s+[Cc]hapter\s+[Nn]otes?|Subheading\s+[Nn]otes?)\z/i)
+        text.match?(/\A###\s+(?:Additional\s+(?:[Cc]hapter|[Ss]ection)\s+[Nn]otes?|Subheading\s+[Nn]otes?)\z/i)
       end
 
       def markdown_note_section_heading(text)
@@ -443,6 +446,7 @@ module CustomsTariffImporter
         formatted.present? &&
           lines.last.present? &&
           (markdown_bullet?(lines.last) ||
+           note_section_heading?(formatted) ||
            markdown_bullet?(formatted) ||
            source_indented_marker_line?(formatted) ||
            source_indented_marker_continuation?(formatted, lines) ||

--- a/app/lib/customs_tariff_importer/notes_extractor/formatter.rb
+++ b/app/lib/customs_tariff_importer/notes_extractor/formatter.rb
@@ -57,14 +57,15 @@ module CustomsTariffImporter
 
       class MarkerHierarchy
         ROMAN_MARKER_PATTERN = /(?:i{1,3}|iv|v|vi{0,3}|ix)/i
-        MARKER_TEXT_PATTERN = /\A(?:[a-z]\.|\([A-Z]\)|\([ivxlcdm]+\)|[ivxlcdm]+\.|\(\d+\)|\d+\.)\s+\S/i
-        ALPHABETIC_MARKER_TEXT_PATTERN = /\A[a-z]\.\s+\S/i
+        ALPHABETIC_DOTTED_MARKER_PATTERN = /(?:[a-z]|ij)\./i
+        MARKER_TEXT_PATTERN = /\A(?:#{ALPHABETIC_DOTTED_MARKER_PATTERN}|\([A-Z]\)|\([ivxlcdm]+\)|[ivxlcdm]+\.|\(\d+\)|\d+\.)\s+\S/i
+        ALPHABETIC_MARKER_TEXT_PATTERN = /\A#{ALPHABETIC_DOTTED_MARKER_PATTERN}\s+\S/i
         ROMAN_MARKER_TEXT_PATTERN = /\A#{ROMAN_MARKER_PATTERN}\.\s+\S/
         UPPERCASE_BRACKET_MARKER_TEXT_PATTERN = /\A\([A-Z]\)\s+\S/
         CHILD_MARKER_TEXT_PATTERN = /\A(?:\(\d+\)|\d+\.|#{ROMAN_MARKER_PATTERN}\.|\(#{ROMAN_MARKER_PATTERN}\))\s+\S/
-        SOURCE_MARKER_LINE_PATTERN = /\A\s+(?:-\s+)?(?:[a-z]\.|\([A-Z]\)|\([ivxlcdm]+\)|[ivxlcdm]+\.|\(\d+\)|\d+\.)\s+\S/i
-        MARKER_LINE_PATTERN = /\A(?<spaces> *)(?:-\s+)?(?<marker>\(\d+\)|\d+\.|[a-z]\.|\([a-z]+\))\s+\S/i
-        SOURCE_PARENT_MARKER_LINE_PATTERN = /\A\s+(?:-\s+)?(?:[a-z]\.|\((?![ivx]+\))[a-z]\))\s+\S/i
+        SOURCE_MARKER_LINE_PATTERN = /\A\s+(?:-\s+)?(?:#{ALPHABETIC_DOTTED_MARKER_PATTERN}|\([A-Z]\)|\([ivxlcdm]+\)|[ivxlcdm]+\.|\(\d+\)|\d+\.)\s+\S/i
+        MARKER_LINE_PATTERN = /\A(?<spaces> *)(?:-\s+)?(?<marker>\(\d+\)|\d+\.|ij\.|#{ROMAN_MARKER_PATTERN}\.|[a-z]\.|\([a-z]+\))\s+\S/i
+        SOURCE_PARENT_MARKER_LINE_PATTERN = /\A\s+(?:-\s+)?(?:#{ALPHABETIC_DOTTED_MARKER_PATTERN}|\((?![ivx]+\))[a-z]\))\s+\S/i
         SOURCE_CHILD_MARKER_LINE_PATTERN = /\A\s+(?:-\s+)?(?:\(\d+\)|\d+\.|#{ROMAN_MARKER_PATTERN}\.|\(#{ROMAN_MARKER_PATTERN}\))\s+\S/
 
         def initialize
@@ -73,22 +74,38 @@ module CustomsTariffImporter
 
         def reset
           @pending_parent_depth = nil
+          @active_child_family = nil
         end
 
         def child_indent_level(text)
-          @pending_parent_depth + 1 if self.class.child_marker_text?(text) && @pending_parent_depth
+          return unless @pending_parent_depth
+
+          marker = self.class.marker_from_text(text)
+          return unless marker && self.class.child_marker?(marker)
+
+          family = self.class.child_marker_family(marker)
+          if @active_child_family
+            @pending_parent_depth + 1 if family == @active_child_family
+          elsif self.class.first_child_marker?(marker)
+            @pending_parent_depth + 1
+          end
         end
 
         def observe(formatted, in_numbered_note:, paragraph_indent_level:, paragraph_first_line_indent_level:)
           if source_child_marker_line?(formatted, paragraph_indent_level:) ||
               first_line_source_child_marker_line?(formatted, paragraph_indent_level:, paragraph_first_line_indent_level:)
+            marker = self.class.marker_from_line(formatted)
+            @active_child_family = self.class.child_marker_family(marker) if marker
             @pending_parent_depth
           elsif source_parent_marker_line?(formatted, paragraph_indent_level:)
             @pending_parent_depth = formatted_indent_level(formatted)
+            @active_child_family = nil
           elsif first_line_source_parent_marker_line?(formatted, paragraph_indent_level:, paragraph_first_line_indent_level:)
             @pending_parent_depth = formatted_indent_level(formatted)
+            @active_child_family = nil
           elsif logical_parent_marker_line?(formatted, in_numbered_note:)
             @pending_parent_depth = formatted_indent_level(formatted)
+            @active_child_family = nil
           else
             reset
           end
@@ -142,6 +159,14 @@ module CustomsTariffImporter
           parsed_line(line)&.fetch(:indent_level)
         end
 
+        def self.marker_from_text(text)
+          text.to_s.match(MARKER_LINE_PATTERN)&.[](:marker)
+        end
+
+        def self.marker_from_line(line)
+          parsed_line(line)&.fetch(:text)
+        end
+
         def self.parsed_line(line)
           return unless (match = line.to_s.match(MARKER_LINE_PATTERN))
 
@@ -149,7 +174,7 @@ module CustomsTariffImporter
         end
 
         def self.parent_marker?(marker)
-          marker.match?(/\A[a-z]\.\z/i) || marker.match?(/\A\((?![ivx]+\))[a-z]+\)\z/i)
+          marker.match?(/\A#{ALPHABETIC_DOTTED_MARKER_PATTERN}\z/i) || marker.match?(/\A\((?![ivx]+\))[a-z]+\)\z/i)
         end
 
         def self.child_marker?(marker)
@@ -160,7 +185,11 @@ module CustomsTariffImporter
           marker.match?(/\A(?:1\.|\(1\)|i\.|\(i\))\z/i)
         end
 
-        private_class_method :parsed_line, :parent_marker?, :child_marker?, :first_child_marker?
+        def self.child_marker_family(marker)
+          marker.match?(/\A(?:\d+\.|\(\d+\))\z/) ? :number : :roman
+        end
+
+        private_class_method :parsed_line
 
         private
 
@@ -759,7 +788,7 @@ module CustomsTariffImporter
       end
 
       def final_indented_marker_line?(line)
-        line.to_s.match?(/\A {4}(?:[a-z]{1,4}[.)]|\([a-z]\)|\([A-Z]\)|\([1-9]\d*\)|[ivxlcdm]+\.)\s+\S/i)
+        MarkerHierarchy.indent_level(line).to_i.positive? && MarkerHierarchy.marker_from_line(line).present?
       end
 
       def normalize_omitted_additional_chapter_note_one(lines)
@@ -808,16 +837,32 @@ module CustomsTariffImporter
         parent_indices, child_indices, stop_index, parent_indent_level = source_nested_marker_group(lines, start_index)
         return start_index + 1 if child_indices.empty?
 
-        parent_indices.each { |index| lines[index] = lines[index].sub(/\A {4}/, '    - ') }
+        parent_indices.each do |index|
+          lines[index] = marker_list_line(lines[index], indent_level: MarkerHierarchy.indent_level(lines[index]), bullet: true)
+        end
         child_indices.each { |index| lines[index] = nested_child_marker_line(lines[index], parent_indent_level:) }
         stop_index
       end
 
       def nested_child_marker_line(line, parent_indent_level:)
-        child_indent = '    ' * (parent_indent_level.to_i + 1)
-        return line.sub(/\A {4,}/, child_indent) if line.match?(/\A {4,}\d+\.\s+\S/)
+        marker_list_line(
+          line,
+          indent_level: parent_indent_level.to_i + 1,
+          bullet: !dotted_numeric_marker_line?(line),
+        )
+      end
 
-        line.sub(/\A {4,}/, "#{child_indent}- ")
+      def marker_list_line(line, indent_level:, bullet:)
+        content = line.sub(/\A */, '').sub(/\A-\s+/, '')
+        "#{markdown_indent(indent_level)}#{'- ' if bullet}#{content}"
+      end
+
+      def dotted_numeric_marker_line?(line)
+        MarkerHierarchy.marker_from_line(line).to_s.match?(/\A\d+\.\z/)
+      end
+
+      def markdown_indent(indent_level)
+        '    ' * indent_level.to_i
       end
 
       def source_nested_marker_group(lines, start_index)
@@ -887,7 +932,7 @@ module CustomsTariffImporter
           lines.insert(index, '') if lines[index - 1].present?
           index += 1
 
-          lines[index] = lines[index].sub(/\A {4}/, '    - ')
+          lines[index] = marker_list_line(lines[index], indent_level: MarkerHierarchy.indent_level(lines[index]), bullet: true)
           expected_letter = expected_letter.next
           index += 1
         end
@@ -897,7 +942,9 @@ module CustomsTariffImporter
       end
 
       def lettered_paragraph_item?(line, expected_letter)
-        line.match?(/\A {4}(?:#{expected_letter}\.|\(#{expected_letter}\))\s+\S/)
+        return false unless MarkerHierarchy.indent_level(line).to_i.positive?
+
+        [expected_letter, "(#{expected_letter})"].include?(MarkerHierarchy.marker_from_line(line).to_s.downcase.delete_suffix('.'))
       end
 
       def join_split_paragraph_continuations(lines)

--- a/app/lib/customs_tariff_importer/notes_extractor/formatter.rb
+++ b/app/lib/customs_tariff_importer/notes_extractor/formatter.rb
@@ -729,8 +729,8 @@ module CustomsTariffImporter
       end
 
       def source_indented_marker_line?(formatted)
-        paragraph_indent_level.positive? &&
-          MarkerHierarchy.source_marker_line?(formatted)
+        formatted_source_marker_line?(formatted) &&
+          (paragraph_indent_level.positive? || paragraph_first_line_indent_level.positive?)
       end
 
       def source_indented_marker_continuation?(formatted, lines)
@@ -738,6 +738,10 @@ module CustomsTariffImporter
 
         MarkerHierarchy.source_marker_line?(lines.last) &&
           formatted.match?(/\A\s+\S/)
+      end
+
+      def formatted_source_marker_line?(formatted)
+        MarkerHierarchy.source_marker_line?(formatted)
       end
 
       def closed_source_indented_marker_list_paragraph?(formatted)

--- a/app/lib/customs_tariff_importer/notes_extractor/formatter.rb
+++ b/app/lib/customs_tariff_importer/notes_extractor/formatter.rb
@@ -1,6 +1,199 @@
 module CustomsTariffImporter
   class NotesExtractor
     class Formatter
+      class ParagraphPreprocessor
+        COMPACT_NUMBERED_MARKER_PATTERN = /\A([1-9]\d*)\.(?=(?:\([a-z]\)|[A-Z]\.|[[:alpha:]]))/i
+        DOTLESS_NUMBERED_NOTE_PATTERN = /\A([1-9]\d*)\s+(?=[A-Z]|\u201C|\()/
+        NUMBERED_NOTE_PATTERN = /\A[1-9]\d*\.(?!\d)/
+        SOURCE_BULLET_MARKER_PATTERN = /\A\s*(?:-|•|—|–)\s*/
+
+        def initialize(numbering_counters)
+          @numbering_counters = numbering_counters
+        end
+
+        def call(text, current_paragraph:, last_top_level_note_number:)
+          text = normalize_source_bullet_marker(text)
+          text = normalize_compact_numbered_marker(text)
+          text = normalize_dotless_numbered_note(text, last_top_level_note_number)
+          normalize_visual_numbering(text, current_paragraph)
+        end
+
+        private
+
+        def normalize_source_bullet_marker(text)
+          return text unless text.match?(SOURCE_BULLET_MARKER_PATTERN)
+
+          "- #{text.sub(SOURCE_BULLET_MARKER_PATTERN, '')}"
+        end
+
+        def normalize_compact_numbered_marker(text)
+          text.sub(COMPACT_NUMBERED_MARKER_PATTERN, '\1. ')
+        end
+
+        def normalize_dotless_numbered_note(text, last_top_level_note_number)
+          return text unless (match = text.match(DOTLESS_NUMBERED_NOTE_PATTERN))
+
+          note_number = match[1].to_i
+          expected_note_number = last_top_level_note_number ? last_top_level_note_number + 1 : 1
+          continues_sequence = note_number == expected_note_number
+          return text unless continues_sequence
+
+          text.sub(/\A([1-9]\d*)\s+/, '\1. ')
+        end
+
+        def normalize_visual_numbering(text, current_paragraph)
+          numbering = current_paragraph&.fetch(:numbering, nil)
+          return text unless numbering && numbering[:id].positive? && numbering[:level].zero?
+          return text if text.match?(NUMBERED_NOTE_PATTERN)
+
+          "#{next_visual_number(numbering)}. #{text}"
+        end
+
+        def next_visual_number(numbering)
+          key = [numbering[:id], numbering[:level]]
+          @numbering_counters[key] = @numbering_counters.fetch(key, 0) + 1
+        end
+      end
+
+      class MarkerHierarchy
+        ROMAN_MARKER_PATTERN = /(?:i{1,3}|iv|v|vi{0,3}|ix)/i
+        MARKER_TEXT_PATTERN = /\A(?:[a-z]\.|\([A-Z]\)|\([ivxlcdm]+\)|[ivxlcdm]+\.|\(\d+\)|\d+\.)\s+\S/i
+        ALPHABETIC_MARKER_TEXT_PATTERN = /\A[a-z]\.\s+\S/i
+        ROMAN_MARKER_TEXT_PATTERN = /\A#{ROMAN_MARKER_PATTERN}\.\s+\S/
+        UPPERCASE_BRACKET_MARKER_TEXT_PATTERN = /\A\([A-Z]\)\s+\S/
+        CHILD_MARKER_TEXT_PATTERN = /\A(?:\(\d+\)|\d+\.|#{ROMAN_MARKER_PATTERN}\.|\(#{ROMAN_MARKER_PATTERN}\))\s+\S/
+        SOURCE_MARKER_LINE_PATTERN = /\A\s+(?:-\s+)?(?:[a-z]\.|\([A-Z]\)|\([ivxlcdm]+\)|[ivxlcdm]+\.|\(\d+\)|\d+\.)\s+\S/i
+        MARKER_LINE_PATTERN = /\A(?<spaces> *)(?:-\s+)?(?<marker>\(\d+\)|\d+\.|[a-z]\.|\([a-z]+\))\s+\S/i
+        SOURCE_PARENT_MARKER_LINE_PATTERN = /\A\s+(?:-\s+)?(?:[a-z]\.|\((?![ivx]+\))[a-z]\))\s+\S/i
+        SOURCE_CHILD_MARKER_LINE_PATTERN = /\A\s+(?:-\s+)?(?:\(\d+\)|\d+\.|#{ROMAN_MARKER_PATTERN}\.|\(#{ROMAN_MARKER_PATTERN}\))\s+\S/
+
+        def initialize
+          reset
+        end
+
+        def reset
+          @pending_parent_depth = nil
+        end
+
+        def child_indent_level(text)
+          @pending_parent_depth + 1 if self.class.child_marker_text?(text) && @pending_parent_depth
+        end
+
+        def observe(formatted, in_numbered_note:, paragraph_indent_level:, paragraph_first_line_indent_level:)
+          if source_child_marker_line?(formatted, paragraph_indent_level:) ||
+              first_line_source_child_marker_line?(formatted, paragraph_indent_level:, paragraph_first_line_indent_level:)
+            @pending_parent_depth
+          elsif source_parent_marker_line?(formatted, paragraph_indent_level:)
+            @pending_parent_depth = formatted_indent_level(formatted)
+          elsif first_line_source_parent_marker_line?(formatted, paragraph_indent_level:, paragraph_first_line_indent_level:)
+            @pending_parent_depth = formatted_indent_level(formatted)
+          elsif logical_parent_marker_line?(formatted, in_numbered_note:)
+            @pending_parent_depth = formatted_indent_level(formatted)
+          else
+            reset
+          end
+        end
+
+        def self.marker_text?(text)
+          text.match?(MARKER_TEXT_PATTERN)
+        end
+
+        def self.alphabetic_marker_text?(text)
+          text.match?(ALPHABETIC_MARKER_TEXT_PATTERN)
+        end
+
+        def self.roman_marker_text?(text)
+          text.match?(ROMAN_MARKER_TEXT_PATTERN)
+        end
+
+        def self.child_marker_text?(text)
+          text.match?(CHILD_MARKER_TEXT_PATTERN)
+        end
+
+        def self.bullet_marker_text?(text)
+          text.match?(UPPERCASE_BRACKET_MARKER_TEXT_PATTERN) || roman_marker_text?(text)
+        end
+
+        def self.parent_line?(line)
+          parsed_line(line)&.then { |marker| marker[:indent_level].positive? && parent_marker?(marker[:text]) }
+        end
+
+        def self.child_line?(line)
+          parsed_line(line)&.then { |marker| marker[:indent_level].positive? && child_marker?(marker[:text]) }
+        end
+
+        def self.first_child_line?(line)
+          parsed_line(line)&.then { |marker| marker[:indent_level].positive? && first_child_marker?(marker[:text]) }
+        end
+
+        def self.source_marker_line?(line)
+          line.to_s.match?(SOURCE_MARKER_LINE_PATTERN)
+        end
+
+        def self.child_line_deeper_than?(line, parent_indent_level)
+          parsed_line(line)&.then { |marker| marker[:indent_level] > parent_indent_level && child_marker?(marker[:text]) }
+        end
+
+        def self.first_child_line_deeper_than?(line, parent_indent_level)
+          parsed_line(line)&.then { |marker| marker[:indent_level] > parent_indent_level && first_child_marker?(marker[:text]) }
+        end
+
+        def self.indent_level(line)
+          parsed_line(line)&.fetch(:indent_level)
+        end
+
+        def self.parsed_line(line)
+          return unless (match = line.to_s.match(MARKER_LINE_PATTERN))
+
+          { indent_level: match[:spaces].length / 4, text: match[:marker] }
+        end
+
+        def self.parent_marker?(marker)
+          marker.match?(/\A[a-z]\.\z/i) || marker.match?(/\A\((?![ivx]+\))[a-z]+\)\z/i)
+        end
+
+        def self.child_marker?(marker)
+          marker.match?(/\A(?:\d+\.|\(\d+\)|#{ROMAN_MARKER_PATTERN}\.|\(#{ROMAN_MARKER_PATTERN}\))\z/)
+        end
+
+        def self.first_child_marker?(marker)
+          marker.match?(/\A(?:1\.|\(1\)|i\.|\(i\))\z/i)
+        end
+
+        private_class_method :parsed_line, :parent_marker?, :child_marker?, :first_child_marker?
+
+        private
+
+        def source_parent_marker_line?(formatted, paragraph_indent_level:)
+          paragraph_indent_level.positive? &&
+            formatted.match?(SOURCE_PARENT_MARKER_LINE_PATTERN)
+        end
+
+        def first_line_source_parent_marker_line?(formatted, paragraph_indent_level:, paragraph_first_line_indent_level:)
+          paragraph_indent_level.zero? &&
+            paragraph_first_line_indent_level.positive? &&
+            self.class.parent_line?(formatted)
+        end
+
+        def logical_parent_marker_line?(formatted, in_numbered_note:)
+          in_numbered_note && self.class.parent_line?(formatted)
+        end
+
+        def source_child_marker_line?(formatted, paragraph_indent_level:)
+          paragraph_indent_level.positive? && formatted.match?(SOURCE_CHILD_MARKER_LINE_PATTERN)
+        end
+
+        def first_line_source_child_marker_line?(formatted, paragraph_indent_level:, paragraph_first_line_indent_level:)
+          paragraph_indent_level.zero? &&
+            paragraph_first_line_indent_level.positive? &&
+            self.class.child_line?(formatted)
+        end
+
+        def formatted_indent_level(formatted)
+          formatted[/\A */].length / 4
+        end
+      end
+
       def initialize
         reset_note_formatting_context
       end
@@ -36,6 +229,8 @@ module CustomsTariffImporter
         @previous_markdown_bullet_indent = nil
         @current_paragraph = nil
         @numbering_counters = {}
+        @paragraph_preprocessor = ParagraphPreprocessor.new(@numbering_counters)
+        @marker_hierarchy = MarkerHierarchy.new
       end
 
       def normalize_note_lines(lines, chapter: false, section: false, current_chapter: nil)
@@ -57,7 +252,7 @@ module CustomsTariffImporter
           normalize_omitted_additional_chapter_note_one(lines)
         end
 
-        normalize_compact_numbered_letter_markers(lines)
+        normalize_source_nested_marker_lists(lines)
         normalize_indented_marker_spacing(lines) if section
         normalize_lettered_paragraph_lists(lines)
         join_split_paragraph_continuations(lines)
@@ -262,18 +457,25 @@ module CustomsTariffImporter
       def formatted_note_line(text)
         return text if text.blank?
 
+        text = @paragraph_preprocessor.call(
+          text,
+          current_paragraph: @current_paragraph,
+          last_top_level_note_number: @last_top_level_note_number,
+        )
+
         if @previous_markdown_bullet_indent && bullet_continuation_line?(text)
           return "#{' ' * (@previous_markdown_bullet_indent + 4)}#{text.sub(/\A\s*/, '')}"
         end
 
-        text = normalize_dotless_numbered_note(text)
-        text = normalize_visual_numbering(text)
         return markdown_note_section_heading(text) if note_section_heading?(text)
         return nested_numbered_subnote_start(text) if nested_numbered_subnote_start?(text)
-        return indented_marker_line(text) if indented_marker?(text)
+        return indented_marker_line(text) if child_indented_marker?(text)
+        return first_line_indented_marker_line(text) if child_first_line_indented_marker?(text)
         return "    #{text}" if nested_numbered_note?(text)
         return text if numbered_note?(text)
+        return indented_marker_line(text) if indented_marker?(text)
         return markdown_bullet_line(text) if source_bullet_line?(text)
+        return first_line_indented_marker_line(text) if first_line_indented_marker?(text)
         return missing_source_bullet_line(text) if missing_source_bullet_line?(text)
         return "    #{text.sub(/\A\s*/, '')}" if @in_numbered_note
 
@@ -292,7 +494,6 @@ module CustomsTariffImporter
           @in_source_indented_marker_list = true
           @source_indented_marker_list_closed = false
           @previous_markdown_bullet_indent = nil
-          return
         end
 
         if source_indented_marker_list_ended?(text)
@@ -305,6 +506,7 @@ module CustomsTariffImporter
           @in_nested_numbered_subnote = true
           @source_indented_marker_list_closed = false
           @previous_markdown_bullet_indent = nil
+          @marker_hierarchy.reset
           return
         end
 
@@ -312,6 +514,7 @@ module CustomsTariffImporter
           @in_numbered_note = true
           @in_nested_numbered_subnote = true
           @previous_markdown_bullet_indent = nil
+          @marker_hierarchy.reset
           return
         end
 
@@ -327,6 +530,13 @@ module CustomsTariffImporter
           elsif @previous_markdown_bullet_indent && bullet_continuation_line?(text)
             formatted[/\A */].length - 4
           end
+
+        @marker_hierarchy.observe(
+          formatted,
+          in_numbered_note: @in_numbered_note,
+          paragraph_indent_level:,
+          paragraph_first_line_indent_level:,
+        )
       end
 
       def numbered_note?(text)
@@ -339,35 +549,6 @@ module CustomsTariffImporter
         return false unless @in_numbered_note && @last_top_level_note_number
 
         text[/\A([1-9]\d*)\./, 1].to_i <= @last_top_level_note_number
-      end
-
-      def dotless_numbered_note?(text)
-        return false unless (match = text.match(/\A([1-9]\d*)\s+(?:[A-Z]|\u201C|\()/))
-
-        note_number = match[1].to_i
-        return note_number == 1 if @last_top_level_note_number.nil?
-
-        note_number == @last_top_level_note_number + 1
-      end
-
-      def normalize_dotless_numbered_note(text)
-        return text unless dotless_numbered_note?(text)
-
-        text.sub(/\A([1-9]\d*)\s+/, '\1. ')
-      end
-
-      def normalize_visual_numbering(text)
-        numbering = @current_paragraph&.fetch(:numbering, nil)
-        return text unless numbering && numbering[:id].positive? && numbering[:level].zero?
-        return text if numbered_note?(text)
-
-        number = next_visual_number(numbering)
-        "#{number}. #{text}"
-      end
-
-      def next_visual_number(numbering)
-        key = [numbering[:id], numbering[:level]]
-        @numbering_counters[key] = @numbering_counters.fetch(key, 0) + 1
       end
 
       def nested_numbered_subnote_start?(text)
@@ -403,8 +584,27 @@ module CustomsTariffImporter
         "#{' ' * @previous_markdown_bullet_indent}- #{text.sub(/\A\s*/, '')}"
       end
 
+      def first_line_indented_marker?(text)
+        paragraph_indent_level.zero? &&
+          paragraph_first_line_indent_level.positive? &&
+          indented_marker_text?(text)
+      end
+
+      def first_line_indented_marker_line(text)
+        indent_level = @in_numbered_note ? (@marker_hierarchy.child_indent_level(text) || 1) : paragraph_first_line_indent_level
+        "#{'    ' * indent_level}#{text}"
+      end
+
+      def child_first_line_indented_marker?(text)
+        first_line_indented_marker?(text) && @marker_hierarchy.child_indent_level(text)
+      end
+
       def indented_marker?(text)
         paragraph_indent_level.positive? && indented_marker_text?(text)
+      end
+
+      def child_indented_marker?(text)
+        indented_marker?(text) && @marker_hierarchy.child_indent_level(text)
       end
 
       def indented_marker_line(text)
@@ -414,10 +614,9 @@ module CustomsTariffImporter
 
       def indented_marker_indent_level(text)
         return 1 if alphabetic_marker_text?(text) && !roman_marker_text?(text)
-        return 1 if numeric_bracket_marker_text?(text)
-        return 1 if roman_bracket_marker_text?(text)
+        return @marker_hierarchy.child_indent_level(text) if @marker_hierarchy.child_indent_level(text)
 
-        paragraph_indent_level
+        [paragraph_indent_level, 1].min
       end
 
       def indented_marker_prefix(text)
@@ -433,27 +632,19 @@ module CustomsTariffImporter
       end
 
       def indented_marker_text?(text)
-        text.match?(/\A(?:[a-z]\.|\([A-Z]\)|\([ivxlcdm]+\)|[ivxlcdm]+\.|\(\d+\))\s+\S/i)
+        MarkerHierarchy.marker_text?(text)
       end
 
       def alphabetic_marker_text?(text)
-        text.match?(/\A[a-z]\.\s+\S/i)
+        MarkerHierarchy.alphabetic_marker_text?(text)
       end
 
       def roman_marker_text?(text)
-        text.match?(/\A(?:i{1,3}|iv|v|vi{0,3}|ix)\.\s+\S/i)
-      end
-
-      def numeric_bracket_marker_text?(text)
-        text.match?(/\A\(\d+\)\s+\S/)
-      end
-
-      def roman_bracket_marker_text?(text)
-        text.match?(/\A\((?:i{1,3}|iv|v|vi{0,3}|ix)\)\s+\S/i)
+        MarkerHierarchy.roman_marker_text?(text)
       end
 
       def bullet_marker_text?(text)
-        text.match?(/\A\([A-Z]\)\s+\S/) || roman_marker_text?(text)
+        MarkerHierarchy.bullet_marker_text?(text)
       end
 
       def bullet_continuation_line?(text)
@@ -510,13 +701,13 @@ module CustomsTariffImporter
 
       def source_indented_marker_line?(formatted)
         paragraph_indent_level.positive? &&
-          formatted.match?(/\A\s+(?:-\s+)?(?:[a-z]\.|\([A-Z]\)|[ivxlcdm]+\.|\(\d+\))\s+\S/i)
+          MarkerHierarchy.source_marker_line?(formatted)
       end
 
       def source_indented_marker_continuation?(formatted, lines)
         return false unless paragraph_indent_level.positive?
 
-        lines.last.to_s.match?(/\A\s+(?:[a-z]\.|\([A-Z]\)|\([ivxlcdm]+\)|[ivxlcdm]+\.|\(\d+\))\s+\S/i) &&
+        MarkerHierarchy.source_marker_line?(lines.last) &&
           formatted.match?(/\A\s+\S/)
       end
 
@@ -602,10 +793,72 @@ module CustomsTariffImporter
           line.match?(/\A###\s+Additional\s+[Cc]hapter\s+[Nn]otes?\z/i)
       end
 
-      def normalize_compact_numbered_letter_markers(lines)
-        lines.map! { |line| line.sub(/\A([1-9]\d*)\.(\([a-z]\))/, '\1. \2') }
-        lines.map! { |line| line.sub(/\A([1-9]\d*)\.([A-Z]\.)/, '\1. \2') }
-        lines.map! { |line| line.sub(/\A([1-9]\d*)\.(?=[A-Z][a-z])/, '\1. ') }
+      def normalize_source_nested_marker_lists(lines)
+        index = 0
+        while index < lines.length
+          if parent_marker_line?(lines[index])
+            index = normalize_source_nested_marker_list(lines, index)
+          else
+            index += 1
+          end
+        end
+      end
+
+      def normalize_source_nested_marker_list(lines, start_index)
+        parent_indices, child_indices, stop_index, parent_indent_level = source_nested_marker_group(lines, start_index)
+        return start_index + 1 if child_indices.empty?
+
+        parent_indices.each { |index| lines[index] = lines[index].sub(/\A {4}/, '    - ') }
+        child_indices.each { |index| lines[index] = nested_child_marker_line(lines[index], parent_indent_level:) }
+        stop_index
+      end
+
+      def nested_child_marker_line(line, parent_indent_level:)
+        child_indent = '    ' * (parent_indent_level.to_i + 1)
+        return line.sub(/\A {4,}/, child_indent) if line.match?(/\A {4,}\d+\.\s+\S/)
+
+        line.sub(/\A {4,}/, "#{child_indent}- ")
+      end
+
+      def source_nested_marker_group(lines, start_index)
+        parent_indices = []
+        child_indices = []
+        index = start_index
+        parent_indent_level = nil
+
+        loop do
+          index = next_content_line_index(lines, index)
+          break unless index && parent_marker_line?(lines[index])
+
+          parent_indices << index
+          parent_indent_level = MarkerHierarchy.indent_level(lines[index])
+          index += 1
+
+          while (index = next_content_line_index(lines, index))
+            break if parent_marker_line?(lines[index])
+            return [parent_indices, child_indices, index, parent_indent_level] unless child_marker_line?(lines[index], parent_indent_level)
+            return [parent_indices, [], index, parent_indent_level] if child_indices.empty? && !first_child_marker_line?(lines[index], parent_indent_level)
+
+            child_indices << index
+            index += 1
+          end
+
+          break unless index
+        end
+
+        [parent_indices, child_indices, index || lines.length, parent_indent_level]
+      end
+
+      def parent_marker_line?(line)
+        MarkerHierarchy.parent_line?(line)
+      end
+
+      def child_marker_line?(line, parent_indent_level = 0)
+        MarkerHierarchy.child_line_deeper_than?(line, parent_indent_level)
+      end
+
+      def first_child_marker_line?(line, parent_indent_level = 0)
+        MarkerHierarchy.first_child_line_deeper_than?(line, parent_indent_level)
       end
 
       def normalize_lettered_paragraph_lists(lines)

--- a/app/lib/customs_tariff_importer/notes_extractor/formatter.rb
+++ b/app/lib/customs_tariff_importer/notes_extractor/formatter.rb
@@ -363,11 +363,11 @@ module CustomsTariffImporter
       end
 
       def source_bullet_line?(text)
-        text.match?(/\A\s*(?:-|•|—)\s+\S/)
+        text.match?(/\A\s*(?:-|•|—|–)\s*\S/)
       end
 
       def markdown_bullet_line(text)
-        bullet_text = text.sub(/\A\s*(?:-|•|—)\s+/, '')
+        bullet_text = text.sub(/\A\s*(?:-|•|—|–)\s*/, '')
         "#{'    ' if @in_numbered_note}- #{bullet_text}"
       end
 
@@ -549,6 +549,7 @@ module CustomsTariffImporter
       end
 
       def normalize_compact_numbered_letter_markers(lines)
+        lines.map! { |line| line.sub(/\A([1-9]\d*)\.(\([a-z]\))/, '\1. \2') }
         lines.map! { |line| line.sub(/\A([1-9]\d*)\.([A-Z]\.)/, '\1. \2') }
         lines.map! { |line| line.sub(/\A([1-9]\d*)\.(?=[A-Z][a-z])/, '\1. ') }
       end

--- a/app/lib/customs_tariff_importer/notes_extractor/formatter.rb
+++ b/app/lib/customs_tariff_importer/notes_extractor/formatter.rb
@@ -55,13 +55,12 @@ module CustomsTariffImporter
         end
       end
 
-      class MarkerHierarchy
+      class MarkerTrie
         ROMAN_MARKER_PATTERN = /(?:i{1,3}|iv|v|vi{0,3}|ix)/i
         ALPHABETIC_DOTTED_MARKER_PATTERN = /(?:[a-z]|ij)\./i
         MARKER_TEXT_PATTERN = /\A(?:#{ALPHABETIC_DOTTED_MARKER_PATTERN}|\([A-Z]\)|\([ivxlcdm]+\)|[ivxlcdm]+\.|\(\d+\)|\d+\.)\s+\S/i
         ALPHABETIC_MARKER_TEXT_PATTERN = /\A#{ALPHABETIC_DOTTED_MARKER_PATTERN}\s+\S/i
         ROMAN_MARKER_TEXT_PATTERN = /\A#{ROMAN_MARKER_PATTERN}\.\s+\S/
-        UPPERCASE_BRACKET_MARKER_TEXT_PATTERN = /\A\([A-Z]\)\s+\S/
         CHILD_MARKER_TEXT_PATTERN = /\A(?:\(\d+\)|\d+\.|#{ROMAN_MARKER_PATTERN}\.|\(#{ROMAN_MARKER_PATTERN}\))\s+\S/
         SOURCE_MARKER_LINE_PATTERN = /\A\s+(?:-\s+)?(?:#{ALPHABETIC_DOTTED_MARKER_PATTERN}|\([A-Z]\)|\([ivxlcdm]+\)|[ivxlcdm]+\.|\(\d+\)|\d+\.)\s+\S/i
         MARKER_LINE_PATTERN = /\A(?<spaces> *)(?:-\s+)?(?<marker>\(\d+\)|\d+\.|ij\.|#{ROMAN_MARKER_PATTERN}\.|[a-z]\.|\([a-z]+\))\s+\S/i
@@ -128,11 +127,19 @@ module CustomsTariffImporter
         end
 
         def self.bullet_marker_text?(text)
-          text.match?(UPPERCASE_BRACKET_MARKER_TEXT_PATTERN) || roman_marker_text?(text)
+          roman_marker_text?(text)
         end
 
         def self.parent_line?(line)
           parsed_line(line)&.then { |marker| marker[:indent_level].positive? && parent_marker?(marker[:text]) }
+        end
+
+        def self.first_parent_line?(line)
+          parsed_line(line)&.then { |marker| marker[:indent_level].positive? && first_parent_marker?(marker[:text]) }
+        end
+
+        def self.promotable_parent_line?(line)
+          parsed_line(line)&.then { |marker| marker[:indent_level].positive? && promotable_parent_marker?(marker[:text]) }
         end
 
         def self.child_line?(line)
@@ -155,6 +162,10 @@ module CustomsTariffImporter
           parsed_line(line)&.then { |marker| marker[:indent_level] > parent_indent_level && first_child_marker?(marker[:text]) }
         end
 
+        def self.roman_child_line_deeper_than?(line, parent_indent_level)
+          parsed_line(line)&.then { |marker| marker[:indent_level] > parent_indent_level && roman_child_marker?(marker[:text]) }
+        end
+
         def self.indent_level(line)
           parsed_line(line)&.fetch(:indent_level)
         end
@@ -174,11 +185,28 @@ module CustomsTariffImporter
         end
 
         def self.parent_marker?(marker)
-          marker.match?(/\A#{ALPHABETIC_DOTTED_MARKER_PATTERN}\z/i) || marker.match?(/\A\((?![ivx]+\))[a-z]+\)\z/i)
+          (marker.match?(/\A#{ALPHABETIC_DOTTED_MARKER_PATTERN}\z/i) && !roman_child_marker?(marker)) ||
+            marker.match?(/\A\((?![ivx]+\))[a-z]+\)\z/i)
+        end
+
+        def self.first_parent_marker?(marker)
+          marker.match?(/\Aa\.\z/) || marker.match?(/\A\(a\)\z/)
+        end
+
+        def self.promotable_parent_marker?(marker)
+          first_parent_marker?(marker) || marker.match?(/\A\(A\)\z/)
+        end
+
+        def self.uppercase_parent_marker?(marker)
+          marker.match?(/\A\([A-Z]\)\z/)
         end
 
         def self.child_marker?(marker)
           marker.match?(/\A(?:\d+\.|\(\d+\)|#{ROMAN_MARKER_PATTERN}\.|\(#{ROMAN_MARKER_PATTERN}\))\z/)
+        end
+
+        def self.roman_child_marker?(marker)
+          marker.match?(/\A(?:#{ROMAN_MARKER_PATTERN}\.|\(#{ROMAN_MARKER_PATTERN}\))\z/i)
         end
 
         def self.first_child_marker?(marker)
@@ -259,7 +287,7 @@ module CustomsTariffImporter
         @current_paragraph = nil
         @numbering_counters = {}
         @paragraph_preprocessor = ParagraphPreprocessor.new(@numbering_counters)
-        @marker_hierarchy = MarkerHierarchy.new
+        @marker_trie = MarkerTrie.new
       end
 
       def normalize_note_lines(lines, chapter: false, section: false, current_chapter: nil)
@@ -267,7 +295,8 @@ module CustomsTariffImporter
         lines = lines.dup
         start_index = 0
 
-        remove_section_note_preamble(lines) if section
+        remove_malformed_duplicate_markdown_artifacts(lines)
+        remove_note_preamble(lines) if chapter || section
 
         if chapter
           loop do
@@ -282,6 +311,7 @@ module CustomsTariffImporter
         end
 
         normalize_source_nested_marker_lists(lines)
+        normalize_plain_marker_code_block_indents(lines)
         normalize_indented_marker_spacing(lines) if section
         normalize_lettered_paragraph_lists(lines)
         join_split_paragraph_continuations(lines)
@@ -465,10 +495,24 @@ module CustomsTariffImporter
 
       def normalize_table_row(row, columns)
         if columns == 2 && row.length == 3
-          [row.first(2).reject(&:blank?).join(' '), row.last]
+          [combined_two_column_table_label(row.first(2)), row.last]
         else
           row.first(columns).fill('', row.length...columns)
         end
+      end
+
+      def combined_two_column_table_label(cells)
+        compact_cells = cells.reject(&:blank?)
+        return compact_cells.first.to_s if compact_cells.uniq.one?
+        return "#{compact_cells.first} (#{compact_cells.second})" if chemical_symbol_name_cells?(compact_cells)
+
+        compact_cells.join(' ')
+      end
+
+      def chemical_symbol_name_cells?(cells)
+        cells.length == 2 &&
+          cells.first.match?(/\A[A-Z][a-z]?\z/) &&
+          cells.second.match?(/\A[A-Z][a-z]+\z/)
       end
 
       def markdown_table_row(cells)
@@ -535,7 +579,7 @@ module CustomsTariffImporter
           @in_nested_numbered_subnote = true
           @source_indented_marker_list_closed = false
           @previous_markdown_bullet_indent = nil
-          @marker_hierarchy.reset
+          @marker_trie.reset
           return
         end
 
@@ -543,7 +587,7 @@ module CustomsTariffImporter
           @in_numbered_note = true
           @in_nested_numbered_subnote = true
           @previous_markdown_bullet_indent = nil
-          @marker_hierarchy.reset
+          @marker_trie.reset
           return
         end
 
@@ -560,7 +604,7 @@ module CustomsTariffImporter
             formatted[/\A */].length - 4
           end
 
-        @marker_hierarchy.observe(
+        @marker_trie.observe(
           formatted,
           in_numbered_note: @in_numbered_note,
           paragraph_indent_level:,
@@ -620,12 +664,12 @@ module CustomsTariffImporter
       end
 
       def first_line_indented_marker_line(text)
-        indent_level = @in_numbered_note ? (@marker_hierarchy.child_indent_level(text) || 1) : paragraph_first_line_indent_level
+        indent_level = @in_numbered_note ? (@marker_trie.child_indent_level(text) || 1) : paragraph_first_line_indent_level
         "#{'    ' * indent_level}#{text}"
       end
 
       def child_first_line_indented_marker?(text)
-        first_line_indented_marker?(text) && @marker_hierarchy.child_indent_level(text)
+        first_line_indented_marker?(text) && @marker_trie.child_indent_level(text)
       end
 
       def indented_marker?(text)
@@ -633,7 +677,7 @@ module CustomsTariffImporter
       end
 
       def child_indented_marker?(text)
-        indented_marker?(text) && @marker_hierarchy.child_indent_level(text)
+        indented_marker?(text) && @marker_trie.child_indent_level(text)
       end
 
       def indented_marker_line(text)
@@ -643,7 +687,7 @@ module CustomsTariffImporter
 
       def indented_marker_indent_level(text)
         return 1 if alphabetic_marker_text?(text) && !roman_marker_text?(text)
-        return @marker_hierarchy.child_indent_level(text) if @marker_hierarchy.child_indent_level(text)
+        return @marker_trie.child_indent_level(text) if @marker_trie.child_indent_level(text)
 
         [paragraph_indent_level, 1].min
       end
@@ -661,19 +705,19 @@ module CustomsTariffImporter
       end
 
       def indented_marker_text?(text)
-        MarkerHierarchy.marker_text?(text)
+        MarkerTrie.marker_text?(text)
       end
 
       def alphabetic_marker_text?(text)
-        MarkerHierarchy.alphabetic_marker_text?(text)
+        MarkerTrie.alphabetic_marker_text?(text)
       end
 
       def roman_marker_text?(text)
-        MarkerHierarchy.roman_marker_text?(text)
+        MarkerTrie.roman_marker_text?(text)
       end
 
       def bullet_marker_text?(text)
-        MarkerHierarchy.bullet_marker_text?(text)
+        MarkerTrie.bullet_marker_text?(text)
       end
 
       def bullet_continuation_line?(text)
@@ -711,17 +755,27 @@ module CustomsTariffImporter
       def blank_line_needed_before?(formatted, lines)
         formatted.present? &&
           lines.last.present? &&
+          !consecutive_markdown_table_rows?(lines.last, formatted) &&
           (markdown_bullet?(lines.last) ||
            note_section_heading?(formatted) ||
            markdown_bullet?(formatted) ||
            source_indented_marker_list_ended?(formatted) ||
            closed_source_indented_marker_list_paragraph?(formatted) ||
            source_indented_marker_line?(formatted) ||
+           source_indented_paragraph?(formatted) ||
            source_indented_marker_continuation?(formatted, lines) ||
            nested_numbered_subnote?(formatted) ||
            numbered_note?(formatted) ||
            standalone_bold_line?(formatted) ||
            consecutive_variable_definition_paragraphs?(lines.last, formatted))
+      end
+
+      def consecutive_markdown_table_rows?(previous, current)
+        markdown_table_row?(previous) && markdown_table_row?(current)
+      end
+
+      def markdown_table_row?(line)
+        line.to_s.strip.match?(/\A\|.*\|\z/)
       end
 
       def consecutive_variable_definition_paragraphs?(previous, formatted)
@@ -736,12 +790,20 @@ module CustomsTariffImporter
       def source_indented_marker_continuation?(formatted, lines)
         return false unless paragraph_indent_level.positive?
 
-        MarkerHierarchy.source_marker_line?(lines.last) &&
+        MarkerTrie.source_marker_line?(lines.last) &&
           formatted.match?(/\A\s+\S/)
       end
 
+      def source_indented_paragraph?(formatted)
+        @in_numbered_note &&
+          paragraph_indent_level.positive? &&
+          formatted.match?(/\A {4}\S/) &&
+          !formatted_source_marker_line?(formatted) &&
+          !markdown_table_row?(formatted)
+      end
+
       def formatted_source_marker_line?(formatted)
-        MarkerHierarchy.source_marker_line?(formatted)
+        MarkerTrie.source_marker_line?(formatted)
       end
 
       def closed_source_indented_marker_list_paragraph?(formatted)
@@ -762,17 +824,37 @@ module CustomsTariffImporter
         text.match?(/\A {4}[1-9]\d*\.(?!\d)\s+\S/)
       end
 
-      def remove_section_note_preamble(lines)
-        lines.delete_if { |line| section_note_preamble?(line) }
+      def remove_malformed_duplicate_markdown_artifacts(lines)
+        lines.delete_if.with_index { |_line, index| malformed_duplicate_markdown_artifact?(lines, index) }
+      end
+
+      # Chapter 76 source contains a literal "**Other elements" before the real heading.
+      def malformed_duplicate_markdown_artifact?(lines, index)
+        text = lines[index].to_s.strip
+        return false unless text.match?(/\A\*\*[^*]/) && !text.end_with?('**')
+
+        normalized_note_text(next_content_line(lines, index + 1)) == text.delete_prefix('**').strip
+      end
+
+      def next_content_line(lines, start_index)
+        lines[start_index..]&.find(&:present?)
+      end
+
+      def normalized_note_text(line)
+        line.to_s.strip.delete_prefix('**').delete_suffix('**')
+      end
+
+      def remove_note_preamble(lines)
+        lines.delete_if { |line| note_preamble?(line) }
         lines.shift while lines.any? && lines.first.blank?
       end
 
-      def section_note_preamble?(line)
+      def note_preamble?(line)
         line.to_s
           .strip
           .delete_prefix('**')
           .delete_suffix('**')
-          .match?(/\AThere are important section (?:note|noted|notes) for this part of the tariff:?\z/i)
+          .match?(/\AThere are important (?:(?:chapter|section) )?(?:note|noted|notes) for this part of the tariff:?\z/i)
       end
 
       def normalize_indented_marker_spacing(lines)
@@ -792,7 +874,7 @@ module CustomsTariffImporter
       end
 
       def final_indented_marker_line?(line)
-        MarkerHierarchy.indent_level(line).to_i.positive? && MarkerHierarchy.marker_from_line(line).present?
+        MarkerTrie.indent_level(line).to_i.positive? && MarkerTrie.marker_from_line(line).present?
       end
 
       def normalize_omitted_additional_chapter_note_one(lines)
@@ -829,7 +911,7 @@ module CustomsTariffImporter
       def normalize_source_nested_marker_lists(lines)
         index = 0
         while index < lines.length
-          if parent_marker_line?(lines[index])
+          if promotable_parent_marker_line?(lines[index])
             index = normalize_source_nested_marker_list(lines, index)
           else
             index += 1
@@ -837,12 +919,27 @@ module CustomsTariffImporter
         end
       end
 
+      def normalize_plain_marker_code_block_indents(lines)
+        lines.map! do |line|
+          plain_deep_marker_line?(line) ? marker_list_line(line, indent_level: 1, bullet: false) : line
+        end
+      end
+
+      def plain_deep_marker_line?(line)
+        MarkerTrie.indent_level(line).to_i > 1 &&
+          MarkerTrie.marker_from_line(line).present? &&
+          !markdown_bullet?(line) &&
+          !dotted_numeric_marker_line?(line)
+      end
+
       def normalize_source_nested_marker_list(lines, start_index)
         parent_indices, child_indices, stop_index, parent_indent_level = source_nested_marker_group(lines, start_index)
         return start_index + 1 if child_indices.empty?
+        return start_index + 1 if uppercase_parent_marker_line?(lines[start_index]) &&
+          !roman_child_marker_line?(lines[child_indices.first], parent_indent_level)
 
         parent_indices.each do |index|
-          lines[index] = marker_list_line(lines[index], indent_level: MarkerHierarchy.indent_level(lines[index]), bullet: true)
+          lines[index] = marker_list_line(lines[index], indent_level: MarkerTrie.indent_level(lines[index]), bullet: true)
         end
         child_indices.each { |index| lines[index] = nested_child_marker_line(lines[index], parent_indent_level:) }
         stop_index
@@ -862,7 +959,7 @@ module CustomsTariffImporter
       end
 
       def dotted_numeric_marker_line?(line)
-        MarkerHierarchy.marker_from_line(line).to_s.match?(/\A\d+\.\z/)
+        MarkerTrie.marker_from_line(line).to_s.match?(/\A\d+\.\z/)
       end
 
       def markdown_indent(indent_level)
@@ -880,7 +977,7 @@ module CustomsTariffImporter
           break unless index && parent_marker_line?(lines[index])
 
           parent_indices << index
-          parent_indent_level = MarkerHierarchy.indent_level(lines[index])
+          parent_indent_level = MarkerTrie.indent_level(lines[index])
           index += 1
 
           while (index = next_content_line_index(lines, index))
@@ -899,15 +996,31 @@ module CustomsTariffImporter
       end
 
       def parent_marker_line?(line)
-        MarkerHierarchy.parent_line?(line)
+        MarkerTrie.parent_line?(line)
+      end
+
+      def first_parent_marker_line?(line)
+        MarkerTrie.first_parent_line?(line)
+      end
+
+      def promotable_parent_marker_line?(line)
+        MarkerTrie.promotable_parent_line?(line)
+      end
+
+      def uppercase_parent_marker_line?(line)
+        MarkerTrie.uppercase_parent_marker?(MarkerTrie.marker_from_line(line).to_s)
       end
 
       def child_marker_line?(line, parent_indent_level = 0)
-        MarkerHierarchy.child_line_deeper_than?(line, parent_indent_level)
+        MarkerTrie.child_line_deeper_than?(line, parent_indent_level)
       end
 
       def first_child_marker_line?(line, parent_indent_level = 0)
-        MarkerHierarchy.first_child_line_deeper_than?(line, parent_indent_level)
+        MarkerTrie.first_child_line_deeper_than?(line, parent_indent_level)
+      end
+
+      def roman_child_marker_line?(line, parent_indent_level = 0)
+        MarkerTrie.roman_child_line_deeper_than?(line, parent_indent_level)
       end
 
       def normalize_lettered_paragraph_lists(lines)
@@ -936,7 +1049,7 @@ module CustomsTariffImporter
           lines.insert(index, '') if lines[index - 1].present?
           index += 1
 
-          lines[index] = marker_list_line(lines[index], indent_level: MarkerHierarchy.indent_level(lines[index]), bullet: true)
+          lines[index] = marker_list_line(lines[index], indent_level: MarkerTrie.indent_level(lines[index]), bullet: true)
           expected_letter = expected_letter.next
           index += 1
         end
@@ -946,9 +1059,9 @@ module CustomsTariffImporter
       end
 
       def lettered_paragraph_item?(line, expected_letter)
-        return false unless MarkerHierarchy.indent_level(line).to_i.positive?
+        return false unless MarkerTrie.indent_level(line).to_i.positive?
 
-        [expected_letter, "(#{expected_letter})"].include?(MarkerHierarchy.marker_from_line(line).to_s.downcase.delete_suffix('.'))
+        [expected_letter, "(#{expected_letter})"].include?(MarkerTrie.marker_from_line(line).to_s.downcase.delete_suffix('.'))
       end
 
       def join_split_paragraph_continuations(lines)

--- a/spec/lib/customs_tariff_importer/notes_extractor_spec.rb
+++ b/spec/lib/customs_tariff_importer/notes_extractor_spec.rb
@@ -478,9 +478,13 @@ RSpec.describe CustomsTariffImporter::NotesExtractor do
           [
             '3. For the purposes of headings 3003 and 3004, the following are to be treated:',
             '    - (a) as unmixed products:',
+            '',
             '        - (1) unmixed products dissolved in water;',
+            '',
             '        - (2) all goods of Chapter 28 or 29; and',
+            '',
             '    - (b) as products which have been mixed:',
+            '',
             '        - (1) colloidal solutions and suspensions;',
           ].join("\n"),
         )
@@ -489,7 +493,9 @@ RSpec.describe CustomsTariffImporter::NotesExtractor do
             '### Subheading notes',
             '',
             '1. For the purposes of subheadings 3002 13 and 3002 14, the following are to be treated:',
+            '',
             '    - (a) as unmixed products, pure products, whether or not containing impurities;',
+            '',
             '    - (b) as products which have been mixed:',
             '',
             '        - (1) the products mentioned in (a) above dissolved in water or in other solvents;',
@@ -1079,6 +1085,32 @@ RSpec.describe CustomsTariffImporter::NotesExtractor do
             '    b. articles of Chapter 96.',
             '',
             '3. Subject to the provisions of note 7, headings 4801 to 4805 include paper.',
+          ].join("\n"),
+        )
+      end
+
+      it 'spaces first-line indented marker siblings like source-indented marker siblings' do
+        result = parse_paragraphs([
+          paragraph('CHAPTER 49'),
+          paragraph('Chapter Notes'),
+          paragraph('1.This chapter does not cover:'),
+          paragraph('a. photographic negatives or positives on transparent bases (Chapter 37);', first_line_indent: 720),
+          paragraph('b. maps, plans or globes, in relief, whether or not printed (heading 9023);', first_line_indent: 720),
+          paragraph('c. playing cards or other goods of Chapter 95; or', first_line_indent: 720),
+          paragraph('d. original engravings. prints or lithographs (heading 9702).', indent: 720),
+        ])
+
+        expect(result.chapters['49']).to include(
+          [
+            '1. This chapter does not cover:',
+            '',
+            '    a. photographic negatives or positives on transparent bases (Chapter 37);',
+            '',
+            '    b. maps, plans or globes, in relief, whether or not printed (heading 9023);',
+            '',
+            '    c. playing cards or other goods of Chapter 95; or',
+            '',
+            '    d. original engravings. prints or lithographs (heading 9702).',
           ].join("\n"),
         )
       end

--- a/spec/lib/customs_tariff_importer/notes_extractor_spec.rb
+++ b/spec/lib/customs_tariff_importer/notes_extractor_spec.rb
@@ -658,6 +658,77 @@ RSpec.describe CustomsTariffImporter::NotesExtractor do
         )
       end
 
+      it 'promotes source-indented numeric marker runs after semantic lead-ins' do
+        result = parse_paragraphs([
+          paragraph('CHAPTER 85'),
+          paragraph('Chapter Notes'),
+          paragraph('12. For the purpose of heading 8541 and 8542:'),
+          paragraph('(a) (i) “Semiconductor devices” are semiconductor devices.', indent: 720),
+          paragraph('The following expressions mean :', first_line_indent: 720),
+          paragraph('(1) “Semiconductor-based” means built on a semiconductor substrate.', indent: 720),
+          paragraph('(2) “Physical or chemical phenomena” relate to pressure and light.', indent: 720),
+          paragraph('(ii) “Light-emitting diodes (LED)” are semiconductor devices.', indent: 720),
+          paragraph('b. ‘Electronic integrated circuits’ are:', first_line_indent: 720),
+          paragraph('(1) monolithic integrated circuits;', indent: 720),
+          paragraph('(2) hybrid integrated circuits;', indent: 720),
+          paragraph('For the purpose of this definition:', first_line_indent: 720),
+          paragraph('(1) ‘Components’ may be discrete.', indent: 720),
+          paragraph('(2) ‘Silicon based’ means built on silicon.', indent: 720),
+          paragraph('(3) (a) ‘Silicon based sensors’ consist of structures.', indent: 720),
+          paragraph('(b) ‘Silicon based actuators’ convert signals.', indent: 720),
+        ])
+
+        expect(result.chapters['85']).to include(
+          [
+            '    The following expressions mean :',
+            '',
+            '    - (1) “Semiconductor-based” means built on a semiconductor substrate.',
+            '',
+            '    - (2) “Physical or chemical phenomena” relate to pressure and light.',
+            '',
+            '    (ii) “Light-emitting diodes (LED)” are semiconductor devices.',
+            '',
+            '    b. ‘Electronic integrated circuits’ are:',
+            '',
+            '    - (1) monolithic integrated circuits;',
+            '',
+            '    - (2) hybrid integrated circuits;',
+            '',
+            '    For the purpose of this definition:',
+            '',
+            '    - (1) ‘Components’ may be discrete.',
+            '',
+            '    - (2) ‘Silicon based’ means built on silicon.',
+            '',
+            '    - (3) (a) ‘Silicon based sensors’ consist of structures.',
+            '',
+            '    (b) ‘Silicon based actuators’ convert signals.',
+          ].join("\n"),
+        )
+      end
+
+      it 'keeps alphabetic marker runs after semantic lead-ins as source-indented paragraphs' do
+        result = parse_paragraphs([
+          paragraph('SECTION XV'),
+          paragraph('Section Notes'),
+          paragraph('7. Classification of composite articles:'),
+          paragraph('For this purpose:', first_line_indent: 720),
+          paragraph('a. Iron and steel are regarded as one metal.', indent: 720),
+          paragraph('b. An alloy is regarded as entirely composed of that metal.', indent: 720),
+        ])
+
+        expect(result.sections[15]).to include(
+          [
+            '    For this purpose:',
+            '',
+            '    a. Iron and steel are regarded as one metal.',
+            '',
+            '    b. An alloy is regarded as entirely composed of that metal.',
+          ].join("\n"),
+        )
+        expect(result.sections[15]).not_to include('    - a.')
+      end
+
       it 'stops collecting chapter notes when a 10-digit commodity code is encountered' do
         result = parse([
           'CHAPTER 1',

--- a/spec/lib/customs_tariff_importer/notes_extractor_spec.rb
+++ b/spec/lib/customs_tariff_importer/notes_extractor_spec.rb
@@ -329,6 +329,39 @@ RSpec.describe CustomsTariffImporter::NotesExtractor do
         )
       end
 
+      it 'normalises compact bracketed subnotes and bullet glyphs' do
+        result = parse([
+          'CHAPTER 20',
+          'Chapter Notes',
+          'Additional chapter notes',
+          '2.(a) The sugar content is multiplied by one of the following factors:',
+          '•0.93 in respect of products of codes 2008 20 to 2008 80;',
+          '•0.95 in respect of products of the other headings.',
+          '(b) The expression Brix value means the direct reading.',
+          '3. Products are considered as containing added sugar when:',
+          '•pineapples and grapes: 13 %,',
+          '•other fruits: 9 %.',
+        ])
+
+        expect(result.chapters['20']).to include(
+          [
+            '2. (a) The sugar content is multiplied by one of the following factors:',
+            '',
+            '    - 0.93 in respect of products of codes 2008 20 to 2008 80;',
+            '',
+            '    - 0.95 in respect of products of the other headings.',
+            '',
+            '    (b) The expression Brix value means the direct reading.',
+            '',
+            '3. Products are considered as containing added sugar when:',
+            '',
+            '    - pineapples and grapes: 13 %,',
+            '',
+            '    - other fruits: 9 %.',
+          ].join("\n"),
+        )
+      end
+
       it 'stops collecting chapter notes when a 10-digit commodity code is encountered' do
         result = parse([
           'CHAPTER 1',

--- a/spec/lib/customs_tariff_importer/notes_extractor_spec.rb
+++ b/spec/lib/customs_tariff_importer/notes_extractor_spec.rb
@@ -99,8 +99,16 @@ RSpec.describe CustomsTariffImporter::NotesExtractor do
       texts.map { |t| { style: '', text: t } }
     end
 
+    def paragraph(text, indent: 0, first_line_indent: 0)
+      { style: '', text:, indent:, first_line_indent: }
+    end
+
     def parse(texts)
       described_class.new('1.30', '').send(:parse_notes, paragraphs(*texts))
+    end
+
+    def parse_paragraphs(paragraphs)
+      described_class.new('1.30', '').send(:parse_notes, paragraphs)
     end
 
     describe 'General Rules of Interpretation' do
@@ -358,6 +366,51 @@ RSpec.describe CustomsTariffImporter::NotesExtractor do
             '    - pineapples and grapes: 13 %,',
             '',
             '    - other fruits: 9 %.',
+          ].join("\n"),
+        )
+      end
+
+      it 'ends an alphabetic sublist and keeps following paragraphs under their numbered note' do
+        result = parse_paragraphs([
+          paragraph('CHAPTER 23'),
+          paragraph('Chapter Notes'),
+          paragraph('Additional chapter notes'),
+          paragraph('2. Code 2306 90 05 includes only residues containing:'),
+          paragraph('a. products of an oil content of less than 3 %;', indent: 720),
+          paragraph('b. products of an oil content of not less than 3 %;', indent: 720),
+          paragraph('For the determination of the starch and protein content, the methods are to be applied.'),
+          paragraph('For the determination of the oil and moisture content, the methods are to be applied.'),
+          paragraph('Products containing components added after processing are excluded.'),
+          paragraph('3. For the purposes of codes 2307 00 11, the following expressions apply:'),
+          paragraph('•‘actual alcoholic strength by mass’: the number of kilograms of pure alcohol contained in 100 kg of the product,', indent: 720),
+          paragraph('•‘potential alcoholic strength by mass’: the number of kilograms of pure alcohol capable of being produced by total fermentation of the sugars contained in 100 kg of the product,', indent: 720),
+          paragraph('•‘total alcoholic strength by mass’: the sum of the actual and potential alcoholic strengths by mass,', indent: 720),
+          paragraph('% mas’: the symbol for alcoholic strength by mass.', first_line_indent: 720),
+        ])
+
+        expect(result.chapters['23']).to include(
+          [
+            '2. Code 2306 90 05 includes only residues containing:',
+            '',
+            '    a. products of an oil content of less than 3 %;',
+            '',
+            '    b. products of an oil content of not less than 3 %;',
+            '',
+            '    For the determination of the starch and protein content, the methods are to be applied.',
+            '',
+            '    For the determination of the oil and moisture content, the methods are to be applied.',
+            '',
+            '    Products containing components added after processing are excluded.',
+            '',
+            '3. For the purposes of codes 2307 00 11, the following expressions apply:',
+            '',
+            '    - ‘actual alcoholic strength by mass’: the number of kilograms of pure alcohol contained in 100 kg of the product,',
+            '',
+            '    - ‘potential alcoholic strength by mass’: the number of kilograms of pure alcohol capable of being produced by total fermentation of the sugars contained in 100 kg of the product,',
+            '',
+            '    - ‘total alcoholic strength by mass’: the sum of the actual and potential alcoholic strengths by mass,',
+            '',
+            '    - % mas’: the symbol for alcoholic strength by mass.',
           ].join("\n"),
         )
       end

--- a/spec/lib/customs_tariff_importer/notes_extractor_spec.rb
+++ b/spec/lib/customs_tariff_importer/notes_extractor_spec.rb
@@ -208,6 +208,51 @@ RSpec.describe CustomsTariffImporter::NotesExtractor do
         end
       end
 
+      it 'removes advisory chapter note preambles' do
+        [
+          '**There are important notes for this part of the tariff:**',
+          '**There are important chapter notes for this part of the tariff:**',
+        ].each do |preamble|
+          result = parse_paragraphs([
+            paragraph('CHAPTER 70'),
+            paragraph('Chapter Notes'),
+            paragraph(preamble),
+            paragraph('1.This chapter does not cover:'),
+            paragraph('a. goods of heading 3207;', indent: 720),
+          ])
+
+          expect(result.chapters['70']).not_to include('There are important')
+          expect(result.chapters['70']).to start_with(
+            [
+              '1. This chapter does not cover:',
+              '',
+              '    a. goods of heading 3207;',
+            ].join("\n"),
+          )
+        end
+      end
+
+      it 'removes malformed literal bold markers duplicated by the next source paragraph' do
+        result = parse([
+          'CHAPTER 76',
+          'Subheading notes',
+          '**Other elements',
+          '**Other elements**',
+          '1.This chapter does not cover:',
+        ])
+
+        expect(result.chapters['76']).to include(
+          [
+            '### Subheading notes',
+            '',
+            '**Other elements**',
+            '',
+            '1. This chapter does not cover:',
+          ].join("\n"),
+        )
+        expect(result.chapters['76']).not_to include("**Other elements\n")
+      end
+
       it 'does not save a section with no notes' do
         result = parse(['SECTION I', 'CHAPTER 1'])
         expect(result.sections).to be_empty
@@ -547,6 +592,68 @@ RSpec.describe CustomsTariffImporter::NotesExtractor do
             '        1. weighing not more than 80 g/m2; or',
             '',
             '        2. coloured throughout the mass; or',
+          ].join("\n"),
+        )
+      end
+
+      it 'does not promote an uppercase marker group unless it starts at the first parent marker' do
+        result = parse_paragraphs([
+          paragraph('CHAPTER 84'),
+          paragraph('Chapter Notes'),
+          paragraph('6. (A) For the purposes of heading 8471, automatic data-processing machines means machines, capable of'),
+          paragraph('(1) storing the processing program;', indent: 1440),
+          paragraph('(2) being freely programmed;', indent: 720, first_line_indent: 720),
+          paragraph('(B) Automatic data-processing machines may be in the form of systems.', indent: 720),
+          paragraph('(C) A unit is part of an automatic data processing system if it meets all the following conditions:', indent: 720),
+          paragraph('(1) it is principally used in an automatic data-processing system;', indent: 1440),
+          paragraph('(2) it is connectable to the central processing unit;', indent: 1440),
+          paragraph('Separately presented units are to be classified in heading 8471.', indent: 720),
+          paragraph('(D) Heading 8471 does not cover the following:', indent: 720),
+          paragraph('(1) printers, copying machines, facsimile machines;', indent: 720, first_line_indent: 720),
+        ])
+
+        expect(result.chapters['84']).to include(
+          [
+            '6. (A) For the purposes of heading 8471, automatic data-processing machines means machines, capable of',
+            '',
+            '    (1) storing the processing program;',
+            '',
+            '    (2) being freely programmed;',
+            '',
+            '    (B) Automatic data-processing machines may be in the form of systems.',
+            '',
+            '    (C) A unit is part of an automatic data processing system if it meets all the following conditions:',
+            '',
+            '    (1) it is principally used in an automatic data-processing system;',
+            '',
+            '    (2) it is connectable to the central processing unit;',
+            '',
+            '    Separately presented units are to be classified in heading 8471.',
+            '',
+            '    (D) Heading 8471 does not cover the following:',
+            '',
+            '    (1) printers, copying machines, facsimile machines;',
+          ].join("\n"),
+        )
+        expect(result.chapters['84']).not_to include('    - (B)')
+      end
+
+      it 'separates source-indented paragraphs within numbered notes' do
+        result = parse_paragraphs([
+          paragraph('CHAPTER 84'),
+          paragraph('Chapter Notes'),
+          paragraph('10. For the purposes of heading 8485, additive manufacturing means layering material.'),
+          paragraph(
+            'Subject to Note 1 to Section XVI and Note 1 to Chapter 84, machines answering to heading 8485 are classified there.',
+            indent: 720,
+          ),
+        ])
+
+        expect(result.chapters['84']).to include(
+          [
+            '10. For the purposes of heading 8485, additive manufacturing means layering material.',
+            '',
+            '    Subject to Note 1 to Section XVI and Note 1 to Chapter 84, machines answering to heading 8485 are classified there.',
           ].join("\n"),
         )
       end
@@ -1219,6 +1326,7 @@ RSpec.describe CustomsTariffImporter::NotesExtractor do
           | Ag Silver \\| gold \\\\ alloy | 0,25 |
           | Other elements are, for example, Al, Be, Co, Fe, Mn, Ni, Si. | 0.3 |
         MARKDOWN
+        expect(result.chapters['74']).to have_valid_markdown_tables
         expect(result.chapters['74']).not_to include("Ag\n    Silver\n    0,25")
       end
 
@@ -1391,6 +1499,35 @@ RSpec.describe CustomsTariffImporter::NotesExtractor do
       end
 
       it 'keeps source-indented definition paragraphs and roman bracket conditions out of code blocks' do
+        table_xml = <<~XML
+          <w:tbl>
+            <w:tr>
+              <w:tc>
+                <w:tcPr><w:gridSpan w:val="2"/></w:tcPr>
+                <w:p><w:r><w:t>Element</w:t></w:r></w:p>
+              </w:tc>
+              <w:tc><w:p><w:r><w:t>Limiting content % by weight</w:t></w:r></w:p></w:tc>
+            </w:tr>
+            <w:tr>
+              <w:tc><w:p><w:r><w:t>Fe</w:t></w:r></w:p></w:tc>
+              <w:tc><w:p><w:r><w:t>Iron</w:t></w:r></w:p></w:tc>
+              <w:tc><w:p><w:r><w:t>0.5</w:t></w:r></w:p></w:tc>
+            </w:tr>
+            <w:tr>
+              <w:tc><w:p><w:r><w:t>O</w:t></w:r></w:p></w:tc>
+              <w:tc><w:p><w:r><w:t>Oxygen</w:t></w:r></w:p></w:tc>
+              <w:tc><w:p><w:r><w:t>0.4</w:t></w:r></w:p></w:tc>
+            </w:tr>
+            <w:tr>
+              <w:tc>
+                <w:tcPr><w:gridSpan w:val="2"/></w:tcPr>
+                <w:p><w:r><w:t>Other elements, each</w:t></w:r></w:p>
+              </w:tc>
+              <w:tc><w:p><w:r><w:t>0.3</w:t></w:r></w:p></w:tc>
+            </w:tr>
+          </w:tbl>
+        XML
+
         docx_content = build_docx_from_body_xml([
           paragraph_xml('CHAPTER 75', bold: true),
           paragraph_xml('Subheading notes', bold: true),
@@ -1399,6 +1536,7 @@ RSpec.describe CustomsTariffImporter::NotesExtractor do
           indented_paragraph_xml('Metal containing by weight at least 99 % of nickel plus cobalt, provided that:', left: 720),
           indented_paragraph_xml('(i) the cobalt content by weight does not exceed 1.5 %, and', left: 1800),
           indented_paragraph_xml('(ii) the content by weight of any other element does not exceed the limit specified in the following table:', left: 1800),
+          table_xml,
         ].join("\n"))
 
         result = described_class.new('1.30', docx_content).call
@@ -1416,8 +1554,15 @@ RSpec.describe CustomsTariffImporter::NotesExtractor do
             '    (i) the cobalt content by weight does not exceed 1.5 %, and',
             '',
             '    (ii) the content by weight of any other element does not exceed the limit specified in the following table:',
+            '',
+            '    | Element | Limiting content % by weight |',
+            '    | --- | --- |',
+            '    | Fe (Iron) | 0.5 |',
+            '    | O (Oxygen) | 0.4 |',
+            '    | Other elements, each | 0.3 |',
           ].join("\n"),
         )
+        expect(result.chapters['75']).to have_valid_markdown_tables
       end
 
       it 'preserves source bold without inventing bold for plain paragraphs' do

--- a/spec/lib/customs_tariff_importer/notes_extractor_spec.rb
+++ b/spec/lib/customs_tariff_importer/notes_extractor_spec.rb
@@ -729,6 +729,31 @@ RSpec.describe CustomsTariffImporter::NotesExtractor do
         expect(result.sections[15]).not_to include('    - a.')
       end
 
+      it 'does not treat letter v in an alphabetic marker run as a roman child marker' do
+        result = parse_paragraphs([
+          paragraph('CHAPTER 95'),
+          paragraph('Chapter Notes'),
+          paragraph('1. This chapter does not cover:'),
+          paragraph('u. lighting strings of all kinds;', indent: 720, first_line_indent: 720),
+          paragraph('v. monopods, bipods, tripods and similar articles;', indent: 720, first_line_indent: 720),
+          paragraph('w. racket strings, tents or other camping goods;', indent: 1440),
+          paragraph('x. tableware, kitchenware, toilet articles.', indent: 1440),
+        ])
+
+        expect(result.chapters['95']).to include(
+          [
+            '    u. lighting strings of all kinds;',
+            '',
+            '    v. monopods, bipods, tripods and similar articles;',
+            '',
+            '    w. racket strings, tents or other camping goods;',
+            '',
+            '    x. tableware, kitchenware, toilet articles.',
+          ].join("\n"),
+        )
+        expect(result.chapters['95']).not_to include('    - v.')
+      end
+
       it 'stops collecting chapter notes when a 10-digit commodity code is encountered' do
         result = parse([
           'CHAPTER 1',

--- a/spec/lib/customs_tariff_importer/notes_extractor_spec.rb
+++ b/spec/lib/customs_tariff_importer/notes_extractor_spec.rb
@@ -202,6 +202,52 @@ RSpec.describe CustomsTariffImporter::NotesExtractor do
         expect(result.sections).to be_empty
       end
 
+      it 'resets indentation for additional section notes' do
+        result = parse([
+          'SECTION XVI',
+          'Section Notes',
+          '6. Throughout the nomenclature, the expression electrical and electronic waste means:',
+          '(C) This section does not cover municipal waste.',
+          'Additional section notes',
+          '1. Tools necessary for the assembly or maintenance of machines are to be classified with those machines.',
+          '2. General rule of interpretation 2(a) is also applicable to machines imported in split consignments.',
+        ])
+
+        expect(result.sections[16]).to include(
+          [
+            '6. Throughout the nomenclature, the expression electrical and electronic waste means:',
+            '',
+            '    (C) This section does not cover municipal waste.',
+            '',
+            '### Additional section notes',
+            '',
+            '1. Tools necessary for the assembly or maintenance of machines are to be classified with those machines.',
+            '',
+            '2. General rule of interpretation 2(a) is also applicable to machines imported in split consignments.',
+          ].join("\n"),
+        )
+      end
+
+      it 'does not inherit general rule indentation state' do
+        result = parse([
+          'General Interpretive Rules',
+          'Rule 2',
+          '2. A reference to an article includes incomplete articles.',
+          'SECTION I',
+          'Section Notes',
+          '1. Any reference in this section to a particular genus or species includes the young of that genus or species.',
+          '2. References to dried products also cover dehydrated, evaporated or freeze-dried products.',
+        ])
+
+        expect(result.sections[1]).to eq(
+          [
+            '1. Any reference in this section to a particular genus or species includes the young of that genus or species.',
+            '',
+            '2. References to dried products also cover dehydrated, evaporated or freeze-dried products.',
+          ].join("\n"),
+        )
+      end
+
       context 'when a chapter header appears before the section notes heading' do
         it 'still captures the section notes' do
           result = parse([
@@ -260,6 +306,27 @@ RSpec.describe CustomsTariffImporter::NotesExtractor do
         expect(result.chapters['01']).to include('Primary note.')
         expect(result.chapters['01']).to include('Additional Chapter Notes')
         expect(result.chapters['01']).to include('Extra note.')
+      end
+
+      it 'separates additional chapter note headings from preceding numbered notes' do
+        result = parse([
+          'CHAPTER 9',
+          'Chapter Notes',
+          '1. Primary note.',
+          '2. Second primary note.',
+          'Additional chapter notes',
+          '1. Additional note.',
+        ])
+
+        expect(result.chapters['09']).to include(
+          [
+            '2. Second primary note.',
+            '',
+            '### Additional chapter notes',
+            '',
+            '1. Additional note.',
+          ].join("\n"),
+        )
       end
 
       it 'stops collecting chapter notes when a 10-digit commodity code is encountered' do
@@ -454,6 +521,7 @@ RSpec.describe CustomsTariffImporter::NotesExtractor do
             'a. Refined copper:',
             '',
             'Metal containing copper.',
+            '',
             '### Subheading note',
             '',
             'In this chapter, the following expressions have the meanings hereby assigned to them:',
@@ -504,6 +572,7 @@ RSpec.describe CustomsTariffImporter::NotesExtractor do
             '    - not more than 6 % of manganese',
             '',
             '    b. spiegeleisen',
+            '',
             '### Additional chapter note',
             '',
             '1. For the purposes of code 7201 50 10:',

--- a/spec/lib/customs_tariff_importer/notes_extractor_spec.rb
+++ b/spec/lib/customs_tariff_importer/notes_extractor_spec.rb
@@ -184,6 +184,7 @@ RSpec.describe CustomsTariffImporter::NotesExtractor do
             '1.This section does not cover:',
             '    a. prepared paints;',
             '    b. ferro-cerium;',
+            '    ij. articles of Chapter 46;',
             '2.Throughout the nomenclature, the expression means:',
             '    a. articles of heading 7307;',
           ])
@@ -196,6 +197,8 @@ RSpec.describe CustomsTariffImporter::NotesExtractor do
               '    a. prepared paints;',
               '',
               '    b. ferro-cerium;',
+              '',
+              '    ij. articles of Chapter 46;',
               '',
               '2. Throughout the nomenclature, the expression means:',
               '',
@@ -1053,6 +1056,29 @@ RSpec.describe CustomsTariffImporter::NotesExtractor do
           [
             '1. Previous note.',
             '    4 The goods are put up in containers.',
+          ].join("\n"),
+        )
+      end
+
+      it 'unindents a compact top-level note after a source-indented lettered list' do
+        result = parse_paragraphs([
+          paragraph('CHAPTER 48'),
+          paragraph('Chapter Notes'),
+          paragraph('2. This chapter does not cover:'),
+          paragraph('a. articles of Chapter 95; or', indent: 720, first_line_indent: 720),
+          paragraph('b. articles of Chapter 96.', indent: 1440),
+          paragraph('3.Subject to the provisions of note 7, headings 4801 to 4805 include paper.', indent: 720),
+        ])
+
+        expect(result.chapters['48']).to include(
+          [
+            '2. This chapter does not cover:',
+            '',
+            '    a. articles of Chapter 95; or',
+            '',
+            '    b. articles of Chapter 96.',
+            '',
+            '3. Subject to the provisions of note 7, headings 4801 to 4805 include paper.',
           ].join("\n"),
         )
       end

--- a/spec/lib/customs_tariff_importer/notes_extractor_spec.rb
+++ b/spec/lib/customs_tariff_importer/notes_extractor_spec.rb
@@ -415,6 +415,133 @@ RSpec.describe CustomsTariffImporter::NotesExtractor do
         )
       end
 
+      it 'promotes marker paragraphs to markdown lists only when the source has child markers' do
+        result = parse_paragraphs([
+          paragraph('CHAPTER 30'),
+          paragraph('Chapter Notes'),
+          paragraph('1. This chapter does not cover:'),
+          paragraph('(a) foods or beverages;'),
+          paragraph('(b) products containing nicotine.'),
+          paragraph('3. For the purposes of headings 3003 and 3004, the following are to be treated:'),
+          paragraph('(a) as unmixed products:'),
+          paragraph('(1) unmixed products dissolved in water;', first_line_indent: 720),
+          paragraph('(2) all goods of Chapter 28 or 29; and', first_line_indent: 720),
+          paragraph('(b) as products which have been mixed:'),
+          paragraph('(1) colloidal solutions and suspensions;', first_line_indent: 720),
+          paragraph('Subheading notes'),
+          paragraph('1. For the purposes of subheadings 3002 13 and 3002 14, the following are to be treated:'),
+          paragraph('(a) as unmixed products, pure products, whether or not containing impurities;', first_line_indent: 720),
+          paragraph('(b) as products which have been mixed:', first_line_indent: 720),
+          paragraph('(1) the products mentioned in (a) above dissolved in water or in other solvents;', indent: 1440),
+          paragraph('(2) the products mentioned in (a) and (b) (1) above with an added stabiliser;', indent: 1440),
+          paragraph('Additional chapter note'),
+          paragraph('1. Heading 3004 includes herbal medicinal preparations if they bear the following statements of:'),
+          paragraph('(a) the specific diseases, ailments or their symptoms for which the product is to be used;', indent: 720),
+          paragraph('(b) the concentration of active substance or substances contained therein;', first_line_indent: 720),
+          paragraph('(c) dosage; and', first_line_indent: 720),
+          paragraph('(d) mode of application.', first_line_indent: 720),
+          paragraph('CHAPTER 39'),
+          paragraph('Chapter Notes'),
+          paragraph('2. This chapter does not cover:'),
+          paragraph('(u) articles of Chapter 90;'),
+          paragraph('(v) articles of Chapter 91;'),
+          paragraph('(w) articles of Chapter 92;'),
+          paragraph('(x) articles of Chapter 94;'),
+          paragraph('CHAPTER 40'),
+          paragraph('Chapter Notes'),
+          paragraph('5. (A) Headings 4001 and 4002 do not apply to rubber compounded with:'),
+          paragraph('(1) vulcanising agents;'),
+          paragraph('(2) pigments;'),
+          paragraph('(B) The presence of the following substances shall not affect classification:'),
+          paragraph('(1) emulsifiers or anti-tack agents;'),
+          paragraph('(2) small amounts of breakdown products of emulsifiers;'),
+          paragraph('CHAPTER 48'),
+          paragraph('Chapter Notes'),
+          paragraph('5. For the purposes of heading 4802, the following criteria apply:'),
+          paragraph('(A). For paper weighing not more than 150 g/m2:'),
+          paragraph('a. containing 10 % or more fibres, and', indent: 1440),
+          paragraph('1.weighing not more than 80 g/m2; or', indent: 1440, first_line_indent: 720),
+          paragraph('2.coloured throughout the mass; or', indent: 1440, first_line_indent: 720),
+        ])
+
+        expect(result.chapters['30']).to include(
+          [
+            '1. This chapter does not cover:',
+            '    (a) foods or beverages;',
+            '    (b) products containing nicotine.',
+          ].join("\n"),
+        )
+        expect(result.chapters['30']).to include(
+          [
+            '3. For the purposes of headings 3003 and 3004, the following are to be treated:',
+            '    - (a) as unmixed products:',
+            '        - (1) unmixed products dissolved in water;',
+            '        - (2) all goods of Chapter 28 or 29; and',
+            '    - (b) as products which have been mixed:',
+            '        - (1) colloidal solutions and suspensions;',
+          ].join("\n"),
+        )
+        expect(result.chapters['30']).to include(
+          [
+            '### Subheading notes',
+            '',
+            '1. For the purposes of subheadings 3002 13 and 3002 14, the following are to be treated:',
+            '    - (a) as unmixed products, pure products, whether or not containing impurities;',
+            '    - (b) as products which have been mixed:',
+            '',
+            '        - (1) the products mentioned in (a) above dissolved in water or in other solvents;',
+            '',
+            '        - (2) the products mentioned in (a) and (b) (1) above with an added stabiliser;',
+          ].join("\n"),
+        )
+        expect(result.chapters['30']).to include(
+          [
+            '### Additional chapter note',
+            '',
+            '1. Heading 3004 includes herbal medicinal preparations if they bear the following statements of:',
+            '',
+            '    (a) the specific diseases, ailments or their symptoms for which the product is to be used;',
+            '',
+            '    (b) the concentration of active substance or substances contained therein;',
+            '',
+            '    (c) dosage; and',
+            '',
+            '    (d) mode of application.',
+          ].join("\n"),
+        )
+        expect(result.chapters['39']).to include(
+          [
+            '2. This chapter does not cover:',
+            '    (u) articles of Chapter 90;',
+            '    (v) articles of Chapter 91;',
+            '    (w) articles of Chapter 92;',
+            '    (x) articles of Chapter 94;',
+          ].join("\n"),
+        )
+        expect(result.chapters['40']).to include(
+          [
+            '5. (A) Headings 4001 and 4002 do not apply to rubber compounded with:',
+            '    (1) vulcanising agents;',
+            '    (2) pigments;',
+            '    (B) The presence of the following substances shall not affect classification:',
+            '    (1) emulsifiers or anti-tack agents;',
+            '    (2) small amounts of breakdown products of emulsifiers;',
+          ].join("\n"),
+        )
+        expect(result.chapters['48']).to include(
+          [
+            '5. For the purposes of heading 4802, the following criteria apply:',
+            '    (A). For paper weighing not more than 150 g/m2:',
+            '',
+            '    - a. containing 10 % or more fibres, and',
+            '',
+            '        1. weighing not more than 80 g/m2; or',
+            '',
+            '        2. coloured throughout the mass; or',
+          ].join("\n"),
+        )
+      end
+
       it 'stops collecting chapter notes when a 10-digit commodity code is encountered' do
         result = parse([
           'CHAPTER 1',

--- a/spec/support/matchers/have_valid_markdown_tables.rb
+++ b/spec/support/matchers/have_valid_markdown_tables.rb
@@ -1,0 +1,71 @@
+RSpec::Matchers.define :have_valid_markdown_tables do
+  match do |actual|
+    @errors = []
+
+    markdown_table_blocks(actual.to_s).each_with_index do |block, block_index|
+      validate_markdown_table_block(block, block_index + 1)
+    end
+
+    @errors.empty?
+  end
+
+  failure_message do
+    "expected markdown tables to be valid:\n#{@errors.join("\n")}"
+  end
+
+  def validate_markdown_table_block(block, block_number)
+    if block.length < 2
+      @errors << "table #{block_number} has #{block.length} row; expected at least a header and separator"
+      return
+    end
+
+    unless markdown_table_separator?(block.second[:text])
+      @errors << "table #{block_number} row #{block.second[:line_number]} is not a separator row"
+    end
+
+    expected_columns = markdown_table_cells(block.first[:text]).length
+    block.each do |row|
+      actual_columns = markdown_table_cells(row[:text]).length
+      next if actual_columns == expected_columns
+
+      @errors << "table #{block_number} row #{row[:line_number]} has #{actual_columns} cells; expected #{expected_columns}"
+    end
+  end
+
+  def markdown_table_blocks(markdown)
+    markdown.lines.map.with_index(1) { |line, line_number| { text: line.chomp, line_number: } }
+      .chunk_while { |previous, current| markdown_table_line?(previous[:text]) && markdown_table_line?(current[:text]) }
+      .select { |block| markdown_table_line?(block.first[:text]) }
+  end
+
+  def markdown_table_line?(line)
+    line.to_s.strip.match?(/\A\|.*\|\z/)
+  end
+
+  def markdown_table_separator?(line)
+    markdown_table_cells(line).all? { |cell| cell.match?(/\A:?-+:?\z/) }
+  end
+
+  def markdown_table_cells(line)
+    inner = line.strip.delete_prefix('|').delete_suffix('|')
+    split_unescaped_pipes(inner).map(&:strip)
+  end
+
+  def split_unescaped_pipes(text)
+    cells = ['']
+    escaped = false
+
+    text.each_char do |character|
+      if character == '|' && !escaped
+        cells << ''
+      else
+        cells.last << character
+      end
+
+      escaped = character == '\\' && !escaped
+      escaped = false if character != '\\'
+    end
+
+    cells
+  end
+end


### PR DESCRIPTION
### Jira link

[AI-884](https://transformuk.atlassian.net/browse/AI-884)

### What?

- [x] Reset formatter state after General Interpretive Rules so Section 1 does not inherit indentation.
- [x] Treat Additional section notes as a structural note heading.
- [x] Separate additional chapter and subheading note headings from preceding numbered note content.
- [x] Normalise compact markers such as `2.(a)` and source bullet glyphs such as `•0.93`.
- [x] Preserve source-driven indentation for chapter 23 note 2 without inventing deeper ingredient bullets.
- [x] Read first-line indentation so chapter 23 `% mas` is kept as a bullet under note 3.
- [x] Promote marker paragraphs to markdown lists only when the source has child marker indentation and that child sequence resets to its first marker, preserving chapter 30 sublists without changing flat marker lists.

### Why?

The custom tariff note importer was losing and leaking formatting state across different note sections. That made admin previews inconsistent with the source DOCX and forced operators to manually reason about whether generated markdown reflected the source material.

The important discovery is that the DOCX does provide structural signals for some cases, but not all. This PR uses source signals when they exist, and avoids inventing extra structure from prose alone.

### Risk

**Risk level:** 🟢

**Reason for rating:** This fixes unreleased custom tariff note import functionality while we are still testing and refining the generated markdown. The changes are covered by focused parser specs and local reimport checks.
