### PR TITLE
OTTIMP-665 Add tariff change where declarable has children added

### DIFF
--- a/app/services/tariff_changes_service.rb
+++ b/app/services/tariff_changes_service.rb
@@ -147,6 +147,8 @@ class TariffChangesService
     # Multiple child creations can map to same parent on same run; keep earliest child date_of_effect.
     parent_date_of_effect_by_sid = created_children.each_with_object({}) do |child, dates_by_parent_sid|
       parent = child.parent
+      next if parent.nil?
+
       child_change = created_child_changes_by_sid[child.goods_nomenclature_sid]
       next if child_change.nil?
 

--- a/app/services/tariff_changes_service.rb
+++ b/app/services/tariff_changes_service.rb
@@ -87,6 +87,8 @@ class TariffChangesService
       add_change_record(change, change[:goods_nomenclature_item_id], change[:object_sid])
     end
 
+    add_parent_declarability_loss_records
+
     @changes[:commodity_descriptions].each do |change|
       next if matching_commodity_change?(change[:goods_nomenclature_sid], change[:action])
 
@@ -121,6 +123,66 @@ class TariffChangesService
           declarables_for(goods_nomenclatures[goods_nomenclature_sid])
         end
       end
+    end
+  end
+
+  def add_parent_declarability_loss_records
+    parent_declarability_loss_changes.each do |change|
+      next if matching_commodity_change?(change[:goods_nomenclature_sid], change[:action])
+
+      add_change_record(change, change[:goods_nomenclature_item_id], change[:goods_nomenclature_sid])
+    end
+  end
+
+  def parent_declarability_loss_changes
+    created_child_changes = @changes[:commodities]
+      .select { |change| change[:action] == BaseChanges::CREATION }
+    created_child_changes_by_sid = created_child_changes.index_by { |change| change[:object_sid] }
+    created_child_sids = created_child_changes_by_sid.keys.compact.uniq
+
+    return [] if created_child_sids.empty?
+
+    created_children = GoodsNomenclature.where(goods_nomenclature_sid: created_child_sids).eager(:parent).all
+    parents = created_children.filter_map(&:parent).uniq(&:goods_nomenclature_sid)
+    # Multiple child creations can map to same parent on same run; keep earliest child date_of_effect.
+    parent_date_of_effect_by_sid = created_children.each_with_object({}) do |child, dates_by_parent_sid|
+      parent = child.parent
+      child_change = created_child_changes_by_sid[child.goods_nomenclature_sid]
+      next if child_change.nil?
+
+      candidate_date = child_change[:date_of_effect]
+      existing_date = dates_by_parent_sid[parent.goods_nomenclature_sid]
+
+      dates_by_parent_sid[parent.goods_nomenclature_sid] =
+        if existing_date.nil? || (candidate_date && candidate_date < existing_date)
+          candidate_date
+        else
+          existing_date
+        end
+    end
+
+    return [] if parents.empty?
+
+    parent_sids = parents.map(&:goods_nomenclature_sid)
+    previous_parents_by_sid = TimeMachine.at(date - 1.day) do
+      GoodsNomenclature.where(goods_nomenclature_sid: parent_sids).all.index_by(&:goods_nomenclature_sid)
+    end
+
+    parents.filter_map do |parent|
+      previous_parent = previous_parents_by_sid[parent.goods_nomenclature_sid]
+
+      next unless previous_parent&.declarable?
+
+      {
+        type: 'Commodity',
+        object_sid: parent.goods_nomenclature_sid,
+        goods_nomenclature_item_id: parent.goods_nomenclature_item_id,
+        goods_nomenclature_sid: parent.goods_nomenclature_sid,
+        action: BaseChanges::ENDING,
+        date_of_effect: parent_date_of_effect_by_sid[parent.goods_nomenclature_sid],
+        validity_start_date: parent.validity_start_date&.to_date,
+        validity_end_date: parent.validity_end_date&.to_date,
+      }
     end
   end
 

--- a/app/services/tariff_changes_service.rb
+++ b/app/services/tariff_changes_service.rb
@@ -175,15 +175,17 @@ class TariffChangesService
 
       next unless previous_parent&.declarable?
 
+      end_date = parent_date_of_effect_by_sid[parent.goods_nomenclature_sid]&.-(1.day)
+
       {
         type: 'Commodity',
         object_sid: parent.goods_nomenclature_sid,
         goods_nomenclature_item_id: parent.goods_nomenclature_item_id,
         goods_nomenclature_sid: parent.goods_nomenclature_sid,
         action: BaseChanges::ENDING,
-        date_of_effect: parent_date_of_effect_by_sid[parent.goods_nomenclature_sid],
+        date_of_effect: end_date,
         validity_start_date: parent.validity_start_date&.to_date,
-        validity_end_date: parent.validity_end_date&.to_date,
+        validity_end_date: end_date,
       }
     end
   end

--- a/spec/services/tariff_changes_service_spec.rb
+++ b/spec/services/tariff_changes_service_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe TariffChangesService do
         goods_nomenclature_item_id: '0101010100',
         object_sid: 12_345,
         goods_nomenclature_sid: 12_345,
-        action: 'creation',
+        action: TariffChangesService::BaseChanges::CREATION,
         date_of_effect: date,
         validity_start_date: date,
         validity_end_date: nil,
@@ -189,7 +189,7 @@ RSpec.describe TariffChangesService do
         goods_nomenclature_item_id: '0102020200',
         object_sid: 23_456,
         goods_nomenclature_sid: 23_456,
-        action: 'update',
+        action: TariffChangesService::BaseChanges::UPDATE,
         date_of_effect: date,
         validity_start_date: date,
         validity_end_date: nil,
@@ -200,7 +200,7 @@ RSpec.describe TariffChangesService do
         type: 'Measure',
         object_sid: 54_321,
         goods_nomenclature_sid: 67_890,
-        action: 'creation',
+        action: TariffChangesService::BaseChanges::CREATION,
         date_of_effect: date,
         validity_start_date: date,
         validity_end_date: nil,
@@ -260,7 +260,7 @@ RSpec.describe TariffChangesService do
         object_sid: 12_345,
         goods_nomenclature_item_id: '0101010100',
         goods_nomenclature_sid: 12_345,
-        action: 'creation',
+        action: TariffChangesService::BaseChanges::CREATION,
         operation_date: date,
         date_of_effect: date,
         validity_start_date: date,
@@ -344,7 +344,7 @@ RSpec.describe TariffChangesService do
       change_1 = {
         goods_nomenclature_item_id: '0102000000',
         type: 'Commodity',
-        action: 'creation',
+        action: TariffChangesService::BaseChanges::CREATION,
         object_sid: 12_345,
         goods_nomenclature_sid: 12_345,
         operation_date: date,
@@ -355,7 +355,7 @@ RSpec.describe TariffChangesService do
       change_2 = {
         goods_nomenclature_item_id: '0101000000',
         type: 'Measure',
-        action: 'update',
+        action: TariffChangesService::BaseChanges::UPDATE,
         object_sid: 23_456,
         goods_nomenclature_sid: 23_456,
         operation_date: date,
@@ -366,7 +366,7 @@ RSpec.describe TariffChangesService do
       change_3 = {
         goods_nomenclature_item_id: '0101000000',
         type: 'Commodity',
-        action: 'creation',
+        action: TariffChangesService::BaseChanges::CREATION,
         object_sid: 34_567,
         goods_nomenclature_sid: 34_567,
         operation_date: date,
@@ -393,7 +393,7 @@ RSpec.describe TariffChangesService do
         type: 'Measure',
         object_sid: measure.measure_sid,
         goods_nomenclature_sid: measure.goods_nomenclature_sid,
-        action: 'creation',
+        action: TariffChangesService::BaseChanges::CREATION,
         date_of_effect: date,
         validity_start_date: date,
         validity_end_date: nil,
@@ -430,7 +430,7 @@ RSpec.describe TariffChangesService do
         goods_nomenclature_item_id: '0102020200',
         object_sid: 23_456,
         goods_nomenclature_sid: 23_456,
-        action: 'update',
+        action: TariffChangesService::BaseChanges::UPDATE,
       }
     end
     let(:measure_change) do
@@ -651,7 +651,7 @@ RSpec.describe TariffChangesService do
         commodities: [{
           type: 'Commodity',
           object_sid: child_sid,
-          action: 'creation',
+          action: TariffChangesService::BaseChanges::CREATION,
           date_of_effect: child_date_of_effect,
         }],
         commodity_descriptions: [],
@@ -674,7 +674,7 @@ RSpec.describe TariffChangesService do
           type: 'Commodity',
           goods_nomenclature_sid: parent_sid,
           goods_nomenclature_item_id: '0101000001',
-          action: 'ending',
+          action: TariffChangesService::BaseChanges::ENDING,
           date_of_effect: child_date_of_effect - 1.day,
           validity_end_date: child_date_of_effect - 1.day,
         ),
@@ -706,7 +706,7 @@ RSpec.describe TariffChangesService do
       {
         type: 'Commodity',
         object_sid: 98_765,
-        action: 'creation',
+        action: TariffChangesService::BaseChanges::CREATION,
         date_of_effect: date,
         validity_start_date: date,
         validity_end_date: nil,
@@ -724,7 +724,7 @@ RSpec.describe TariffChangesService do
           object_sid: 98_765,
           goods_nomenclature_item_id: '0101010100',
           goods_nomenclature_sid: 12_345,
-          action: 'creation',
+          action: TariffChangesService::BaseChanges::CREATION,
           operation_date: date,
           date_of_effect: date,
           validity_start_date: date,
@@ -749,7 +749,7 @@ RSpec.describe TariffChangesService do
         {
           type: 'Measure',
           object_sid: measure.measure_sid,
-          action: 'creation',
+          action: TariffChangesService::BaseChanges::CREATION,
           date_of_effect: date,
           validity_start_date: date,
           validity_end_date: nil,
@@ -776,7 +776,7 @@ RSpec.describe TariffChangesService do
           {
             type: 'Measure',
             object_sid: 99_999,
-            action: 'creation',
+            action: TariffChangesService::BaseChanges::CREATION,
             date_of_effect: date,
             validity_start_date: date,
             validity_end_date: nil,
@@ -801,12 +801,12 @@ RSpec.describe TariffChangesService do
         {
           goods_nomenclature_sid: 12_345,
           type: 'Commodity',
-          action: 'creation',
+          action: TariffChangesService::BaseChanges::CREATION,
         },
         {
           goods_nomenclature_sid: 67_890,
           type: 'Measure',
-          action: 'update',
+          action: TariffChangesService::BaseChanges::UPDATE,
         },
       ])
     end

--- a/spec/services/tariff_changes_service_spec.rb
+++ b/spec/services/tariff_changes_service_spec.rb
@@ -675,7 +675,8 @@ RSpec.describe TariffChangesService do
           goods_nomenclature_sid: parent_sid,
           goods_nomenclature_item_id: '0101000001',
           action: 'ending',
-          date_of_effect: child_date_of_effect,
+          date_of_effect: child_date_of_effect - 1.day,
+          validity_end_date: child_date_of_effect - 1.day,
         ),
       )
     end

--- a/spec/services/tariff_changes_service_spec.rb
+++ b/spec/services/tariff_changes_service_spec.rb
@@ -680,6 +680,15 @@ RSpec.describe TariffChangesService do
       )
     end
 
+    it 'ignores created declarables with no parent' do
+      root_child = instance_double(GoodsNomenclature, goods_nomenclature_sid: child_sid, parent: nil)
+      allow(children_scope).to receive(:all).and_return([root_child])
+
+      result = TimeMachine.at(date) { service.parent_declarability_loss_changes }
+
+      expect(result).to eq([])
+    end
+
     it 'returns empty when parent was not declarable yesterday' do
       allow(parents_scope).to receive(:all).and_return([
         instance_double(GoodsNomenclature, goods_nomenclature_sid: parent_sid, declarable?: false),

--- a/spec/services/tariff_changes_service_spec.rb
+++ b/spec/services/tariff_changes_service_spec.rb
@@ -625,6 +625,72 @@ RSpec.describe TariffChangesService do
     end
   end
 
+  describe '#parent_declarability_loss_changes' do
+    let(:child_sid) { 91_001 }
+    let(:parent_sid) { 91_000 }
+    let(:child_date_of_effect) { date + 2.days }
+    let(:parent_current) do
+      instance_double(
+        GoodsNomenclature,
+        goods_nomenclature_sid: parent_sid,
+        goods_nomenclature_item_id: '0101000001',
+        validity_start_date: date - 1.year,
+        validity_end_date: nil,
+        declarable?: false,
+      )
+    end
+    let(:parent_previous) { instance_double(GoodsNomenclature, goods_nomenclature_sid: parent_sid, declarable?: true) }
+    let(:child_current) { instance_double(GoodsNomenclature, goods_nomenclature_sid: child_sid, parent: parent_current) }
+    # rubocop:disable RSpec/VerifiedDoubles
+    let(:children_scope) { double('ChildrenScope') }
+    let(:parents_scope) { double('ParentsScope') }
+    # rubocop:enable RSpec/VerifiedDoubles
+
+    before do
+      service.instance_variable_set(:@changes, {
+        commodities: [{
+          type: 'Commodity',
+          object_sid: child_sid,
+          action: 'creation',
+          date_of_effect: child_date_of_effect,
+        }],
+        commodity_descriptions: [],
+        measures: [],
+      })
+
+      allow(GoodsNomenclature).to receive(:where).with(goods_nomenclature_sid: [child_sid]).and_return(children_scope)
+      allow(children_scope).to receive(:eager).with(:parent).and_return(children_scope)
+      allow(children_scope).to receive(:all).and_return([child_current])
+
+      allow(GoodsNomenclature).to receive(:where).with(goods_nomenclature_sid: [parent_sid]).and_return(parents_scope)
+      allow(parents_scope).to receive(:all).and_return([parent_previous])
+    end
+
+    it 'returns an ending commodity change for parent that was declarable yesterday' do
+      result = TimeMachine.at(date) { service.parent_declarability_loss_changes }
+
+      expect(result).to include(
+        hash_including(
+          type: 'Commodity',
+          goods_nomenclature_sid: parent_sid,
+          goods_nomenclature_item_id: '0101000001',
+          action: 'ending',
+          date_of_effect: child_date_of_effect,
+        ),
+      )
+    end
+
+    it 'returns empty when parent was not declarable yesterday' do
+      allow(parents_scope).to receive(:all).and_return([
+        instance_double(GoodsNomenclature, goods_nomenclature_sid: parent_sid, declarable?: false),
+      ])
+
+      result = TimeMachine.at(date) { service.parent_declarability_loss_changes }
+
+      expect(result).to eq([])
+    end
+  end
+
   describe '#add_change_record' do
     let(:change) do
       {


### PR DESCRIPTION
## What:
If a declarable commodity has children added to it, it will no longer be declarable. There is no oplog event on the new parent, and so this change is not currently created as a TariffChange object.
Now when a new commodity is added, if its parent was previously declarable, a TariffChange record is created with the date of effect set to the last day the parent was declarable.

## Why:
Adds events for missing tariff change data.

## Ticket:
https://transformuk.atlassian.net/browse/OTTIMP-665

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Enhances data for CCWL without changing existing functionality.
