### PR TITLE
AI-888: Increase backend internal search timeout

### DIFF
--- a/app/lib/trade_tariff_backend.rb
+++ b/app/lib/trade_tariff_backend.rb
@@ -13,6 +13,7 @@ require_relative 'trade_tariff_backend/config'
 require_relative 'trade_tariff_backend/clients'
 require_relative 'trade_tariff_backend/tariff_update_event_listener'
 require_relative 'trade_tariff_backend/search_response'
+require_relative 'trade_tariff_backend/service_timeout'
 
 module TradeTariffBackend
   extend Config

--- a/app/lib/trade_tariff_backend/service_timeout.rb
+++ b/app/lib/trade_tariff_backend/service_timeout.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module TradeTariffBackend
+  class ServiceTimeout
+    DEFAULT_TIMEOUT = 50
+    DEFAULT_PATH_OVERRIDES = '/uk/internal/search:100,/xi/internal/search:100'
+
+    class << self
+      def timeout_for(path)
+        path_timeouts.each do |prefix, seconds|
+          return seconds if path_match?(path, prefix)
+        end
+
+        default_timeout
+      end
+
+      def default_timeout
+        ENV.fetch('RACK_TIMEOUT_SERVICE_TIMEOUT', DEFAULT_TIMEOUT).to_i
+      end
+
+      def path_timeouts
+        parse_path_timeouts
+      end
+
+    private
+
+      def parse_path_timeouts
+        ENV.fetch('RACK_TIMEOUT_PATH_OVERRIDES', DEFAULT_PATH_OVERRIDES)
+           .split(',')
+           .filter_map do |entry|
+             parts = entry.strip.split(':')
+             next if parts.length < 2
+
+             [parts[0], parts[1].to_i]
+           end
+      end
+
+      def path_match?(path, prefix)
+        path == prefix || path.start_with?("#{prefix}/")
+      end
+    end
+
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      timeout = self.class.timeout_for(env['PATH_INFO'])
+      ::Timeout.timeout(timeout) { @app.call(env) }
+    end
+  end
+end

--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -12,6 +12,7 @@ ENV['RACK_TIMEOUT_WAIT_TIMEOUT'] ||= '100'
 # Requests exceeding this will be terminated (SIGTERM sent to worker).
 # Current setting: 50 seconds
 ENV['RACK_TIMEOUT_SERVICE_TIMEOUT'] ||= '50'
+ENV['RACK_TIMEOUT_PATH_OVERRIDES'] ||= TradeTariffBackend::ServiceTimeout::DEFAULT_PATH_OVERRIDES
 
 # Other available settings (using defaults if not set):
 # - RACK_TIMEOUT_WAIT_OVERTIME: Additional wait time for requests with a body (POST, PUT, etc.) (default: 60)
@@ -21,3 +22,12 @@ ENV['RACK_TIMEOUT_SERVICE_TIMEOUT'] ||= '50'
 # Disable verbose logging - only log when timeouts actually occur
 # Timeout exceptions will still be raised and logged by Rails as 503 errors
 Rack::Timeout::Logger.disable if Rails.env.production?
+
+if defined?(Rack::Timeout)
+  Rails.application.config.middleware.delete Rack::Timeout
+end
+
+Rails.application.config.middleware.insert_after(
+  ActionDispatch::RequestId,
+  TradeTariffBackend::ServiceTimeout,
+)

--- a/spec/lib/trade_tariff_backend/service_timeout_spec.rb
+++ b/spec/lib/trade_tariff_backend/service_timeout_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+RSpec.describe TradeTariffBackend::ServiceTimeout do
+  subject(:middleware) { described_class.new(app) }
+
+  let(:app) { ->(_env) { [200, {}, %w[OK]] } }
+
+  around do |example|
+    original_timeout = ENV['RACK_TIMEOUT_SERVICE_TIMEOUT']
+    original_overrides = ENV['RACK_TIMEOUT_PATH_OVERRIDES']
+    example.run
+  ensure
+    ENV['RACK_TIMEOUT_SERVICE_TIMEOUT'] = original_timeout
+    ENV['RACK_TIMEOUT_PATH_OVERRIDES'] = original_overrides
+  end
+
+  before do
+    allow(Timeout).to receive(:timeout).and_call_original
+  end
+
+  describe '#call' do
+    context 'with default path overrides' do
+      before do
+        ENV['RACK_TIMEOUT_SERVICE_TIMEOUT'] = '50'
+        ENV.delete('RACK_TIMEOUT_PATH_OVERRIDES')
+      end
+
+      it 'applies 100s timeout to /uk/internal/search' do
+        middleware.call('PATH_INFO' => '/uk/internal/search')
+        expect(Timeout).to have_received(:timeout).with(100)
+      end
+
+      it 'applies 100s timeout to /xi/internal/search' do
+        middleware.call('PATH_INFO' => '/xi/internal/search')
+        expect(Timeout).to have_received(:timeout).with(100)
+      end
+
+      it 'applies default timeout to internal search suggestions' do
+        middleware.call('PATH_INFO' => '/uk/internal/search_suggestions')
+        expect(Timeout).to have_received(:timeout).with(50)
+      end
+
+      it 'applies default timeout to public search' do
+        middleware.call('PATH_INFO' => '/uk/api/search')
+        expect(Timeout).to have_received(:timeout).with(50)
+      end
+    end
+
+    context 'with custom path overrides' do
+      before do
+        ENV['RACK_TIMEOUT_SERVICE_TIMEOUT'] = '50'
+        ENV['RACK_TIMEOUT_PATH_OVERRIDES'] = '/api/slow:60'
+      end
+
+      it 'uses the custom override' do
+        middleware.call('PATH_INFO' => '/api/slow')
+        expect(Timeout).to have_received(:timeout).with(60)
+      end
+
+      it 'uses the default timeout for non-matching paths' do
+        middleware.call('PATH_INFO' => '/uk/internal/search')
+        expect(Timeout).to have_received(:timeout).with(50)
+      end
+    end
+
+    context 'with empty RACK_TIMEOUT_PATH_OVERRIDES' do
+      before do
+        ENV['RACK_TIMEOUT_SERVICE_TIMEOUT'] = '40'
+        ENV['RACK_TIMEOUT_PATH_OVERRIDES'] = ''
+      end
+
+      it 'uses the default timeout for all paths' do
+        middleware.call('PATH_INFO' => '/uk/internal/search')
+        expect(Timeout).to have_received(:timeout).with(40)
+      end
+    end
+
+    it 'calls the downstream app' do
+      status, = middleware.call('PATH_INFO' => '/')
+      expect(status).to eq(200)
+    end
+  end
+end


### PR DESCRIPTION
## What:
Adds a backend `TradeTariffBackend::ServiceTimeout` middleware matching the frontend timeout override pattern.

The default override gives `/uk/internal/search` and `/xi/internal/search` a 100 second service timeout while keeping the existing 50 second default for other backend paths, including internal search suggestions and public search.

## Why:
Staging search requests can exceed the existing backend Rack timeout during internal search, even after the frontend timeout was increased. The observed crash for “smoked fish” timed out in backend internal search at about 50 seconds, so the backend internal search route needs the same timeout as the frontend caller.

## Ticket:
https://transformuk.atlassian.net/browse/AI-888

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Low risk. The change is scoped to internal search timeout handling, keeps other backend paths on the existing default timeout, and is covered by unit tests plus existing e2e coverage for the search behaviour.
