### PR TITLE
Upgrade devcontainer Ruby to 4.0.5

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Make sure RUBY_VERSION matches the Ruby version in .ruby-version
-ARG RUBY_VERSION=3.4.7
+ARG RUBY_VERSION=4.0.5
 FROM ruby:$RUBY_VERSION-alpine3.22
 
 RUN apk add --update build-base docker gcompat git gpg postgresql-dev postgresql-client pre-commit python3 openssh shared-mime-info tzdata gnupg yaml-dev zlib-dev


### PR DESCRIPTION
### Jira link

No Jira ticket/issue.

### What?

- [x] Update the devcontainer Ruby build arg to 4.0.5.

### Why?

Ruby 4.0.5 is the current Ruby release and the devcontainer should match the application Ruby version used by the global upgrade target.

### Risk

**Risk level:** 🟢

**Reason for rating:** Development container only; no production runtime or application behaviour changes.

### Verification

- [x] `docker build -f .devcontainer/Dockerfile .`