### PR TITLE
AI-890: Replace MCP search API shape

### DIFF
--- a/app/controllers/api/v2/classification_search_controller.rb
+++ b/app/controllers/api/v2/classification_search_controller.rb
@@ -1,0 +1,27 @@
+module Api
+  module V2
+    class ClassificationSearchController < ApiController
+      no_caching
+
+      def search
+        result = ClassificationSearchService.new(params).call
+
+        if result.is_a?(Hash) && result[:errors]
+          render json: result, status: :unprocessable_content
+        else
+          render json: result
+        end
+      rescue HybridRetrievalService::AllLegsFailed => e
+        render json: {
+          errors: [
+            {
+              status: '500',
+              title: 'Classification search failed',
+              detail: e.message,
+            },
+          ],
+        }, status: :internal_server_error
+      end
+    end
+  end
+end

--- a/app/controllers/api/v2/knowledge_graph/queries_controller.rb
+++ b/app/controllers/api/v2/knowledge_graph/queries_controller.rb
@@ -1,0 +1,38 @@
+module Api
+  module V2
+    module KnowledgeGraph
+      class QueriesController < ApiController
+        no_caching
+
+        def create
+          result = ::TariffKnowledge::GraphQuery.call(attributes)
+
+          if result[:errors]
+            render json: { errors: jsonapi_errors(result[:errors]) }, status: :unprocessable_content
+          else
+            render json: result
+          end
+        end
+
+        private
+
+        def attributes
+          params.fetch(:data, {}).fetch(:attributes, {}).to_unsafe_h
+        end
+
+        def jsonapi_errors(errors)
+          errors.map do |error|
+            {
+              status: '422',
+              title: 'Invalid knowledge graph query',
+              detail: error[:detail],
+              source: {
+                pointer: error[:pointer],
+              },
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/engines/v2_api.rb
+++ b/app/engines/v2_api.rb
@@ -141,6 +141,11 @@ V2Api.routes.draw do
       post 'search' => 'search#search'
       get 'search' => 'search#search'
       get 'search_suggestions' => 'search#suggestions'
+      match 'classification_search' => 'classification_search#search', via: %i[get post]
+
+      namespace :knowledge_graph do
+        resources :queries, only: %i[create]
+      end
 
       get '/headings/:id/tree' => 'headings#tree'
 

--- a/app/models/tariff_knowledge/edge.rb
+++ b/app/models/tariff_knowledge/edge.rb
@@ -11,6 +11,16 @@ module TariffKnowledge
     FOR_DECLARABLE = 'for_declarable'.freeze
     DERIVED_FROM = 'derived_from'.freeze
 
+    TYPES = [
+      CONTAINS,
+      APPLIES_TO,
+      REFERENCES,
+      EXPANDS_TO,
+      SUMMARISES,
+      FOR_DECLARABLE,
+      DERIVED_FROM,
+    ].freeze
+
     many_to_one :source_node,
                 class: 'TariffKnowledge::Node',
                 key: :source_node_id

--- a/app/serializers/api/v2/classification_search_result_serializer.rb
+++ b/app/serializers/api/v2/classification_search_result_serializer.rb
@@ -1,0 +1,31 @@
+module Api
+  module V2
+    class ClassificationSearchResultSerializer
+      include JSONAPI::Serializer
+
+      set_type :classification_search_result
+      set_id :goods_nomenclature_sid
+
+      attributes :goods_nomenclature_item_id,
+                 :goods_nomenclature_sid,
+                 :producline_suffix,
+                 :goods_nomenclature_class,
+                 :description,
+                 :formatted_description,
+                 :self_text,
+                 :classification_description,
+                 :full_description,
+                 :heading_description,
+                 :declarable,
+                 :score,
+                 :confidence
+
+      def self.serialize(collection, meta:)
+        {
+          data: collection.map { |record| new(record).serializable_hash[:data] },
+          meta:,
+        }
+      end
+    end
+  end
+end

--- a/app/services/api/v2/classification_search_service.rb
+++ b/app/services/api/v2/classification_search_service.rb
@@ -1,0 +1,78 @@
+module Api
+  module V2
+    class ClassificationSearchService
+      include Api::Internal::QueryProcessing
+
+      DEFAULT_LIMIT = 30
+      MAX_LIMIT = 50
+
+      def initialize(params = {})
+        @params = params
+        sanitiser_result = Api::Internal::InputSanitiser.new(params[:q]).call
+
+        if sanitiser_result[:errors]
+          @sanitiser_errors = sanitiser_result
+          @query = ''
+        else
+          @query = process_query(sanitiser_result[:query])
+        end
+      end
+
+      def call
+        return @sanitiser_errors if @sanitiser_errors
+        return empty_response if @query.blank?
+
+        result = HybridRetrievalService.call(
+          query: @query,
+          expanded_query: expanded_query,
+          as_of: parse_date(@params[:as_of]),
+          request_id: request_id,
+          limit: limit,
+        )
+
+        ClassificationSearchResultSerializer.serialize(
+          result.results,
+          meta: response_meta(result),
+        )
+      end
+
+      private
+
+      def empty_response
+        {
+          data: [],
+          meta: {
+            request_id: request_id,
+            retrieval_method: 'hybrid',
+            expanded_query: expanded_query || @query,
+            result_count: 0,
+            max_score: nil,
+          },
+        }
+      end
+
+      def response_meta(result)
+        {
+          request_id: request_id,
+          retrieval_method: 'hybrid',
+          expanded_query: result.expanded_query,
+          result_count: result.results.size,
+          max_score: result.results.map(&:score).compact.max,
+        }
+      end
+
+      def expanded_query
+        @params[:expanded_query].to_s.strip.presence
+      end
+
+      def request_id
+        @request_id ||= @params[:request_id].presence || TradeTariffRequest.request_id.presence || SecureRandom.uuid
+      end
+
+      def limit
+        raw_limit = @params[:limit].presence || DEFAULT_LIMIT
+        [[raw_limit.to_i, 1].max, MAX_LIMIT].min
+      end
+    end
+  end
+end

--- a/app/services/tariff_knowledge/graph_query.rb
+++ b/app/services/tariff_knowledge/graph_query.rb
@@ -1,0 +1,304 @@
+module TariffKnowledge
+  class GraphQuery
+    DEFAULT_MAX_DEPTH = 1
+    HARD_MAX_DEPTH = 3
+    DEFAULT_MAX_NODES = 100
+    HARD_MAX_NODES = 250
+    DEFAULT_MAX_EDGES = 250
+    HARD_MAX_EDGES = 500
+
+    PRESETS = {
+      'note_mentions' => [
+        {
+          'edge_type' => Edge::APPLIES_TO,
+          'direction' => 'incoming',
+          'node_types' => [Node::NOTE_FRAGMENT],
+        },
+        {
+          'edge_type' => Edge::REFERENCES,
+          'direction' => 'outgoing',
+          'from' => 'result_nodes',
+          'node_types' => [Node::RANGE],
+        },
+        {
+          'edge_type' => Edge::EXPANDS_TO,
+          'direction' => 'outgoing',
+          'node_types' => [Node::GOODS_NOMENCLATURE],
+        },
+        {
+          'edge_type' => Edge::CONTAINS,
+          'direction' => 'incoming',
+          'from' => 'result_nodes',
+          'node_types' => [Node::NOTE_SOURCE],
+        },
+      ].freeze,
+    }.freeze
+
+    def self.call(attributes)
+      new(attributes).call
+    end
+
+    def initialize(attributes)
+      @attributes = attributes.to_h.deep_stringify_keys
+      @errors = []
+      @nodes_by_id = {}
+      @edges_by_id = {}
+      @primary_node_ids = []
+      @truncated = false
+      @truncation_reason = nil
+    end
+
+    def call
+      validate
+      return { errors: } if errors.any?
+
+      traverse
+
+      {
+        data: primary_nodes.map { |node| node_resource(node) },
+        included: included_resources,
+        meta: {
+          subject_count: subject_nodes.size,
+          result_count: primary_nodes.size,
+          truncated:,
+          truncation_reason:,
+        }.compact,
+      }
+    end
+
+    private
+
+    attr_reader :attributes, :errors, :truncated, :truncation_reason
+
+    def validate
+      validate_limits
+      validate_traversals
+      errors << error('/data/attributes/subjects', 'subjects must resolve at least one graph node') if subject_nodes.empty?
+    end
+
+    def validate_limits
+      if max_depth > HARD_MAX_DEPTH
+        errors << error('/data/attributes/traversals/0/max_depth', "max_depth must be less than or equal to #{HARD_MAX_DEPTH}")
+      end
+
+      if max_nodes > HARD_MAX_NODES
+        errors << error('/data/attributes/limits/max_nodes', "max_nodes must be less than or equal to #{HARD_MAX_NODES}")
+      end
+
+      if max_edges > HARD_MAX_EDGES
+        errors << error('/data/attributes/limits/max_edges', "max_edges must be less than or equal to #{HARD_MAX_EDGES}")
+      end
+    end
+
+    def validate_traversals
+      if traversals.empty?
+        errors << error('/data/attributes/traversals', 'traversals must be supplied unless a supported preset is used')
+      end
+
+      traversals.each_with_index do |traversal, index|
+        unless edge_types.include?(traversal['edge_type'])
+          errors << error("/data/attributes/traversals/#{index}/edge_type", "edge_type must be one of #{edge_types.join(', ')}")
+        end
+
+        unless %w[incoming outgoing].include?(traversal['direction'])
+          errors << error("/data/attributes/traversals/#{index}/direction", 'direction must be incoming or outgoing')
+        end
+      end
+    end
+
+    def error(pointer, detail)
+      {
+        pointer:,
+        detail:,
+      }
+    end
+
+    def traverse
+      current_nodes = subject_nodes
+
+      traversals.each_with_index do |traversal, index|
+        break if truncated
+
+        source_nodes = traversal['from'] == 'result_nodes' ? primary_nodes : current_nodes
+        edges = matching_edges(source_nodes, traversal)
+        register_edges(edges)
+
+        connected_nodes = connected_nodes(edges, traversal)
+        connected_nodes = connected_nodes.select { |node| traversal['node_types'].include?(node.node_type) } if traversal['node_types'].present?
+        register_nodes(connected_nodes)
+
+        if index.zero?
+          @primary_node_ids = connected_nodes.map(&:id)
+        end
+
+        current_nodes = connected_nodes
+      end
+    end
+
+    def matching_edges(nodes, traversal)
+      return [] if nodes.empty?
+
+      id_column = traversal['direction'] == 'incoming' ? :target_node_id : :source_node_id
+      Edge
+        .where(relationship_type: traversal['edge_type'], id_column => nodes.map(&:id))
+        .limit(remaining_edge_capacity + 1)
+        .all
+        .tap { |edges| truncate!('max_edges') if edges.size > remaining_edge_capacity }
+        .first(remaining_edge_capacity)
+    end
+
+    def connected_nodes(edges, traversal)
+      id_method = traversal['direction'] == 'incoming' ? :source_node_id : :target_node_id
+      ids = edges.map(&id_method).uniq
+      Node
+        .where(id: ids)
+        .limit(remaining_node_capacity + 1)
+        .all
+        .tap { |nodes| truncate!('max_nodes') if nodes.size > remaining_node_capacity }
+        .first(remaining_node_capacity)
+    end
+
+    def truncate!(reason)
+      @truncated = true
+      @truncation_reason = reason if @truncation_reason.blank?
+    end
+
+    def register_nodes(nodes)
+      nodes.each { |node| @nodes_by_id[node.id] ||= node }
+    end
+
+    def register_edges(edges)
+      edges.each { |edge| @edges_by_id[edge.id] ||= edge }
+    end
+
+    def subject_nodes
+      @subject_nodes ||= resolve_subjects.tap { |nodes| register_nodes(nodes) }
+    end
+
+    def resolve_subjects
+      subjects.flat_map { |subject| resolve_subject(subject) }.uniq(&:id)
+    end
+
+    def resolve_subject(subject)
+      return Node.by_key(subject['node_key']).all if subject['node_key'].present?
+
+      case subject['type']
+      when Node::GOODS_NOMENCLATURE
+        resolve_goods_nomenclature(subject.fetch('identifiers', {}))
+      else
+        []
+      end
+    end
+
+    def resolve_goods_nomenclature(identifiers)
+      dataset = Node.goods_nomenclatures
+      clauses = []
+      clauses << { goods_nomenclature_sid: identifiers['goods_nomenclature_sid'].to_i } if identifiers['goods_nomenclature_sid'].present?
+      clauses << { goods_nomenclature_item_id: identifiers['goods_nomenclature_item_id'].to_s } if identifiers['goods_nomenclature_item_id'].present?
+      return [] if clauses.empty?
+
+      clauses
+        .map { |clause| dataset.where(clause) }
+        .reduce(:union)
+        .all
+    end
+
+    def primary_nodes
+      @primary_node_ids.map { |id| @nodes_by_id[id] }.compact
+    end
+
+    def included_resources
+      included = []
+      edge_resources = @edges_by_id.values.sort_by(&:id).map { |edge| edge_resource(edge) }
+      node_resources = included_nodes.map { |node| node_resource(node) }
+      included.concat(edge_resources)
+      included.concat(node_resources)
+      included
+    end
+
+    def included_nodes
+      primary_ids = primary_nodes.map(&:id)
+      @nodes_by_id.values.reject { |node| primary_ids.include?(node.id) }.sort_by(&:key)
+    end
+
+    def node_resource(node)
+      {
+        type: 'knowledge_graph_node',
+        id: node.key,
+        attributes: {
+          node_type: node.node_type,
+          key: node.key,
+          title: node.title,
+          content: node.content,
+          source_type: node.source_type,
+          source_id: node.source_id,
+          source_version: node.source_version,
+          goods_nomenclature_item_id: node.goods_nomenclature_item_id,
+          goods_nomenclature_sid: node.goods_nomenclature_sid,
+          producline_suffix: node.producline_suffix,
+          goods_nomenclature_type: node.goods_nomenclature_type,
+        }.compact,
+      }
+    end
+
+    def edge_resource(edge)
+      {
+        type: 'knowledge_graph_edge',
+        id: edge.id.to_s,
+        attributes: {
+          relationship_type: edge.relationship_type,
+        },
+        relationships: {
+          source: { data: resource_identifier(@nodes_by_id[edge.source_node_id]) },
+          target: { data: resource_identifier(@nodes_by_id[edge.target_node_id]) },
+        },
+      }
+    end
+
+    def resource_identifier(node)
+      return unless node
+
+      {
+        type: 'knowledge_graph_node',
+        id: node.key,
+      }
+    end
+
+    def subjects
+      Array(attributes['subjects'])
+    end
+
+    def traversals
+      @traversals ||= begin
+        configured = Array(attributes['traversals']).map(&:to_h).map(&:deep_stringify_keys)
+        configured.presence || PRESETS.fetch(attributes['preset'].to_s, [])
+      end
+    end
+
+    def max_depth
+      @max_depth ||= traversals.map { |traversal| traversal['max_depth'].presence || limits['max_depth'].presence || DEFAULT_MAX_DEPTH }.map(&:to_i).max || DEFAULT_MAX_DEPTH
+    end
+
+    def max_nodes
+      @max_nodes ||= (limits['max_nodes'].presence || DEFAULT_MAX_NODES).to_i
+    end
+
+    def max_edges
+      @max_edges ||= (limits['max_edges'].presence || DEFAULT_MAX_EDGES).to_i
+    end
+
+    def remaining_node_capacity
+      [max_nodes - @nodes_by_id.size, 0].max
+    end
+
+    def remaining_edge_capacity
+      [max_edges - @edges_by_id.size, 0].max
+    end
+
+    def limits
+      @limits ||= attributes.fetch('limits', {}).to_h
+    end
+
+    def edge_types = Edge::TYPES
+  end
+end

--- a/lib/tasks/swagger.rake
+++ b/lib/tasks/swagger.rake
@@ -3,6 +3,9 @@ require 'json'
 namespace :swagger do
   swagger_spec_pattern = 'spec/swagger/**/*_spec.rb'
   swagger_json_path = File.expand_path('../../swagger/v2/swagger.json', __dir__)
+  draft_swagger_specs = %w[
+    spec/swagger/api/v2/classification_search_spec.rb
+  ].freeze
 
   # Paths that have specs (useful for contract testing) but must not appear in
   # the public API docs. Excluded because they are frontend-internal endpoints
@@ -15,6 +18,7 @@ namespace :swagger do
   # with meaningful non-frontend traffic belongs in the public docs, not here.
   internal_paths = %w[
     /api/chemicals/{id}
+    /api/classification_search
     /api/commodities/{commodity_id}/validity_periods
     /api/headings/{heading_id}/validity_periods
     /api/news/items/{id}
@@ -42,7 +46,7 @@ namespace :swagger do
 
   desc 'Generate swagger documentation from spec metadata (no database required)'
   task :generate do
-    ENV['PATTERN'] = swagger_spec_pattern
+    ENV['PATTERN'] = Dir.glob(swagger_spec_pattern).reject { |path| draft_swagger_specs.include?(path) }.join(',')
     Rake::Task['rswag:specs:swaggerize'].invoke
     post_process.call
   end
@@ -55,12 +59,15 @@ namespace :swagger do
     # Controllers that are deliberately not documented:
     #   - abstract base classes that define no routes of their own
     #   - internal/authenticated endpoints not part of the public API
+    #   - draft MCP-facing APIs that should not be published until release
     excluded = %w[
+      classification_search_controller.rb
       exchange_rates/base_controller.rb
       green_lanes/base_controller.rb
       green_lanes/faq_feedback_controller.rb
       green_lanes/goods_nomenclatures_controller.rb
       green_lanes/themes_controller.rb
+      knowledge_graph/queries_controller.rb
       enquiry_form/revised_submissions_controller.rb
       enquiry_form/submissions_controller.rb
       errors_controller.rb

--- a/spec/models/tariff_knowledge/edge_spec.rb
+++ b/spec/models/tariff_knowledge/edge_spec.rb
@@ -26,4 +26,20 @@ RSpec.describe TariffKnowledge::Edge do
       expect(described_class.by_relationship(described_class::APPLIES_TO).all).to contain_exactly(edge)
     end
   end
+
+  describe '::TYPES' do
+    it 'lists every valid relationship type' do
+      expect(described_class::TYPES).to eq(
+        [
+          described_class::CONTAINS,
+          described_class::APPLIES_TO,
+          described_class::REFERENCES,
+          described_class::EXPANDS_TO,
+          described_class::SUMMARISES,
+          described_class::FOR_DECLARABLE,
+          described_class::DERIVED_FROM,
+        ],
+      )
+    end
+  end
 end

--- a/spec/requests/api/v2/classification_search_controller_spec.rb
+++ b/spec/requests/api/v2/classification_search_controller_spec.rb
@@ -1,0 +1,116 @@
+RSpec.describe 'Classification search API' do
+  describe 'GET /classification_search' do
+    subject(:make_request) do
+      get '/uk/api/classification_search', params: params, headers: request_headers(version: 2)
+    end
+
+    let(:params) { { q: 'wireless noise cancelling headphones', limit: 5, request_id: 'test-request-id' } }
+    let(:result) do
+      GoodsNomenclatureResult.new(
+        id: '123',
+        goods_nomenclature_item_id: '8518300090',
+        goods_nomenclature_sid: 123,
+        producline_suffix: '80',
+        goods_nomenclature_class: 'Commodity',
+        description: 'Headphones and earphones',
+        formatted_description: 'Headphones and earphones',
+        self_text: 'Headphones and earphones',
+        classification_description: 'Headphones and earphones',
+        full_description: 'Electrical machinery > Headphones and earphones',
+        heading_description: 'Headphones and earphones',
+        declarable: true,
+        score: 0.03125,
+        confidence: nil,
+      )
+    end
+
+    before do
+      allow(AdminConfiguration).to receive(:enabled?).with('input_sanitiser_enabled').and_return(false)
+      allow(HybridRetrievalService).to receive(:call).and_return(
+        HybridRetrievalService::Result.new(results: [result], expanded_query: 'wireless headphones', source_results: [result]),
+      )
+    end
+
+    it 'returns a hybrid shortlist' do
+      make_request
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)).to include(
+        'data' => [
+          include(
+            'type' => 'classification_search_result',
+            'id' => '123',
+            'attributes' => include(
+              'goods_nomenclature_item_id' => '8518300090',
+              'goods_nomenclature_sid' => 123,
+              'declarable' => true,
+              'score' => 0.03125,
+            ),
+          ),
+        ],
+        'meta' => include(
+          'request_id' => 'test-request-id',
+          'retrieval_method' => 'hybrid',
+          'expanded_query' => 'wireless headphones',
+          'result_count' => 1,
+          'max_score' => 0.03125,
+        ),
+      )
+    end
+
+    it 'passes bounded retrieval arguments' do
+      make_request
+
+      expect(HybridRetrievalService).to have_received(:call).with(
+        query: 'wireless noise cancelling headphones',
+        expanded_query: nil,
+        as_of: Time.zone.today,
+        request_id: 'test-request-id',
+        limit: 5,
+      )
+    end
+
+    context 'without a query' do
+      let(:params) { {} }
+
+      it 'returns an empty shortlist' do
+        make_request
+
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)).to include(
+          'data' => [],
+          'meta' => include('retrieval_method' => 'hybrid', 'result_count' => 0),
+        )
+      end
+    end
+
+    context 'with invalid input' do
+      let(:params) { { q: "bad\u0001query" } }
+
+      before do
+        allow(AdminConfiguration).to receive(:enabled?).with('input_sanitiser_enabled').and_return(true)
+        allow(AdminConfiguration).to receive(:integer_value).with('input_sanitiser_max_length').and_return(1000)
+      end
+
+      it 'returns a validation error' do
+        make_request
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(JSON.parse(response.body)).to include('errors' => [include('title' => 'Invalid query')])
+      end
+    end
+
+    context 'when hybrid retrieval fails' do
+      before do
+        allow(HybridRetrievalService).to receive(:call).and_raise(HybridRetrievalService::AllLegsFailed, 'all legs failed')
+      end
+
+      it 'returns a backend error' do
+        make_request
+
+        expect(response).to have_http_status(:internal_server_error)
+        expect(JSON.parse(response.body)).to include('errors' => [include('title' => 'Classification search failed')])
+      end
+    end
+  end
+end

--- a/spec/requests/api/v2/knowledge_graph/queries_controller_spec.rb
+++ b/spec/requests/api/v2/knowledge_graph/queries_controller_spec.rb
@@ -1,0 +1,136 @@
+RSpec.describe 'Knowledge graph queries API' do
+  describe 'POST /knowledge_graph/queries' do
+    subject(:make_request) do
+      post '/uk/api/knowledge_graph/queries',
+           params: params,
+           headers: request_headers(version: 2),
+           as: :json
+    end
+
+    let(:goods_node) do
+      create(:tariff_knowledge_node, goods_nomenclature_item_id: '0101210000', goods_nomenclature_sid: 123)
+    end
+
+    let(:fragment) do
+      create(
+        :tariff_knowledge_node,
+        :note_fragment,
+        key: 'note_fragment:chapter-01:1',
+        title: 'Chapter 01 note 1',
+        content: 'This chapter covers live horses.',
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '01',
+      )
+    end
+
+    let(:range_node) do
+      create(
+        :tariff_knowledge_node,
+        node_type: TariffKnowledge::Node::RANGE,
+        key: 'range:0101',
+        title: '0101',
+        content: 'Heading 0101',
+        goods_nomenclature_sid: nil,
+        goods_nomenclature_item_id: nil,
+        producline_suffix: nil,
+        goods_nomenclature_type: nil,
+      )
+    end
+
+    let(:params) do
+      {
+        data: {
+          type: 'knowledge_graph_query',
+          attributes: {
+            preset: 'note_mentions',
+            subjects: [
+              {
+                type: 'goods_nomenclature',
+                identifiers: {
+                  goods_nomenclature_sid: 123,
+                },
+              },
+            ],
+            include: %w[nodes edges],
+          },
+        },
+      }
+    end
+
+    before do
+      create(:tariff_knowledge_edge, source_node: fragment, target_node: goods_node, relationship_type: TariffKnowledge::Edge::APPLIES_TO)
+      create(:tariff_knowledge_edge, source_node: fragment, target_node: range_node, relationship_type: TariffKnowledge::Edge::REFERENCES)
+      create(:tariff_knowledge_edge, source_node: range_node, target_node: goods_node, relationship_type: TariffKnowledge::Edge::EXPANDS_TO)
+    end
+
+    it 'returns graph nodes and edges for the note mentions preset' do
+      make_request
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+
+      expect(body).to include(
+        'data' => include(
+          include(
+            'type' => 'knowledge_graph_node',
+            'id' => 'note_fragment:chapter-01:1',
+            'attributes' => include(
+              'node_type' => 'note_fragment',
+              'key' => 'note_fragment:chapter-01:1',
+              'content' => 'This chapter covers live horses.',
+            ),
+          ),
+        ),
+        'included' => include(
+          include(
+            'type' => 'knowledge_graph_edge',
+            'attributes' => include('relationship_type' => 'applies_to'),
+          ),
+          include(
+            'type' => 'knowledge_graph_edge',
+            'attributes' => include('relationship_type' => 'expands_to'),
+          ),
+          include(
+            'type' => 'knowledge_graph_node',
+            'id' => 'range:0101',
+            'attributes' => include('node_type' => 'range', 'title' => '0101'),
+          ),
+        ),
+        'meta' => include(
+          'subject_count' => 1,
+          'result_count' => 1,
+          'truncated' => false,
+        ),
+      )
+    end
+
+    context 'with an over-limit depth' do
+      let(:params) do
+        {
+          data: {
+            type: 'knowledge_graph_query',
+            attributes: {
+              subjects: [{ node_key: 'goods_nomenclature:123' }],
+              traversals: [{ edge_type: 'applies_to', direction: 'incoming', max_depth: 4 }],
+            },
+          },
+        }
+      end
+
+      it 'returns a validation error' do
+        make_request
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(JSON.parse(response.body)).to include(
+          'errors' => include(
+            include(
+              'title' => 'Invalid knowledge graph query',
+              'detail' => 'max_depth must be less than or equal to 3',
+              'source' => include('pointer' => '/data/attributes/traversals/0/max_depth'),
+            ),
+          ),
+        )
+      end
+    end
+  end
+end

--- a/spec/services/tariff_knowledge/graph_query_spec.rb
+++ b/spec/services/tariff_knowledge/graph_query_spec.rb
@@ -1,0 +1,29 @@
+RSpec.describe TariffKnowledge::GraphQuery do
+  describe '.call' do
+    it 'returns plain validation failures without HTTP presentation fields' do
+      result = described_class.call(
+        subjects: [],
+        traversals: [
+          {
+            edge_type: 'not_an_edge',
+            direction: 'sideways',
+          },
+        ],
+      )
+
+      expect(result).to include(
+        errors: include(
+          include(
+            pointer: '/data/attributes/traversals/0/edge_type',
+            detail: "edge_type must be one of #{TariffKnowledge::Edge::TYPES.join(', ')}",
+          ),
+          include(
+            pointer: '/data/attributes/traversals/0/direction',
+            detail: 'direction must be incoming or outgoing',
+          ),
+        ),
+      )
+      expect(result[:errors].first).not_to include(:status, :title, :source)
+    end
+  end
+end

--- a/spec/swagger/api/v2/classification_search_spec.rb
+++ b/spec/swagger/api/v2/classification_search_spec.rb
@@ -1,0 +1,129 @@
+require 'swagger_helper'
+
+RSpec.describe 'Classification Search', skip: 'Draft MCP API docs are held back until release', swagger_doc: 'v2/swagger.json', type: :request do
+  let(:Accept) { 'application/vnd.hmrc.2.0+json' }
+
+  path '/api/classification_search' do
+    parameter name: :Accept, in: :header, required: true,
+              schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
+              description: 'API version negotiation header'
+    parameter name: :q, in: :query, required: true,
+              schema: { type: :string },
+              description: 'Product description to search for classification candidates'
+    parameter name: :limit, in: :query, required: false,
+              schema: { type: :integer, minimum: 1, maximum: 50 },
+              description: 'Maximum number of candidates to return'
+    parameter name: :as_of, in: :query, required: false,
+              schema: { type: :string, format: :date },
+              description: 'Return data as it appeared on this date'
+    parameter name: :expanded_query, in: :query, required: false,
+              schema: { type: :string },
+              description: 'Optional expanded query text to use for retrieval'
+
+    get 'Get hybrid classification candidates' do
+      tags 'Classification Search'
+      produces 'application/json'
+      description 'Returns a hybrid semantic shortlist of candidate goods nomenclatures for a product description.'
+      operationId 'classificationSearch'
+
+      response '200', 'classification candidates found' do
+        schema type: :object,
+               required: %w[data meta],
+               properties: {
+                 data: {
+                   type: :array,
+                   items: {
+                     type: :object,
+                     properties: {
+                       id: { type: :string },
+                       type: { type: :string, enum: %w[classification_search_result] },
+                       attributes: {
+                         type: :object,
+                         properties: {
+                           goods_nomenclature_item_id: { type: :string, nullable: true },
+                           goods_nomenclature_sid: { type: :integer, nullable: true },
+                           producline_suffix: { type: :string, nullable: true },
+                           goods_nomenclature_class: { type: :string, nullable: true },
+                           description: { type: :string, nullable: true },
+                           formatted_description: { type: :string, nullable: true },
+                           self_text: { type: :string, nullable: true },
+                           classification_description: { type: :string, nullable: true },
+                           full_description: { type: :string, nullable: true },
+                           heading_description: { type: :string, nullable: true },
+                           declarable: { type: :boolean, nullable: true },
+                           score: { type: :number, nullable: true },
+                           confidence: { type: :number, nullable: true },
+                         },
+                       },
+                     },
+                   },
+                 },
+                 meta: {
+                   type: :object,
+                   properties: {
+                     request_id: { type: :string },
+                     retrieval_method: { type: :string, enum: %w[hybrid] },
+                     expanded_query: { type: :string, nullable: true },
+                     result_count: { type: :integer },
+                     max_score: { type: :number, nullable: true },
+                   },
+                 },
+               }
+
+        let(:q) { 'wireless headphones' }
+        let(:limit) { 5 }
+
+        before do
+          allow(Api::V2::ClassificationSearchService).to receive(:new).and_return(
+            instance_double(Api::V2::ClassificationSearchService, call: { data: [], meta: { request_id: 'test', retrieval_method: 'hybrid', expanded_query: 'wireless headphones', result_count: 0, max_score: nil } }),
+          )
+        end
+
+        run_test!
+      end
+    end
+
+    post 'Post hybrid classification candidates' do
+      tags 'Classification Search'
+      consumes 'application/json'
+      produces 'application/json'
+      description 'Returns a hybrid semantic shortlist of candidate goods nomenclatures for a product description.'
+      operationId 'postClassificationSearch'
+
+      parameter name: :body, in: :body, required: true,
+                schema: {
+                  type: :object,
+                  required: %w[q],
+                  properties: {
+                    q: { type: :string },
+                    limit: { type: :integer, minimum: 1, maximum: 50 },
+                    as_of: { type: :string, format: :date },
+                    expanded_query: { type: :string },
+                  },
+                }
+
+      response '200', 'classification candidates found' do
+        schema type: :object,
+               required: %w[data meta],
+               properties: {
+                 data: { type: :array },
+                 meta: { type: :object },
+               }
+
+        let(:body) { { q: 'wireless headphones', limit: 5 } }
+        let(:q) { nil }
+        let(:limit) { nil }
+        let(:as_of) { nil }
+        let(:expanded_query) { nil }
+
+        before do
+          allow(Api::V2::ClassificationSearchService).to receive(:new).and_return(
+            instance_double(Api::V2::ClassificationSearchService, call: { data: [], meta: { request_id: 'test', retrieval_method: 'hybrid', expanded_query: 'wireless headphones', result_count: 0, max_score: nil } }),
+          )
+        end
+
+        run_test!
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

[AI-890](https://transformuk.atlassian.net/browse/AI-890)

### What?

- [x] Replace the draft MCP search API shape with a V2 `classification_search` endpoint backed by `HybridRetrievalService`
- [x] Add a generic V2 `knowledge_graph/queries` endpoint for capped graph traversals
- [x] Add a `note_mentions` graph query preset for chapter and section note evidence
- [x] Keep draft MCP-facing APIs out of generated public swagger until release
- [x] Add request/service/model coverage for search, graph query behaviour, edge type validation, and JSON:API error rendering

### API semantics

- This is the replacement MCP search API shape. Classification is the search use case: semantic shortlist retrieval happens through `classification_search`, and supporting tariff-note evidence is fetched through `knowledge_graph/queries`.
- `classification_search` supports `GET` and `POST`, matching the existing search-style endpoint convention for simple query params.
- `knowledge_graph/queries` is `POST` only because subjects, traversals, limits, and presets are structured JSON payloads.
- Query templates are selected through `data.attributes.preset`, for example `preset: "note_mentions"`, keeping the graph query as one JSON:API-style resource.
- Explicit graph traversals remain available through `data.attributes.traversals` for non-preset queries.
- Validation failures are rendered by the controller as JSON:API `errors`; the graph query service returns plain pointer/detail validation failures and does not own HTTP presentation.
- Valid edge relationship types are centralised on `TariffKnowledge::Edge::TYPES`.

### Why?

MCP clients need a recall-focused search shortlist and explicit tariff-note evidence so classification flows can combine semantic retrieval with tariff hierarchy and legal note checks.

### Risk

**Risk level:** 🟢

**Reason for rating:** Introduces the replacement read-only MCP search API shape without changing existing production API behaviour on `main`.
