### PR TITLE
[HMRC-2296] Task to check for database backup freshness

### DIFF
--- a/bin/check-database-backup-freshness
+++ b/bin/check-database-backup-freshness
@@ -199,17 +199,21 @@ epoch_for_timestamp() {
 
 archive_key_for_epoch() {
   local epoch=$1
+  local offset_seconds=${2:-0}
+  local archive_epoch
+
+  archive_epoch=$((epoch + offset_seconds))
 
   # bin/backup-database uses plain date +"%Y/%m/%d" in a Europe/London
-  # container. EventBridge runs cron(0 23 * * ? *) in UTC, so during BST the
-  # archive prefix is the next London calendar day even though S3 LastModified
-  # is still on the previous UTC date.
-  if TZ="$BACKUP_ARCHIVE_TIME_ZONE" date -d "@$epoch" +"%Y/%m/%d" >/dev/null 2>&1; then
-    echo "$(TZ="$BACKUP_ARCHIVE_TIME_ZONE" date -d "@$epoch" +"%Y/%m/%d")/tariff-merged-${ENVIRONMENT}.sql.gz"
+  # container. The latest object's LastModified is upload completion time, so a
+  # backup that starts before midnight and finishes after midnight may archive
+  # under the previous date.
+  if TZ="$BACKUP_ARCHIVE_TIME_ZONE" date -d "@$archive_epoch" +"%Y/%m/%d" >/dev/null 2>&1; then
+    echo "$(TZ="$BACKUP_ARCHIVE_TIME_ZONE" date -d "@$archive_epoch" +"%Y/%m/%d")/tariff-merged-${ENVIRONMENT}.sql.gz"
     return
   fi
 
-  echo "$(TZ="$BACKUP_ARCHIVE_TIME_ZONE" date -r "$epoch" +"%Y/%m/%d")/tariff-merged-${ENVIRONMENT}.sql.gz"
+  echo "$(TZ="$BACKUP_ARCHIVE_TIME_ZONE" date -r "$archive_epoch" +"%Y/%m/%d")/tariff-merged-${ENVIRONMENT}.sql.gz"
 }
 
 reasons=()
@@ -238,8 +242,26 @@ if latest_last_modified=$(head_object_last_modified "$LATEST_KEY"); then
     status=$?
 
     if [ "$status" -eq 1 ]; then
-      freshness_ok=0
-      reasons+=("archive key $archive_key is missing")
+      expected_archive_key=$archive_key
+      archive_key=$(archive_key_for_epoch "$latest_epoch" -86400)
+
+      if archive_last_modified=$(head_object_last_modified "$archive_key"); then
+        archive_epoch=$(epoch_for_timestamp "$archive_last_modified")
+
+        if [ "$archive_epoch" -lt "$latest_epoch" ]; then
+          freshness_ok=0
+          reasons+=("archive key $archive_key is older than latest key $LATEST_KEY")
+        fi
+      else
+        status=$?
+
+        if [ "$status" -eq 1 ]; then
+          freshness_ok=0
+          reasons+=("archive keys $expected_archive_key and $archive_key are missing")
+        else
+          exit "$status"
+        fi
+      fi
     else
       exit "$status"
     fi

--- a/bin/check-database-backup-freshness
+++ b/bin/check-database-backup-freshness
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+
+[[ "${TRACE:-}" ]] && set -o xtrace
+set -o errexit
+set -o nounset
+set -o pipefail
+
+START_TIME=$(date +%s)
+
+METRIC_NAMESPACE="${METRIC_NAMESPACE:-TradeTariff/DatabaseBackup}"
+METRIC_NAME="${METRIC_NAME:-DatabaseBackupFreshnessOk}"
+BACKUP_FRESHNESS_THRESHOLD_SECONDS="${BACKUP_FRESHNESS_THRESHOLD_SECONDS:-86400}" # 24 Hours
+BACKUP_ARCHIVE_TIME_ZONE="${BACKUP_ARCHIVE_TIME_ZONE:-Europe/London}"
+PUBLISH_METRIC=false
+METRIC_PUBLICATION_STATUS="not attempted"
+
+usage() {
+  echo "Usage: $0 [--publish]"
+  echo
+  echo "Checks the database backup objects in S3."
+  echo
+  echo "Options:"
+  echo "  --publish  Publish the freshness result as a CloudWatch metric."
+}
+
+for arg in "$@"; do
+  case "$arg" in
+    --publish)
+      PUBLISH_METRIC=true
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $arg"
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "${ENVIRONMENT:-}" ]; then
+  echo "You need to set the ENVIRONMENT environment variable."
+  exit 1
+fi
+
+if [ -z "${S3_BUCKET:-}" ]; then
+  echo "You need to set the S3_BUCKET environment variable."
+  exit 1
+fi
+
+if ! [[ "$BACKUP_FRESHNESS_THRESHOLD_SECONDS" =~ ^[0-9]+$ ]]; then
+  echo "BACKUP_FRESHNESS_THRESHOLD_SECONDS must be an integer number of seconds."
+  exit 1
+fi
+
+LATEST_KEY="${LATEST_KEY:-tariff-merged-${ENVIRONMENT}.sql.gz}"
+BACKUP_JOB_NAME="${BACKUP_JOB_NAME:-backend-database-backup-${ENVIRONMENT}}"
+
+publish_freshness_metric() {
+  local value=$1
+
+  if [ "$PUBLISH_METRIC" = false ]; then
+    METRIC_PUBLICATION_STATUS="not published; value would be $value"
+    return
+  fi
+
+  aws cloudwatch put-metric-data \
+    --namespace "$METRIC_NAMESPACE" \
+    --metric-name "$METRIC_NAME" \
+    --dimensions \
+      "Name=Environment,Value=$ENVIRONMENT" \
+      "Name=Bucket,Value=$S3_BUCKET" \
+      "Name=LatestKey,Value=$LATEST_KEY" \
+    --unit Count \
+    --value "$value" > /dev/null
+
+  METRIC_PUBLICATION_STATUS="published value $value"
+}
+
+format_duration() {
+  local total_seconds=$1
+  local days
+  local hours
+  local minutes
+  local seconds
+
+  if [ "$total_seconds" = "unknown" ]; then
+    echo "unknown"
+    return
+  fi
+
+  days=$((total_seconds / 86400))
+  hours=$(((total_seconds % 86400) / 3600))
+  minutes=$(((total_seconds % 3600) / 60))
+  seconds=$((total_seconds % 60))
+
+  if [ "$days" -gt 0 ]; then
+    echo "${days}d ${hours}h ${minutes}m ${seconds}s"
+  elif [ "$hours" -gt 0 ]; then
+    echo "${hours}h ${minutes}m ${seconds}s"
+  elif [ "$minutes" -gt 0 ]; then
+    echo "${minutes}m ${seconds}s"
+  else
+    echo "${seconds}s"
+  fi
+}
+
+print_report() {
+  local status=$1
+  local end_time
+  local elapsed_time
+  local latest_age_display="unknown"
+  local latest_age_seconds_display="unknown"
+  local archive_last_modified_display="${archive_last_modified:-missing}"
+
+  end_time=$(date +%s)
+  elapsed_time=$((end_time - START_TIME))
+
+  if [ -n "${latest_age_seconds:-}" ]; then
+    latest_age_display=$(format_duration "$latest_age_seconds")
+    latest_age_seconds_display="${latest_age_seconds}s"
+  fi
+
+  cat <<REPORT
+Database backup freshness check
+Status: $status
+Environment: $ENVIRONMENT
+Bucket: $S3_BUCKET
+Backup job: $BACKUP_JOB_NAME
+
+Last backup
+  Key: $LATEST_KEY
+  Last modified: ${latest_last_modified:-missing}
+  Age: $latest_age_display ($latest_age_seconds_display)
+  Threshold: $(format_duration "$BACKUP_FRESHNESS_THRESHOLD_SECONDS") (${BACKUP_FRESHNESS_THRESHOLD_SECONDS}s)
+
+Archive backup
+  Key: ${archive_key:-not checked}
+  Last modified: $archive_last_modified_display
+  Archive date timezone: $BACKUP_ARCHIVE_TIME_ZONE
+
+CloudWatch metric: $METRIC_PUBLICATION_STATUS
+Elapsed: $(format_duration "$elapsed_time") (${elapsed_time}s)
+REPORT
+
+  if [ "$status" = "FAIL" ]; then
+    printf '\nReasons:\n'
+    printf '  - %s\n' "${reasons[@]}"
+  fi
+}
+
+head_object_last_modified() {
+  local key=$1
+  local error_file
+  local status
+
+  error_file=$(mktemp)
+
+  set +o errexit
+  aws s3api head-object \
+    --bucket "$S3_BUCKET" \
+    --key "$key" \
+    --query LastModified \
+    --output text 2>"$error_file"
+  status=$?
+  set -o errexit
+
+  if [ "$status" -eq 0 ]; then
+    rm "$error_file"
+    return 0
+  fi
+
+  if grep -Eq "(404|Not Found|NotFound|NoSuchKey)" "$error_file"; then
+    rm "$error_file"
+    return 1
+  fi
+
+  echo "Unable to inspect s3://$S3_BUCKET/$key." >&2
+  cat "$error_file" >&2
+  rm "$error_file"
+
+  return "$status"
+}
+
+epoch_for_timestamp() {
+  local timestamp=$1
+  local timestamp_without_colon_offset
+
+  if date -d "$timestamp" +%s >/dev/null 2>&1; then
+    date -d "$timestamp" +%s
+    return
+  fi
+
+  timestamp_without_colon_offset=$(echo "$timestamp" | sed -E 's/([+-][0-9]{2}):([0-9]{2})$/\1\2/')
+  date -j -f "%Y-%m-%dT%H:%M:%S%z" "$timestamp_without_colon_offset" +%s
+}
+
+archive_key_for_epoch() {
+  local epoch=$1
+
+  # bin/backup-database uses plain date +"%Y/%m/%d" in a Europe/London
+  # container. EventBridge runs cron(0 23 * * ? *) in UTC, so during BST the
+  # archive prefix is the next London calendar day even though S3 LastModified
+  # is still on the previous UTC date.
+  if TZ="$BACKUP_ARCHIVE_TIME_ZONE" date -d "@$epoch" +"%Y/%m/%d" >/dev/null 2>&1; then
+    echo "$(TZ="$BACKUP_ARCHIVE_TIME_ZONE" date -d "@$epoch" +"%Y/%m/%d")/tariff-merged-${ENVIRONMENT}.sql.gz"
+    return
+  fi
+
+  echo "$(TZ="$BACKUP_ARCHIVE_TIME_ZONE" date -r "$epoch" +"%Y/%m/%d")/tariff-merged-${ENVIRONMENT}.sql.gz"
+}
+
+reasons=()
+freshness_ok=1
+now_epoch=$(date +%s)
+
+if latest_last_modified=$(head_object_last_modified "$LATEST_KEY"); then
+  latest_epoch=$(epoch_for_timestamp "$latest_last_modified")
+  latest_age_seconds=$((now_epoch - latest_epoch))
+
+  if [ "$latest_age_seconds" -gt "$BACKUP_FRESHNESS_THRESHOLD_SECONDS" ]; then
+    freshness_ok=0
+    reasons+=("latest object is ${latest_age_seconds}s old, over threshold ${BACKUP_FRESHNESS_THRESHOLD_SECONDS}s")
+  fi
+
+  archive_key=$(archive_key_for_epoch "$latest_epoch")
+
+  if archive_last_modified=$(head_object_last_modified "$archive_key"); then
+    archive_epoch=$(epoch_for_timestamp "$archive_last_modified")
+
+    if [ "$archive_epoch" -lt "$latest_epoch" ]; then
+      freshness_ok=0
+      reasons+=("archive key $archive_key is older than latest key $LATEST_KEY")
+    fi
+  else
+    status=$?
+
+    if [ "$status" -eq 1 ]; then
+      freshness_ok=0
+      reasons+=("archive key $archive_key is missing")
+    else
+      exit "$status"
+    fi
+  fi
+else
+  status=$?
+
+  if [ "$status" -eq 1 ]; then
+    freshness_ok=0
+    reasons+=("latest key $LATEST_KEY is missing")
+  else
+    exit "$status"
+  fi
+fi
+
+publish_freshness_metric "$freshness_ok"
+
+if [ "$freshness_ok" -eq 1 ]; then
+  print_report "PASS"
+  exit 0
+fi
+
+print_report "FAIL"
+
+exit 0

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -38,9 +38,12 @@ Terraform to deploy the service into AWS.
 | Name | Type |
 | ---- | ---- |
 | [aws_cloudwatch_event_rule.database_backup](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
+| [aws_cloudwatch_event_rule.database_backup_freshness_check](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_rule.database_replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_target.database_backup](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
+| [aws_cloudwatch_event_target.database_backup_freshness_check](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
 | [aws_cloudwatch_event_target.database_replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
+| [aws_cloudwatch_metric_alarm.database_backup_freshness](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_iam_policy.eventbridge_pass_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.eventbridge_ecs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |

--- a/terraform/backend_job.tf
+++ b/terraform/backend_job.tf
@@ -89,10 +89,7 @@ resource "aws_cloudwatch_event_target" "database_backup_freshness_check" {
       name    = "backend-job"
       command = ["/bin/sh", "-c", "./bin/check-database-backup-freshness --publish"]
       environment = [
-        { name = "ENVIRONMENT", value = var.environment },
-        { name = "S3_BUCKET", value = "trade-tariff-database-backups-${local.account_id}" },
-        { name = "AWS_REGION", value = var.region },
-        { name = "AWS_DEFAULT_REGION", value = var.region },
+        { name = "S3_BUCKET", value = "trade-tariff-database-backups-${local.account_id}" }
       ]
     }]
   })

--- a/terraform/backend_job.tf
+++ b/terraform/backend_job.tf
@@ -73,7 +73,7 @@ resource "aws_cloudwatch_event_rule" "database_backup_freshness_check" {
 
   name                = "backend-database-backup-freshness-check-${var.environment}"
   description         = "Checks database backup freshness for ${var.environment}"
-  schedule_expression = "cron(0 1 * * ? *)"
+  schedule_expression = "cron(0 6 * * ? *)"
   state               = "ENABLED"
 }
 

--- a/terraform/backend_job.tf
+++ b/terraform/backend_job.tf
@@ -68,6 +68,74 @@ resource "aws_cloudwatch_event_target" "database_backup" {
   }
 }
 
+resource "aws_cloudwatch_event_rule" "database_backup_freshness_check" {
+  count = var.enable_alarms ? 1 : 0
+
+  name                = "backend-database-backup-freshness-check-${var.environment}"
+  description         = "Checks database backup freshness for ${var.environment}"
+  schedule_expression = "cron(0 1 * * ? *)"
+  state               = "ENABLED"
+}
+
+resource "aws_cloudwatch_event_target" "database_backup_freshness_check" {
+  count = var.enable_alarms ? 1 : 0
+
+  rule     = aws_cloudwatch_event_rule.database_backup_freshness_check[0].name
+  arn      = data.aws_ecs_cluster.this.arn
+  role_arn = aws_iam_role.eventbridge_ecs.arn
+
+  input = jsonencode({
+    containerOverrides = [{
+      name    = "backend-job"
+      command = ["/bin/sh", "-c", "./bin/check-database-backup-freshness --publish"]
+      environment = [
+        { name = "ENVIRONMENT", value = var.environment },
+        { name = "S3_BUCKET", value = "trade-tariff-database-backups-${local.account_id}" },
+        { name = "AWS_REGION", value = var.region },
+        { name = "AWS_DEFAULT_REGION", value = var.region },
+      ]
+    }]
+  })
+
+  ecs_target {
+    task_count          = 1
+    task_definition_arn = data.aws_ecs_task_definition.backend_job.arn
+    launch_type         = "FARGATE"
+    network_configuration {
+      subnets          = data.aws_subnets.private.ids
+      security_groups  = [data.aws_security_group.this.id]
+      assign_public_ip = false
+    }
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "database_backup_freshness" {
+  count = var.enable_alarms ? 1 : 0
+
+  alarm_name          = "backend-database-backup-freshness-${var.environment}"
+  alarm_description   = "Alerts when the latest ${var.environment} database backup is stale, missing, or has not reported freshness."
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = 1
+  datapoints_to_alarm = 1
+  threshold           = 1
+  treat_missing_data  = "breaching"
+
+  namespace   = "TradeTariff/DatabaseBackup"
+  metric_name = "DatabaseBackupFreshnessOk"
+  statistic   = "Minimum"
+  period      = 86400
+  unit        = "Count"
+
+  dimensions = {
+    Environment = var.environment
+    Bucket      = "trade-tariff-database-backups-${local.account_id}"
+    LatestKey   = "tariff-merged-${var.environment}.sql.gz"
+  }
+
+  alarm_actions = [data.aws_sns_topic.slack_topic.arn]
+  ok_actions    = [data.aws_sns_topic.slack_topic.arn]
+}
+
 resource "aws_cloudwatch_event_rule" "database_replication" {
   count = var.environment != "production" ? 1 : 0
 

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -79,6 +79,12 @@ data "aws_iam_policy_document" "task" {
   }
 
   statement {
+    effect    = "Allow"
+    actions   = ["cloudwatch:PutMetricData"]
+    resources = ["*"]
+  }
+
+  statement {
     effect = "Allow"
     actions = [
       "s3:ListBucket",


### PR DESCRIPTION
## What:

Takes `ENVIRONMENT` and `S3_BUCKET` and checks the latest db dumps `LastModified` timestamp, compares it to `now` with a freshness threshold (default 24 hours, but adjustable). Also checks the archive copy and expects an archive to exist matching that latest updated dump.

We then publish it as a cloudwatch metric with the `--publish` flag. 1 for healthy, 0 for unhealthy.

Unhealthy cases are:
- Latest dump is missing
- Latest dump exists but is older than 24 hours
- Daily archive is missing
- Daily archive exists but is older than the latest dump

Also handles the case where BST time kicks in and our backup naming conventions shift by 1 day. 

Run with:

```
ENVIRONMENT=production S3_BUCKET=trade-tariff-database-backups-1234 bin/check-database-backup-freshness --publish
```

Also produces a human readable output:

```
Database backup freshness check
Status: FAIL
Environment: development
Bucket: trade-tariff-database-backups-1234
Backup job: backend-database-backup-development

Last backup
  Key: tariff-merged-development.sql.gz
  Last modified: 2026-06-16T23:01:34+00:00
  Age: 1d 15h 13m 58s (141238s)
  Threshold: 1d 0h 0m 0s (86400s)

Archive backup
  Key: 2026/06/17/tariff-merged-development.sql.gz
  Last modified: 2026-06-16T23:26:16+00:00
  Archive date timezone: Europe/London

CloudWatch metric: not published; value would be 0
Elapsed: 1s (1s)

Reasons:
  - latest object is 141238s old, over threshold 86400s
```

## Why:
Operators rely on the production database dump for local restores and downstream environment refreshes. A recent outage meant the scheduled backup path stopped producing an updated dump, but the team only found out after the dump was needed.

This PR lays the ground work for an automated task to check this, publish as a cloudwatch metric, and trigger a slack notification.

## Ticket:
[HMRC-2296](https://transformuk.atlassian.net/browse/HMRC-2296)

## Risk:
 🟢

**Reason for rating:**
Doesn't change anything existing, just adds another task to run