### PR TITLE
feat(tariff-knowledge): add ATAR semantic rule loading

### DIFF
--- a/app/services/tariff_knowledge/compressed_note_generator.rb
+++ b/app/services/tariff_knowledge/compressed_note_generator.rb
@@ -81,7 +81,7 @@ module TariffKnowledge
             range_node = range_nodes[edge.source_node_id]
             reference_edges_by_range_id.fetch(range_node&.id, []).filter_map do |reference_edge|
               fragment_node = fragment_nodes[reference_edge.source_node_id]
-              if fragment_node && applicable_fragment_ids.include?(fragment_node.id)
+              if fragment_node && (applicable_fragment_ids.include?(fragment_node.id) || semantic_rule_fact_evidence?(fragment_node, range_node))
                 [fragment_node, range_node, source_nodes_by_fragment_id[fragment_node.id]]
               end
             end
@@ -174,8 +174,9 @@ module TariffKnowledge
     def evidence_metadata(fragment_node, range_node, source_node)
       range_metadata = range_node ? range_node.metadata.to_h : {}
       context = source_context(fragment_node, source_node)
+      semantic_rule_facts = semantic_rule_facts(fragment_node, context, range_node)
 
-      {
+      metadata = {
         'source_node_key' => fragment_node.key,
         'source_type' => fragment_node.source_type.to_s.underscore,
         'source_id' => fragment_node.source_id,
@@ -191,9 +192,80 @@ module TariffKnowledge
         'range_title' => range_node&.title,
         'relationships' => relationships_for(range_node),
       }
+      metadata['semantic_rule_facts'] = semantic_rule_facts if semantic_rule_facts.any?
+      metadata['semantic_context'] = semantic_context(semantic_rule_facts) if semantic_rule_facts.any?
+      metadata
     end
 
     def relationships_for(range_node) = range_node ? [Edge::REFERENCES, Edge::EXPANDS_TO, Edge::APPLIES_TO] : [Edge::APPLIES_TO]
+
+    def semantic_rule_fact_evidence?(fragment_node, range_node)
+      semantic_rule_facts(fragment_node, fragment_node.content.to_s.squish, range_node).any?
+    end
+
+    def semantic_rule_facts(fragment_node, context, range_node)
+      SemanticRuleFactValidator.call(
+        facts: fragment_node.metadata.to_h['semantic_rule_facts'],
+        source_text: context,
+        valid_references: valid_references_for(fragment_node, range_node),
+        target_references: valid_target_references_for(range_node),
+      )
+    end
+
+    def valid_references_for(fragment_node, range_node)
+      references = [source_reference_for(fragment_node)]
+      return references.compact unless range_node
+
+      range_metadata = range_node.metadata.to_h
+      references << { 'type' => range_metadata['range_type'], 'code' => range_metadata['code'] }
+      references.compact.uniq
+    end
+
+    def valid_target_references_for(range_node)
+      return [] unless range_node
+
+      range_metadata = range_node.metadata.to_h
+      [{ 'type' => range_metadata['range_type'], 'code' => range_metadata['code'] }]
+    end
+
+    def source_reference_for(fragment_node)
+      case fragment_node.source_type
+      when 'customs_tariff_section_note'
+        { 'type' => 'section', 'code' => fragment_node.source_id }
+      when 'customs_tariff_chapter_note'
+        { 'type' => 'chapter', 'code' => fragment_node.source_id }
+      when 'customs_tariff_general_rule'
+        { 'type' => 'rule', 'code' => fragment_node.source_id }
+      end
+    end
+
+    def semantic_context(semantic_rule_facts)
+      "Generated rule facts: #{semantic_rule_fact_summaries(semantic_rule_facts).join(' ')}"
+    end
+
+    def semantic_rule_fact_summaries(semantic_rule_facts)
+      semantic_rule_facts.map do |fact|
+        "#{[
+          fact['relationship_type'],
+          fact.dig('target', 'type'),
+          fact.dig('target', 'code'),
+          conditions_text(fact['conditions']),
+          exceptions_text(fact['exceptions']),
+        ].compact.join(' ')}."
+      end
+    end
+
+    def conditions_text(conditions)
+      return if conditions.blank?
+
+      "when #{conditions.join('; ')}"
+    end
+
+    def exceptions_text(exceptions)
+      return if exceptions.blank?
+
+      "except #{exceptions.join('; ')}"
+    end
 
     def source_context(fragment_node, source_node)
       return fragment_node.content.to_s.squish unless source_node

--- a/app/services/tariff_knowledge/relevant_note_fragment_selector.rb
+++ b/app/services/tariff_knowledge/relevant_note_fragment_selector.rb
@@ -1,9 +1,9 @@
 module TariffKnowledge
   class RelevantNoteFragmentSelector
     # The classifier prompt needs source evidence, not complete compressed notes.
-    # These caps keep one broad chapter/section note from dominating the prompt:
-    # at most two fragments may come from one compressed note, and at most eight
-    # fragments are emitted for the whole candidate set.
+    # These caps keep one broad chapter/section note from dominating prompts
+    # with several candidate notes. When only one note is selected, it may use
+    # the global budget.
     MAX_FRAGMENTS_PER_NOTE = 2
     MAX_TOTAL_FRAGMENTS = 8
 
@@ -17,7 +17,8 @@ module TariffKnowledge
       'inclusion' => 2,
       'reference' => 1,
     }.freeze
-    RANGE_MATCH_SCORE = 8
+    CHAPTER_RANGE_MATCH_SCORE = 8
+    HEADING_RANGE_MATCH_SCORE = 14
     MENTIONED_RANGE_SCORE = 4
     MAX_MENTIONED_RANGE_SCORE = 12
     QUERY_TERM_SCORE = 2
@@ -55,19 +56,23 @@ module TariffKnowledge
         end
       end
 
-      cap_total_fragments(contexts.values.filter_map { |context| selected_context(context) })
+      selectable_contexts = contexts.values.select { |context| qualifying_fragments(context).any? }
+      per_note_limit = selectable_contexts.one? ? MAX_TOTAL_FRAGMENTS : MAX_FRAGMENTS_PER_NOTE
+      cap_total_fragments(selectable_contexts.filter_map { |context| selected_context(context, per_note_limit) })
     end
 
   private
 
     attr_reader :query, :search_results, :notes_by_item_id
 
-    def selected_context(context)
-      fragments = context[:fragments].values.select { |fragment| fragment[:score] >= MIN_SCORE }
-        .sort_by { |fragment| [-fragment[:score], fragment[:source].to_s, fragment[:key].to_s] }.first(MAX_FRAGMENTS_PER_NOTE)
+    def selected_context(context, per_note_limit)
+      fragments = qualifying_fragments(context)
+        .sort_by { |fragment| [-fragment[:score], fragment[:source].to_s, fragment[:key].to_s] }.first(per_note_limit)
         .map { |fragment| fragment.except(:key) }
       { key: context[:key], commodity_codes: context[:commodity_codes].uniq, fragments: } if fragments.any?
     end
+
+    def qualifying_fragments(context) = context[:fragments].values.select { |fragment| fragment[:score] >= MIN_SCORE }
 
     def cap_total_fragments(contexts)
       remaining = MAX_TOTAL_FRAGMENTS
@@ -85,10 +90,11 @@ module TariffKnowledge
       # explaining the relationship that made that fragment evidence for a code.
       fragment_evidence_records(note).filter_map do |evidence_record|
         fragment_node = fragment_node_for(evidence_record)
-        text = (evidence_record['source_context'].presence || fragment_node&.content).to_s.squish
-        next if text.blank?
+        source_text = (evidence_record['source_context'].presence || fragment_node&.content).to_s.squish
+        next if source_text.blank?
 
-        score, reasons = score_fragment(evidence_record, text)
+        score, reasons = score_fragment(evidence_record, source_text)
+        text = [source_text, evidence_record['semantic_context'].presence].compact.join(' ').squish
         {
           key: evidence_record['source_node_key'],
           source: evidence_record['source_title'] || fragment_node&.title,
@@ -140,7 +146,14 @@ module TariffKnowledge
     def range_match_rule(evidence_record)
       return unless range_match?(evidence_record)
 
-      [RANGE_MATCH_SCORE, "references retrieved #{evidence_record['range_type']} #{evidence_record['range_code']}"]
+      [
+        range_match_score(evidence_record),
+        "references retrieved #{evidence_record['range_type']} #{evidence_record['range_code']}",
+      ]
+    end
+
+    def range_match_score(evidence_record)
+      evidence_record['range_type'] == 'heading' ? HEADING_RANGE_MATCH_SCORE : CHAPTER_RANGE_MATCH_SCORE
     end
 
     def mentioned_range_rule(text)

--- a/app/services/tariff_knowledge/semantic_rule_fact_extraction.rb
+++ b/app/services/tariff_knowledge/semantic_rule_fact_extraction.rb
@@ -1,0 +1,138 @@
+module TariffKnowledge
+  class SemanticRuleFactExtraction
+    Result = Data.define(:fragment_count, :fact_count, :goods_nomenclature_count)
+
+    def self.call(fragment_node_ids: nil)
+      new(fragment_node_ids).call
+    end
+
+    def initialize(fragment_node_ids)
+      @fragment_node_ids = fragment_node_ids
+    end
+
+    def call
+      fragment_count = 0
+      fact_count = 0
+      processed_fragment_node_ids = []
+
+      referenced_fragments.each do |fragment_node, source_reference, candidate_references|
+        facts = SemanticRuleFactExtractor.call(fragment_node:, source_reference:, candidate_references:)
+        fragment_count += 1
+        fact_count += facts.size
+        processed_fragment_node_ids << fragment_node.id
+      end
+
+      affected_goods_nomenclature_sids = affected_goods_nomenclature_sids(processed_fragment_node_ids)
+      CompressedNoteGenerator.call(goods_nomenclature_sids: affected_goods_nomenclature_sids) if affected_goods_nomenclature_sids.any?
+
+      Result.new(
+        fragment_count:,
+        fact_count:,
+        goods_nomenclature_count: affected_goods_nomenclature_sids.size,
+      )
+    end
+
+  private
+
+    attr_reader :fragment_node_ids
+
+    def referenced_fragments
+      references_by_fragment_id.filter_map do |fragment_node_id, references|
+        fragment_node = fragment_nodes_by_id[fragment_node_id]
+        next unless fragment_node && references.any?
+
+        [fragment_node, source_reference_for(fragment_node), references]
+      end
+    end
+
+    def source_reference_for(fragment_node)
+      case fragment_node.source_type
+      when 'customs_tariff_section_note'
+        { 'type' => 'section', 'code' => fragment_node.source_id }
+      when 'customs_tariff_chapter_note'
+        { 'type' => 'chapter', 'code' => fragment_node.source_id }
+      when 'customs_tariff_general_rule'
+        { 'type' => 'rule', 'code' => fragment_node.source_id }
+      end
+    end
+
+    def references_by_fragment_id
+      @references_by_fragment_id ||= reference_edges.each_with_object({}) do |edge, grouped|
+        range_node = range_nodes_by_id[edge.target_node_id]
+        next unless range_node
+
+        range_metadata = range_node.metadata.to_h
+        grouped[edge.source_node_id] ||= []
+        grouped[edge.source_node_id] << {
+          'type' => range_metadata['range_type'],
+          'code' => range_metadata['code'],
+        }
+      end
+    end
+
+    def reference_edges
+      dataset = Edge.by_relationship(Edge::REFERENCES)
+      dataset = dataset.where(source_node_id: fragment_node_ids) if fragment_node_ids.present?
+      dataset.all
+    end
+
+    def fragment_nodes_by_id
+      @fragment_nodes_by_id ||= begin
+        dataset = Node.note_fragments.where(id: references_source_node_ids)
+        dataset = dataset.where(source_version: current_source_version) if current_source_version.present?
+        dataset.all.index_by(&:id)
+      end
+    end
+
+    def range_nodes_by_id
+      @range_nodes_by_id ||= Node
+        .where(node_type: Node::RANGE, id: reference_edges.map(&:target_node_id).uniq)
+        .all
+        .index_by(&:id)
+    end
+
+    def references_source_node_ids
+      reference_edges.map(&:source_node_id).uniq
+    end
+
+    def affected_goods_nomenclature_sids(fragment_node_ids)
+      return [] if fragment_node_ids.empty?
+
+      direct_sids = Edge
+        .by_relationship(Edge::APPLIES_TO)
+        .where(source_node_id: fragment_node_ids)
+        .association_join(:target_node)
+        .exclude(target_node__goods_nomenclature_sid: nil)
+        .select_map(Sequel[:target_node][:goods_nomenclature_sid])
+
+      range_node_ids = Edge
+        .by_relationship(Edge::REFERENCES)
+        .where(source_node_id: fragment_node_ids)
+        .select_map(:target_node_id)
+
+      expanded_sids = Edge
+        .by_relationship(Edge::EXPANDS_TO)
+        .where(source_node_id: range_node_ids)
+        .association_join(:target_node)
+        .exclude(target_node__goods_nomenclature_sid: nil)
+        .select_map(Sequel[:target_node][:goods_nomenclature_sid])
+
+      (direct_sids + expanded_sids)
+        .compact
+        .uniq
+        .sort
+    end
+
+    def current_source_version
+      return @current_source_version if defined?(@current_source_version)
+
+      @current_source_version = TimeMachine.at(@time_machine_date ||= Time.current) do
+        CustomsTariffUpdate
+          .actual
+          .exclude(status: SourceGraphLoader::EXCLUDED_UPDATE_STATUSES)
+          .order(Sequel.desc(:validity_start_date))
+          .get(:version)
+      end
+    end
+  end
+end

--- a/app/services/tariff_knowledge/semantic_rule_fact_extractor.rb
+++ b/app/services/tariff_knowledge/semantic_rule_fact_extractor.rb
@@ -1,0 +1,78 @@
+module TariffKnowledge
+  class SemanticRuleFactExtractor
+    def self.call(fragment_node:, source_reference:, candidate_references:)
+      new(fragment_node, source_reference, candidate_references).call
+    end
+
+    def initialize(fragment_node, source_reference, candidate_references)
+      @fragment_node = fragment_node
+      @source_reference = source_reference
+      @candidate_references = candidate_references
+    end
+
+    def call
+      facts = SemanticRuleFactValidator.call(
+        facts: extracted_facts,
+        source_text: fragment_node.content,
+        valid_references:,
+        target_references: candidate_references,
+      )
+      persist(facts)
+      facts
+    end
+
+  private
+
+    attr_reader :fragment_node, :source_reference, :candidate_references
+
+    def valid_references
+      [source_reference, *candidate_references].compact.uniq
+    end
+
+    def extracted_facts
+      response = OpenaiClient.call(prompt)
+      return [] unless response.is_a?(Hash)
+
+      facts = response.fetch('facts', [])
+      facts.is_a?(Array) ? facts : []
+    end
+
+    def persist(facts)
+      metadata = fragment_node.metadata.to_h
+      metadata['semantic_rule_facts'] = facts
+      Node.where(id: fragment_node.id).update(metadata: Sequel.pg_jsonb(metadata))
+      fragment_node.refresh
+    end
+
+    def prompt
+      <<~PROMPT
+        Evaluate deterministic candidate tariff connections for this source note fragment.
+
+        Return JSON with a top-level "facts" array. Each fact must match this schema:
+        {
+          "source_reference": "source label",
+          "source_span": "exact quoted text from the source fragment",
+          "relationship_type": "excludes|includes|constrains|references|classifies",
+          "subject": { "type": "section|chapter|heading|commodity|range|rule", "code": "01" },
+          "target": { "type": "chapter|heading|commodity|range|rule", "code": "0101" },
+          "conditions": ["condition text"],
+          "exceptions": ["exception text"],
+          "confidence": "high|medium|low"
+        }
+
+        Use only exact source_span text copied from the source fragment.
+        Use only this deterministic source reference as the subject unless the source text explicitly names a candidate target:
+        #{JSON.pretty_generate(source_reference)}
+
+        Evaluate only these deterministic candidate target references:
+        #{JSON.pretty_generate(candidate_references)}
+
+        Use only subject and target references from this combined allow-list:
+        #{JSON.pretty_generate(valid_references)}
+
+        Source fragment:
+        #{fragment_node.content}
+      PROMPT
+    end
+  end
+end

--- a/app/services/tariff_knowledge/semantic_rule_fact_validator.rb
+++ b/app/services/tariff_knowledge/semantic_rule_fact_validator.rb
@@ -1,0 +1,106 @@
+module TariffKnowledge
+  class SemanticRuleFactValidator
+    RELATIONSHIP_TYPES = %w[excludes includes constrains references classifies].freeze
+    ACCEPTED_CONFIDENCES = %w[high medium].freeze
+    REFERENCE_PATTERNS = {
+      'section' => /\A\d{1,2}\z/,
+      'chapter' => /\A\d{2}\z/,
+      'heading' => /\A\d{4}\z/,
+      'commodity' => /\A\d{10}\z/,
+      'range' => /\A\d{2,10}(?:-\d{2,10})?\z/,
+      'rule' => /\A(?:GIR\s*)?\d+\z/i,
+    }.freeze
+
+    def self.call(facts:, source_text:, valid_references:, target_references: nil)
+      new(facts, source_text, valid_references, target_references).call
+    end
+
+    def initialize(facts, source_text, valid_references, target_references)
+      @facts = Array(facts)
+      @source_text = source_text.to_s
+      @valid_references = Array(valid_references).filter_map { |reference| normalized_hash(reference)&.slice('type', 'code') }.to_set
+      @target_references = Array(target_references || valid_references).filter_map { |reference| normalized_hash(reference)&.slice('type', 'code') }.to_set
+    end
+
+    def call
+      facts.filter_map { |fact| normalize_fact(fact) }
+    end
+
+  private
+
+    attr_reader :facts, :source_text, :valid_references, :target_references
+
+    def normalize_fact(fact)
+      return unless fact.is_a?(Hash)
+
+      normalize(fact)
+    end
+
+    def normalize(fact)
+      source_span = fact['source_span'].to_s.squish
+      relationship_type = fact['relationship_type'].to_s
+      subject = normalized_reference(fact['subject'])
+      target = normalized_reference(fact['target'])
+      confidence = fact['confidence'].to_s
+      source_reference = normalized_required_string(fact['source_reference'])
+      conditions = normalized_string_array(fact['conditions'])
+      exceptions = normalized_string_array(fact['exceptions'])
+
+      return if source_span.blank?
+      return unless source_text.include?(source_span)
+      return unless RELATIONSHIP_TYPES.include?(relationship_type)
+      return unless source_reference
+      return unless subject && target && valid_reference?(subject) && valid_target_reference?(target)
+      return unless conditions && exceptions
+      return unless ACCEPTED_CONFIDENCES.include?(confidence)
+
+      {
+        'source_reference' => source_reference,
+        'source_span' => source_span,
+        'relationship_type' => relationship_type,
+        'subject' => subject,
+        'target' => target,
+        'conditions' => conditions,
+        'exceptions' => exceptions,
+        'confidence' => confidence,
+      }
+    end
+
+    def normalized_reference(reference)
+      reference = normalized_hash(reference)
+      return unless reference
+
+      type = reference['type'].to_s
+      code = reference['code'].to_s
+      return unless REFERENCE_PATTERNS.fetch(type, nil)&.match?(code)
+
+      { 'type' => type, 'code' => code }
+    end
+
+    def valid_reference?(reference)
+      valid_references.include?(reference)
+    end
+
+    def valid_target_reference?(reference)
+      valid_reference?(reference) && target_references.include?(reference)
+    end
+
+    def normalized_string_array(values)
+      return [] if values.nil?
+      return unless values.is_a?(Array)
+      return unless values.all? { |value| value.is_a?(String) }
+
+      values.filter_map do |value|
+        value.squish.presence
+      end
+    end
+
+    def normalized_required_string(value)
+      value.squish.presence if value.is_a?(String)
+    end
+
+    def normalized_hash(value)
+      value if value.is_a?(Hash)
+    end
+  end
+end

--- a/app/services/tariff_knowledge/source_graph_loader.rb
+++ b/app/services/tariff_knowledge/source_graph_loader.rb
@@ -307,7 +307,7 @@ module TariffKnowledge
       key = attributes.fetch(:key)
       now = Time.zone.now
       values = attributes.merge(
-        metadata: Sequel.pg_jsonb(attributes.fetch(:metadata, { 'loader' => self.class.name })),
+        metadata: Sequel.pg_jsonb(metadata_for_node(attributes)),
         created_at: now,
         updated_at: now,
       )
@@ -317,6 +317,23 @@ module TariffKnowledge
           .insert(values)
 
       Node.by_key(key).first
+    end
+
+    def metadata_for_node(attributes)
+      metadata = attributes.fetch(:metadata, { 'loader' => self.class.name }).to_h
+      return metadata unless attributes[:node_type] == Node::NOTE_FRAGMENT
+
+      semantic_rule_facts = reusable_semantic_rule_facts(attributes.fetch(:key), attributes[:content])
+      semantic_rule_facts.any? ? metadata.merge('semantic_rule_facts' => semantic_rule_facts) : metadata
+    end
+
+    def reusable_semantic_rule_facts(key, content)
+      existing_node = Node.by_key(key).first
+      Array(existing_node&.metadata.to_h.fetch('semantic_rule_facts', nil)).select do |fact|
+        source_span = fact['source_span'].to_s.squish if fact.is_a?(Hash)
+
+        source_span.present? && content.to_s.include?(source_span)
+      end
     end
 
     def upsert_edge(source_node, target_node, relationship_type)

--- a/lib/tasks/tariff_knowledge.rake
+++ b/lib/tasks/tariff_knowledge.rake
@@ -48,4 +48,12 @@ namespace :tariff_knowledge do
       end
     end
   end
+
+  namespace :semantic_rule_facts do
+    desc 'Run semantic rule fact extraction for referenced tariff knowledge note fragments'
+    task extract: :environment do
+      result = TariffKnowledge::SemanticRuleFactExtraction.call
+      puts "Semantic rule fact extraction complete: #{result.fragment_count} fragments, #{result.fact_count} facts, #{result.goods_nomenclature_count} compressed notes refreshed."
+    end
+  end
 end

--- a/spec/lib/tasks/tariff_knowledge_rake_spec.rb
+++ b/spec/lib/tasks/tariff_knowledge_rake_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'tariff_knowledge rake tasks' do
       tariff_knowledge:declarable_nodes:run
       tariff_knowledge:compressed_notes:refresh:enqueue
       tariff_knowledge:compressed_notes:refresh:run
+      tariff_knowledge:semantic_rule_facts:extract
     ].each { |task| Rake::Task[task].reenable if Rake::Task.task_defined?(task) }
   end
 
@@ -86,6 +87,29 @@ RSpec.describe 'tariff_knowledge rake tasks' do
 
       expect(TariffKnowledge::CompressedNoteRefresh).to have_received(:call)
     end
+  end
+
+  describe 'tariff_knowledge:semantic_rule_facts:extract' do
+    it 'runs semantic rule fact extraction inline' do
+      allow(TariffKnowledge::SemanticRuleFactExtraction)
+        .to receive(:call)
+        .and_return(TariffKnowledge::SemanticRuleFactExtraction::Result.new(fragment_count: 2, fact_count: 3, goods_nomenclature_count: 1))
+
+      output = capture_output { Rake::Task['tariff_knowledge:semantic_rule_facts:extract'].invoke }
+
+      expect(TariffKnowledge::SemanticRuleFactExtraction).to have_received(:call)
+      expect(output).to include('2 fragments, 3 facts, 1 compressed notes refreshed')
+    end
+  end
+
+  def capture_output
+    original_stdout = $stdout
+    output = StringIO.new
+    $stdout = output
+    yield
+    output.string
+  ensure
+    $stdout = original_stdout
   end
 end
 # rubocop:enable RSpec/DescribeClass

--- a/spec/services/tariff_knowledge/compressed_note_generator_spec.rb
+++ b/spec/services/tariff_knowledge/compressed_note_generator_spec.rb
@@ -42,6 +42,8 @@ RSpec.describe TariffKnowledge::CompressedNoteGenerator do
         key: 'note_fragment:customs_tariff_chapter_note:1.31:01:0001',
         title: 'Chapter 01 notes fragment 1',
         content: '1. This chapter includes:',
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '01',
       )
     end
     let(:fragment_node) do
@@ -51,6 +53,8 @@ RSpec.describe TariffKnowledge::CompressedNoteGenerator do
         key: 'note_fragment:customs_tariff_chapter_note:1.31:01:0002',
         title: 'Chapter 01 notes fragment 2',
         content: 'Heading 0101 covers live horses.',
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '01',
       )
     end
 
@@ -147,11 +151,9 @@ RSpec.describe TariffKnowledge::CompressedNoteGenerator do
       expect(note.content).to include('Heading 0101 covers live horses.')
       expect(note.content).to include('Chapter 01 notes fragment 3')
       expect(note.content).to include('Live animals are classified in this chapter.')
-      expect(note.metadata.to_hash).to include(
-        'source_node_keys' => [
-          'note_fragment:customs_tariff_chapter_note:1.31:01:0002',
-          'note_fragment:customs_tariff_chapter_note:1.31:01:0003',
-        ],
+      expect(note.metadata.to_hash['source_node_keys']).to contain_exactly(
+        'note_fragment:customs_tariff_chapter_note:1.31:01:0002',
+        'note_fragment:customs_tariff_chapter_note:1.31:01:0003',
       )
       direct_evidence = note.metadata.to_hash['evidence'].find do |evidence|
         evidence['source_node_key'] == 'note_fragment:customs_tariff_chapter_note:1.31:01:0003'
@@ -387,6 +389,158 @@ RSpec.describe TariffKnowledge::CompressedNoteGenerator do
       evidence = TariffKnowledge::CompressedNote[123].metadata['evidence'].first
       expect(evidence['source_context']).to eq('1. This chapter includes: ii. Heading 0101 covers live horses.')
       expect(evidence['context_type']).to eq('inclusion')
+    end
+
+    it 'adds valid semantic rule facts to source-backed evidence context' do
+      fragment_node.update(
+        metadata: Sequel.pg_jsonb_wrap(
+          'semantic_rule_facts' => [
+            {
+              'source_reference' => 'Chapter 01 note 1',
+              'source_span' => 'Heading 0101 covers live horses.',
+              'relationship_type' => 'includes',
+              'subject' => { 'type' => 'chapter', 'code' => '01' },
+              'target' => { 'type' => 'heading', 'code' => '0101' },
+              'conditions' => ['live horses'],
+              'exceptions' => [],
+              'confidence' => 'high',
+            },
+          ],
+        ),
+      )
+
+      described_class.call(goods_nomenclature_sids: [123])
+
+      evidence = TariffKnowledge::CompressedNote[123].metadata['evidence'].first
+      expect(evidence['semantic_rule_facts']).to contain_exactly(
+        include(
+          'source_reference' => 'Chapter 01 note 1',
+          'source_span' => 'Heading 0101 covers live horses.',
+          'relationship_type' => 'includes',
+          'target' => { 'type' => 'heading', 'code' => '0101' },
+          'confidence' => 'high',
+        ),
+      )
+      expect(evidence['source_context']).to eq('1. This chapter includes: Heading 0101 covers live horses.')
+      expect(evidence['semantic_context'])
+        .to include('Generated rule facts: includes heading 0101 when live horses.')
+    end
+
+    it 'validates semantic rule facts from section note source references' do
+      source_node.update(
+        key: 'note_source:customs_tariff_section_note:1.31:1',
+        title: 'Section 1 notes',
+      )
+      lead_in_fragment_node.update(
+        key: 'note_fragment:customs_tariff_section_note:1.31:1:0001',
+        title: 'Section 1 notes fragment 1',
+        source_type: 'customs_tariff_section_note',
+        source_id: '1',
+      )
+      fragment_node.update(
+        key: 'note_fragment:customs_tariff_section_note:1.31:1:0002',
+        title: 'Section 1 notes fragment 2',
+        source_type: 'customs_tariff_section_note',
+        source_id: '1',
+        metadata: Sequel.pg_jsonb_wrap(
+          'semantic_rule_facts' => [
+            {
+              'source_reference' => 'Section 1 note 1',
+              'source_span' => 'Heading 0101 covers live horses.',
+              'relationship_type' => 'includes',
+              'subject' => { 'type' => 'section', 'code' => '1' },
+              'target' => { 'type' => 'heading', 'code' => '0101' },
+              'conditions' => ['live horses'],
+              'exceptions' => [],
+              'confidence' => 'high',
+            },
+          ],
+        ),
+      )
+
+      described_class.call(goods_nomenclature_sids: [123])
+
+      evidence = TariffKnowledge::CompressedNote[123].metadata['evidence'].first
+      expect(evidence['semantic_rule_facts']).to contain_exactly(
+        include(
+          'source_reference' => 'Section 1 note 1',
+          'subject' => { 'type' => 'section', 'code' => '1' },
+          'target' => { 'type' => 'heading', 'code' => '0101' },
+        ),
+      )
+      expect(evidence['semantic_context'])
+        .to include('Generated rule facts: includes heading 0101 when live horses.')
+    end
+
+    it 'uses accepted semantic rule facts to bridge referenced ranges without mechanical applicability' do
+      TariffKnowledge::Edge
+        .where(
+          source_node_id: fragment_node.id,
+          target_node_id: declarable_node.id,
+          relationship_type: TariffKnowledge::Edge::APPLIES_TO,
+        )
+        .delete
+      fragment_node.update(
+        metadata: Sequel.pg_jsonb_wrap(
+          'semantic_rule_facts' => [
+            {
+              'source_reference' => 'Chapter 01 note 1',
+              'source_span' => 'Heading 0101 covers live horses.',
+              'relationship_type' => 'includes',
+              'subject' => { 'type' => 'chapter', 'code' => '01' },
+              'target' => { 'type' => 'heading', 'code' => '0101' },
+              'conditions' => ['live horses'],
+              'exceptions' => [],
+              'confidence' => 'high',
+            },
+          ],
+        ),
+      )
+
+      described_class.call(goods_nomenclature_sids: [123])
+
+      evidence = TariffKnowledge::CompressedNote[123].metadata['evidence'].first
+      expect(evidence).to include(
+        'source_node_key' => 'note_fragment:customs_tariff_chapter_note:1.31:01:0002',
+        'range_node_key' => 'range:heading:0101',
+      )
+      expect(evidence['semantic_context'])
+        .to include('Generated rule facts: includes heading 0101 when live horses.')
+    end
+
+    it 'rejects semantic rule facts without exact source spans or valid tariff references' do
+      fragment_node.update(
+        metadata: Sequel.pg_jsonb_wrap(
+          'semantic_rule_facts' => [
+            {
+              'source_reference' => 'Chapter 01 note 1',
+              'source_span' => 'text that is not in the source',
+              'relationship_type' => 'includes',
+              'subject' => { 'type' => 'chapter', 'code' => '01' },
+              'target' => { 'type' => 'heading', 'code' => '0101' },
+              'conditions' => [],
+              'exceptions' => [],
+              'confidence' => 'high',
+            },
+            {
+              'source_reference' => 'Chapter 01 note 1',
+              'source_span' => 'Heading 0101 covers live horses.',
+              'relationship_type' => 'includes',
+              'subject' => { 'type' => 'chapter', 'code' => '01' },
+              'target' => { 'type' => 'heading', 'code' => '9999' },
+              'conditions' => [],
+              'exceptions' => [],
+              'confidence' => 'high',
+            },
+          ],
+        ),
+      )
+
+      described_class.call(goods_nomenclature_sids: [123])
+
+      evidence = TariffKnowledge::CompressedNote[123].metadata['evidence'].first
+      expect(evidence).not_to include('semantic_rule_facts')
+      expect(evidence).not_to include('semantic_context')
     end
   end
 

--- a/spec/services/tariff_knowledge/relevant_note_fragment_selector_spec.rb
+++ b/spec/services/tariff_knowledge/relevant_note_fragment_selector_spec.rb
@@ -132,6 +132,88 @@ RSpec.describe TariffKnowledge::RelevantNoteFragmentSelector do
     expect(contexts.first[:fragments].first[:why_relevant]).to include('references retrieved heading 9506')
   end
 
+  it 'prioritises heading-level semantic range evidence over broader chapter evidence' do
+    heading_note_content = 'compressed note 9405500010'
+    heading_note = create(
+      :tariff_knowledge_compressed_note,
+      goods_nomenclature_item_id: '9405500010',
+      content: heading_note_content,
+      context_hash: Digest::SHA256.hexdigest(heading_note_content),
+      metadata: Sequel.pg_jsonb_wrap(
+        'evidence' => [
+          evidence_for(
+            'note_fragment:customs_tariff_chapter_note:1.31:90:9405',
+            'searchlights or spotlights of heading 9405;',
+            'reference',
+            range_type: 'heading',
+            range_code: '9405',
+            semantic_context: 'Generated rule facts: references heading 9405.',
+          ),
+          evidence_for(
+            'note_fragment:customs_tariff_chapter_note:1.31:90:94',
+            'articles of Chapter 94, for example furniture, lamps and lighting fittings.',
+            'exclusion',
+            range_type: 'chapter',
+            range_code: '94',
+            semantic_context: 'Generated rule facts: excludes chapter 94.',
+          ),
+          evidence_for(
+            'note_fragment:customs_tariff_chapter_note:1.31:94:generic',
+            'Generic Chapter 94 furniture note.',
+            'reference',
+          ),
+        ],
+      ),
+    )
+
+    contexts = described_class.call(
+      query: 'decorative lantern candle holder',
+      search_results: [
+        search_result_class.new(
+          goods_nomenclature_item_id: '9405500010',
+          description: 'Non-electrical luminaires and lighting fittings',
+          full_description: nil,
+          score: 10,
+        ),
+      ],
+      notes_by_item_id: { '9405500010' => heading_note },
+    )
+
+    fragment_texts = contexts.first[:fragments].pluck(:text)
+    expect(fragment_texts.first).to include('heading 9405')
+  end
+
+  it 'includes validated semantic context without replacing source context' do
+    semantic_note = create_note_with_evidence(
+      '9506911000',
+      evidence_for(
+        'note_fragment:customs_tariff_chapter_note:1.31:95:semantic',
+        'Heading 9506 includes articles and equipment for general physical exercise.',
+        'inclusion',
+        range_type: 'heading',
+        range_code: '9506',
+        semantic_context: 'Generated rule facts: includes heading 9506 when general physical exercise.',
+      ),
+    )
+
+    contexts = described_class.call(
+      query: 'exercise apparatus',
+      search_results: [
+        search_result_class.new(
+          goods_nomenclature_item_id: '9506911000',
+          description: 'Articles and equipment for general physical exercise',
+          full_description: nil,
+          score: 10,
+        ),
+      ],
+      notes_by_item_id: { '9506911000' => semantic_note },
+    )
+
+    text = contexts.first[:fragments].first[:text]
+    expect(text).to include('Heading 9506 includes articles')
+    expect(text).to include('Generated rule facts: includes heading 9506')
+  end
+
   it 'caps total emitted fragments across all selected notes' do
     contexts = described_class.call(
       query: 'plastic exercise article',
@@ -150,6 +232,55 @@ RSpec.describe TariffKnowledge::RelevantNoteFragmentSelector do
     )
 
     expect(contexts.sum { |context| context[:fragments].size }).to eq(described_class::MAX_TOTAL_FRAGMENTS)
+  end
+
+  it 'allows a single selected note to use the global fragment budget' do
+    contexts = described_class.call(
+      query: 'plastic exercise article',
+      search_results: [
+        search_result_class.new(
+          goods_nomenclature_item_id: '9506911000',
+          description: 'Articles and equipment for general physical exercise',
+          full_description: nil,
+          score: 10,
+        ),
+      ],
+      notes_by_item_id: { '9506911000' => create_note_with_fragments('9506911000', 1) },
+    )
+
+    expect(contexts.first[:fragments].size).to eq(6)
+  end
+
+  it 'allows the only qualifying note to use the global fragment budget' do
+    irrelevant_note = create_note_with_evidence(
+      '6403999110',
+      evidence_for(
+        'note_fragment:customs_tariff_chapter_note:1.31:12:irrelevant',
+        'Candles of heading 3406 are excluded.',
+        'reference',
+        range_type: 'heading',
+        range_code: '3406',
+      ),
+    )
+
+    contexts = described_class.call(
+      query: 'plastic exercise article',
+      search_results: [
+        search_result_class.new(
+          goods_nomenclature_item_id: '9506911000',
+          description: 'Articles and equipment for general physical exercise',
+          full_description: nil,
+          score: 10,
+        ),
+      ],
+      notes_by_item_id: {
+        '9506911000' => create_note_with_fragments('9506911000', 1),
+        '6403999110' => irrelevant_note,
+      },
+    )
+
+    expect(contexts.size).to eq(1)
+    expect(contexts.first[:fragments].size).to eq(6)
   end
 
   it 'applies the global fragment cap to the highest scoring notes first' do
@@ -199,7 +330,7 @@ RSpec.describe TariffKnowledge::RelevantNoteFragmentSelector do
     expect(contexts).to be_empty
   end
 
-  def evidence_for(key, text, context_type, range_type: nil, range_code: nil, source_type: 'customs_tariff_chapter_note')
+  def evidence_for(key, text, context_type, range_type: nil, range_code: nil, source_type: 'customs_tariff_chapter_note', semantic_context: nil)
     {
       'source_node_key' => key,
       'source_type' => source_type,
@@ -210,7 +341,9 @@ RSpec.describe TariffKnowledge::RelevantNoteFragmentSelector do
       'range_type' => range_type,
       'range_code' => range_code,
       'relationships' => [TariffKnowledge::Edge::APPLIES_TO],
-    }
+    }.tap do |evidence|
+      evidence['semantic_context'] = semantic_context if semantic_context
+    end
   end
 
   def create_note_with_fragments(item_id, note_index)

--- a/spec/services/tariff_knowledge/semantic_rule_fact_extraction_spec.rb
+++ b/spec/services/tariff_knowledge/semantic_rule_fact_extraction_spec.rb
@@ -1,0 +1,134 @@
+RSpec.describe TariffKnowledge::SemanticRuleFactExtraction do
+  describe '.call' do
+    let(:referenced_fragment) do
+      create(
+        :tariff_knowledge_node,
+        :note_fragment,
+        content: 'Heading 0101 covers live horses.',
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '01',
+      )
+    end
+    let(:unreferenced_fragment) do
+      create(
+        :tariff_knowledge_node,
+        :note_fragment,
+        content: 'Generic note text.',
+      )
+    end
+    let(:range_node) do
+      create(
+        :tariff_knowledge_node,
+        node_type: TariffKnowledge::Node::RANGE,
+        key: 'range:heading:0101',
+        title: 'Heading 0101',
+        goods_nomenclature_sid: nil,
+        goods_nomenclature_item_id: nil,
+        producline_suffix: nil,
+        goods_nomenclature_type: nil,
+        metadata: Sequel.pg_jsonb_wrap({ 'range_type' => 'heading', 'code' => '0101' }),
+      )
+    end
+
+    before do
+      create(
+        :tariff_knowledge_edge,
+        source_node: referenced_fragment,
+        target_node: range_node,
+        relationship_type: TariffKnowledge::Edge::REFERENCES,
+      )
+      allow(TariffKnowledge::SemanticRuleFactExtractor).to receive(:call).and_return([])
+    end
+
+    it 'extracts facts only for fragments with deterministic references' do
+      result = described_class.call(fragment_node_ids: [referenced_fragment.id, unreferenced_fragment.id])
+
+      expect(result).to have_attributes(fragment_count: 1, fact_count: 0)
+      expect(TariffKnowledge::SemanticRuleFactExtractor)
+        .to have_received(:call)
+        .with(
+          fragment_node: referenced_fragment,
+          source_reference: { 'type' => 'chapter', 'code' => '01' },
+          candidate_references: [{ 'type' => 'heading', 'code' => '0101' }],
+        )
+    end
+
+    it 'passes section note source references to the extractor' do
+      referenced_fragment.update(
+        source_type: 'customs_tariff_section_note',
+        source_id: '1',
+      )
+
+      described_class.call(fragment_node_ids: [referenced_fragment.id])
+
+      expect(TariffKnowledge::SemanticRuleFactExtractor)
+        .to have_received(:call)
+        .with(
+          fragment_node: referenced_fragment,
+          source_reference: { 'type' => 'section', 'code' => '1' },
+          candidate_references: [{ 'type' => 'heading', 'code' => '0101' }],
+        )
+    end
+
+    it 'skips fragments from stale source versions when a current update exists' do
+      create(:customs_tariff_update, version: '1.30', validity_start_date: 2.days.ago)
+      create(:customs_tariff_update, version: '1.31', validity_start_date: 1.day.ago)
+      referenced_fragment.update(source_version: '1.30')
+
+      result = described_class.call(fragment_node_ids: [referenced_fragment.id])
+
+      expect(result).to have_attributes(fragment_count: 0, fact_count: 0)
+      expect(TariffKnowledge::SemanticRuleFactExtractor).not_to have_received(:call)
+    end
+
+    it 'regenerates compressed notes for goods affected by extracted fragments' do
+      declarable_node = create(
+        :tariff_knowledge_node,
+        goods_nomenclature_sid: 123,
+        goods_nomenclature_item_id: '0101210000',
+      )
+      create(
+        :tariff_knowledge_edge,
+        source_node: referenced_fragment,
+        target_node: declarable_node,
+        relationship_type: TariffKnowledge::Edge::APPLIES_TO,
+      )
+      allow(TariffKnowledge::SemanticRuleFactExtractor)
+        .to receive(:call)
+        .and_return([{ 'source_span' => 'Heading 0101 covers live horses.' }])
+      allow(TariffKnowledge::CompressedNoteGenerator).to receive(:call)
+
+      result = described_class.call(fragment_node_ids: [referenced_fragment.id])
+
+      expect(result).to have_attributes(fragment_count: 1, fact_count: 1, goods_nomenclature_count: 1)
+      expect(TariffKnowledge::CompressedNoteGenerator)
+        .to have_received(:call)
+        .with(goods_nomenclature_sids: [123])
+    end
+
+    it 'regenerates compressed notes for goods affected through referenced ranges' do
+      declarable_node = create(
+        :tariff_knowledge_node,
+        goods_nomenclature_sid: 123,
+        goods_nomenclature_item_id: '0101210000',
+      )
+      create(
+        :tariff_knowledge_edge,
+        source_node: range_node,
+        target_node: declarable_node,
+        relationship_type: TariffKnowledge::Edge::EXPANDS_TO,
+      )
+      allow(TariffKnowledge::SemanticRuleFactExtractor)
+        .to receive(:call)
+        .and_return([{ 'source_span' => 'Heading 0101 covers live horses.' }])
+      allow(TariffKnowledge::CompressedNoteGenerator).to receive(:call)
+
+      result = described_class.call(fragment_node_ids: [referenced_fragment.id])
+
+      expect(result).to have_attributes(fragment_count: 1, fact_count: 1, goods_nomenclature_count: 1)
+      expect(TariffKnowledge::CompressedNoteGenerator)
+        .to have_received(:call)
+        .with(goods_nomenclature_sids: [123])
+    end
+  end
+end

--- a/spec/services/tariff_knowledge/semantic_rule_fact_extractor_spec.rb
+++ b/spec/services/tariff_knowledge/semantic_rule_fact_extractor_spec.rb
@@ -1,0 +1,88 @@
+RSpec.describe TariffKnowledge::SemanticRuleFactExtractor do
+  describe '.call' do
+    let(:fragment_node) do
+      create(
+        :tariff_knowledge_node,
+        :note_fragment,
+        content: 'Heading 0101 covers live horses.',
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '01',
+      )
+    end
+    let(:source_reference) { { 'type' => 'chapter', 'code' => '01' } }
+    let(:candidate_references) { [{ 'type' => 'heading', 'code' => '0101' }] }
+    let(:accepted_fact) do
+      {
+        'source_reference' => 'Chapter 01 note 1',
+        'source_span' => 'Heading 0101 covers live horses.',
+        'relationship_type' => 'includes',
+        'subject' => { 'type' => 'chapter', 'code' => '01' },
+        'target' => { 'type' => 'heading', 'code' => '0101' },
+        'conditions' => ['live horses'],
+        'exceptions' => [],
+        'confidence' => 'high',
+      }
+    end
+
+    before do
+      allow(OpenaiClient).to receive(:call).and_return(
+        'facts' => [
+          accepted_fact,
+          accepted_fact.merge('source_span' => 'not in source'),
+          accepted_fact.merge('target' => { 'type' => 'chapter', 'code' => '01' }),
+        ],
+      )
+    end
+
+    it 'persists validated source-backed facts' do
+      facts = described_class.call(fragment_node:, source_reference:, candidate_references:)
+
+      expect(facts).to contain_exactly(include('source_span' => 'Heading 0101 covers live horses.'))
+      expect(fragment_node.refresh.metadata.to_h['semantic_rule_facts'])
+        .to contain_exactly(include('source_span' => 'Heading 0101 covers live horses.'))
+    end
+
+    it 'prompts for candidate connection evaluation within deterministic bounds' do
+      described_class.call(fragment_node:, source_reference:, candidate_references:)
+
+      expect(OpenaiClient).to have_received(:call) do |context, **_options|
+        expect(context).to include('source_span')
+        expect(context).to include('relationship_type')
+        expect(context).to include('conditions')
+        expect(context).to include('Evaluate only these deterministic candidate target references')
+        expect(context).to include('"type": "heading"')
+        expect(context).to include('"code": "0101"')
+        expect(context).to include('Return JSON')
+      end
+    end
+
+    it 'rejects malformed extractor responses without raising' do
+      allow(OpenaiClient).to receive(:call).and_return('not json')
+
+      facts = described_class.call(fragment_node:, source_reference:, candidate_references:)
+
+      expect(facts).to be_empty
+      expect(fragment_node.refresh.metadata.to_h['semantic_rule_facts']).to be_empty
+    end
+
+    it 'rejects top-level array responses without raising' do
+      allow(OpenaiClient).to receive(:call).and_return([{ 'facts' => [accepted_fact] }])
+
+      facts = described_class.call(fragment_node:, source_reference:, candidate_references:)
+
+      expect(facts).to be_empty
+      expect(fragment_node.refresh.metadata.to_h['semantic_rule_facts']).to be_empty
+    end
+
+    it 'rejects non-array fact payloads without raising' do
+      allow(OpenaiClient).to receive(:call).and_return(
+        'facts' => accepted_fact,
+      )
+
+      facts = described_class.call(fragment_node:, source_reference:, candidate_references:)
+
+      expect(facts).to be_empty
+      expect(fragment_node.refresh.metadata.to_h['semantic_rule_facts']).to be_empty
+    end
+  end
+end

--- a/spec/services/tariff_knowledge/semantic_rule_fact_validator_spec.rb
+++ b/spec/services/tariff_knowledge/semantic_rule_fact_validator_spec.rb
@@ -1,0 +1,128 @@
+RSpec.describe TariffKnowledge::SemanticRuleFactValidator do
+  describe '.call' do
+    let(:source_text) { 'Chapter 01 includes Heading 0101 covers live horses.' }
+    let(:valid_fact) do
+      {
+        'source_reference' => 'Chapter 01 note 1',
+        'source_span' => 'Heading 0101 covers live horses.',
+        'relationship_type' => 'includes',
+        'subject' => { 'type' => 'chapter', 'code' => '01' },
+        'target' => { 'type' => 'heading', 'code' => '0101' },
+        'conditions' => ['live horses'],
+        'exceptions' => [],
+        'confidence' => 'high',
+      }
+    end
+
+    it 'keeps schema-valid facts with exact source spans' do
+      facts = described_class.call(
+        facts: [valid_fact],
+        source_text:,
+        valid_references: [
+          { 'type' => 'chapter', 'code' => '01' },
+          { 'type' => 'heading', 'code' => '0101' },
+        ],
+      )
+
+      expect(facts).to contain_exactly(
+        include(
+          'source_span' => 'Heading 0101 covers live horses.',
+          'relationship_type' => 'includes',
+          'target' => { 'type' => 'heading', 'code' => '0101' },
+        ),
+      )
+    end
+
+    it 'rejects facts that are malformed or not source backed' do
+      facts = described_class.call(
+        facts: [
+          nil,
+          'not a hash',
+          valid_fact.merge('source_span' => 'not present in source'),
+          valid_fact.merge('source_reference' => ''),
+          valid_fact.merge('relationship_type' => 'maybe'),
+          valid_fact.merge('subject' => 'not a hash'),
+          valid_fact.merge('subject' => { 'type' => 'commodity', 'code' => '9999999999' }),
+          valid_fact.merge('target' => 'not a hash'),
+          valid_fact.merge('target' => { 'type' => 'heading', 'code' => '9999' }),
+          valid_fact.merge('conditions' => 'invented condition'),
+          valid_fact.merge('conditions' => [123]),
+          valid_fact.merge('exceptions' => 'invented exception'),
+        ],
+        source_text:,
+        valid_references: [
+          'not a hash',
+          { 'type' => 'chapter', 'code' => '01' },
+          { 'type' => 'heading', 'code' => '0101' },
+        ],
+      )
+
+      expect(facts).to be_empty
+    end
+
+    it 'rejects a single malformed fact object without raising' do
+      facts = described_class.call(
+        facts: 'not a hash',
+        source_text:,
+        valid_references: [
+          { 'type' => 'chapter', 'code' => '01' },
+          { 'type' => 'heading', 'code' => '0101' },
+        ],
+      )
+
+      expect(facts).to be_empty
+    end
+
+    it 'rejects low-confidence facts from automatic context' do
+      facts = described_class.call(
+        facts: [valid_fact.merge('confidence' => 'low')],
+        source_text:,
+        valid_references: [
+          { 'type' => 'chapter', 'code' => '01' },
+          { 'type' => 'heading', 'code' => '0101' },
+        ],
+      )
+
+      expect(facts).to be_empty
+    end
+
+    it 'requires targets to be deterministic candidate targets when supplied' do
+      facts = described_class.call(
+        facts: [
+          valid_fact.merge(
+            'target' => { 'type' => 'chapter', 'code' => '01' },
+            'source_span' => 'Chapter 01 includes',
+          ),
+          valid_fact,
+        ],
+        source_text:,
+        valid_references: [
+          { 'type' => 'chapter', 'code' => '01' },
+          { 'type' => 'heading', 'code' => '0101' },
+        ],
+        target_references: [{ 'type' => 'heading', 'code' => '0101' }],
+      )
+
+      expect(facts).to contain_exactly(include('target' => { 'type' => 'heading', 'code' => '0101' }))
+    end
+
+    it 'accepts section source references as deterministic subjects' do
+      fact = valid_fact.merge(
+        'source_reference' => 'Section 1 note 1',
+        'subject' => { 'type' => 'section', 'code' => '1' },
+      )
+
+      facts = described_class.call(
+        facts: [fact],
+        source_text:,
+        valid_references: [
+          { 'type' => 'section', 'code' => '1' },
+          { 'type' => 'heading', 'code' => '0101' },
+        ],
+        target_references: [{ 'type' => 'heading', 'code' => '0101' }],
+      )
+
+      expect(facts).to contain_exactly(include('subject' => { 'type' => 'section', 'code' => '1' }))
+    end
+  end
+end

--- a/spec/services/tariff_knowledge/source_graph_loader_spec.rb
+++ b/spec/services/tariff_knowledge/source_graph_loader_spec.rb
@@ -569,6 +569,70 @@ RSpec.describe TariffKnowledge::SourceGraphLoader do
         .to be_present
     end
 
+    it 'preserves source-backed semantic facts when reloading unchanged fragments' do
+      create(
+        :customs_tariff_chapter_note,
+        :approved,
+        customs_tariff_update: update,
+        chapter_id: '01',
+        content: 'Heading 0101 covers live horses.',
+      )
+
+      described_class.call
+
+      fragment_node = TariffKnowledge::Node.by_key('note_fragment:customs_tariff_chapter_note:1.31:01:0001').first
+      semantic_rule_facts = [
+        {
+          'source_reference' => 'Chapter 01 note 1',
+          'source_span' => 'Heading 0101 covers live horses.',
+          'relationship_type' => 'includes',
+          'subject' => { 'type' => 'chapter', 'code' => '01' },
+          'target' => { 'type' => 'heading', 'code' => '0101' },
+          'conditions' => ['live horses'],
+          'exceptions' => [],
+          'confidence' => 'high',
+        },
+      ]
+      TariffKnowledge::Node
+        .where(id: fragment_node.id)
+        .update(metadata: Sequel.pg_jsonb('semantic_rule_facts' => semantic_rule_facts))
+
+      described_class.call
+
+      expect(fragment_node.refresh.metadata.to_h['semantic_rule_facts'])
+        .to eq(semantic_rule_facts)
+    end
+
+    it 'drops semantic facts with stale or blank source spans when reloading fragments' do
+      note = create(
+        :customs_tariff_chapter_note,
+        :approved,
+        customs_tariff_update: update,
+        chapter_id: '01',
+        content: 'Heading 0101 covers live horses.',
+      )
+
+      described_class.call
+
+      fragment_node = TariffKnowledge::Node.by_key('note_fragment:customs_tariff_chapter_note:1.31:01:0001').first
+      TariffKnowledge::Node
+        .where(id: fragment_node.id)
+        .update(
+          metadata: Sequel.pg_jsonb(
+            'semantic_rule_facts' => [
+              { 'source_span' => 'Heading 0101 covers live horses.' },
+              { 'source_span' => '' },
+              { 'source_span' => 'Not in source.' },
+            ],
+          ),
+        )
+      note.update(content: 'Heading 0101 covers racehorses.')
+
+      described_class.call
+
+      expect(fragment_node.refresh.metadata.to_h).not_to include('semantic_rule_facts')
+    end
+
     it 'keeps positive references when another clause in the fragment is negated' do
       create(
         :customs_tariff_chapter_note,


### PR DESCRIPTION
## What:
Adds semantic rule fact extraction for tariff knowledge note fragments, including validation, extraction orchestration, compressed-note context projection, and rake task support.

This is the ATAR-loading / hybrid extraction slice only. It does not include the ignored ATAR benchmark tooling or validation output files.

## Why:
ATAR evidence showed that mechanical extraction alone under-recognised legal references. This keeps the hybrid decision: LLM extraction proposes source-backed semantic facts, then deterministic validation checks target references and source text before facts are used in compressed-note contexts.

## Ticket:
N/A

## Risk:
**Risk level:** 🟠

**Reason for rating:**
Medium risk because this changes classification/search context generation for tariff knowledge compressed notes. It is additive to KG/compressed-note evidence but affects what context can be sent to the classifier.

## Validation / benchmark notes:
- ATAR golden set used during development: 25 available/current rulings in the cached benchmark run.
- Commodity mix included current ATARs across chapters including 16, 39, 53, 84, 94 and others; examples included lanterns (9405), machinery (8479), plastics (3920/3914), linen fabrics (5309), and prepared chicken (1602).
- Known failure examples before broader context work: missing GIR references for ATAR 600015856 and 600015690; non-GIR missing references remained in some runs.
- Subagent/review reconciliation: review feedback identified this as hybrid/directional validation, not proof of full recall. ATAR tooling/results remain local validation artifacts and are intentionally not included in this PR.

## Verification:
- `bundle exec rspec spec/services/tariff_knowledge/semantic_rule_fact_extraction_spec.rb spec/services/tariff_knowledge/semantic_rule_fact_extractor_spec.rb spec/services/tariff_knowledge/semantic_rule_fact_validator_spec.rb spec/services/tariff_knowledge/compressed_note_generator_spec.rb spec/services/tariff_knowledge/relevant_note_fragment_selector_spec.rb spec/services/tariff_knowledge/source_graph_loader_spec.rb spec/lib/tasks/tariff_knowledge_rake_spec.rb` - 74 examples, 0 failures.