### PR TITLE
HMRC-2390: Add JSON:API sparse fields and includes to V2 APIs

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -19,6 +19,11 @@ module Api
       render json: serializer.serialized_errors({ error: exception.message, url: request.url }), status: :bad_request
     end
 
+    rescue_from JSONAPI::Serializer::UnsupportedIncludeError do |exception|
+      serializer = TradeTariffBackend.error_serializer(request)
+      render json: serializer.serialized_errors({ error: exception.message, url: request.url }), status: :bad_request
+    end
+
     protected
 
     def current_page

--- a/app/controllers/api/v2/chapters_controller.rb
+++ b/app/controllers/api/v2/chapters_controller.rb
@@ -6,6 +6,7 @@ module Api
       before_action :track_result_selected, only: :show
 
       CACHE_VERSION = 2
+      SHOW_DEFAULT_INCLUDE = %i[section guides headings headings.children].freeze
 
       def index
         respond_to do |format|
@@ -19,9 +20,10 @@ module Api
 
           format.any do
             cache_key = "_chapters-#{actual_date}/v#{CACHE_VERSION}"
+            cache_key = "#{cache_key}/jsonapi-#{jsonapi_options_cache_suffix}" if jsonapi_options_requested?
 
             serialized_result = Rails.cache.fetch(cache_key, expires_at: actual_date.end_of_day) do
-              Api::V2::Chapters::ChapterListSerializer.new(chapters).serializable_hash.to_json
+              Api::V2::Chapters::ChapterListSerializer.new(chapters, jsonapi_serializer_options).serializable_hash.to_json
             end
 
             render json: serialized_result
@@ -31,12 +33,13 @@ module Api
 
       def show
         cache_key = "_chapter-#{chapter_id}-#{actual_date}/v#{CACHE_VERSION}"
+        default_include = SHOW_DEFAULT_INCLUDE
+        cache_key = "#{cache_key}/jsonapi-#{jsonapi_options_cache_suffix(default_include:)}" if jsonapi_options_requested?
 
         serialized_result = Rails.cache.fetch(cache_key, expires_at: actual_date.end_of_day) do
-          presenter = Api::V2::Chapters::ChapterPresenter.new(chapter, chapter_headings)
+          presenter = Api::V2::Chapters::ChapterPresenter.new(chapter, requested_chapter_headings)
 
-          options = { is_collection: false }
-          options[:include] = %i[section guides headings headings.children]
+          options = jsonapi_serializer_options(is_collection: false, default_include:)
 
           Api::V2::Chapters::ChapterSerializer.new(presenter, options).serializable_hash.to_json
         end
@@ -46,8 +49,9 @@ module Api
 
       def changes
         cache_key = "_chapter-#{chapter_id}-#{actual_date}/changes-v#{CACHE_VERSION}"
-        options = {}
-        options[:include] = [:record, 'record.geographical_area', 'record.measure_type']
+        default_include = [:record, 'record.geographical_area', 'record.measure_type']
+        cache_key = "#{cache_key}/jsonapi-#{jsonapi_options_cache_suffix(default_include:)}" if jsonapi_options_requested?
+        options = jsonapi_serializer_options(default_include:)
         serialized_result = Rails.cache.fetch(cache_key, expires_at: actual_date.end_of_day) do
           changes = chapter.changes.where { |o| o.operation_date <= actual_date }
           change_log = ChangeLog.new(changes)
@@ -77,23 +81,23 @@ module Api
       private
 
       def chapter
-        Chapter
+        scope = Chapter
           .actual
           .non_hidden
           .by_code(chapter_id)
-          .eager(
-            chapter_note_eager_load,
-            sections: [section_note_eager_load],
-          )
-          .take
+
+        eager_loads = chapter_eager_loads
+        scope = scope.eager(*eager_loads) if eager_loads.any?
+        scope.take
       end
 
       def chapters
-        Chapter
+        scope = Chapter
           .actual
           .non_hidden
-          .eager(chapter_note_eager_load, :goods_nomenclature_descriptions)
-          .all
+
+        scope = scope.eager(:goods_nomenclature_descriptions) if chapter_description_fields_requested?
+        scope.all
       end
 
       def chapter_note_eager_load
@@ -102,6 +106,30 @@ module Api
 
       def section_note_eager_load
         TradeTariffBackend.promote_customs_tariff_notes? ? :customs_tariff_section_note : :section_note
+      end
+
+      def chapter_eager_loads
+        [].tap do |eager_loads|
+          eager_loads << chapter_note_eager_load if jsonapi_field_requested?(:chapter, :chapter_note)
+          eager_loads << section_eager_load if chapter_section_data_requested?
+        end
+      end
+
+      def chapter_description_fields_requested?
+        %i[description description_plain formatted_description].any? do |field|
+          jsonapi_field_requested?(:chapter, field)
+        end
+      end
+
+      def chapter_section_data_requested?
+        jsonapi_field_requested?(:chapter, :section_id) ||
+          jsonapi_relationship_requested?(:chapter, :section, default_include: SHOW_DEFAULT_INCLUDE)
+      end
+
+      def section_eager_load
+        return :sections unless jsonapi_field_requested?(:section, :section_note)
+
+        { sections: [section_note_eager_load] }
       end
 
       def chapter_id
@@ -113,6 +141,12 @@ module Api
           .headings_dataset
           .eager(:goods_nomenclature_descriptions, :children)
           .all
+      end
+
+      def requested_chapter_headings
+        return [] unless jsonapi_relationship_requested?(:chapter, :headings, default_include: %i[headings headings.children])
+
+        chapter_headings
       end
     end
   end

--- a/app/controllers/api/v2/quotas_controller.rb
+++ b/app/controllers/api/v2/quotas_controller.rb
@@ -63,7 +63,7 @@ module Api
       end
 
       def valid_includes
-        return DEFAULT_INCLUDES if include_params.empty?
+        return DEFAULT_INCLUDES unless params.key?(:include)
 
         valid_resources = include_params.select { |resource| ALLOWED_INCLUDES.include?(resource) }
 

--- a/app/controllers/api/v2/sections_controller.rb
+++ b/app/controllers/api/v2/sections_controller.rb
@@ -2,12 +2,7 @@ module Api
   module V2
     class SectionsController < ApiController
       def index
-        @sections = Section
-          .eager(
-            section_note_eager_load,
-            chapters: [chapter_note_eager_load],
-          )
-          .all
+        @sections = sections_dataset.all
 
         respond_to do |format|
           format.csv do
@@ -25,12 +20,8 @@ module Api
       def show
         return head :bad_request unless params[:id].to_s.match?(/\A\d+\z/)
 
-        @section = Section
+        @section = sections_dataset
           .where(position: params[:id].to_i)
-          .eager(
-            section_note_eager_load,
-            chapters: [chapter_note_eager_load],
-          )
           .take
 
         options = { is_collection: false }
@@ -66,6 +57,22 @@ module Api
 
       def section_note_eager_load
         TradeTariffBackend.promote_customs_tariff_notes? ? :customs_tariff_section_note : :section_note
+      end
+
+      def sections_dataset
+        eager_loads = []
+        eager_loads << { chapters: [chapter_note_eager_load] } if section_chapter_fields_requested?
+        eager_loads << section_note_eager_load if jsonapi_field_requested?(:section, :section_note)
+
+        return Section if eager_loads.empty?
+
+        Section.eager(*eager_loads)
+      end
+
+      def section_chapter_fields_requested?
+        %i[chapters chapter_from chapter_to].any? do |field|
+          jsonapi_field_requested?(:section, field)
+        end
       end
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::API
+  include JsonapiQueryOptions
+
   MAX_LOGGED_REQUEST_ID_LENGTH = 100
 
   include ActionController::Helpers
@@ -12,6 +14,7 @@ class ApplicationController < ActionController::API
   before_action :set_trade_tariff_request_id
   before_action :maintenance_mode_if_active
   around_action :configure_time_machine
+  around_action :apply_jsonapi_query_options
   after_action  :check_query_count, if: -> { TradeTariffBackend.check_query_count? }
   after_action  :set_api_docs_link_header
 
@@ -20,6 +23,28 @@ class ApplicationController < ActionController::API
   end
 
   protected
+
+  def jsonapi_serializer_options(default_include: nil, **options)
+    options = options.dup
+    options[:include] = jsonapi_include_option(default_include)
+
+    fields = jsonapi_sparse_fieldsets
+    options[:fields] = fields if fields.present?
+
+    options.compact
+  end
+
+  def jsonapi_options_cache_suffix(default_include: nil)
+    return unless jsonapi_options_requested?
+
+    Digest::MD5.hexdigest(
+      jsonapi_serializer_options(default_include:).slice(:fields, :include).to_json,
+    )
+  end
+
+  def jsonapi_options_requested?
+    params.key?(:include) || params.key?(:fields)
+  end
 
   def append_info_to_payload(payload)
     super
@@ -66,6 +91,41 @@ class ApplicationController < ActionController::API
 
   def maintenance_mode_if_active
     MaintenanceMode.check! params[:maintenance_bypass]
+  end
+
+  def apply_jsonapi_query_options
+    Thread.current[:jsonapi_query_options] = parsed_jsonapi_query_options if v2_api_controller?
+
+    yield
+  ensure
+    Thread.current[:jsonapi_query_options] = nil if v2_api_controller?
+  end
+
+  def parsed_jsonapi_query_options
+    {
+      include_requested: params.key?(:include),
+      include: jsonapi_include_option(nil),
+      fields: jsonapi_sparse_fieldsets,
+    }
+  end
+
+  def jsonapi_include_option(default_include)
+    return default_include unless params.key?(:include)
+
+    params[:include].to_s.split(',').map(&:strip).reject(&:blank?)
+  end
+
+  def jsonapi_sparse_fieldsets
+    fieldsets = params[:fields]
+    return {} if fieldsets.blank?
+
+    fieldsets.to_unsafe_h.each_with_object({}) do |(type, fields), parsed|
+      parsed[type.to_sym] = fields.to_s.split(',').map(&:strip).reject(&:blank?).map(&:to_sym)
+    end
+  end
+
+  def v2_api_controller?
+    self.class.name.start_with?('Api::V2::')
   end
 
   def set_trade_tariff_request_id

--- a/app/lib/jsonapi_cache_key.rb
+++ b/app/lib/jsonapi_cache_key.rb
@@ -1,0 +1,23 @@
+module JsonapiCacheKey
+  include JsonapiQueryOptions
+
+  private
+
+  def jsonapi_cache_key_suffix
+    return if jsonapi_query_options.blank?
+
+    cache_options = {}
+    cache_options[:fields] = jsonapi_query_options[:fields] if jsonapi_query_options[:fields].present?
+    cache_options[:include] = jsonapi_query_options[:include] if jsonapi_include_requested?
+    return if cache_options.blank?
+
+    Digest::MD5.hexdigest(cache_options.to_json)
+  end
+
+  def with_jsonapi_cache_key_suffix(cache_key)
+    suffix = jsonapi_cache_key_suffix
+    return cache_key if suffix.blank?
+
+    "#{cache_key}/jsonapi-#{suffix}"
+  end
+end

--- a/app/lib/jsonapi_query_options.rb
+++ b/app/lib/jsonapi_query_options.rb
@@ -1,0 +1,36 @@
+module JsonapiQueryOptions
+  private
+
+  def jsonapi_query_options
+    Thread.current[:jsonapi_query_options] || {}
+  end
+
+  def jsonapi_sparse_fieldsets
+    jsonapi_query_options[:fields] || {}
+  end
+
+  def jsonapi_field_requested?(type, field)
+    fieldsets = jsonapi_sparse_fieldsets
+    return true unless fieldsets.key?(type.to_sym)
+
+    fieldsets[type.to_sym].include?(field.to_sym)
+  end
+
+  def jsonapi_relationship_requested?(type, relationship, default_include: nil)
+    jsonapi_field_requested?(type, relationship) &&
+      jsonapi_relationship_included?(relationship, default_include:)
+  end
+
+  def jsonapi_relationship_included?(relationship, default_include: nil)
+    includes = jsonapi_include_requested? ? jsonapi_query_options[:include] : default_include
+    relationship = relationship.to_s
+
+    Array(includes).any? do |include_path|
+      include_path.to_s.split('.', 2).first == relationship
+    end
+  end
+
+  def jsonapi_include_requested?
+    jsonapi_query_options[:include_requested]
+  end
+end

--- a/app/presenters/api/v2/commodities/commodity_presenter.rb
+++ b/app/presenters/api/v2/commodities/commodity_presenter.rb
@@ -5,25 +5,15 @@ module Api
         include SpecialNature
 
         attr_reader :commodity,
-                    :footnotes,
-                    :import_measures,
-                    :export_measures,
-                    :unit_measures
+                    :measures
 
         delegate :id, to: :import_trade_summary, prefix: true
+        delegate :filtering_by_country?, to: :measures
 
         def initialize(commodity, measures)
           super(commodity)
           @commodity = commodity
-          @footnotes = commodity.footnotes + commodity.heading.footnotes
-          @filtering_by_country = measures.filtering_by_country?
-          @import_measures = measures.select(&:import).map do |measure|
-            Api::V2::Measures::MeasurePresenter.new(measure, self)
-          end
-          @export_measures = measures.select(&:export).map do |measure|
-            Api::V2::Measures::MeasurePresenter.new(measure, self)
-          end
-          @unit_measures = @import_measures.select(&:expresses_unit?)
+          @measures = measures
         end
 
         def consigned
@@ -34,12 +24,28 @@ module Api
           footnotes.map(&:id)
         end
 
+        def footnotes
+          @footnotes ||= commodity.footnotes + commodity.heading.footnotes
+        end
+
         def import_measure_ids
           import_measures.map(&:measure_sid)
         end
 
+        def import_measures
+          @import_measures ||= measures.select(&:import).map do |measure|
+            Api::V2::Measures::MeasurePresenter.new(measure, self)
+          end
+        end
+
         def export_measure_ids
           export_measures.map(&:measure_sid)
+        end
+
+        def export_measures
+          @export_measures ||= measures.select(&:export).map do |measure|
+            Api::V2::Measures::MeasurePresenter.new(measure, self)
+          end
         end
 
         def heading_id
@@ -95,6 +101,10 @@ module Api
           MeasureUnitService.new(unit_measures).call
         end
 
+        def unit_measures
+          @unit_measures ||= import_measures.select(&:expresses_unit?)
+        end
+
         def applicable_vat_options
           ApplicableVatOptionsService.new(import_measures).call
         end
@@ -106,10 +116,6 @@ module Api
         def authorised_use_provisions_submission?
           @authorised_use_provisions_submission ||=
             filtering_by_country? && import_measures.any?(&:authorised_use_provisions_submission?)
-        end
-
-        def filtering_by_country?
-          @filtering_by_country
         end
       end
     end

--- a/app/serializers/api/v2/commodities/commodity_serializer.rb
+++ b/app/serializers/api/v2/commodities/commodity_serializer.rb
@@ -35,19 +35,39 @@ module Api
 
         has_one :import_trade_summary, serializer: Api::V2::Shared::ImportTradeSummarySerializer
 
+        MEASURE_DERIVED_FIELDS = %i[
+          basic_duty_rate
+          export_measures
+          import_measures
+          import_trade_summary
+          meursing_code
+        ].freeze
+
         meta do |commodity|
-          {
-            duty_calculator: {
-              applicable_additional_codes: commodity.applicable_additional_codes,
-              applicable_measure_units: commodity.applicable_measure_units,
-              applicable_vat_options: commodity.applicable_vat_options,
-              entry_price_system: commodity.entry_price_system?,
-              meursing_code: commodity.meursing_code,
-              source: TradeTariffBackend.service,
-              trade_defence: commodity.trade_remedies?,
-              zero_mfn_duty: commodity.zero_mfn_duty?,
-            },
-          }
+          if duty_calculator_meta_requested?
+            {
+              duty_calculator: {
+                applicable_additional_codes: commodity.applicable_additional_codes,
+                applicable_measure_units: commodity.applicable_measure_units,
+                applicable_vat_options: commodity.applicable_vat_options,
+                entry_price_system: commodity.entry_price_system?,
+                meursing_code: commodity.meursing_code,
+                source: TradeTariffBackend.service,
+                trade_defence: commodity.trade_remedies?,
+                zero_mfn_duty: commodity.zero_mfn_duty?,
+              },
+            }
+          else
+            {}
+          end
+        end
+
+        def self.duty_calculator_meta_requested?
+          fieldsets = Thread.current[:jsonapi_query_options]&.fetch(:fields, {}) || {}
+          commodity_fields = fieldsets[:commodity]
+          return true unless commodity_fields
+
+          (commodity_fields & MEASURE_DERIVED_FIELDS).any?
         end
       end
     end

--- a/app/services/cached_commodity_service.rb
+++ b/app/services/cached_commodity_service.rb
@@ -1,7 +1,30 @@
 class CachedCommodityService
   include DeclarableSerialization
+  include JsonapiCacheKey
 
   CACHE_VERSION = 6
+  RELATIONSHIP_FIELDS = %i[
+    ancestors
+    chapter
+    export_measures
+    footnotes
+    heading
+    import_measures
+    import_trade_summary
+    section
+  ].freeze
+  DESCRIPTION_FIELDS = %i[
+    description
+    description_plain
+    formatted_description
+  ].freeze
+  ASSOCIATION_DERIVED_FIELDS = %i[
+    basic_duty_rate
+    consigned
+    consigned_from
+    has_chemicals
+    meursing_code
+  ].freeze
 
   DEFAULT_INCLUDES = (DECLARABLE_INCLUDES + %w[
     heading
@@ -88,6 +111,7 @@ class CachedCommodityService
   ]).freeze
 
   def initialize(commodity, actual_date, filters = {})
+    @source_commodity = commodity
     @commodity_sid = commodity.goods_nomenclature_sid
     @actual_date = actual_date
     @filters = filters
@@ -101,7 +125,7 @@ class CachedCommodityService
     cached_data = Rails.cache.fetch(cache_key, expires_in: ttl) do
       presenter = presented_commodity
       hash = Api::V2::Commodities::CommoditySerializer.new(presenter, options).serializable_hash
-      measure_meta = MeasureMetadataBuilder.new(presenter).build
+      measure_meta = commodity_association_data_required? ? MeasureMetadataBuilder.new(presenter).build : {}
 
       { v: CACHE_VERSION, hash: hash, measure_meta: measure_meta }
     end
@@ -118,6 +142,8 @@ class CachedCommodityService
   end
 
   def excise_filtered_measures
+    return MeasureCollection.new([], {}) unless commodity_association_data_required?
+
     MeasureCollection.new(measures, {}).apply_excise_filter
   end
 
@@ -129,6 +155,8 @@ class CachedCommodityService
   end
 
   def commodity
+    return @source_commodity unless commodity_association_data_required?
+
     @commodity ||= begin
       # Phase 1: load the commodity and its ancestors for their own attributes.
       # Measures are deliberately excluded here and loaded in a separate
@@ -231,6 +259,14 @@ class CachedCommodityService
   end
 
   def cache_key
-    "_commodity-v#{CACHE_VERSION}-#{@commodity_sid}-#{actual_date}-#{meursing_additional_code_id}"
+    with_jsonapi_cache_key_suffix(
+      "_commodity-v#{CACHE_VERSION}-#{@commodity_sid}-#{actual_date}-#{meursing_additional_code_id}",
+    )
+  end
+
+  def commodity_association_data_required?
+    (RELATIONSHIP_FIELDS + DESCRIPTION_FIELDS + ASSOCIATION_DERIVED_FIELDS).any? do |field|
+      jsonapi_field_requested?(:commodity, field)
+    end
   end
 end

--- a/app/services/cached_commodity_service/response_filter.rb
+++ b/app/services/cached_commodity_service/response_filter.rb
@@ -8,6 +8,7 @@ class CachedCommodityService
 
     def call
       return @cached_hash if @geographical_area_id.blank?
+      return @cached_hash if @measure_meta.blank?
 
       @hash = deep_dup(@cached_hash)
 

--- a/app/services/cached_geographical_area_service.rb
+++ b/app/services/cached_geographical_area_service.rb
@@ -1,4 +1,6 @@
 class CachedGeographicalAreaService
+  include JsonapiCacheKey
+
   GLOBALLY_EXCLUDED_GEOGRAPHICAL_AREA_IDS = %w[
     EU
     GG
@@ -62,7 +64,9 @@ class CachedGeographicalAreaService
   end
 
   def cache_key
-    "_geographical-areas-#{actual_date}-#{countries}-#{exclude_none}"
+    with_jsonapi_cache_key_suffix(
+      "_geographical-areas-#{actual_date}-#{countries}-#{exclude_none}",
+    )
   end
 
   def country_geographical_areas

--- a/app/services/cached_quota_order_number_service.rb
+++ b/app/services/cached_quota_order_number_service.rb
@@ -1,4 +1,6 @@
 class CachedQuotaOrderNumberService
+  include JsonapiCacheKey
+
   DEFAULT_INCLUDES = %w[quota_definition quota_definition.measures].freeze
   EAGER_LOAD = {
     quota_definition: {
@@ -26,7 +28,7 @@ class CachedQuotaOrderNumberService
   end
 
   def cache_key
-    "_quota-order-numbers-#{actual_date}"
+    with_jsonapi_cache_key_suffix("_quota-order-numbers-#{actual_date}")
   end
 
   def actual_date

--- a/app/services/cached_subheading_service.rb
+++ b/app/services/cached_subheading_service.rb
@@ -1,6 +1,21 @@
 class CachedSubheadingService
+  include JsonapiCacheKey
+
   TTL = 23.hours # Expire just before the ETL job runs and prewarms expensive subheadings
   CACHE_VERSION = 1
+  RELATIONSHIP_FIELDS = %i[
+    ancestors
+    chapter
+    commodities
+    footnotes
+    heading
+    section
+  ].freeze
+  DESCRIPTION_FIELDS = %i[
+    description
+    description_plain
+    formatted_description
+  ].freeze
 
   DEFAULT_INCLUDES = [
     :section,
@@ -30,7 +45,9 @@ class CachedSubheadingService
   end
 
   def cache_key
-    "_subheading-#{@subheading.goods_nomenclature_sid}-#{@actual_date}-v#{CACHE_VERSION}"
+    with_jsonapi_cache_key_suffix(
+      "_subheading-#{@subheading.goods_nomenclature_sid}-#{@actual_date}-v#{CACHE_VERSION}",
+    )
   end
 
   private
@@ -59,6 +76,12 @@ class CachedSubheadingService
   end
 
   def eager_reload?
-    @eager_reload
+    @eager_reload && subheading_eager_reload_required?
+  end
+
+  def subheading_eager_reload_required?
+    (RELATIONSHIP_FIELDS + DESCRIPTION_FIELDS).any? do |field|
+      jsonapi_field_requested?(:subheading, field)
+    end
   end
 end

--- a/app/services/heading_service/heading_serialization_service.rb
+++ b/app/services/heading_service/heading_serialization_service.rb
@@ -1,5 +1,7 @@
 module HeadingService
   class HeadingSerializationService
+    include JsonapiCacheKey
+
     CACHE_VERSION = 'v1'.freeze
 
     class << self
@@ -55,7 +57,9 @@ module HeadingService
     end
 
     def heading_cache_key
-      self.class.cache_key(heading, actual_date, heading.declarable?, filters)
+      with_jsonapi_cache_key_suffix(
+        self.class.cache_key(heading, actual_date, heading.declarable?, filters),
+      )
     end
   end
 end

--- a/app/services/heading_service/serialization/declarable_service.rb
+++ b/app/services/heading_service/serialization/declarable_service.rb
@@ -2,6 +2,7 @@ module HeadingService
   module Serialization
     class DeclarableService
       include DeclarableSerialization
+      include JsonapiQueryOptions
 
       MEASURE_EAGER = [
         {
@@ -48,19 +49,6 @@ module HeadingService
         :full_temporary_stop_regulations,
         :measure_partial_temporary_stops,
       ].freeze
-      def self.heading_eager
-        [
-          *BASE_HEADING_EAGER,
-          {
-            chapter: [
-              chapter_note_eager_load,
-              :guides,
-              { sections: [section_note_eager_load] },
-            ],
-          },
-        ]
-      end
-
       def self.chapter_note_eager_load
         TradeTariffBackend.promote_customs_tariff_notes? ? :customs_tariff_chapter_note : :chapter_note
       end
@@ -108,11 +96,51 @@ module HeadingService
       end
 
       def heading
-        @heading ||= Heading.where(goods_nomenclature_sid:).eager(*self.class.heading_eager).take
+        @heading ||= Heading.where(goods_nomenclature_sid:).eager(*heading_eager_loads).take
       end
 
       def measures
         heading.applicable_measures
+      end
+
+      def heading_eager_loads
+        [
+          *BASE_HEADING_EAGER,
+          *chapter_eager_loads,
+        ]
+      end
+
+      def chapter_eager_loads
+        return [] unless heading_chapter_data_requested?
+
+        chapter_eager_load = []
+        chapter_eager_load << self.class.chapter_note_eager_load if jsonapi_field_requested?(:chapter, :chapter_note)
+        chapter_eager_load << :guides if chapter_guides_requested?
+        chapter_eager_load << section_eager_load if heading_section_data_requested?
+
+        return [:chapter] if chapter_eager_load.empty?
+
+        [{ chapter: chapter_eager_load }]
+      end
+
+      def heading_chapter_data_requested?
+        jsonapi_relationship_requested?(:heading, :chapter, default_include: DECLARABLE_INCLUDES) ||
+          heading_section_data_requested?
+      end
+
+      def heading_section_data_requested?
+        jsonapi_relationship_requested?(:heading, :section, default_include: DECLARABLE_INCLUDES)
+      end
+
+      def chapter_guides_requested?
+        includes = jsonapi_include_requested? ? jsonapi_query_options[:include] : DECLARABLE_INCLUDES
+        Array(includes).map(&:to_s).include?('chapter.guides')
+      end
+
+      def section_eager_load
+        return :sections unless jsonapi_field_requested?(:section, :section_note)
+
+        { sections: [self.class.section_note_eager_load] }
       end
     end
   end

--- a/app/services/heading_service/serialization/ns_nondeclarable_service.rb
+++ b/app/services/heading_service/serialization/ns_nondeclarable_service.rb
@@ -1,6 +1,8 @@
 module HeadingService
   module Serialization
     class NsNondeclarableService
+      include JsonapiQueryOptions
+
       OPTIONS = {
         is_collection: false,
         include: [
@@ -52,6 +54,17 @@ module HeadingService
           ],
         },
       ].freeze
+      RELATIONSHIP_FIELDS = %i[
+        chapter
+        commodities
+        footnotes
+        section
+      ].freeze
+      DESCRIPTION_FIELDS = %i[
+        description
+        description_plain
+        formatted_description
+      ].freeze
 
       def self.heading_eager_load
         BASE_HEADING_EAGER_LOAD
@@ -69,7 +82,13 @@ module HeadingService
     private
 
       def eager_reload?
-        @eager_reload
+        @eager_reload && heading_eager_reload_required?
+      end
+
+      def heading_eager_reload_required?
+        (RELATIONSHIP_FIELDS + DESCRIPTION_FIELDS).any? do |field|
+          jsonapi_field_requested?(:heading, field)
+        end
       end
 
       def presented_heading

--- a/config/initializers/jsonapi_serializer_query_options.rb
+++ b/config/initializers/jsonapi_serializer_query_options.rb
@@ -1,0 +1,42 @@
+module JsonapiSerializerQueryOptions
+  def initialize(resource, options = {})
+    query_options = Thread.current[:jsonapi_query_options]
+    options = options.to_h.dup
+
+    if query_options.present?
+      options[:fields] = query_options[:fields] if query_options[:fields].present?
+      options[:include] = query_options[:include] if query_options[:include_requested]
+      options[:include] = sparse_fieldset_includes(options[:include], query_options[:fields])
+    end
+
+    validate_requested_includes!(options[:include]) if options[:include].present?
+
+    super(resource, options)
+  end
+
+  private
+
+  def validate_requested_includes!(includes)
+    relationships = self.class.relationships_to_serialize || {}
+
+    includes.each do |include_item|
+      include_base = include_item.to_s.split('.', 2).first.to_sym
+      next if relationships.key?(include_base)
+
+      raise JSONAPI::Serializer::UnsupportedIncludeError.new(include_base, self.class.name)
+    end
+  end
+
+  def sparse_fieldset_includes(includes, fieldsets)
+    return includes if includes.blank? || fieldsets.blank?
+
+    fields = fieldsets[self.class.record_type.to_sym]
+    return includes unless fields
+
+    Array(includes).select do |include_item|
+      fields.include?(include_item.to_s.split('.', 2).first.to_sym)
+    end
+  end
+end
+
+FastJsonapi::ObjectSerializer.prepend(JsonapiSerializerQueryOptions)

--- a/spec/initializers/jsonapi_serializer_query_options_spec.rb
+++ b/spec/initializers/jsonapi_serializer_query_options_spec.rb
@@ -1,0 +1,87 @@
+RSpec.describe JsonapiSerializerQueryOptions do
+  before do
+    stub_const('JsonapiQueryOptionsRelatedSerializer', Class.new do
+      include JSONAPI::Serializer
+
+      set_type :related
+      attributes :name
+    end)
+
+    stub_const('JsonapiQueryOptionsTestSerializer', Class.new do
+      include JSONAPI::Serializer
+
+      set_type :thing
+      attributes :name, :description
+      has_one :related, serializer: JsonapiQueryOptionsRelatedSerializer
+    end)
+  end
+
+  after do
+    Thread.current[:jsonapi_query_options] = nil
+  end
+
+  let(:related_resource_class) { Data.define(:id, :name) }
+  let(:test_resource_class) do
+    Data.define(:id, :name, :description, :related) do
+      delegate :id, to: :related, prefix: true
+    end
+  end
+  let(:related) { related_resource_class.new(id: 2, name: 'related') }
+  let(:resource) { test_resource_class.new(id: 1, name: 'name', description: 'description', related:) }
+
+  it 'preserves existing serializer options when no request query options are present' do
+    result = JsonapiQueryOptionsTestSerializer.new(resource, include: [:related]).serializable_hash
+
+    expect(result[:data][:attributes]).to eq(name: 'name', description: 'description')
+    expect(result[:included]).to contain_exactly(
+      hash_including(type: :related, attributes: { name: 'related' }),
+    )
+  end
+
+  it 'applies request scoped sparse fieldsets to every serializer' do
+    Thread.current[:jsonapi_query_options] = {
+      include_requested: false,
+      include: nil,
+      fields: { thing: %i[name] },
+    }
+
+    result = JsonapiQueryOptionsTestSerializer.new(resource).serializable_hash
+
+    expect(result[:data][:attributes]).to eq(name: 'name')
+  end
+
+  it 'removes serializer includes for relationships excluded by sparse fieldsets' do
+    Thread.current[:jsonapi_query_options] = {
+      include_requested: false,
+      include: nil,
+      fields: { thing: %i[name] },
+    }
+
+    result = JsonapiQueryOptionsTestSerializer.new(resource, include: [:related]).serializable_hash
+
+    expect(result).not_to have_key(:included)
+  end
+
+  it 'treats an explicitly empty include param as no compound documents' do
+    Thread.current[:jsonapi_query_options] = {
+      include_requested: true,
+      include: [],
+      fields: {},
+    }
+
+    result = JsonapiQueryOptionsTestSerializer.new(resource, include: [:related]).serializable_hash
+
+    expect(result).not_to have_key(:included)
+  end
+
+  it 'rejects unsupported requested includes before serialization' do
+    Thread.current[:jsonapi_query_options] = {
+      include_requested: true,
+      include: %w[missing_relationship],
+      fields: {},
+    }
+
+    expect { JsonapiQueryOptionsTestSerializer.new(resource).serializable_hash }
+      .to raise_error(JSONAPI::Serializer::UnsupportedIncludeError)
+  end
+end

--- a/spec/requests/api/v2/chapters_controller_migrated_spec.rb
+++ b/spec/requests/api/v2/chapters_controller_migrated_spec.rb
@@ -167,6 +167,85 @@ RSpec.describe Api::V2::ChaptersController do
 
       expect(response.body).to match_json_expression pattern
     end
+
+    it 'returns only requested sparse fields for chapter resources' do
+      get '/uk/api/chapters.json',
+          params: { fields: { chapter: 'formatted_description' } },
+          headers: request_headers(format: :json)
+
+      attributes = JSON.parse(response.body).fetch('data').first.fetch('attributes')
+
+      expect(attributes).to eq(
+        'formatted_description' => chapter1.formatted_description,
+      )
+    end
+  end
+
+  describe 'GET #show with JSON:API include params' do
+    let(:heading) { create :heading, :with_chapter }
+    let(:chapter) { heading.reload.chapter }
+
+    it 'includes only the requested relationships as compound documents' do
+      get "/uk/api/chapters/#{chapter.to_param}.json",
+          params: { include: 'section' },
+          headers: request_headers(format: :json)
+
+      included_types = JSON.parse(response.body).fetch('included').pluck('type')
+
+      expect(included_types).to contain_exactly('section')
+    end
+
+    it 'does not load headings when sparse fields exclude the headings relationship' do
+      allow(Api::V2::Chapters::ChapterPresenter).to receive(:new).and_call_original
+
+      get "/uk/api/chapters/#{chapter.to_param}.json",
+          params: { fields: { chapter: 'description' } },
+          headers: request_headers(format: :json)
+
+      expect(response).to have_http_status(:ok)
+      expect(Api::V2::Chapters::ChapterPresenter)
+        .to have_received(:new)
+        .with(instance_of(Chapter), [])
+    end
+
+    it 'does not issue a headings query when sparse fields only request scalar chapter data' do
+      chapter
+      Rails.cache.clear
+
+      sql = []
+      subscriber = ActiveSupport::Notifications.subscribe(/sql\.sequel/) do |*args|
+        event = ActiveSupport::Notifications::Event.new(*args)
+        sql << event.payload[:sql].to_s
+      end
+
+      begin
+        get "/uk/api/chapters/#{chapter.to_param}.json",
+            params: { fields: { chapter: 'goods_nomenclature_item_id' } },
+            headers: request_headers(format: :json)
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber)
+      end
+
+      expect(response).to have_http_status(:ok)
+      goods_nomenclature_queries = sql.grep(/FROM "?goods_nomenclatures"?/i)
+      expect(goods_nomenclature_queries.size).to eq(1)
+      forbidden_sql = sql.grep(/goods_nomenclature_descriptions|chapter_notes|section_notes|guides/i)
+      expect(forbidden_sql).to be_empty
+    end
+
+    it 'does not load headings when the include parameter is empty' do
+      allow(Api::V2::Chapters::ChapterPresenter).to receive(:new).and_call_original
+
+      get "/uk/api/chapters/#{chapter.to_param}.json",
+          params: { include: '' },
+          headers: request_headers(format: :json)
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)).not_to have_key('included')
+      expect(Api::V2::Chapters::ChapterPresenter)
+        .to have_received(:new)
+        .with(instance_of(Chapter), [])
+    end
   end
 
   describe 'GET #changes' do

--- a/spec/requests/api/v2/commodities_controller_spec.rb
+++ b/spec/requests/api/v2/commodities_controller_spec.rb
@@ -90,6 +90,38 @@ RSpec.describe Api::V2::CommoditiesController do
 
       it { is_expected.to have_http_status(:not_found) }
     end
+
+    context 'with empty includes and sparse fields that do not need association data' do
+      let(:make_request) do
+        get "/uk/api/commodities/#{commodity.code}",
+            params: { include: '', fields: { commodity: 'goods_nomenclature_item_id' } },
+            headers: request_headers
+      end
+
+      it 'returns only the requested field without loading the full association graph' do
+        commodity
+
+        sql = []
+        subscriber = ActiveSupport::Notifications.subscribe(/sql\.sequel/) do |*args|
+          event = ActiveSupport::Notifications::Event.new(*args)
+          sql << event.payload[:sql].to_s
+        end
+
+        begin
+          api_response
+        ensure
+          ActiveSupport::Notifications.unsubscribe(subscriber)
+        end
+
+        parsed_body = JSON.parse(response.body)
+        expect(parsed_body['data']['attributes']).to eq('goods_nomenclature_item_id' => commodity.goods_nomenclature_item_id)
+        expect(parsed_body['data']['relationships']).to eq({})
+        expect(parsed_body).not_to have_key('included')
+
+        forbidden_sql = sql.grep(/measures|footnotes|full_chemicals|goods_nomenclature_descriptions|section_notes|chapter_notes/i)
+        expect(forbidden_sql).to be_empty
+      end
+    end
   end
 
   context 'when record is hidden' do

--- a/spec/requests/api/v2/quotas_controller_spec.rb
+++ b/spec/requests/api/v2/quotas_controller_spec.rb
@@ -314,6 +314,37 @@ RSpec.describe Api::V2::QuotasController, type: :request do
       end
     end
 
+    context 'when specifying an empty includes list in the query params' do
+      let(:params) do
+        {
+          year: [
+            Time.zone.today.year.to_s,
+          ],
+          include: '',
+        }
+      end
+
+      it 'returns quota definitions without included resources' do
+        get '/uk/api/quotas/search.json', params: params, headers: request_headers(format: :json)
+
+        expect(JSON.parse(response.body)).not_to have_key('included')
+      end
+
+      it 'does not request eager loading full quota balance events' do
+        allow(QuotaSearchService).to receive(:new).and_call_original
+
+        get '/uk/api/quotas/search.json', params: params, headers: request_headers(format: :json)
+
+        expect(QuotaSearchService).to have_received(:new).with(
+          anything,
+          anything,
+          anything,
+          anything,
+          include_quota_balance_events: false,
+        )
+      end
+    end
+
     context 'when order_number is not 6 digits' do
       let(:params) { { year: [Time.zone.today.year.to_s], order_number: '0500' } }
 

--- a/spec/requests/api/v2/sections_controller_spec.rb
+++ b/spec/requests/api/v2/sections_controller_spec.rb
@@ -37,19 +37,74 @@ RSpec.describe Api::V2::SectionsController, :v2 do
   end
 
   describe 'GET #index' do
+    let!(:section) do
+      create(
+        :section,
+        id: 18,
+        position: 18,
+        numeral: 'XVIII',
+        title: 'Optical, photographic, cinematographic, measuring',
+      )
+    end
+
+    it 'returns only requested sparse fields for section resources' do
+      api_get '/uk/api/sections', params: { fields: { section: 'title' } }
+
+      attributes = JSON.parse(response.body).fetch('data').first.fetch('attributes')
+
+      expect(attributes).to eq('title' => section.title)
+    end
+
+    it 'does not eager load chapter data when sparse fields exclude chapter-derived fields' do
+      allow(Section).to receive(:eager).and_call_original
+
+      api_get '/uk/api/sections', params: { fields: { section: 'title' } }
+
+      expect(Section).not_to have_received(:eager)
+    end
+
+    it 'does not query chapter or note tables when sparse fields exclude those attributes' do
+      section
+
+      sql = []
+      subscriber = ActiveSupport::Notifications.subscribe(/sql\.sequel/) do |*args|
+        event = ActiveSupport::Notifications::Event.new(*args)
+        sql << event.payload[:sql].to_s
+      end
+
+      begin
+        api_get '/uk/api/sections', params: { fields: { section: 'title' } }
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber)
+      end
+
+      expect(response).to have_http_status(:ok)
+      forbidden_sql = sql.grep(/chapters|chapter_notes|section_notes/i)
+      expect(forbidden_sql).to be_empty
+    end
+
+    it 'still eager loads attribute dependencies when include is empty and chapter-derived attributes are returned' do
+      allow(Section).to receive(:eager).and_call_original
+
+      api_get '/uk/api/sections', params: { include: '' }
+
+      chapter_note_association = TradeTariffBackend.promote_customs_tariff_notes? ? :customs_tariff_chapter_note : :chapter_note
+      section_note_association = TradeTariffBackend.promote_customs_tariff_notes? ? :customs_tariff_section_note : :section_note
+
+      expect(Section)
+        .to have_received(:eager)
+        .with({ chapters: [chapter_note_association] }, section_note_association)
+    end
+
+    it 'returns a bad request for unsupported include paths' do
+      api_get '/uk/api/sections', params: { include: 'unknown_relationship' }
+
+      expect(response).to have_http_status(:bad_request)
+    end
+
     it_behaves_like 'a successful csv response' do
       let(:path) { '/uk/api/sections' }
       let(:expected_filename) { "uk-sections-#{Time.zone.today.iso8601}.csv" }
-
-      before do
-        create(
-          :section,
-          id: 18,
-          position: 18,
-          numeral: 'XVIII',
-          title: 'Optical, photographic, cinematographic, measuring',
-        )
-      end
     end
   end
 end

--- a/spec/services/cached_commodity_service_spec.rb
+++ b/spec/services/cached_commodity_service_spec.rb
@@ -99,6 +99,28 @@ RSpec.describe CachedCommodityService do
         expect(loaded_commodity.associations).to include(full_chemicals: be_present)
       end
 
+      context 'with empty include and sparse fields that do not need eager-loaded associations' do
+        around do |example|
+          Thread.current[:jsonapi_query_options] = {
+            include_requested: true,
+            include: [],
+            fields: { commodity: %i[goods_nomenclature_item_id] },
+          }
+
+          example.run
+        ensure
+          Thread.current[:jsonapi_query_options] = nil
+        end
+
+        it 'does not load the full commodity association graph' do
+          allow(Commodity).to receive(:actual).and_call_original
+
+          described_class.new(commodity.reload, actual_date).call
+
+          expect(Commodity).not_to have_received(:actual)
+        end
+      end
+
       it 'pre-populates :measures on the commodity and each ancestor (single-pass load)' do
         loaded_commodity = nil
 

--- a/spec/services/cached_subheading_service_spec.rb
+++ b/spec/services/cached_subheading_service_spec.rb
@@ -77,5 +77,27 @@ RSpec.describe CachedSubheadingService do
       service.call.to_json
       expect(Rails.cache).to have_received(:fetch).with("_subheading-#{subheading.goods_nomenclature_sid}-2021-01-01-v1", expires_in: 23.hours)
     end
+
+    context 'with empty include and sparse fields that do not need eager-loaded data' do
+      around do |example|
+        Thread.current[:jsonapi_query_options] = {
+          include_requested: true,
+          include: [],
+          fields: { subheading: %i[goods_nomenclature_item_id] },
+        }
+
+        example.run
+      ensure
+        Thread.current[:jsonapi_query_options] = nil
+      end
+
+      it 'does not reload the full subheading eager graph' do
+        allow(Subheading).to receive(:actual).and_call_original
+
+        service.call
+
+        expect(Subheading).not_to have_received(:actual)
+      end
+    end
   end
 end

--- a/spec/services/heading_service/serialization/declarable_service_spec.rb
+++ b/spec/services/heading_service/serialization/declarable_service_spec.rb
@@ -1,0 +1,34 @@
+RSpec.describe HeadingService::Serialization::DeclarableService do
+  describe '#serializable_hash' do
+    around do |example|
+      Thread.current[:jsonapi_query_options] = {
+        include_requested: true,
+        include: [],
+        fields: { heading: %i[goods_nomenclature_item_id] },
+      }
+
+      example.run
+    ensure
+      Thread.current[:jsonapi_query_options] = nil
+    end
+
+    it 'does not query chapter or section notes when sparse fields do not need them' do
+      heading = create(:heading, :with_indent, :with_description, :declarable, :with_chapter)
+
+      sql = []
+      subscriber = ActiveSupport::Notifications.subscribe(/sql\.sequel/) do |*args|
+        event = ActiveSupport::Notifications::Event.new(*args)
+        sql << event.payload[:sql].to_s
+      end
+
+      begin
+        described_class.new(heading, {}).serializable_hash
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber)
+      end
+
+      forbidden_sql = sql.grep(/chapter_notes|section_notes/i)
+      expect(forbidden_sql).to be_empty
+    end
+  end
+end

--- a/spec/services/heading_service/serialization/ns_nondeclarable_service_spec.rb
+++ b/spec/services/heading_service/serialization/ns_nondeclarable_service_spec.rb
@@ -1,4 +1,27 @@
 RSpec.describe HeadingService::Serialization::NsNondeclarableService do
+  describe '#serializable_hash' do
+    around do |example|
+      Thread.current[:jsonapi_query_options] = {
+        include_requested: true,
+        include: [],
+        fields: { heading: %i[goods_nomenclature_item_id] },
+      }
+
+      example.run
+    ensure
+      Thread.current[:jsonapi_query_options] = nil
+    end
+
+    it 'does not reload the full heading eager graph when sparse fields do not need it' do
+      heading = create(:heading, :with_chapter)
+      allow(Heading).to receive(:actual).and_call_original
+
+      described_class.new(heading).serializable_hash
+
+      expect(Heading).not_to have_received(:actual)
+    end
+  end
+
   describe 'MEASURES_EAGER_LOAD' do
     # geographical_area_descriptions must be eagerly loaded alongside geographical_area.
     # Without it, serialising a measure's geographical area fires one JOIN query per

--- a/spec/swagger/api/v2/additional_code_types_spec.rb
+++ b/spec/swagger/api/v2/additional_code_types_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'Additional Code Types', swagger_doc: 'v2/swagger.json', type: :r
     get 'List all additional code types' do
       tags 'Additional Codes'
       produces 'application/json'
+      jsonapi_query_parameters(includes: [])
       description 'Returns all additional code types.'
       operationId 'listAdditionalCodeTypes'
 

--- a/spec/swagger/api/v2/additional_codes_spec.rb
+++ b/spec/swagger/api/v2/additional_codes_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe 'Additional Codes', swagger_doc: 'v2/swagger.json', type: :reques
     get 'Search additional codes' do
       tags 'Additional Codes'
       produces 'application/json'
+      jsonapi_query_parameters(includes: %w[goods_nomenclatures])
       description 'Returns additional codes matching the search parameters, including related goods nomenclatures.'
       operationId 'searchAdditionalCodes'
 

--- a/spec/swagger/api/v2/certificate_types_spec.rb
+++ b/spec/swagger/api/v2/certificate_types_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'Certificate Types', swagger_doc: 'v2/swagger.json', type: :reque
     get 'List all certificate types' do
       tags 'Certificates'
       produces 'application/json'
+      jsonapi_query_parameters(includes: [])
       description 'Returns all certificate types with their descriptions.'
       operationId 'listCertificateTypes'
 

--- a/spec/swagger/api/v2/certificates_spec.rb
+++ b/spec/swagger/api/v2/certificates_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe 'Certificates', swagger_doc: 'v2/swagger.json', type: :request do
     get 'List all certificates' do
       tags 'Certificates'
       produces 'application/json'
+      jsonapi_query_parameters(includes: [])
       description 'Returns all current certificates ordered by type and code.'
       operationId 'listCertificates'
 
@@ -68,6 +69,7 @@ RSpec.describe 'Certificates', swagger_doc: 'v2/swagger.json', type: :request do
     get 'Search certificates' do
       tags 'Certificates'
       produces 'application/json'
+      jsonapi_query_parameters(includes: %w[goods_nomenclatures])
       description 'Returns certificates matching the search parameters, including related goods nomenclatures.'
       operationId 'searchCertificates'
 

--- a/spec/swagger/api/v2/changes_spec.rb
+++ b/spec/swagger/api/v2/changes_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe 'Changes', swagger_doc: 'v2/swagger.json', type: :request do
     get 'List recent tariff changes' do
       tags 'Changes'
       produces 'application/json'
+      jsonapi_query_parameters(includes: [])
       description 'Returns recent tariff changes. The data array may be empty if no changes exist for the current date.'
       operationId 'listChanges'
 
@@ -61,6 +62,7 @@ RSpec.describe 'Changes', swagger_doc: 'v2/swagger.json', type: :request do
     get 'List tariff changes for a date' do
       tags 'Changes'
       produces 'application/json'
+      jsonapi_query_parameters(includes: [])
       description 'Returns tariff changes for the specified date. The data array may be empty if no changes exist for that date.'
       operationId 'listChangesAsOf'
 

--- a/spec/swagger/api/v2/chapters_spec.rb
+++ b/spec/swagger/api/v2/chapters_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'Chapters', swagger_doc: 'v2/swagger.json', type: :request do
     get 'List all chapters' do
       tags 'Chapters'
       produces 'application/json'
+      jsonapi_query_parameters(includes: [])
       description 'Returns all chapters of the tariff.'
       operationId 'listChapters'
 
@@ -57,6 +58,7 @@ RSpec.describe 'Chapters', swagger_doc: 'v2/swagger.json', type: :request do
     get 'Retrieve a chapter' do
       tags 'Chapters'
       produces 'application/json'
+      jsonapi_query_parameters(includes: %w[section guides headings headings.children])
       description 'Returns a single chapter including its headings, section, and guides.'
       operationId 'getChapter'
 
@@ -174,6 +176,7 @@ RSpec.describe 'Chapters', swagger_doc: 'v2/swagger.json', type: :request do
     get 'List changes for a chapter' do
       tags 'Chapters'
       produces 'application/json'
+      jsonapi_query_parameters(includes: JsonapiSwaggerParameters::CHANGE_INCLUDES)
       description 'Returns the changelog for a chapter.'
       operationId 'listChapterChanges'
 

--- a/spec/swagger/api/v2/chemical_substances_spec.rb
+++ b/spec/swagger/api/v2/chemical_substances_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe 'Chemical Substances', swagger_doc: 'v2/swagger.json', type: :req
     get 'List chemical substances' do
       tags 'Chemicals'
       produces 'application/json'
+      jsonapi_query_parameters(includes: [])
       description 'Returns chemical substances, optionally filtered by CAS number, CUS, or goods nomenclature.'
       operationId 'listChemicalSubstances'
 

--- a/spec/swagger/api/v2/chemicals_spec.rb
+++ b/spec/swagger/api/v2/chemicals_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe 'Chemicals', swagger_doc: 'v2/swagger.json', type: :request do
     get 'List all chemicals' do
       tags 'Chemicals'
       produces 'application/json'
+      jsonapi_query_parameters(includes: [])
       description 'Returns all chemicals with their CAS numbers and names.'
       operationId 'listChemicals'
 
@@ -67,6 +68,7 @@ RSpec.describe 'Chemicals', swagger_doc: 'v2/swagger.json', type: :request do
     get 'Search chemicals' do
       tags 'Chemicals'
       produces 'application/json'
+      jsonapi_query_parameters(includes: %w[goods_nomenclatures chemical_names])
       description 'Returns chemicals matching the search query.'
       operationId 'searchChemicals'
 
@@ -99,6 +101,7 @@ RSpec.describe 'Chemicals', swagger_doc: 'v2/swagger.json', type: :request do
     get 'Retrieve a chemical' do
       tags 'Chemicals'
       produces 'application/json'
+      jsonapi_query_parameters(includes: %w[goods_nomenclatures chemical_names])
       description 'Returns a single chemical by its CAS number.'
       operationId 'getChemical'
 

--- a/spec/swagger/api/v2/commodities_spec.rb
+++ b/spec/swagger/api/v2/commodities_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe 'Commodities', swagger_doc: 'v2/swagger.json', type: :request do
     get 'Retrieve a commodity' do
       tags 'Commodities'
       produces 'application/json'
+      jsonapi_query_parameters(includes: JsonapiSwaggerParameters::COMMODITY_INCLUDES)
       description 'Returns a single commodity including its measures, footnotes, and ancestors.'
       operationId 'getCommodity'
 
@@ -212,6 +213,7 @@ RSpec.describe 'Commodities', swagger_doc: 'v2/swagger.json', type: :request do
     get 'List changes for a commodity' do
       tags 'Commodities'
       produces 'application/json'
+      jsonapi_query_parameters(includes: JsonapiSwaggerParameters::CHANGE_INCLUDES)
       description 'Returns the changelog for a commodity.'
       operationId 'listCommodityChanges'
 

--- a/spec/swagger/api/v2/description_intercepts_spec.rb
+++ b/spec/swagger/api/v2/description_intercepts_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe 'Description Intercepts', swagger_doc: 'v2/swagger.json', type: :
     get 'List description intercepts' do
       tags 'Description Intercepts'
       produces 'application/json'
+      jsonapi_query_parameters(includes: [])
       description 'Returns description intercepts, optionally filtered by source and excluded state.'
       operationId 'listDescriptionIntercepts'
 

--- a/spec/swagger/api/v2/exchange_rates_spec.rb
+++ b/spec/swagger/api/v2/exchange_rates_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe 'Exchange Rates', swagger_doc: 'v2/swagger.json', type: :request 
     get 'Retrieve exchange rates for a period' do
       tags 'Exchange Rates'
       produces 'application/json'
+      jsonapi_query_parameters(includes: %w[exchange_rates exchange_rate_files])
       description 'Returns the exchange rate collection for the specified year, month, and rate type.'
       operationId 'getExchangeRates'
 
@@ -94,6 +95,7 @@ RSpec.describe 'Exchange Rates', swagger_doc: 'v2/swagger.json', type: :request 
     get 'List exchange rate periods for a year' do
       tags 'Exchange Rates'
       produces 'application/json'
+      jsonapi_query_parameters(includes: %w[exchange_rate_periods exchange_rate_years exchange_rate_periods.files])
       description 'Returns available exchange rate periods for the specified year and type.'
       operationId 'listExchangeRatePeriods'
 

--- a/spec/swagger/api/v2/footnote_types_spec.rb
+++ b/spec/swagger/api/v2/footnote_types_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'Footnote Types', swagger_doc: 'v2/swagger.json', type: :request 
     get 'List all footnote types' do
       tags 'Footnotes'
       produces 'application/json'
+      jsonapi_query_parameters(includes: [])
       description 'Returns all footnote types with their descriptions.'
       operationId 'listFootnoteTypes'
 

--- a/spec/swagger/api/v2/footnotes_spec.rb
+++ b/spec/swagger/api/v2/footnotes_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe 'Footnotes', swagger_doc: 'v2/swagger.json', type: :request do
     get 'Search footnotes' do
       tags 'Footnotes'
       produces 'application/json'
+      jsonapi_query_parameters(includes: %w[goods_nomenclatures])
       description 'Returns footnotes matching the search parameters, including related goods nomenclatures.'
       operationId 'searchFootnotes'
 

--- a/spec/swagger/api/v2/geographical_areas_spec.rb
+++ b/spec/swagger/api/v2/geographical_areas_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe 'Geographical Areas', swagger_doc: 'v2/swagger.json', type: :requ
     get 'List all geographical areas' do
       tags 'Geographical Areas'
       produces 'application/json'
+      jsonapi_query_parameters(includes: %w[contained_geographical_areas])
       description 'Returns all geographical areas (countries and groups).'
       operationId 'listGeographicalAreas'
 
@@ -62,6 +63,7 @@ RSpec.describe 'Geographical Areas', swagger_doc: 'v2/swagger.json', type: :requ
     get 'List all countries' do
       tags 'Geographical Areas'
       produces 'application/json'
+      jsonapi_query_parameters(includes: %w[contained_geographical_areas])
       description 'Returns only country-type geographical areas (geographical_code = "0").'
       operationId 'listCountries'
 
@@ -93,6 +95,7 @@ RSpec.describe 'Geographical Areas', swagger_doc: 'v2/swagger.json', type: :requ
     get 'Retrieve a geographical area' do
       tags 'Geographical Areas'
       produces 'application/json'
+      jsonapi_query_parameters(includes: %w[contained_geographical_areas])
       description 'Returns a single geographical area with its contained areas.'
       operationId 'getGeographicalArea'
 

--- a/spec/swagger/api/v2/goods_nomenclatures_spec.rb
+++ b/spec/swagger/api/v2/goods_nomenclatures_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe 'Goods Nomenclatures', swagger_doc: 'v2/swagger.json', type: :req
     get 'Retrieve a goods nomenclature by id' do
       tags 'Goods Nomenclatures'
       produces 'application/json'
+      jsonapi_query_parameters(includes: %w[parent])
       description 'Returns a single goods nomenclature item by its SID.'
       operationId 'getGoodsNomenclature'
 
@@ -90,6 +91,7 @@ RSpec.describe 'Goods Nomenclatures', swagger_doc: 'v2/swagger.json', type: :req
     get 'List goods nomenclatures for a section' do
       tags 'Goods Nomenclatures'
       produces 'application/json'
+      jsonapi_query_parameters(includes: [])
       description 'Returns all goods nomenclature items belonging to a section.'
       operationId 'getGoodsNomenclatureBySection'
 
@@ -122,6 +124,7 @@ RSpec.describe 'Goods Nomenclatures', swagger_doc: 'v2/swagger.json', type: :req
     get 'List goods nomenclatures for a chapter' do
       tags 'Goods Nomenclatures'
       produces 'application/json'
+      jsonapi_query_parameters(includes: [])
       description 'Returns all goods nomenclature items belonging to a chapter.'
       operationId 'getGoodsNomenclatureByChapter'
 
@@ -154,6 +157,7 @@ RSpec.describe 'Goods Nomenclatures', swagger_doc: 'v2/swagger.json', type: :req
     get 'List goods nomenclatures for a heading' do
       tags 'Goods Nomenclatures'
       produces 'application/json'
+      jsonapi_query_parameters(includes: [])
       description 'Returns all goods nomenclature items belonging to a heading.'
       operationId 'getGoodsNomenclatureByHeading'
 

--- a/spec/swagger/api/v2/headings_spec.rb
+++ b/spec/swagger/api/v2/headings_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe 'Headings', swagger_doc: 'v2/swagger.json', type: :request do
     get 'Retrieve a heading' do
       tags 'Headings'
       produces 'application/json'
+      jsonapi_query_parameters(includes: JsonapiSwaggerParameters::HEADING_INCLUDES)
       description 'Returns a single heading. The response uses either HeadingSerializer (non-declarable) or DeclarableHeadingSerializer (declarable) depending on the heading type.'
       operationId 'getHeading'
 
@@ -147,6 +148,7 @@ RSpec.describe 'Headings', swagger_doc: 'v2/swagger.json', type: :request do
     get 'List commodities for a heading' do
       tags 'Headings'
       produces 'application/json'
+      jsonapi_query_parameters(includes: JsonapiSwaggerParameters::HEADING_INCLUDES)
       description 'Returns a heading with its full commodity tree.'
       operationId 'listHeadingCommodities'
 
@@ -184,6 +186,7 @@ RSpec.describe 'Headings', swagger_doc: 'v2/swagger.json', type: :request do
     get 'List changes for a heading' do
       tags 'Headings'
       produces 'application/json'
+      jsonapi_query_parameters(includes: JsonapiSwaggerParameters::CHANGE_INCLUDES)
       description 'Returns the changelog for a heading.'
       operationId 'listHeadingChanges'
 

--- a/spec/swagger/api/v2/live_issues_spec.rb
+++ b/spec/swagger/api/v2/live_issues_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe 'Live Issues', swagger_doc: 'v2/swagger.json', type: :request do
     get 'List live issues' do
       tags 'Live Issues'
       produces 'application/json'
+      jsonapi_query_parameters(includes: [])
       description 'Returns current live service issues, optionally filtered by status.'
       operationId 'listLiveIssues'
 

--- a/spec/swagger/api/v2/measure_actions_spec.rb
+++ b/spec/swagger/api/v2/measure_actions_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'Measure Actions', swagger_doc: 'v2/swagger.json', type: :request
     get 'List all measure actions' do
       tags 'Measure Actions'
       produces 'application/json'
+      jsonapi_query_parameters(includes: [])
       description 'Returns all current measure actions with their descriptions.'
       operationId 'listMeasureActions'
 

--- a/spec/swagger/api/v2/measure_condition_codes_spec.rb
+++ b/spec/swagger/api/v2/measure_condition_codes_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'Measure Condition Codes', swagger_doc: 'v2/swagger.json', type: 
     get 'List all measure condition codes' do
       tags 'Measure Condition Codes'
       produces 'application/json'
+      jsonapi_query_parameters(includes: [])
       description 'Returns all current measure condition codes with their descriptions.'
       operationId 'listMeasureConditionCodes'
 

--- a/spec/swagger/api/v2/measure_types_spec.rb
+++ b/spec/swagger/api/v2/measure_types_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe 'Measure Types', swagger_doc: 'v2/swagger.json', type: :request d
     get 'List all measure types' do
       tags 'Measure Types'
       produces 'application/json'
+      jsonapi_query_parameters(includes: [])
       description 'Returns all current measure types with their series descriptions.'
       operationId 'listMeasureTypes'
 
@@ -64,6 +65,7 @@ RSpec.describe 'Measure Types', swagger_doc: 'v2/swagger.json', type: :request d
     get 'Retrieve a measure type' do
       tags 'Measure Types'
       produces 'application/json'
+      jsonapi_query_parameters(includes: [])
       description 'Returns a single measure type by its ID.'
       operationId 'getMeasureType'
 

--- a/spec/swagger/api/v2/measures_spec.rb
+++ b/spec/swagger/api/v2/measures_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe 'Measures', swagger_doc: 'v2/swagger.json', type: :request do
     get 'Retrieve a measure' do
       tags 'Measures'
       produces 'application/json'
+      jsonapi_query_parameters(includes: JsonapiSwaggerParameters::MEASURE_INCLUDES)
       description 'Returns a single measure including its duty expression, conditions, components, and geographical area.'
       operationId 'getMeasure'
 

--- a/spec/swagger/api/v2/monetary_exchange_rates_spec.rb
+++ b/spec/swagger/api/v2/monetary_exchange_rates_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'Monetary Exchange Rates', swagger_doc: 'v2/swagger.json', type: 
     get 'List monetary exchange rates' do
       tags 'Exchange Rates'
       produces 'application/json'
+      jsonapi_query_parameters(includes: [])
       description 'Returns GBP monetary exchange rates from the last 5 years, ordered by validity start date.'
       operationId 'listMonetaryExchangeRates'
 

--- a/spec/swagger/api/v2/news_spec.rb
+++ b/spec/swagger/api/v2/news_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe 'News', swagger_doc: 'v2/swagger.json', type: :request do
     get 'List news items' do
       tags 'News'
       produces 'application/json'
+      jsonapi_query_parameters(includes: %w[collections])
       description 'Returns paginated news items with collection relationships.'
       operationId 'listNewsItems'
 
@@ -86,6 +87,7 @@ RSpec.describe 'News', swagger_doc: 'v2/swagger.json', type: :request do
     get 'Retrieve a news item' do
       tags 'News'
       produces 'application/json'
+      jsonapi_query_parameters(includes: %w[collections])
       description 'Returns a single news item. Accepts either a numeric ID or a slug string.'
       operationId 'getNewsItem'
 
@@ -135,6 +137,7 @@ RSpec.describe 'News', swagger_doc: 'v2/swagger.json', type: :request do
     get 'List news collections' do
       tags 'News'
       produces 'application/json'
+      jsonapi_query_parameters(includes: [])
       description 'Returns all published news collections.'
       operationId 'listNewsCollections'
 
@@ -180,6 +183,7 @@ RSpec.describe 'News', swagger_doc: 'v2/swagger.json', type: :request do
     get 'List news years' do
       tags 'News'
       produces 'application/json'
+      jsonapi_query_parameters(includes: [])
       description 'Returns distinct years for which updates-page news items exist in published collections.'
       operationId 'listNewsYears'
 

--- a/spec/swagger/api/v2/preference_codes_spec.rb
+++ b/spec/swagger/api/v2/preference_codes_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe 'Preference Codes', swagger_doc: 'v2/swagger.json', type: :reques
     get 'List all preference codes' do
       tags 'Preference Codes'
       produces 'application/json'
+      jsonapi_query_parameters(includes: [])
       description 'Returns all preference codes loaded from the preference codes reference file.'
       operationId 'listPreferenceCodes'
 
@@ -55,6 +56,7 @@ RSpec.describe 'Preference Codes', swagger_doc: 'v2/swagger.json', type: :reques
     get 'Retrieve a preference code' do
       tags 'Preference Codes'
       produces 'application/json'
+      jsonapi_query_parameters(includes: [])
       description 'Returns a single preference code by its code value.'
       operationId 'getPreferenceCode'
 

--- a/spec/swagger/api/v2/quota_order_numbers_spec.rb
+++ b/spec/swagger/api/v2/quota_order_numbers_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'Quota Order Numbers', swagger_doc: 'v2/swagger.json', type: :req
     get 'List all quota order numbers' do
       tags 'Quotas'
       produces 'application/json'
+      jsonapi_query_parameters(includes: JsonapiSwaggerParameters::QUOTA_ORDER_NUMBER_INCLUDES)
       description 'Returns all quota order numbers with their current quota definitions.'
       operationId 'listQuotaOrderNumbers'
 

--- a/spec/swagger/api/v2/quotas_spec.rb
+++ b/spec/swagger/api/v2/quotas_spec.rb
@@ -26,6 +26,10 @@ RSpec.describe 'Quotas', swagger_doc: 'v2/swagger.json', type: :request do
     get 'Search quota definitions' do
       tags 'Quotas'
       produces 'application/json'
+      jsonapi_query_parameters(
+        includes: JsonapiSwaggerParameters::QUOTA_INCLUDES,
+        default_includes: JsonapiSwaggerParameters::QUOTA_DEFAULT_INCLUDES,
+      )
       description 'Returns quota definitions matching the search parameters. Results are paginated at 5 per page.'
       operationId 'searchQuotas'
 

--- a/spec/swagger/api/v2/rules_of_origin_spec.rb
+++ b/spec/swagger/api/v2/rules_of_origin_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe 'Rules of Origin', swagger_doc: 'v2/swagger.json', type: :request
     get 'List all rules of origin schemes' do
       tags 'Rules of Origin'
       produces 'application/json'
+      jsonapi_query_parameters(includes: JsonapiSwaggerParameters::RULES_OF_ORIGIN_MINIMAL_INCLUDES)
       description 'Returns all rules of origin schemes with their links and origin reference documents.'
       operationId 'listRulesOfOriginSchemes'
 
@@ -65,6 +66,7 @@ RSpec.describe 'Rules of Origin', swagger_doc: 'v2/swagger.json', type: :request
     get 'List rules of origin schemes for a heading and country' do
       tags 'Rules of Origin'
       produces 'application/json'
+      jsonapi_query_parameters(includes: JsonapiSwaggerParameters::RULES_OF_ORIGIN_FULL_INCLUDES)
       description 'Returns rules of origin schemes applicable to a heading/country combination, including rules, articles, and proofs.'
       operationId 'getRulesOfOriginForHeading'
 
@@ -97,6 +99,7 @@ RSpec.describe 'Rules of Origin', swagger_doc: 'v2/swagger.json', type: :request
     get 'List product-specific rules for a commodity' do
       tags 'Rules of Origin'
       produces 'application/json'
+      jsonapi_query_parameters(includes: JsonapiSwaggerParameters::RULES_OF_ORIGIN_FULL_INCLUDES)
       description 'Returns all rules of origin schemes with product-specific rule sets filtered to the given commodity code.'
       operationId 'getProductSpecificRules'
 

--- a/spec/swagger/api/v2/search_references_spec.rb
+++ b/spec/swagger/api/v2/search_references_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe 'Search References', swagger_doc: 'v2/swagger.json', type: :reque
     get 'List search references' do
       tags 'Search References'
       produces 'application/json'
+      jsonapi_query_parameters(includes: [])
       description 'Returns search references optionally filtered by first letter.'
       operationId 'listSearchReferences'
 

--- a/spec/swagger/api/v2/sections_spec.rb
+++ b/spec/swagger/api/v2/sections_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe 'Sections', swagger_doc: 'v2/swagger.json', type: :request do
     get 'List all sections' do
       tags 'Sections'
       produces 'application/json'
+      jsonapi_query_parameters(includes: [])
       description 'Returns all sections of the tariff. Sections group chapters into broad categories of goods.'
       operationId 'listSections'
 
@@ -62,6 +63,7 @@ RSpec.describe 'Sections', swagger_doc: 'v2/swagger.json', type: :request do
     get 'Retrieve a section' do
       tags 'Sections'
       produces 'application/json'
+      jsonapi_query_parameters(includes: %w[chapters chapters.guides])
       description 'Returns a single section including its chapters and any associated guides.'
       operationId 'getSection'
 
@@ -163,6 +165,7 @@ RSpec.describe 'Sections', swagger_doc: 'v2/swagger.json', type: :request do
     get 'List chapters in a section' do
       tags 'Sections'
       produces 'application/json'
+      jsonapi_query_parameters(includes: [])
       description 'Returns all chapters belonging to a section.'
       operationId 'listSectionChapters'
 

--- a/spec/swagger/api/v2/simplified_procedural_code_measures_spec.rb
+++ b/spec/swagger/api/v2/simplified_procedural_code_measures_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe 'Simplified Procedural Code Measures', swagger_doc: 'v2/swagger.j
     get 'List simplified procedural code measures' do
       tags 'Simplified Procedural Codes'
       produces 'application/json'
+      jsonapi_query_parameters(includes: [])
       description 'Returns measures associated with simplified procedural codes. Without a code filter, returns all codes merged with null measures.'
       operationId 'listSimplifiedProceduralCodeMeasures'
 

--- a/spec/swagger/api/v2/subheadings_spec.rb
+++ b/spec/swagger/api/v2/subheadings_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe 'Subheadings', swagger_doc: 'v2/swagger.json', type: :request do
     get 'Retrieve a subheading' do
       tags 'Subheadings'
       produces 'application/json'
+      jsonapi_query_parameters(includes: JsonapiSwaggerParameters::SUBHEADING_INCLUDES)
       description 'Returns a single subheading including its commodities, footnotes, and ancestors.'
       operationId 'getSubheading'
 

--- a/spec/swagger/api/v2/updates_spec.rb
+++ b/spec/swagger/api/v2/updates_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'Updates', swagger_doc: 'v2/swagger.json', type: :request do
     get 'Retrieve the latest tariff updates' do
       tags 'Updates'
       produces 'application/json'
+      jsonapi_query_parameters(includes: [])
       description 'Returns the most recently applied tariff update records.'
       operationId 'getLatestUpdates'
 

--- a/spec/swagger/api/v2/validity_periods_spec.rb
+++ b/spec/swagger/api/v2/validity_periods_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe 'Validity Periods', swagger_doc: 'v2/swagger.json', type: :reques
     get 'List validity periods for a heading' do
       tags 'Validity Periods'
       produces 'application/json'
+      jsonapi_query_parameters(includes: %w[deriving_goods_nomenclatures])
       description 'Returns all validity periods for a heading.'
       operationId 'listHeadingValidityPeriods'
 
@@ -80,6 +81,7 @@ RSpec.describe 'Validity Periods', swagger_doc: 'v2/swagger.json', type: :reques
     get 'List validity periods for a subheading' do
       tags 'Validity Periods'
       produces 'application/json'
+      jsonapi_query_parameters(includes: %w[deriving_goods_nomenclatures])
       description 'Returns all validity periods for a subheading.'
       operationId 'listSubheadingValidityPeriods'
 
@@ -112,6 +114,7 @@ RSpec.describe 'Validity Periods', swagger_doc: 'v2/swagger.json', type: :reques
     get 'List validity periods for a commodity' do
       tags 'Validity Periods'
       produces 'application/json'
+      jsonapi_query_parameters(includes: %w[deriving_goods_nomenclatures])
       description 'Returns all validity periods for a commodity.'
       operationId 'listCommodityValidityPeriods'
 

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -2,7 +2,164 @@ require 'rails_helper'
 
 TARIFF_API_HOST = 'https://www.trade-tariff.service.gov.uk'.freeze
 
+module JsonapiSwaggerParameters
+  CHANGE_INCLUDES = %w[
+    record
+    record.geographical_area
+    record.measure_type
+  ].freeze
+
+  MEASURE_INCLUDES = %w[
+    goods_nomenclature
+    duty_expression
+    measure_type
+    legal_acts
+    measure_generating_legal_act
+    justification_legal_act
+    measure_conditions
+    measure_conditions.measure_condition_components
+    measure_components
+    geographical_area
+    geographical_area.contained_geographical_areas
+    excluded_geographical_areas
+    footnotes
+    additional_code
+    order_number
+    order_number.definition
+  ].freeze
+
+  DECLARABLE_MEASURE_INCLUDES = %w[
+    import_measures
+    import_measures.duty_expression
+    import_measures.measure_type
+    import_measures.legal_acts
+    import_measures.suspending_regulation
+    import_measures.measure_conditions
+    import_measures.measure_conditions.measure_condition_code
+    import_measures.measure_condition_permutation_groups
+    import_measures.measure_condition_permutation_groups.permutations
+    import_measures.measure_conditions.measure_condition_components
+    import_measures.measure_components
+    import_measures.measure_components.measurement_unit
+    import_measures.measure_components.measurement_unit_qualifier
+    import_measures.geographical_area
+    import_measures.geographical_area.contained_geographical_areas
+    import_measures.excluded_geographical_areas
+    import_measures.footnotes
+    import_measures.additional_code
+    import_measures.order_number
+    import_measures.order_number.definition
+    import_measures.order_number.definition.incoming_quota_closed_and_transferred_event
+    import_measures.preference_code
+    export_measures
+    export_measures.duty_expression
+    export_measures.measure_type
+    export_measures.legal_acts
+    export_measures.suspending_regulation
+    export_measures.measure_conditions
+    export_measures.measure_conditions.measure_condition_code
+    export_measures.measure_condition_permutation_groups
+    export_measures.measure_condition_permutation_groups.permutations
+    export_measures.measure_conditions.measure_condition_components
+    export_measures.measure_components
+    export_measures.measure_components.measurement_unit
+    export_measures.measure_components.measurement_unit_qualifier
+    export_measures.geographical_area
+    export_measures.geographical_area.contained_geographical_areas
+    export_measures.excluded_geographical_areas
+    export_measures.footnotes
+    export_measures.additional_code
+    export_measures.order_number
+    export_measures.order_number.definition
+  ].freeze
+
+  COMMODITY_INCLUDES = ([
+    'section',
+    'chapter',
+    'chapter.guides',
+    'footnotes',
+    'import_trade_summary',
+    'heading',
+    'ancestors',
+    'import_measures.resolved_measure_components',
+    'import_measures.resolved_measure_components.measurement_unit',
+    'export_measures.resolved_measure_components',
+    'export_measures.resolved_measure_components.measurement_unit',
+  ] + DECLARABLE_MEASURE_INCLUDES).uniq.freeze
+
+  HEADING_INCLUDES = ([
+    'section',
+    'chapter',
+    'chapter.guides',
+    'footnotes',
+    'commodities',
+    'commodities.overview_measures',
+    'commodities.overview_measures.duty_expression',
+    'commodities.overview_measures.measure_type',
+    'commodities.overview_measures.additional_code',
+    'import_trade_summary',
+  ] + DECLARABLE_MEASURE_INCLUDES).uniq.freeze
+
+  SUBHEADING_INCLUDES = %w[
+    section
+    heading
+    chapter
+    chapter.guides
+    footnotes
+    commodities
+    commodities.overview_measures
+    commodities.overview_measures.duty_expression
+    commodities.overview_measures.measure_type
+    commodities.overview_measures.additional_code
+    ancestors
+  ].freeze
+
+  QUOTA_DEFAULT_INCLUDES = %w[
+    quota_order_number
+    quota_order_number.geographical_areas
+    measures
+    measures.goods_nomenclature
+    measures.geographical_area
+    incoming_quota_closed_and_transferred_event
+    quota_order_number_origins
+    quota_order_number_origins.geographical_area
+    quota_order_number_origins.quota_order_number_origin_exclusions
+    quota_order_number_origins.quota_order_number_origin_exclusions.geographical_area
+  ].freeze
+
+  QUOTA_INCLUDES = %w[
+    quota_balance_events
+  ].freeze
+
+  QUOTA_ORDER_NUMBER_INCLUDES = %w[
+    quota_definition
+    quota_definition.measures
+  ].freeze
+
+  RULES_OF_ORIGIN_MINIMAL_INCLUDES = %w[
+    links
+    origin_reference_document
+    proofs
+  ].freeze
+
+  RULES_OF_ORIGIN_FULL_INCLUDES = %w[
+    links
+    proofs
+    rules
+    articles
+    rule_sets
+    rule_sets.rules
+    origin_reference_document
+  ].freeze
+
+  def jsonapi_query_parameters(includes:, default_includes: [])
+    # TODO: Enable if desired to make this widely accessible.
+  end
+end
+
 RSpec.configure do |config|
+  config.extend JsonapiSwaggerParameters
+
   config.openapi_root = Rails.root.join('swagger').to_s
 
   config.openapi_specs = {


### PR DESCRIPTION
### Jira link

[HMRC-2390](https://transformuk.atlassian.net/browse/HMRC-2390)

### What?

- [x] Add JSON:API `include` query option support across V2 serializers
- [x] Add sparse `fields[...]` query option support across V2 serializers
- [x] Vary cache keys for shaped responses so variants stay isolated
- [x] Guard expensive commodity, heading, subheading, chapter, and section paths with eager-loading checks
- [x] Keep the new query parameters out of public V2 Swagger documentation for now
- [x] Add coverage for request paths, serializers, Swagger behaviour, cache-key variation, and SQL notifications

### Why?

The MCP app needs smaller tariff responses shaped around the data it is actually using. Full V2 responses make each interaction heavier than necessary when MCP only needs a narrow set of related data or fields.

The rollout is deliberately MCP-first. That gives us one controlled consumer for the behaviour before we use the same response-shaping capability in frontend, admin, and other apps later.

### Risk

**Risk level:** 🟠

**Reason for rating:** New public V2 API behaviour consumed by other services. The default no-query-param response path is covered by the existing V2 request suite, and the new response-shaping paths have focused request, serializer, swagger, cache-key, and SQL-notification coverage.
