### PR TITLE
AI-887: Promote customs tariff notes in V2 responses

### DIFF
--- a/app/controllers/api/v2/chapters_controller.rb
+++ b/app/controllers/api/v2/chapters_controller.rb
@@ -81,6 +81,10 @@ module Api
           .actual
           .non_hidden
           .by_code(chapter_id)
+          .eager(
+            chapter_note_eager_load,
+            sections: [section_note_eager_load],
+          )
           .take
       end
 
@@ -88,8 +92,16 @@ module Api
         Chapter
           .actual
           .non_hidden
-          .eager(:chapter_note, :goods_nomenclature_descriptions)
+          .eager(chapter_note_eager_load, :goods_nomenclature_descriptions)
           .all
+      end
+
+      def chapter_note_eager_load
+        TradeTariffBackend.promote_customs_tariff_notes? ? :customs_tariff_chapter_note : :chapter_note
+      end
+
+      def section_note_eager_load
+        TradeTariffBackend.promote_customs_tariff_notes? ? :customs_tariff_section_note : :section_note
       end
 
       def chapter_id

--- a/app/controllers/api/v2/sections_controller.rb
+++ b/app/controllers/api/v2/sections_controller.rb
@@ -3,7 +3,10 @@ module Api
     class SectionsController < ApiController
       def index
         @sections = Section
-          .eager({ chapters: [:chapter_note] }, :section_note)
+          .eager(
+            section_note_eager_load,
+            chapters: [chapter_note_eager_load],
+          )
           .all
 
         respond_to do |format|
@@ -22,7 +25,13 @@ module Api
       def show
         return head :bad_request unless params[:id].to_s.match?(/\A\d+\z/)
 
-        @section = Section.where(position: params[:id].to_i).take
+        @section = Section
+          .where(position: params[:id].to_i)
+          .eager(
+            section_note_eager_load,
+            chapters: [chapter_note_eager_load],
+          )
+          .take
 
         options = { is_collection: false }
         options[:include] = [:chapters, 'chapters.guides']
@@ -47,6 +56,16 @@ module Api
             render json: Api::V2::Chapters::ChapterListSerializer.new(chapters).serializable_hash
           end
         end
+      end
+
+      private
+
+      def chapter_note_eager_load
+        TradeTariffBackend.promote_customs_tariff_notes? ? :customs_tariff_chapter_note : :chapter_note
+      end
+
+      def section_note_eager_load
+        TradeTariffBackend.promote_customs_tariff_notes? ? :customs_tariff_section_note : :section_note
       end
     end
   end

--- a/app/lib/trade_tariff_backend/config.rb
+++ b/app/lib/trade_tariff_backend/config.rb
@@ -75,6 +75,10 @@ module TradeTariffBackend
       ENV.fetch('ENVIRONMENT', Rails.env)
     end
 
+    def promote_customs_tariff_notes?
+      !environment.production?
+    end
+
     def currency
       SERVICE_CURRENCIES.fetch(service, 'GBP')
     end

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -23,9 +23,23 @@ class Chapter < GoodsNomenclature
   end
 
   one_to_one :chapter_note, primary_key: :chapter_short_code
+  one_to_one :customs_tariff_chapter_note, key: :chapter_id, primary_key: :chapter_short_code do |ds|
+    ds.where(
+      status: CustomsTariffChapterNote::APPROVED,
+      customs_tariff_update_version: CustomsTariffUpdate.approved.actual.select(:version),
+    )
+  end
 
   def guide_ids
     guides.pluck(:id)
+  end
+
+  def public_chapter_note
+    if TradeTariffBackend.promote_customs_tariff_notes?
+      customs_tariff_chapter_note
+    else
+      chapter_note
+    end
   end
 
   def section_id

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -25,8 +25,22 @@ class Section < Sequel::Model
 
   one_to_one :section_note
 
-  one_to_one :customs_tariff_section_note, key: :section_id, primary_key: :id do |ds|
+  one_to_one :current_customs_tariff_section_note, class: :CustomsTariffSectionNote, key: :section_id, primary_key: :id do |ds|
     ds.where(customs_tariff_update_version: CustomsTariffUpdate.actual.select(:version))
+  end
+  one_to_one :customs_tariff_section_note, key: :section_id, primary_key: :id do |ds|
+    ds.where(
+      status: CustomsTariffSectionNote::APPROVED,
+      customs_tariff_update_version: CustomsTariffUpdate.approved.actual.select(:version),
+    )
+  end
+
+  def public_section_note
+    if TradeTariffBackend.promote_customs_tariff_notes?
+      customs_tariff_section_note
+    else
+      section_note
+    end
   end
 
   def first_chapter

--- a/app/presenters/api/v2/headings/chapter_presenter.rb
+++ b/app/presenters/api/v2/headings/chapter_presenter.rb
@@ -3,7 +3,7 @@ module Api
     module Headings
       class ChapterPresenter < SimpleDelegator
         def chapter_note
-          super&.content
+          public_chapter_note&.content
         end
       end
     end

--- a/app/presenters/api/v2/headings/section_presenter.rb
+++ b/app/presenters/api/v2/headings/section_presenter.rb
@@ -3,7 +3,7 @@ module Api
     module Headings
       class SectionPresenter < SimpleDelegator
         def section_note
-          super&.content
+          public_section_note&.content
         end
       end
     end

--- a/app/serializers/api/admin/sections/section_list_serializer.rb
+++ b/app/serializers/api/admin/sections/section_list_serializer.rb
@@ -11,7 +11,7 @@ module Api
         attributes :id, :numeral, :title, :position, :chapter_from, :chapter_to
 
         attribute :section_note_id do |section|
-          note = TradeTariffBackend.uk? ? section.customs_tariff_section_note : section.section_note
+          note = TradeTariffBackend.uk? ? section.current_customs_tariff_section_note : section.section_note
           note&.id
         end
       end

--- a/app/serializers/api/v2/chapters/chapter_serializer.rb
+++ b/app/serializers/api/v2/chapters/chapter_serializer.rb
@@ -16,8 +16,8 @@ module Api
                    :validity_end_date,
                    :description_plain
 
-        attribute :chapter_note, if: proc { |chapter| chapter.chapter_note.present? } do |chapter|
-          chapter.chapter_note.content
+        attribute :chapter_note, if: proc { |chapter| chapter.public_chapter_note.present? } do |chapter|
+          chapter.public_chapter_note.content
         end
 
         attribute :forum_url do |chapter|

--- a/app/serializers/api/v2/chapters/section_serializer.rb
+++ b/app/serializers/api/v2/chapters/section_serializer.rb
@@ -9,8 +9,8 @@ module Api
         set_id :id
 
         attributes :id, :numeral, :title, :position
-        attribute :section_note, if: proc { |section| section.section_note.present? } do |section|
-          section.section_note.content
+        attribute :section_note, if: proc { |section| section.public_section_note.present? } do |section|
+          section.public_section_note.content
         end
       end
     end

--- a/app/serializers/api/v2/commodities/chapter_serializer.rb
+++ b/app/serializers/api/v2/commodities/chapter_serializer.rb
@@ -11,8 +11,8 @@ module Api
         attributes :goods_nomenclature_item_id, :description, :formatted_description,
                    :validity_start_date, :validity_end_date
 
-        attribute :chapter_note, if: proc { |chapter| chapter.chapter_note.present? } do |chapter|
-          chapter.chapter_note.content
+        attribute :chapter_note, if: proc { |chapter| chapter.public_chapter_note.present? } do |chapter|
+          chapter.public_chapter_note.content
         end
 
         has_many :guides, serializer: Api::V2::GuideSerializer

--- a/app/serializers/api/v2/commodities/section_serializer.rb
+++ b/app/serializers/api/v2/commodities/section_serializer.rb
@@ -10,8 +10,8 @@ module Api
 
         attributes :numeral, :title, :position
 
-        attribute :section_note, if: proc { |section| section.section_note.present? } do |section|
-          section.section_note.content
+        attribute :section_note, if: proc { |section| section.public_section_note.present? } do |section|
+          section.public_section_note.content
         end
       end
     end

--- a/app/serializers/api/v2/sections/section_serializer.rb
+++ b/app/serializers/api/v2/sections/section_serializer.rb
@@ -10,8 +10,8 @@ module Api
 
         attributes :id, :numeral, :title, :position, :chapter_from, :chapter_to, :description_plain
 
-        attribute :section_note, if: proc { |section| section.section_note.present? } do |section|
-          section.section_note.content
+        attribute :section_note, if: proc { |section| section.public_section_note.present? } do |section|
+          section.public_section_note.content
         end
 
         has_many :chapters, serializer: Api::V2::Sections::ChapterSerializer

--- a/app/services/cached_commodity_service.rb
+++ b/app/services/cached_commodity_service.rb
@@ -142,7 +142,12 @@ class CachedCommodityService
         .eager(
           goods_nomenclature_descriptions: {},
           heading: %i[footnotes goods_nomenclature_descriptions],
-          chapter: [:chapter_note, :goods_nomenclature_descriptions, :guides, { sections: :section_note }],
+          chapter: [
+            chapter_note_eager_load,
+            :goods_nomenclature_descriptions,
+            :guides,
+            { sections: [section_note_eager_load] },
+          ],
           ancestors: :goods_nomenclature_descriptions,
           full_chemicals: {},
         )
@@ -152,6 +157,14 @@ class CachedCommodityService
       load_quota_associations(result)
       result
     end
+  end
+
+  def chapter_note_eager_load
+    TradeTariffBackend.promote_customs_tariff_notes? ? :customs_tariff_chapter_note : :chapter_note
+  end
+
+  def section_note_eager_load
+    TradeTariffBackend.promote_customs_tariff_notes? ? :customs_tariff_section_note : :section_note
   end
 
   # Eager-load quota_order_number and its definition sub-tree only for

--- a/app/services/cached_subheading_service.rb
+++ b/app/services/cached_subheading_service.rb
@@ -54,7 +54,7 @@ class CachedSubheadingService
         .actual
         .non_hidden
         .where(goods_nomenclature_sid: @subheading.goods_nomenclature_sid)
-        .eager(*HeadingService::Serialization::NsNondeclarableService::HEADING_EAGER_LOAD)
+        .eager(*HeadingService::Serialization::NsNondeclarableService.heading_eager_load)
         .take
   end
 

--- a/app/services/heading_service/precache_service.rb
+++ b/app/services/heading_service/precache_service.rb
@@ -28,7 +28,7 @@ module HeadingService
       Chapter.actual.non_hidden.all do |chapter|
         headings = Chapter.actual
                           .where(goods_nomenclature_sid: chapter.goods_nomenclature_sid)
-                          .eager(*Serialization::NsNondeclarableService::HEADING_EAGER_LOAD)
+                          .eager(*Serialization::NsNondeclarableService.heading_eager_load)
                           .take
                           .children
 

--- a/app/services/heading_service/serialization/declarable_service.rb
+++ b/app/services/heading_service/serialization/declarable_service.rb
@@ -48,7 +48,28 @@ module HeadingService
         :full_temporary_stop_regulations,
         :measure_partial_temporary_stops,
       ].freeze
-      HEADING_EAGER = [
+      def self.heading_eager
+        [
+          *BASE_HEADING_EAGER,
+          {
+            chapter: [
+              chapter_note_eager_load,
+              :guides,
+              { sections: [section_note_eager_load] },
+            ],
+          },
+        ]
+      end
+
+      def self.chapter_note_eager_load
+        TradeTariffBackend.promote_customs_tariff_notes? ? :customs_tariff_chapter_note : :chapter_note
+      end
+
+      def self.section_note_eager_load
+        TradeTariffBackend.promote_customs_tariff_notes? ? :customs_tariff_section_note : :section_note
+      end
+
+      BASE_HEADING_EAGER = [
         {
           measures: MEASURE_EAGER,
           ancestors: [{ measures: MEASURE_EAGER }],
@@ -87,7 +108,7 @@ module HeadingService
       end
 
       def heading
-        @heading ||= Heading.where(goods_nomenclature_sid:).eager(HEADING_EAGER).take
+        @heading ||= Heading.where(goods_nomenclature_sid:).eager(*self.class.heading_eager).take
       end
 
       def measures

--- a/app/services/heading_service/serialization/ns_nondeclarable_service.rb
+++ b/app/services/heading_service/serialization/ns_nondeclarable_service.rb
@@ -31,7 +31,7 @@ module HeadingService
         additional_code: [],
       }.freeze
 
-      HEADING_EAGER_LOAD = [
+      BASE_HEADING_EAGER_LOAD = [
         :goods_nomenclature_descriptions,
         {
           footnotes: :footnote_descriptions,
@@ -52,6 +52,10 @@ module HeadingService
           ],
         },
       ].freeze
+
+      def self.heading_eager_load
+        BASE_HEADING_EAGER_LOAD
+      end
 
       attr_reader :heading
 
@@ -83,7 +87,7 @@ module HeadingService
         Heading.actual
                .non_hidden
                .where(goods_nomenclature_sid: heading.goods_nomenclature_sid)
-               .eager(*HEADING_EAGER_LOAD)
+               .eager(*self.class.heading_eager_load)
                .take
       end
     end

--- a/spec/lib/trade_tariff_backend/config_spec.rb
+++ b/spec/lib/trade_tariff_backend/config_spec.rb
@@ -197,6 +197,28 @@ RSpec.describe TradeTariffBackend::Config do
         expect(config.environment.to_s).to eq('local')
       end
     end
+
+    describe '.promote_customs_tariff_notes?' do
+      it 'returns true in development' do
+        ENV['ENVIRONMENT'] = 'development'
+        expect(config.promote_customs_tariff_notes?).to be true
+      end
+
+      it 'returns true in staging' do
+        ENV['ENVIRONMENT'] = 'staging'
+        expect(config.promote_customs_tariff_notes?).to be true
+      end
+
+      it 'returns false in production' do
+        ENV['ENVIRONMENT'] = 'production'
+        expect(config.promote_customs_tariff_notes?).to be false
+      end
+
+      it 'returns true locally' do
+        ENV.delete('ENVIRONMENT')
+        expect(config.promote_customs_tariff_notes?).to be true
+      end
+    end
   end
 
   describe 'OpenSearch config' do

--- a/spec/models/chapter_spec.rb
+++ b/spec/models/chapter_spec.rb
@@ -61,6 +61,60 @@ RSpec.describe Chapter do
     end
   end
 
+  describe '#customs_tariff_chapter_note' do
+    let!(:chapter) { create(:chapter, goods_nomenclature_item_id: '0100000000') }
+
+    around { |example| TimeMachine.now { example.run } }
+
+    it 'returns the approved note from the currently actual update' do
+      older = create(:customs_tariff_update, :approved, validity_start_date: 1.month.ago, validity_end_date: 1.day.ago)
+      newer = create(:customs_tariff_update, :approved, validity_start_date: Time.zone.today)
+      create(:customs_tariff_chapter_note, :approved, customs_tariff_update: older, chapter_id: chapter.short_code)
+      note = create(:customs_tariff_chapter_note, :approved, customs_tariff_update: newer, chapter_id: chapter.short_code)
+
+      expect(chapter.customs_tariff_chapter_note.id).to eq(note.id)
+    end
+
+    it 'ignores pending notes' do
+      update = create(:customs_tariff_update, :approved)
+      create(:customs_tariff_chapter_note, customs_tariff_update: update, chapter_id: chapter.short_code)
+
+      expect(chapter.customs_tariff_chapter_note).to be_nil
+    end
+  end
+
+  describe '#public_chapter_note' do
+    let!(:chapter) { create(:chapter, goods_nomenclature_item_id: '0100000000') }
+    let!(:legacy_note) { create(:chapter_note, chapter_id: chapter.short_code, content: 'Legacy chapter note') }
+    let!(:customs_tariff_update) { create(:customs_tariff_update, :approved) }
+    let!(:customs_tariff_note) do
+      create(:customs_tariff_chapter_note, :approved,
+             customs_tariff_update:,
+             chapter_id: chapter.short_code,
+             content: 'Imported chapter note')
+    end
+
+    context 'when promoted notes are enabled' do
+      before do
+        allow(TradeTariffBackend).to receive(:promote_customs_tariff_notes?).and_return(true)
+      end
+
+      it 'returns the customs tariff note' do
+        expect(chapter.public_chapter_note).to eq(customs_tariff_note)
+      end
+    end
+
+    context 'when promoted notes are disabled' do
+      before do
+        allow(TradeTariffBackend).to receive(:promote_customs_tariff_notes?).and_return(false)
+      end
+
+      it 'returns the legacy note' do
+        expect(chapter.public_chapter_note).to eq(legacy_note)
+      end
+    end
+  end
+
   describe '#to_param' do
     let(:chapter) { create :chapter, goods_nomenclature_item_id: '1200000000' }
 

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Section do
     end
   end
 
-  describe '#customs_tariff_section_note' do
+  describe '#current_customs_tariff_section_note' do
     let!(:section) { create(:section) }
 
     around { |example| TimeMachine.now { example.run } }
@@ -35,12 +35,66 @@ RSpec.describe Section do
       create(:customs_tariff_section_note, customs_tariff_update: older, section_id: section.id)
       note = create(:customs_tariff_section_note, customs_tariff_update: newer, section_id: section.id)
 
-      expect(section.customs_tariff_section_note.id).to eq(note.id)
+      expect(section.current_customs_tariff_section_note.id).to eq(note.id)
     end
 
     it 'returns nil when no note exists for this section' do
       create(:customs_tariff_update)
+      expect(section.current_customs_tariff_section_note).to be_nil
+    end
+  end
+
+  describe '#customs_tariff_section_note' do
+    let!(:section) { create(:section) }
+
+    around { |example| TimeMachine.now { example.run } }
+
+    it 'returns the approved note from the currently actual update' do
+      older = create(:customs_tariff_update, :approved, validity_start_date: 1.month.ago, validity_end_date: 1.day.ago)
+      newer = create(:customs_tariff_update, :approved, validity_start_date: Time.zone.today)
+      create(:customs_tariff_section_note, :approved, customs_tariff_update: older, section_id: section.id)
+      note = create(:customs_tariff_section_note, :approved, customs_tariff_update: newer, section_id: section.id)
+
+      expect(section.customs_tariff_section_note.id).to eq(note.id)
+    end
+
+    it 'ignores pending notes' do
+      update = create(:customs_tariff_update, :approved)
+      create(:customs_tariff_section_note, customs_tariff_update: update, section_id: section.id)
+
       expect(section.customs_tariff_section_note).to be_nil
+    end
+  end
+
+  describe '#public_section_note' do
+    let!(:section) { create(:section) }
+    let!(:legacy_note) { create(:section_note, section_id: section.id, content: 'Legacy section note') }
+    let!(:customs_tariff_update) { create(:customs_tariff_update, :approved) }
+    let!(:customs_tariff_note) do
+      create(:customs_tariff_section_note, :approved,
+             customs_tariff_update:,
+             section_id: section.id,
+             content: 'Imported section note')
+    end
+
+    context 'when promoted notes are enabled' do
+      before do
+        allow(TradeTariffBackend).to receive(:promote_customs_tariff_notes?).and_return(true)
+      end
+
+      it 'returns the customs tariff note' do
+        expect(section.public_section_note).to eq(customs_tariff_note)
+      end
+    end
+
+    context 'when promoted notes are disabled' do
+      before do
+        allow(TradeTariffBackend).to receive(:promote_customs_tariff_notes?).and_return(false)
+      end
+
+      it 'returns the legacy note' do
+        expect(section.public_section_note).to eq(legacy_note)
+      end
     end
   end
 end

--- a/spec/presenters/api/v2/headings/chapter_presenter_spec.rb
+++ b/spec/presenters/api/v2/headings/chapter_presenter_spec.rb
@@ -2,7 +2,13 @@ RSpec.describe Api::V2::Headings::ChapterPresenter do
   subject(:presenter) { described_class.new chapter }
 
   let(:chapter) { create :chapter, :with_note }
+  let!(:customs_tariff_update) { create(:customs_tariff_update, :approved) }
+  let!(:customs_tariff_chapter_note) do
+    create(:customs_tariff_chapter_note, :approved,
+           customs_tariff_update:,
+           chapter_id: chapter.short_code)
+  end
 
   it { is_expected.to have_attributes goods_nomenclature_sid: chapter.goods_nomenclature_sid }
-  it { is_expected.to have_attributes chapter_note: chapter.chapter_note.content }
+  it { is_expected.to have_attributes chapter_note: customs_tariff_chapter_note.content }
 end

--- a/spec/presenters/api/v2/headings/section_presenter_spec.rb
+++ b/spec/presenters/api/v2/headings/section_presenter_spec.rb
@@ -2,7 +2,13 @@ RSpec.describe Api::V2::Headings::SectionPresenter do
   subject(:presenter) { described_class.new section }
 
   let(:section) { create :section, :with_note }
+  let!(:customs_tariff_update) { create(:customs_tariff_update, :approved) }
+  let!(:customs_tariff_section_note) do
+    create(:customs_tariff_section_note, :approved,
+           customs_tariff_update:,
+           section_id: section.id)
+  end
 
   it { is_expected.to have_attributes id: section.id }
-  it { is_expected.to have_attributes section_note: section.section_note.content }
+  it { is_expected.to have_attributes section_note: customs_tariff_section_note.content }
 end

--- a/spec/requests/api/v2/chapters_controller_migrated_spec.rb
+++ b/spec/requests/api/v2/chapters_controller_migrated_spec.rb
@@ -3,7 +3,17 @@ RSpec.describe Api::V2::ChaptersController do
     let(:heading) { create :heading, :with_chapter }
     let(:chapter) { heading.reload.chapter }
     let!(:section) { chapter.section }
-    let!(:section_note) { create :section_note, section_id: section.id }
+    let!(:customs_tariff_update) { create(:customs_tariff_update, :approved) }
+    let!(:customs_tariff_chapter_note) do
+      create(:customs_tariff_chapter_note, :approved,
+             customs_tariff_update:,
+             chapter_id: chapter.short_code)
+    end
+    let!(:customs_tariff_section_note) do
+      create(:customs_tariff_section_note, :approved,
+             customs_tariff_update:,
+             section_id: section.id)
+    end
 
     let(:pattern) do
       {
@@ -15,7 +25,7 @@ RSpec.describe Api::V2::ChaptersController do
             goods_nomenclature_item_id: chapter.goods_nomenclature_item_id,
             description: chapter.description,
             formatted_description: chapter.formatted_description,
-            chapter_note: chapter.chapter_note.content,
+            chapter_note: customs_tariff_chapter_note.content,
             forum_url: chapter.forum_link&.url,
             section_id: section.id,
             validity_start_date: chapter.validity_start_date,
@@ -56,7 +66,7 @@ RSpec.describe Api::V2::ChaptersController do
               position: section.position,
               title: section.title,
               numeral: section.numeral,
-              section_note: section_note.content,
+              section_note: customs_tariff_section_note.content,
             },
           },
           {

--- a/spec/requests/api/v2/chapters_controller_spec.rb
+++ b/spec/requests/api/v2/chapters_controller_spec.rb
@@ -41,6 +41,46 @@ RSpec.describe Api::V2::ChaptersController, :v2 do
           expires_at:,
         )
     end
+
+    context 'when customs tariff notes are promoted' do
+      let!(:customs_tariff_update) { create(:customs_tariff_update, :approved) }
+
+      before do
+        Rails.cache.clear
+        create(:chapter_note, chapter_id: chapter.short_code, content: 'Legacy chapter note')
+        create(:customs_tariff_chapter_note, :approved,
+               customs_tariff_update:,
+               chapter_id: chapter.short_code,
+               content: 'Imported chapter note')
+        allow(TradeTariffBackend).to receive(:promote_customs_tariff_notes?).and_return(true)
+      end
+
+      it 'returns the imported chapter note' do
+        api_get "/uk/api/chapters/#{chapter.short_code}"
+
+        expect(JSON.parse(response.body).dig('data', 'attributes', 'chapter_note')).to eq('Imported chapter note')
+      end
+    end
+
+    context 'when customs tariff notes are not promoted' do
+      let!(:legacy_note) { create(:chapter_note, chapter_id: chapter.short_code, content: 'Legacy chapter note') }
+      let!(:customs_tariff_update) { create(:customs_tariff_update, :approved) }
+
+      before do
+        Rails.cache.clear
+        create(:customs_tariff_chapter_note, :approved,
+               customs_tariff_update:,
+               chapter_id: chapter.short_code,
+               content: 'Imported chapter note')
+        allow(TradeTariffBackend).to receive(:promote_customs_tariff_notes?).and_return(false)
+      end
+
+      it 'returns the legacy chapter note' do
+        api_get "/uk/api/chapters/#{chapter.short_code}"
+
+        expect(JSON.parse(response.body).dig('data', 'attributes', 'chapter_note')).to eq(legacy_note.content)
+      end
+    end
   end
 
   describe 'GET #changes' do

--- a/spec/requests/api/v2/sections_controller_migrated_spec.rb
+++ b/spec/requests/api/v2/sections_controller_migrated_spec.rb
@@ -4,7 +4,12 @@ RSpec.describe Api::V2::SectionsController do
     let(:chapter) { heading.reload.chapter }
     let(:chapter_guide) { chapter.guides.first }
     let(:section) { chapter.section }
-    let!(:section_note) { create :section_note, section_id: section.id }
+    let!(:customs_tariff_update) { create(:customs_tariff_update, :approved) }
+    let!(:customs_tariff_section_note) do
+      create(:customs_tariff_section_note, :approved,
+             customs_tariff_update:,
+             section_id: section.id)
+    end
 
     let(:pattern) do
       {
@@ -19,7 +24,7 @@ RSpec.describe Api::V2::SectionsController do
             chapter_from: section.chapter_from,
             chapter_to: section.chapter_to,
             description_plain: section.description_plain,
-            section_note: section_note.content,
+            section_note: customs_tariff_section_note.content,
           },
           relationships: {
             chapters: {

--- a/spec/requests/api/v2/sections_controller_spec.rb
+++ b/spec/requests/api/v2/sections_controller_spec.rb
@@ -1,4 +1,41 @@
 RSpec.describe Api::V2::SectionsController, :v2 do
+  describe 'GET #show' do
+    let!(:section) { create(:section) }
+    let!(:legacy_note) { create(:section_note, section_id: section.id, content: 'Legacy section note') }
+    let!(:customs_tariff_update) { create(:customs_tariff_update, :approved) }
+
+    before do
+      create(:customs_tariff_section_note, :approved,
+             customs_tariff_update:,
+             section_id: section.id,
+             content: 'Imported section note')
+    end
+
+    context 'when customs tariff notes are promoted' do
+      before do
+        allow(TradeTariffBackend).to receive(:promote_customs_tariff_notes?).and_return(true)
+      end
+
+      it 'returns the imported section note' do
+        api_get "/uk/api/sections/#{section.position}"
+
+        expect(JSON.parse(response.body).dig('data', 'attributes', 'section_note')).to eq('Imported section note')
+      end
+    end
+
+    context 'when customs tariff notes are not promoted' do
+      before do
+        allow(TradeTariffBackend).to receive(:promote_customs_tariff_notes?).and_return(false)
+      end
+
+      it 'returns the legacy section note' do
+        api_get "/uk/api/sections/#{section.position}"
+
+        expect(JSON.parse(response.body).dig('data', 'attributes', 'section_note')).to eq(legacy_note.content)
+      end
+    end
+  end
+
   describe 'GET #index' do
     it_behaves_like 'a successful csv response' do
       let(:path) { '/uk/api/sections' }


### PR DESCRIPTION
## What:

- [x] Add a `TradeTariffBackend.promote_customs_tariff_notes?` environment gate for non-production
- [x] Add public chapter/section note accessors that switch between legacy notes and approved customs tariff notes
- [x] Keep existing V2 `chapter_note` and `section_note` response fields while changing their source when the gate is enabled
- [x] Conditionally eager-load the legacy or promoted note associations across the affected V2 chapter, section, heading, and commodity paths
- [x] Add model, config and request coverage for promoted and legacy note behaviour

## Why:

Approved imported tariff notes need to be validated through the same V2 response fields frontend consumers already read. Non-production can serve the new approved notes through `chapter_note` and `section_note`, while production keeps the legacy note tables until the content has been checked.

## Ticket:

[AI-887](https://transformuk.atlassian.net/browse/AI-887)

## Risk:
**Risk level:** 🟢

**Reason for rating:** Non-production only via `!environment.production?`. Production keeps serving legacy notes, and the response field names stay unchanged.
