### PR TITLE
AI-997: Load structured note blocks into the tariff knowledge graph

### DIFF
--- a/app/models/tariff_knowledge/node.rb
+++ b/app/models/tariff_knowledge/node.rb
@@ -7,6 +7,7 @@ module TariffKnowledge
     GOODS_NOMENCLATURE = 'goods_nomenclature'.freeze
     SECTION = 'section'.freeze
     NOTE_SOURCE = 'note_source'.freeze
+    NOTE_BLOCK = 'note_block'.freeze
     NOTE_FRAGMENT = 'note_fragment'.freeze
     RANGE = 'range'.freeze
     COMPRESSED_NOTE = 'compressed_note'.freeze
@@ -33,6 +34,10 @@ module TariffKnowledge
 
       def note_fragments
         where(node_type: NOTE_FRAGMENT)
+      end
+
+      def note_blocks
+        where(node_type: NOTE_BLOCK)
       end
     end
 

--- a/app/services/tariff_knowledge/compressed_note_generator.rb
+++ b/app/services/tariff_knowledge/compressed_note_generator.rb
@@ -10,10 +10,18 @@ module TariffKnowledge
 
     def call
       nodes = declarable_nodes
-      evidence_by_node_id = evidence_by_declarable_node_id(nodes)
+      apply_edges = apply_edges_for_declarable_nodes(nodes)
+      evidence_by_node_id = evidence_by_declarable_node_id(nodes, apply_edges)
+      block_evidence_by_node_id = block_evidence_by_declarable_node_id(nodes, apply_edges)
+      contained_fragment_key_lookup = contained_fragment_keys_by_block_node_id(block_evidence_by_node_id.values.flatten)
 
       nodes.filter_map do |declarable_node|
-        generate_for(declarable_node, evidence_by_node_id.fetch(declarable_node.id, []))
+        generate_for(
+          declarable_node,
+          evidence_by_node_id.fetch(declarable_node.id, []),
+          block_evidence_by_node_id.fetch(declarable_node.id, []),
+          contained_fragment_key_lookup,
+        )
       end
     end
 
@@ -27,16 +35,16 @@ module TariffKnowledge
           .all
     end
 
-    def generate_for(declarable_node, evidence)
-      return mark_existing_note_stale(declarable_node) if evidence.empty?
+    def generate_for(declarable_node, evidence, block_evidence, contained_fragment_keys_by_block_node_id)
+      return mark_existing_note_stale(declarable_node) if evidence.empty? && block_evidence.empty?
 
-      content = content_for(declarable_node, evidence)
+      content = evidence.any? ? content_for(declarable_node, evidence) : block_content_for(block_evidence)
       attributes = {
         goods_nomenclature_item_id: declarable_node.goods_nomenclature_item_id,
         producline_suffix: declarable_node.producline_suffix,
         goods_nomenclature_type: declarable_node.goods_nomenclature_type,
         content:,
-        metadata: Sequel.pg_jsonb(metadata_for(evidence)),
+        metadata: Sequel.pg_jsonb(metadata_for(evidence, block_evidence, contained_fragment_keys_by_block_node_id)),
         context_hash: Digest::SHA256.hexdigest(content),
         generated_at: Time.zone.now,
         # Pipeline generation resets lifecycle flags. Reviewers can later mark
@@ -51,7 +59,14 @@ module TariffKnowledge
       upsert_note(declarable_node, attributes)
     end
 
-    def evidence_by_declarable_node_id(declarable_nodes)
+    def apply_edges_for_declarable_nodes(declarable_nodes)
+      declarable_node_ids = declarable_nodes.map(&:id)
+      return [] if declarable_node_ids.empty?
+
+      Edge.by_relationship(Edge::APPLIES_TO).where(target_node_id: declarable_node_ids).all
+    end
+
+    def evidence_by_declarable_node_id(declarable_nodes, apply_edges)
       declarable_node_ids = declarable_nodes.map(&:id)
       return {} if declarable_node_ids.empty?
 
@@ -65,7 +80,6 @@ module TariffKnowledge
       expansion_edges = Edge.by_relationship(Edge::EXPANDS_TO).where(target_node_id: declarable_node_ids).all
       range_nodes = nodes_by_id(expansion_edges.map(&:source_node_id), Node.where(node_type: Node::RANGE))
       reference_edges = Edge.by_relationship(Edge::REFERENCES).where(target_node_id: range_nodes.keys).all
-      apply_edges = Edge.by_relationship(Edge::APPLIES_TO).where(target_node_id: declarable_node_ids).all
       fragment_nodes = current_fragment_nodes((reference_edges + apply_edges).map(&:source_node_id))
       expansion_edges_by_target_id = expansion_edges.group_by(&:target_node_id)
       reference_edges_by_range_id = reference_edges.group_by(&:target_node_id)
@@ -100,6 +114,24 @@ module TariffKnowledge
       end
     end
 
+    def block_evidence_by_declarable_node_id(declarable_nodes, apply_edges)
+      declarable_node_ids = declarable_nodes.map(&:id)
+      return {} if declarable_node_ids.empty?
+
+      block_nodes = current_block_nodes(apply_edges.map(&:source_node_id))
+      apply_edges_by_target_id = apply_edges.group_by(&:target_node_id)
+
+      declarable_nodes.each_with_object({}) do |declarable_node, grouped|
+        block_evidence = apply_edges_by_target_id
+          .fetch(declarable_node.id, [])
+          .filter_map { |edge| block_nodes[edge.source_node_id] }
+          .uniq(&:id)
+          .sort_by { |block_node| [block_node.source_type.to_s, block_node.source_id.to_s, block_node.key.to_s] }
+
+        grouped[declarable_node.id] = block_evidence if block_evidence.any?
+      end
+    end
+
     def nodes_by_id(ids, dataset)
       ids = ids.compact.uniq
       ids.empty? ? {} : dataset.where(id: ids).all.index_by(&:id)
@@ -107,6 +139,12 @@ module TariffKnowledge
 
     def current_fragment_nodes(ids)
       dataset = Node.note_fragments
+      dataset = dataset.where(source_version: current_source_version) if current_source_version.present?
+      nodes_by_id(ids, dataset)
+    end
+
+    def current_block_nodes(ids)
+      dataset = Node.note_blocks
       dataset = dataset.where(source_version: current_source_version) if current_source_version.present?
       nodes_by_id(ids, dataset)
     end
@@ -152,6 +190,12 @@ module TariffKnowledge
       content.compact.join("\n\n")
     end
 
+    def block_content_for(block_evidence)
+      block_evidence.map { |block_node| "#{block_node.title}\n#{block_node.content}" }
+                    .uniq
+                    .join("\n\n")
+    end
+
     def general_rule_fragment?(fragment_node)
       fragment_node.source_type == 'customs_tariff_general_rule' ||
         fragment_node.key.include?(':customs_tariff_general_rule:')
@@ -163,11 +207,12 @@ module TariffKnowledge
         'The full rule fragments are retained in this note provenance.'
     end
 
-    def metadata_for(evidence)
+    def metadata_for(evidence, block_evidence, contained_fragment_keys_by_block_node_id)
       {
         'source_node_keys' => evidence.map { |fragment_node, _range_node, _source_node| fragment_node.key }.uniq,
         'range_node_keys' => evidence.filter_map { |_fragment_node, range_node, _source_node| range_node&.key }.uniq,
         'evidence' => evidence.map { |fragment_node, range_node, source_node| evidence_metadata(fragment_node, range_node, source_node) },
+        'evidence_blocks' => block_evidence.map { |block_node| block_evidence_metadata(block_node, contained_fragment_keys_by_block_node_id) },
       }
     end
 
@@ -191,6 +236,43 @@ module TariffKnowledge
         'range_title' => range_node&.title,
         'relationships' => relationships_for(range_node),
       }
+    end
+
+    def block_evidence_metadata(block_node, contained_fragment_keys_by_block_node_id)
+      block_metadata = block_node.metadata.to_h
+
+      {
+        'source_node_key' => block_node.key,
+        'source_type' => block_node.source_type.to_s.underscore,
+        'source_id' => block_node.source_id,
+        'source_version' => block_node.source_version,
+        'source_title' => block_node.title,
+        'source_context' => block_node.content.to_s.squish,
+        'block_type' => block_metadata['block_type'],
+        'term' => block_metadata['term'],
+        'path' => block_metadata['path'],
+        'fragment_node_keys' => contained_fragment_keys_by_block_node_id.fetch(block_node.id, []),
+      }
+    end
+
+    def contained_fragment_keys_by_block_node_id(block_nodes)
+      block_node_ids = block_nodes.map(&:id).uniq
+      return {} if block_node_ids.empty?
+
+      contains_edges = Edge.by_relationship(Edge::CONTAINS).where(source_node_id: block_node_ids).all
+      fragment_nodes = current_fragment_nodes(contains_edges.map(&:target_node_id))
+
+      contains_edges.each_with_object({}) { |edge, grouped|
+        fragment_node = fragment_nodes[edge.target_node_id]
+        next unless fragment_node
+
+        grouped[edge.source_node_id] ||= []
+        grouped[edge.source_node_id] << fragment_node
+      }.transform_values do |fragment_nodes_for_block|
+        fragment_nodes_for_block
+          .sort_by { |fragment_node| [fragment_sequence(fragment_node), fragment_node.key.to_s, fragment_node.id] }
+          .map(&:key)
+      end
     end
 
     def relationships_for(range_node) = range_node ? [Edge::REFERENCES, Edge::EXPANDS_TO, Edge::APPLIES_TO] : [Edge::APPLIES_TO]

--- a/app/services/tariff_knowledge/compressed_note_generator.rb
+++ b/app/services/tariff_knowledge/compressed_note_generator.rb
@@ -115,17 +115,35 @@ module TariffKnowledge
     end
 
     def block_evidence_by_declarable_node_id(declarable_nodes, apply_edges)
-      declarable_node_ids = declarable_nodes.map(&:id)
-      return {} if declarable_node_ids.empty?
+      return {} if declarable_nodes.empty?
 
-      block_nodes = current_block_nodes(apply_edges.map(&:source_node_id))
+      # Blocks are not given full-chapter APPLIES_TO edges. Resolve them through
+      # contained fragments that already apply (or expand) to the declarable:
+      #   declarable <- APPLIES_TO/range <- fragment <- CONTAINS <- block
       apply_edges_by_target_id = apply_edges.group_by(&:target_node_id)
+      fragment_nodes = current_fragment_nodes(apply_edges.map(&:source_node_id))
+      return {} if fragment_nodes.empty?
+
+      contains_edges = Edge.by_relationship(Edge::CONTAINS).where(target_node_id: fragment_nodes.keys).all
+      block_nodes = current_block_nodes(contains_edges.map(&:source_node_id))
+      return {} if block_nodes.empty?
+
+      block_ids_by_fragment_id = contains_edges.each_with_object(Hash.new { |h, k| h[k] = [] }) do |edge, grouped|
+        next unless block_nodes[edge.source_node_id]
+
+        grouped[edge.target_node_id] << edge.source_node_id
+      end
 
       declarable_nodes.each_with_object({}) do |declarable_node, grouped|
-        block_evidence = apply_edges_by_target_id
+        applicable_fragment_ids = apply_edges_by_target_id
           .fetch(declarable_node.id, [])
-          .filter_map { |edge| block_nodes[edge.source_node_id] }
-          .uniq(&:id)
+          .map(&:source_node_id)
+          .select { |source_node_id| fragment_nodes[source_node_id] }
+
+        block_evidence = applicable_fragment_ids
+          .flat_map { |fragment_id| block_ids_by_fragment_id.fetch(fragment_id, []) }
+          .uniq
+          .filter_map { |block_id| block_nodes[block_id] }
           .sort_by { |block_node| [block_node.source_type.to_s, block_node.source_id.to_s, block_node.key.to_s] }
 
         grouped[declarable_node.id] = block_evidence if block_evidence.any?
@@ -165,10 +183,16 @@ module TariffKnowledge
       fragment_node_ids = fragment_nodes.map(&:id).uniq
       return {} if fragment_node_ids.empty?
 
+      # Fragments may also be CONTAINED by note blocks. Only NOTE_SOURCE parents
+      # are provenance for evidence metadata; block membership must not overwrite
+      # (or nil out) that parent when multi-parent CONTAINS edges exist.
       contains_edges = Edge.by_relationship(Edge::CONTAINS).where(target_node_id: fragment_node_ids).all
       source_nodes = nodes_by_id(contains_edges.map(&:source_node_id), Node.where(node_type: Node::NOTE_SOURCE))
       contains_edges.each_with_object({}) do |edge, grouped|
-        grouped[edge.target_node_id] = source_nodes[edge.source_node_id]
+        source_node = source_nodes[edge.source_node_id]
+        next unless source_node
+
+        grouped[edge.target_node_id] = source_node
       end
     end
 

--- a/app/services/tariff_knowledge/note_block_parser.rb
+++ b/app/services/tariff_knowledge/note_block_parser.rb
@@ -5,6 +5,7 @@ module TariffKnowledge
     DEFINITION_MARKER = /\A(?<marker>[a-z]|ij)\.\s+(?<term>[[:alpha:]][[:alnum:][:space:]-]+)\z/i
     ROOT_MARKER = /\A(?<marker>\d+)\.\s+/
     BULLET_MARKER = /\A[-–—]\s+/
+    HEADING_MARKER = /\A#+\s+(?<title>.+)\z/
 
     def self.call(...) = new(...).call
 
@@ -19,11 +20,20 @@ module TariffKnowledge
       blocks = []
       current_root = nil
       current_definition = nil
+      current_section_slug = nil
 
       fragments.each do |fragment|
         text = fragment.content.to_s.squish
+        heading_match = text.match(HEADING_MARKER)
         root_match = text.match(ROOT_MARKER)
         definition_match = text.match(DEFINITION_MARKER)
+
+        if heading_match
+          current_section_slug = heading_match[:title].parameterize(separator: '_')
+          current_root = nil
+          current_definition = nil
+          next
+        end
 
         if root_match
           current_root = root_match[:marker]
@@ -31,7 +41,7 @@ module TariffKnowledge
         end
 
         if definition_match && current_root
-          current_definition = new_definition_block(current_root, definition_match, fragment)
+          current_definition = new_definition_block(current_section_slug, current_root, definition_match, fragment)
           blocks << current_definition
           next
         end
@@ -46,19 +56,23 @@ module TariffKnowledge
 
     attr_reader :source_type, :source_id, :source_version, :fragments
 
-    def new_definition_block(root_marker, definition_match, fragment)
+    def new_definition_block(section_slug, root_marker, definition_match, fragment)
       term = definition_match[:term].squish
       marker = definition_match[:marker].downcase
+      path = [section_slug, root_marker, marker].compact
+      metadata = {
+        'path' => path,
+        'marker' => marker,
+        'block_type' => 'definition',
+        'term' => term.downcase,
+      }
+      metadata['section'] = section_slug if section_slug
+
       Block.new(
-        key: "note_block:#{source_type}:#{source_version}:#{source_id}:#{root_marker}:#{marker}",
+        key: "note_block:#{source_type}:#{source_version}:#{source_id}:#{path.join(':')}",
         title: term,
         content: fragment.content.to_s.squish,
-        metadata: {
-          'path' => [root_marker, marker],
-          'marker' => marker,
-          'block_type' => 'definition',
-          'term' => term.downcase,
-        },
+        metadata:,
         fragment_keys: [fragment.key],
       )
     end

--- a/app/services/tariff_knowledge/note_block_parser.rb
+++ b/app/services/tariff_knowledge/note_block_parser.rb
@@ -2,92 +2,76 @@ module TariffKnowledge
   class NoteBlockParser
     Block = Data.define(:key, :title, :content, :metadata, :fragment_keys)
 
-    DEFINITION_MARKER = /\A(?<marker>[a-z]|ij)\.\s+(?<term>[[:alpha:]][[:alnum:][:space:]-]+)\z/i
-    ROOT_MARKER = /\A(?<marker>\d+)\.\s+/
-    BULLET_MARKER = /\A[-–—]\s+/
-    HEADING_MARKER = /\A#+\s+(?<title>.+)\z/
-
     def self.call(...) = new(...).call
 
-    def initialize(source_type:, source_id:, source_version:, fragments:)
+    def initialize(source_type:, source_id:, source_version:, fragments:, structure_parser: NoteStructureParser)
       @source_type = source_type
       @source_id = source_id.to_s
       @source_version = source_version.to_s
       @fragments = fragments
+      @structure_parser = structure_parser
     end
 
     def call
-      blocks = []
-      current_root = nil
-      current_definition = nil
-      current_section_slug = nil
+      tree = structure_parser.call(
+        source_type:,
+        source_id:,
+        source_version:,
+        fragments:,
+      )
 
-      fragments.each do |fragment|
-        text = fragment.content.to_s.squish
-        heading_match = text.match(HEADING_MARKER)
-        root_match = text.match(ROOT_MARKER)
-        definition_match = text.match(DEFINITION_MARKER)
-
-        if heading_match
-          current_section_slug = heading_match[:title].parameterize(separator: '_')
-          current_root = nil
-          current_definition = nil
-          next
-        end
-
-        if root_match
-          current_root = root_match[:marker]
-          current_definition = nil
-        end
-
-        if definition_match && current_root
-          current_definition = new_definition_block(current_section_slug, current_root, definition_match, fragment)
-          blocks << current_definition
-          next
-        end
-
-        append_to_definition(current_definition, fragment) if current_definition && belongs_to_definition?(text)
-      end
-
-      blocks
+      flatten_nodes(tree.nodes).filter_map { |node| block_for(node) }
     end
 
   private
 
-    attr_reader :source_type, :source_id, :source_version, :fragments
+    attr_reader :source_type, :source_id, :source_version, :fragments, :structure_parser
 
-    def new_definition_block(section_slug, root_marker, definition_match, fragment)
-      term = definition_match[:term].squish
-      marker = definition_match[:marker].downcase
-      path = [section_slug, root_marker, marker].compact
+    def flatten_nodes(nodes)
+      nodes.flat_map { |node| [node, *flatten_nodes(node.children)] }
+    end
+
+    def block_for(node)
+      path = node.path.map(&:to_s)
+      return unless definition_path?(path)
+
+      marker = node.marker.to_s
+      term = node.title.to_s.squish
+      return if term.blank?
+
+      fragment_keys = descendant_fragment_keys(node)
       metadata = {
         'path' => path,
         'marker' => marker,
         'block_type' => 'definition',
         'term' => term.downcase,
+        'marker_kind' => node.kind.to_s,
       }
-      metadata['section'] = section_slug if section_slug
+      metadata['section'] = section_slug(path) if section_slug(path)
 
       Block.new(
         key: "note_block:#{source_type}:#{source_version}:#{source_id}:#{path.join(':')}",
         title: term,
-        content: fragment.content.to_s.squish,
+        content: descendant_content(node),
         metadata:,
-        fragment_keys: [fragment.key],
+        fragment_keys:,
       )
     end
 
-    def belongs_to_definition?(text)
-      return true if text.match?(BULLET_MARKER)
-      return false if text.match?(DEFINITION_MARKER)
-      return false if text.match?(ROOT_MARKER)
-
-      true
+    def section_slug(path)
+      path.first unless path.first.to_s.match?(/\A\d+\z/)
     end
 
-    def append_to_definition(block, fragment)
-      block.content << " #{fragment.content.to_s.squish}"
-      block.fragment_keys << fragment.key
+    def definition_path?(path)
+      path.any? { |segment| segment.match?(/\A\d+\z/) }
+    end
+
+    def descendant_content(node)
+      [node.content, *node.children.map { |child| descendant_content(child) }].join(' ').squish
+    end
+
+    def descendant_fragment_keys(node)
+      [node.fragment_keys, *node.children.map { |child| descendant_fragment_keys(child) }].flatten
     end
   end
 end

--- a/app/services/tariff_knowledge/note_block_parser.rb
+++ b/app/services/tariff_knowledge/note_block_parser.rb
@@ -20,7 +20,7 @@ module TariffKnowledge
         fragments:,
       )
 
-      flatten_nodes(tree.nodes).filter_map { |node| block_for(node) }
+      uniquify_duplicate_paths(flatten_nodes(tree.nodes).filter_map { |node| block_for(node) })
     end
 
   private
@@ -32,6 +32,8 @@ module TariffKnowledge
     end
 
     def block_for(node)
+      return unless %i[alpha roman].include?(node.kind)
+
       path = node.path.map(&:to_s)
       return unless definition_path?(path)
 
@@ -60,6 +62,31 @@ module TariffKnowledge
 
     def section_slug(path)
       path.first unless path.first.to_s.match?(/\A\d+\z/)
+    end
+
+    def uniquify_duplicate_paths(blocks)
+      key_counts = Hash.new(0)
+
+      blocks.map do |block|
+        key_counts[block.key] += 1
+        next block if key_counts[block.key] == 1
+
+        with_path_scope(block, "repeat_#{key_counts[block.key]}")
+      end
+    end
+
+    def with_path_scope(block, scope)
+      path = block.metadata.fetch('path')
+      scoped_path = [*path[0...-1], scope, path.last]
+      metadata = block.metadata.merge('path' => scoped_path)
+
+      Block.new(
+        key: "note_block:#{source_type}:#{source_version}:#{source_id}:#{scoped_path.join(':')}",
+        title: block.title,
+        content: block.content,
+        metadata:,
+        fragment_keys: block.fragment_keys,
+      )
     end
 
     def definition_path?(path)

--- a/app/services/tariff_knowledge/note_block_parser.rb
+++ b/app/services/tariff_knowledge/note_block_parser.rb
@@ -1,0 +1,79 @@
+module TariffKnowledge
+  class NoteBlockParser
+    Block = Data.define(:key, :title, :content, :metadata, :fragment_keys)
+
+    DEFINITION_MARKER = /\A(?<marker>[a-z]|ij)\.\s+(?<term>[[:alpha:]][[:alnum:][:space:]-]+)\z/i
+    ROOT_MARKER = /\A(?<marker>\d+)\.\s+/
+    BULLET_MARKER = /\A[-–—]\s+/
+
+    def self.call(...) = new(...).call
+
+    def initialize(source_type:, source_id:, source_version:, fragments:)
+      @source_type = source_type
+      @source_id = source_id.to_s
+      @source_version = source_version.to_s
+      @fragments = fragments
+    end
+
+    def call
+      blocks = []
+      current_root = nil
+      current_definition = nil
+
+      fragments.each do |fragment|
+        text = fragment.content.to_s.squish
+        root_match = text.match(ROOT_MARKER)
+        definition_match = text.match(DEFINITION_MARKER)
+
+        if root_match
+          current_root = root_match[:marker]
+          current_definition = nil
+        end
+
+        if definition_match && current_root
+          current_definition = new_definition_block(current_root, definition_match, fragment)
+          blocks << current_definition
+          next
+        end
+
+        append_to_definition(current_definition, fragment) if current_definition && belongs_to_definition?(text)
+      end
+
+      blocks
+    end
+
+  private
+
+    attr_reader :source_type, :source_id, :source_version, :fragments
+
+    def new_definition_block(root_marker, definition_match, fragment)
+      term = definition_match[:term].squish
+      marker = definition_match[:marker].downcase
+      Block.new(
+        key: "note_block:#{source_type}:#{source_version}:#{source_id}:#{root_marker}:#{marker}",
+        title: term,
+        content: fragment.content.to_s.squish,
+        metadata: {
+          'path' => [root_marker, marker],
+          'marker' => marker,
+          'block_type' => 'definition',
+          'term' => term.downcase,
+        },
+        fragment_keys: [fragment.key],
+      )
+    end
+
+    def belongs_to_definition?(text)
+      return true if text.match?(BULLET_MARKER)
+      return false if text.match?(DEFINITION_MARKER)
+      return false if text.match?(ROOT_MARKER)
+
+      true
+    end
+
+    def append_to_definition(block, fragment)
+      block.content << " #{fragment.content.to_s.squish}"
+      block.fragment_keys << fragment.key
+    end
+  end
+end

--- a/app/services/tariff_knowledge/note_fragment_splitter.rb
+++ b/app/services/tariff_knowledge/note_fragment_splitter.rb
@@ -1,0 +1,74 @@
+module TariffKnowledge
+  class NoteFragmentSplitter
+    LIST_MARKER_PATTERN = /\A(?:ij|\(?[a-z]\)?|[ivx]+|\d+)\.\z/i
+    TRAILING_LIST_MARKER_PATTERN = /\A(.+?)\s+((?:ij|\(?[a-z]\)?|[ivx]+|\d+)\.)\z/im
+
+    def self.call(...) = new(...).call
+
+    def initialize(content)
+      @content = content
+    end
+
+    def call
+      content
+        .to_s
+        .split(/\n{2,}|(?<=[.!?])\s+/)
+        .map(&:strip)
+        .reject(&:blank?)
+        .then { |split_fragments| merge_orphaned_list_markers(split_fragments) }
+        .then { |split_fragments| merge_dangling_numeric_references(split_fragments) }
+    end
+
+  private
+
+    attr_reader :content
+
+    def merge_orphaned_list_markers(split_fragments)
+      split_fragments.each_with_object([]) do |fragment, merged|
+        fragment = "#{merged.pop} #{fragment}" if list_marker_sequence?(merged.last)
+        match = fragment.match(TRAILING_LIST_MARKER_PATTERN)
+        text, marker = match&.captures
+
+        if match && !list_marker_sequence?(text.strip)
+          merged.push(text.strip, marker)
+        else
+          merged << (match ? "#{text.strip} #{marker}" : fragment)
+        end
+      end
+    end
+
+    def list_marker_sequence?(fragment)
+      fragment.present? && fragment.split.all? { |part| part.match?(LIST_MARKER_PATTERN) }
+    end
+
+    def merge_dangling_numeric_references(split_fragments)
+      split_fragments.each_with_object([]) do |fragment, merged|
+        if merged.last && dangling_numeric_reference?(merged.last, fragment)
+          attach_reference_fragment(fragment, merged)
+        else
+          merged << fragment
+        end
+      end
+    end
+
+    def dangling_numeric_reference?(previous_fragment, fragment)
+      numeric_reference_context?(previous_fragment, fragment) ||
+        (fragment.match?(/\AC\.(?:\s+.+)?\z/i) && previous_fragment.match?(/\d\z/))
+    end
+
+    def attach_reference_fragment(fragment, merged)
+      reference, remaining_fragment = fragment.match(/\A((?:\d{1,4}|C)\.)\s*(.*)\z/i).captures
+      merged[-1] = "#{merged.last} #{reference}"
+      merged << remaining_fragment.strip if remaining_fragment.present?
+    end
+
+    def numeric_reference_context?(previous_fragment, fragment)
+      fragment.match?(/\A\d{1,4}\.(?:\s+.+)?\z/) &&
+        (
+          previous_fragment.match?(/\b(?:heading|headings|chapter|chapters|rule|rules|and|or|to)\z/i) ||
+            previous_fragment.match?(/\d\z/) ||
+            fragment.match?(/\A(?:19|20)\d{2}\.(?:\s+.+)?\z/)
+        )
+    end
+  end
+end

--- a/app/services/tariff_knowledge/note_marker_classifier.rb
+++ b/app/services/tariff_knowledge/note_marker_classifier.rb
@@ -3,6 +3,8 @@ module TariffKnowledge
     Event = Data.define(:fragment, :kind, :marker, :depth, :path_segment, :title, :body, :raw_text)
 
     HEADING_MARKER = /\A#+\s+(?<title>.+)\z/
+    BULLET_ALPHA_SECTION = /\A\((?<marker>[A-Z])\)\.?\s+(?<body>.+)\z/
+    ALPHA_SECTION_MARKER = /\A\((?<marker>[A-Z])\)\.\z/
 
     def self.call(...) = new(...).call
 
@@ -18,12 +20,21 @@ module TariffKnowledge
       return heading_event(heading_match[:title].squish, text) if heading_match
 
       token, body = text.split(/\s+/, 2)
+      alpha_section_match = token.to_s.match(ALPHA_SECTION_MARKER)
+
+      return alpha_section_event(alpha_section_match[:marker], body.to_s.squish, text) if alpha_section_match
+
       marker_match = trie.match(token)
 
       return continuation_event(text) unless marker_match
       return continuation_event(text) unless valid_marker_boundary?(token, marker_match)
 
-      marker_event(marker_match, marker_body(token, marker_match, body), text)
+      marker_body = marker_body(token, marker_match, body)
+      embedded_section = embedded_bullet_alpha_section(marker_match, marker_body)
+
+      return alpha_section_event(embedded_section[:marker], embedded_section[:body], text) if embedded_section
+
+      marker_event(marker_match, marker_body, text)
     end
 
   private
@@ -46,16 +57,31 @@ module TariffKnowledge
     end
 
     def marker_event(marker_match, body, raw_text)
-      title, event_body = title_and_body(marker_match, body)
+      kind = marker_kind(marker_match)
+      marker = marker(marker_match)
+      title, event_body = title_and_body(kind, marker_match, body)
 
       Event.new(
         fragment:,
-        kind: marker_match.kind,
-        marker: marker_match.marker,
+        kind:,
+        marker:,
         depth: marker_match.depth,
-        path_segment: marker_match.marker,
+        path_segment: marker,
         title:,
         body: event_body,
+        raw_text:,
+      )
+    end
+
+    def alpha_section_event(marker, body, raw_text)
+      Event.new(
+        fragment:,
+        kind: :alpha_section,
+        marker:,
+        depth: 2,
+        path_segment: marker,
+        title: body.presence,
+        body: '',
         raw_text:,
       )
     end
@@ -73,11 +99,11 @@ module TariffKnowledge
       )
     end
 
-    def title_and_body(marker_match, body)
-      case marker_match.kind
+    def title_and_body(kind, marker_match, body)
+      case kind
       when :numeric
         [marker_match.marker, body]
-      when :alpha
+      when :alpha, :alpha_section
         [body.presence, '']
       else
         [nil, body]
@@ -88,6 +114,32 @@ module TariffKnowledge
       suffix = token[marker_match.length..]
 
       [suffix, body].compact_blank.join(' ').squish
+    end
+
+    def marker_kind(marker_match)
+      return :alpha_section if uppercase_alpha_marker?(marker_match)
+
+      marker_match.kind
+    end
+
+    def marker(marker_match)
+      return marker_match.marker.upcase if uppercase_alpha_marker?(marker_match)
+
+      marker_match.marker
+    end
+
+    def uppercase_alpha_marker?(marker_match)
+      marker_match.kind == :alpha && marker_text(marker_match).match?(/[A-Z]/)
+    end
+
+    def marker_text(marker_match)
+      fragment.content.to_s.squish.first(marker_match.length)
+    end
+
+    def embedded_bullet_alpha_section(marker_match, body)
+      return unless marker_match.kind == :bullet
+
+      body.match(BULLET_ALPHA_SECTION)
     end
 
     def valid_marker_boundary?(token, marker_match)

--- a/app/services/tariff_knowledge/note_marker_classifier.rb
+++ b/app/services/tariff_knowledge/note_marker_classifier.rb
@@ -1,0 +1,102 @@
+module TariffKnowledge
+  class NoteMarkerClassifier
+    Event = Data.define(:fragment, :kind, :marker, :depth, :path_segment, :title, :body, :raw_text)
+
+    HEADING_MARKER = /\A#+\s+(?<title>.+)\z/
+
+    def self.call(...) = new(...).call
+
+    def initialize(fragment, trie: NoteMarkerTrie.default)
+      @fragment = fragment
+      @trie = trie
+    end
+
+    def call
+      text = fragment.content.to_s.squish
+      heading_match = text.match(HEADING_MARKER)
+
+      return heading_event(heading_match[:title].squish, text) if heading_match
+
+      token, body = text.split(/\s+/, 2)
+      marker_match = trie.match(token)
+
+      return continuation_event(text) unless marker_match
+      return continuation_event(text) unless valid_marker_boundary?(token, marker_match)
+
+      marker_event(marker_match, marker_body(token, marker_match, body), text)
+    end
+
+  private
+
+    attr_reader :fragment, :trie
+
+    def heading_event(title, raw_text)
+      path_segment = title.parameterize(separator: '_')
+
+      Event.new(
+        fragment:,
+        kind: :heading,
+        marker: path_segment,
+        depth: 0,
+        path_segment:,
+        title:,
+        body: '',
+        raw_text:,
+      )
+    end
+
+    def marker_event(marker_match, body, raw_text)
+      title, event_body = title_and_body(marker_match, body)
+
+      Event.new(
+        fragment:,
+        kind: marker_match.kind,
+        marker: marker_match.marker,
+        depth: marker_match.depth,
+        path_segment: marker_match.marker,
+        title:,
+        body: event_body,
+        raw_text:,
+      )
+    end
+
+    def continuation_event(raw_text)
+      Event.new(
+        fragment:,
+        kind: :continuation,
+        marker: nil,
+        depth: nil,
+        path_segment: nil,
+        title: nil,
+        body: raw_text,
+        raw_text:,
+      )
+    end
+
+    def title_and_body(marker_match, body)
+      case marker_match.kind
+      when :numeric
+        [marker_match.marker, body]
+      when :alpha
+        [body.presence, '']
+      else
+        [nil, body]
+      end
+    end
+
+    def marker_body(token, marker_match, body)
+      suffix = token[marker_match.length..]
+
+      [suffix, body].compact_blank.join(' ').squish
+    end
+
+    def valid_marker_boundary?(token, marker_match)
+      suffix = token[marker_match.length..].to_s
+
+      # Exact marker tokens are always valid. Compact prefixes are deliberately
+      # narrow: only numeric markers may absorb an alphabetic suffix such as
+      # "1.foo"; decimals and abbreviation-like alpha/roman prefixes stay prose.
+      suffix.blank? || marker_match.kind == :numeric && suffix.match?(/\A[[:alpha:]]/)
+    end
+  end
+end

--- a/app/services/tariff_knowledge/note_marker_trie.rb
+++ b/app/services/tariff_knowledge/note_marker_trie.rb
@@ -1,0 +1,82 @@
+module TariffKnowledge
+  class NoteMarkerTrie
+    Match = Data.define(:kind, :marker, :depth, :token, :length)
+
+    ROMAN_MARKERS = %w[i ii iii iv v vi vii viii ix x xi xii].freeze
+    DOTTED_ALPHA_MARKERS = ('a'..'z').map { |letter| "#{letter}." }.freeze
+    ALPHA_MARKERS = (
+      DOTTED_ALPHA_MARKERS +
+      ((('a'..'z').to_a - %w[i v x]) + %w[ij]).flat_map { |letter| ["(#{letter})", "#{letter})"] } +
+      %w[ij.]
+    ).freeze
+    ROMAN_MARKER_TOKENS = (
+      (ROMAN_MARKERS - %w[i v x]).flat_map { |roman| ["#{roman}.", "(#{roman})", "#{roman})"] } +
+      %w[i v x].flat_map { |roman| ["(#{roman})", "#{roman})"] }
+    ).freeze
+
+    DEFAULT_MARKERS = {
+      numeric: { depth: 1, tokens: (1..99).map { |number| "#{number}." } },
+      roman: { depth: 3, tokens: ROMAN_MARKER_TOKENS },
+      alpha: { depth: 2, tokens: ALPHA_MARKERS },
+      bullet: { depth: 4, tokens: ['-', '–', '—'] },
+    }.freeze
+
+    def self.default = @default ||= new(DEFAULT_MARKERS)
+
+    def initialize(marker_families)
+      @root = {}
+
+      marker_families.each do |kind, definition|
+        definition.fetch(:tokens).each do |token|
+          register(token, kind, definition.fetch(:depth))
+        end
+      end
+    end
+
+    def match(token)
+      node = root
+      best_match = nil
+      normalized_token = token.to_s.strip.downcase
+
+      normalized_token.each_char do |character|
+        node = node[character]
+        break unless node
+
+        best_match = node[:match] if node[:match]
+      end
+
+      best_match
+    end
+
+  private
+
+    attr_reader :root
+
+    def register(token, kind, depth)
+      node = root
+      normalized_token = token.downcase
+
+      normalized_token.each_char do |character|
+        node[character] ||= {}
+        node = node[character]
+      end
+
+      node[:match] = Match.new(
+        kind:,
+        marker: normalize_marker(token),
+        depth:,
+        token:,
+        length: token.length,
+      )
+    end
+
+    def normalize_marker(token)
+      marker = token.downcase
+
+      return marker if DEFAULT_MARKERS.fetch(:bullet).fetch(:tokens).include?(marker)
+
+      marker = marker.delete_prefix('(').delete_suffix(')') if marker.start_with?('(') && marker.end_with?(')')
+      marker.delete_suffix('.').delete_suffix(')')
+    end
+  end
+end

--- a/app/services/tariff_knowledge/note_marker_trie.rb
+++ b/app/services/tariff_knowledge/note_marker_trie.rb
@@ -75,8 +75,7 @@ module TariffKnowledge
 
       return marker if DEFAULT_MARKERS.fetch(:bullet).fetch(:tokens).include?(marker)
 
-      marker = marker.delete_prefix('(').delete_suffix(')') if marker.start_with?('(') && marker.end_with?(')')
-      marker.delete_suffix('.').delete_suffix(')')
+      marker.delete_prefix('(').delete_suffix('.').delete_suffix(')').delete_suffix(')')
     end
   end
 end

--- a/app/services/tariff_knowledge/note_structure_parser.rb
+++ b/app/services/tariff_knowledge/note_structure_parser.rb
@@ -3,7 +3,7 @@ module TariffKnowledge
     Tree = Data.define(:nodes, :events, :orphans)
     Node = Data.define(:kind, :marker, :path, :title, :content, :fragment_keys, :children)
 
-    BLOCK_CANDIDATE_KINDS = %i[alpha roman].freeze
+    BLOCK_CANDIDATE_KINDS = %i[alpha_section alpha roman].freeze
 
     def self.call(...) = new(...).call
 
@@ -55,11 +55,12 @@ module TariffKnowledge
     end
 
     def add_block_candidate(event)
-      reset_at_depth(event.depth)
-      path_segments[event.depth] = event.path_segment
+      depth = block_depth(event)
+      reset_at_depth(depth)
+      path_segments[depth] = event.path_segment
 
       block = MutableNode.new(event, path)
-      parent = nearest_active_block(event.depth - 1)
+      parent = nearest_active_block(depth - 1)
 
       if parent
         parent.children.push(block)
@@ -67,7 +68,7 @@ module TariffKnowledge
         root_nodes << block
       end
 
-      active_blocks[event.depth] = block
+      active_blocks[depth] = block
     end
 
     def append_to_active_block(event)
@@ -99,6 +100,17 @@ module TariffKnowledge
         .select { |depth, _| max_depth.nil? || depth <= max_depth }
         .max_by { |depth, _| depth }
         &.last
+    end
+
+    def block_depth(event)
+      case event.kind
+      when :alpha
+        active_blocks[event.depth]&.kind == :alpha_section ? event.depth + 1 : event.depth
+      when :roman
+        active_blocks[event.depth]&.kind == :alpha ? event.depth + 1 : event.depth
+      else
+        event.depth
+      end
     end
 
     class MutableNode

--- a/app/services/tariff_knowledge/note_structure_parser.rb
+++ b/app/services/tariff_knowledge/note_structure_parser.rb
@@ -1,0 +1,139 @@
+module TariffKnowledge
+  class NoteStructureParser
+    Tree = Data.define(:nodes, :events, :orphans)
+    Node = Data.define(:kind, :marker, :path, :title, :content, :fragment_keys, :children)
+
+    BLOCK_CANDIDATE_KINDS = %i[alpha roman].freeze
+
+    def self.call(...) = new(...).call
+
+    def initialize(source_type:, source_id:, source_version:, fragments:, classifier: NoteMarkerClassifier)
+      @source_type = source_type
+      @source_id = source_id.to_s
+      @source_version = source_version.to_s
+      @fragments = fragments
+      @classifier = classifier
+      @events = []
+      @orphans = []
+      @root_nodes = []
+      @path_segments = {}
+      @active_blocks = {}
+    end
+
+    def call
+      fragments.each do |fragment|
+        event = classifier.call(fragment)
+        events << event
+
+        process(event)
+      end
+
+      Tree.new(
+        nodes: root_nodes.map(&:to_node),
+        events:,
+        orphans:,
+      )
+    end
+
+  private
+
+    attr_reader :classifier, :events, :fragments, :orphans, :root_nodes, :path_segments, :active_blocks
+
+    def process(event)
+      case event.kind
+      when :heading
+        reset_context
+        path_segments[event.depth] = event.path_segment
+      when :numeric
+        reset_at_depth(event.depth)
+        path_segments[event.depth] = event.path_segment
+      when *BLOCK_CANDIDATE_KINDS
+        add_block_candidate(event)
+      when :bullet, :continuation
+        append_to_active_block(event)
+      end
+    end
+
+    def add_block_candidate(event)
+      reset_at_depth(event.depth)
+      path_segments[event.depth] = event.path_segment
+
+      block = MutableNode.new(event, path)
+      parent = nearest_active_block(event.depth - 1)
+
+      if parent
+        parent.children.push(block)
+      else
+        root_nodes << block
+      end
+
+      active_blocks[event.depth] = block
+    end
+
+    def append_to_active_block(event)
+      block = nearest_active_block
+
+      if block
+        block.append(event)
+      else
+        orphans << event
+      end
+    end
+
+    def reset_context
+      path_segments.clear
+      active_blocks.clear
+    end
+
+    def reset_at_depth(depth)
+      path_segments.delete_if { |segment_depth, _| segment_depth >= depth }
+      active_blocks.delete_if { |block_depth, _| block_depth >= depth }
+    end
+
+    def path
+      path_segments.sort_by { |depth, _| depth }.map(&:last)
+    end
+
+    def nearest_active_block(max_depth = nil)
+      active_blocks
+        .select { |depth, _| max_depth.nil? || depth <= max_depth }
+        .max_by { |depth, _| depth }
+        &.last
+    end
+
+    class MutableNode
+      attr_reader :kind, :marker, :path, :title, :children
+
+      def initialize(event, path)
+        @kind = event.kind
+        @marker = event.marker
+        @path = path
+        @title = event.title || event.body.presence
+        @content_parts = [event.raw_text]
+        @fragment_keys = [event.fragment.key]
+        @children = []
+      end
+
+      def append(event)
+        content_parts << event.raw_text
+        fragment_keys << event.fragment.key
+      end
+
+      def to_node
+        Node.new(
+          kind:,
+          marker:,
+          path: path.dup.freeze,
+          title:,
+          content: content_parts.join(' ').squish,
+          fragment_keys: fragment_keys.dup.freeze,
+          children: children.map(&:to_node).freeze,
+        )
+      end
+
+    private
+
+      attr_reader :content_parts, :fragment_keys
+    end
+  end
+end

--- a/app/services/tariff_knowledge/note_structure_validator.rb
+++ b/app/services/tariff_knowledge/note_structure_validator.rb
@@ -1,0 +1,142 @@
+module TariffKnowledge
+  class NoteStructureValidator
+    Result = Data.define(
+      :source_type,
+      :source_id,
+      :source_version,
+      :fragment_count,
+      :event_count,
+      :root_node_count,
+      :total_node_count,
+      :orphan_event_count,
+      :orphan_event_keys,
+      :duplicate_block_keys,
+      :uncontained_fragment_keys,
+      :issues,
+    )
+    Issue = Data.define(:severity, :code, :message, :details)
+    Fragment = Data.define(:key, :content)
+
+    def self.call(...) = new(...).call
+
+    def initialize(
+      source_type:,
+      source_id:,
+      source_version:,
+      fragments: nil,
+      content: nil,
+      structure_parser: NoteStructureParser,
+      block_parser: NoteBlockParser
+    )
+      @source_type = source_type.to_s
+      @source_id = source_id.to_s
+      @source_version = source_version.to_s
+      @fragments = fragments
+      @content = content
+      @structure_parser = structure_parser
+      @block_parser = block_parser
+    end
+
+    def call
+      source_fragments = fragments || fragments_from_content
+      tree = parse_tree(source_fragments)
+      blocks = parse_blocks(source_fragments)
+      issues = []
+
+      orphan_event_keys = tree.orphans.map { |event| event.fragment.key }
+      duplicate_block_keys = duplicate_keys(blocks.map(&:key))
+      uncontained_fragment_keys = uncontained_fragment_keys(source_fragments, blocks, tree.events)
+
+      issues << issue('warning', 'orphan_events', "#{orphan_event_keys.count} events could not attach to a note block", 'fragment_keys' => orphan_event_keys) if orphan_event_keys.any?
+      issues << issue('error', 'duplicate_block_keys', "#{duplicate_block_keys.count} duplicate note block keys were emitted", 'block_keys' => duplicate_block_keys) if duplicate_block_keys.any?
+      if uncontained_fragment_keys.any?
+        issues << issue(
+          'warning',
+          'uncontained_fragments',
+          "#{uncontained_fragment_keys.count} fragments were not contained by any emitted note block",
+          'fragment_keys' => uncontained_fragment_keys,
+        )
+      end
+
+      Result.new(
+        source_type:,
+        source_id:,
+        source_version:,
+        fragment_count: source_fragments.count,
+        event_count: tree.events.count,
+        root_node_count: tree.nodes.count,
+        total_node_count: total_node_count(tree.nodes),
+        orphan_event_count: orphan_event_keys.count,
+        orphan_event_keys:,
+        duplicate_block_keys:,
+        uncontained_fragment_keys:,
+        issues:,
+      )
+    end
+
+  private
+
+    attr_reader :source_type, :source_id, :source_version, :fragments, :content, :structure_parser, :block_parser
+
+    def parse_tree(source_fragments)
+      structure_parser.call(
+        source_type:,
+        source_id:,
+        source_version:,
+        fragments: source_fragments,
+      )
+    end
+
+    def parse_blocks(source_fragments)
+      block_parser.call(
+        source_type:,
+        source_id:,
+        source_version:,
+        fragments: source_fragments,
+      )
+    end
+
+    def fragments_from_content
+      split_content.map.with_index(1) do |fragment_content, index|
+        Fragment.new(
+          key: "note_fragment:#{source_type}:#{source_version}:#{source_id}:#{sprintf('%04d', index)}",
+          content: fragment_content,
+        )
+      end
+    end
+
+    def split_content
+      NoteFragmentSplitter.call(content)
+    end
+
+    def duplicate_keys(keys)
+      keys.tally.select { |_, count| count > 1 }.keys
+    end
+
+    def uncontained_fragment_keys(_source_fragments, blocks, events)
+      block_fragment_keys = blocks.flat_map(&:fragment_keys).uniq
+
+      containable_event_keys(events)
+        .excluding(*block_fragment_keys)
+    end
+
+    def containable_event_keys(events)
+      events
+        .select { |event| %i[alpha roman bullet].include?(event.kind) }
+        .map { |event| event.fragment.key }
+    end
+
+    def total_node_count(nodes)
+      nodes.sum { |node| 1 + total_node_count(node.children) }
+    end
+
+    def issue(severity, code, message, details)
+      Issue.new(
+        severity:,
+        code:,
+        message:,
+        details:,
+      )
+    end
+  end
+end

--- a/app/services/tariff_knowledge/relevant_note_fragment_selector.rb
+++ b/app/services/tariff_knowledge/relevant_note_fragment_selector.rb
@@ -26,6 +26,8 @@ module TariffKnowledge
     EXACT_PHRASE_SCORE = 14
     EXACT_TERM_SCORE = 4
     DEFINITION_BLOCK_SCORE = 4
+    BM25_SCORE_MULTIPLIER = 2
+    MAX_BM25_SCORE = 8
     MAX_REASON_CODES = 4
     MAX_REASON_TERMS = 5
 
@@ -36,6 +38,7 @@ module TariffKnowledge
       ->(evidence_record, _text) { range_match_rule(evidence_record) },
       ->(_evidence, text) { mentioned_range_rule(text) },
       ->(_evidence, text) { query_term_rule(text) },
+      ->(_evidence, text) { bm25_rule(text) },
       ->(evidence_record, _text) { same_chapter_rule(evidence_record) },
     ].freeze
     STOP_WORDS = %w[above an and are article articles as at be by chapter chapters code codes for from goods has have heading headings in into is it its kind made nomenclature of on or other purposes than that the this to use used with without].to_set.freeze
@@ -183,6 +186,7 @@ module TariffKnowledge
         range_match_rule(evidence_block),
         mentioned_range_rule(text),
         query_term_rule(block_query_text(text, suppressed_single_word_match)),
+        bm25_rule(block_query_text(text, suppressed_single_word_match)),
         same_chapter_rule(evidence_block),
       ].compact.each { |points, reason| score, reasons = add_score(score, reasons, points, reason) }
 
@@ -216,6 +220,21 @@ module TariffKnowledge
       [
         [overlap.size * QUERY_TERM_SCORE, MAX_QUERY_TERM_SCORE].min,
         "matches query terms #{overlap.first(MAX_REASON_TERMS).join(', ')}",
+      ]
+    end
+
+    def bm25_rule(text)
+      return if bm25_query_tokens.empty?
+
+      matched_terms = bm25_query_tokens.intersection(tokenize(text)).to_a
+      return if matched_terms.size < 2
+
+      bm25_score = bm25_scorer.score(text)
+      return unless bm25_score.positive?
+
+      [
+        [[(bm25_score * BM25_SCORE_MULTIPLIER).round, 1].max, MAX_BM25_SCORE].min,
+        "BM25 lexical match #{matched_terms.first(MAX_REASON_TERMS).join(', ')}",
       ]
     end
 
@@ -260,6 +279,8 @@ module TariffKnowledge
     end
 
     def relevance_tokens = @relevance_tokens ||= tokenize(query)
+
+    def bm25_query_tokens = @bm25_query_tokens ||= relevance_tokens
 
     def query_phrase = @query_phrase ||= query.to_s.squish.downcase
 
@@ -309,6 +330,21 @@ module TariffKnowledge
 
     def ordered_tokens(text) = text.to_s.downcase.scan(/[a-z0-9]{3,}/).reject { |token| STOP_WORDS.include?(token) }
 
+    def bm25_scorer
+      @bm25_scorer ||= Bm25Scorer.new(
+        documents: evidence_corpus,
+        query_tokens: bm25_query_tokens,
+        stop_words: STOP_WORDS,
+      )
+    end
+
+    def evidence_corpus
+      @evidence_corpus ||= notes_by_item_id.values.flat_map do |note|
+        block_evidence_records(note).map { |record| record['source_context'].to_s } +
+          fragment_evidence_records(note).map { |record| [record['source_context'], record['semantic_context']].compact.join(' ') }
+      end
+    end
+
     def candidate_chapters = @candidate_chapters ||= candidate_item_ids.map { |item_id| item_id.first(2) }.uniq
 
     def candidate_headings = @candidate_headings ||= candidate_item_ids.map { |item_id| item_id.first(4) }.uniq
@@ -316,5 +352,60 @@ module TariffKnowledge
     def candidate_ranges = @candidate_ranges ||= (candidate_chapters + candidate_headings).uniq
 
     def candidate_item_ids = @candidate_item_ids ||= search_results.map(&:goods_nomenclature_item_id).compact_blank.uniq
+
+    class Bm25Scorer
+      K1 = 1.2
+      B = 0.75
+
+      def initialize(documents:, query_tokens:, stop_words:)
+        @stop_words = stop_words
+        @query_tokens = query_tokens.to_a
+        @document_tokens = documents.map { |document| tokenize(document) }.reject(&:empty?)
+        @average_document_length = average_document_length
+        @document_frequencies = document_frequencies
+      end
+
+      def score(document)
+        tokens = tokenize(document)
+        return 0.0 if tokens.empty? || query_tokens.empty? || document_tokens.empty?
+
+        term_frequencies = tokens.tally
+        query_tokens.sum do |term|
+          next 0.0 unless term_frequencies[term]
+
+          idf(term) * term_weight(term_frequencies[term], tokens.length)
+        end
+      end
+
+    private
+
+      attr_reader :query_tokens, :document_tokens, :stop_words
+
+      def tokenize(text) = text.to_s.downcase.scan(/[a-z0-9]{3,}/).reject { |token| stop_words.include?(token) }
+
+      def average_document_length
+        return 0.0 if document_tokens.empty?
+
+        document_tokens.sum(&:length).fdiv(document_tokens.length)
+      end
+
+      def document_frequencies
+        document_tokens.each_with_object(Hash.new(0)) do |tokens, frequencies|
+          tokens.uniq.each { |token| frequencies[token] += 1 }
+        end
+      end
+
+      def idf(term)
+        document_count = document_tokens.length
+        frequency = document_frequencies.fetch(term, 0)
+
+        Math.log(1 + ((document_count - frequency + 0.5) / (frequency + 0.5)))
+      end
+
+      def term_weight(term_frequency, document_length)
+        denominator = term_frequency + K1 * (1 - B + (B * document_length / average_document_length))
+        (term_frequency * (K1 + 1)) / denominator
+      end
+    end
   end
 end

--- a/app/services/tariff_knowledge/relevant_note_fragment_selector.rb
+++ b/app/services/tariff_knowledge/relevant_note_fragment_selector.rb
@@ -23,6 +23,8 @@ module TariffKnowledge
     QUERY_TERM_SCORE = 2
     MAX_QUERY_TERM_SCORE = 10
     SAME_CHAPTER_SCORE = 1
+    EXACT_PHRASE_SCORE = 14
+    DEFINITION_BLOCK_SCORE = 4
     MAX_REASON_CODES = 4
     MAX_REASON_TERMS = 5
 
@@ -81,6 +83,27 @@ module TariffKnowledge
     end
 
     def scored_fragments(note)
+      scored_block_records(note) + scored_fragment_records(note)
+    end
+
+    def scored_block_records(note)
+      block_evidence_records(note).filter_map do |evidence_block|
+        source_text = evidence_block['source_context'].to_s.squish
+        next if source_text.blank?
+
+        score, reasons = score_block(evidence_block, source_text)
+        {
+          key: evidence_block['source_node_key'],
+          source: evidence_block['source_title'],
+          type: evidence_block['block_type'],
+          text: source_text.truncate(MAX_FRAGMENT_CHARS, omission: '...'),
+          score:,
+          why_relevant: reasons.join('; '),
+        }
+      end
+    end
+
+    def scored_fragment_records(note)
       # Each record is compressed-note metadata pointing to a source fragment and
       # explaining the relationship that made that fragment evidence for a code.
       fragment_evidence_records(note).filter_map do |evidence_record|
@@ -129,6 +152,28 @@ module TariffKnowledge
 
       SCORING_RULES.each do |rule|
         rule_result = instance_exec(evidence_record, text, &rule)
+        score, reasons = add_score(score, reasons, *rule_result) if rule_result
+      end
+
+      [score, reasons]
+    end
+
+    def score_block(evidence_block, text)
+      score = 0
+      reasons = []
+
+      if exact_query_phrase?(evidence_block['term'])
+        score, reasons = add_score(score, reasons, EXACT_PHRASE_SCORE, "exact phrase match #{query_phrase} in term")
+      elsif exact_query_phrase?(text)
+        score, reasons = add_score(score, reasons, EXACT_PHRASE_SCORE, "exact phrase match #{query_phrase}")
+      end
+
+      if evidence_block['block_type'] == 'definition'
+        score, reasons = add_score(score, reasons, DEFINITION_BLOCK_SCORE, 'definition block')
+      end
+
+      SCORING_RULES.each do |rule|
+        rule_result = instance_exec(evidence_block, text, &rule)
         score, reasons = add_score(score, reasons, *rule_result) if rule_result
       end
 
@@ -197,6 +242,8 @@ module TariffKnowledge
 
     def fragment_evidence_records(note) = Array(note.metadata.to_h['evidence'])
 
+    def block_evidence_records(note) = Array(note.metadata.to_h['evidence_blocks'])
+
     def fallback_fragment_keys(note)
       fragment_evidence_records(note).filter_map do |evidence_record|
         evidence_record['source_node_key'] if evidence_record['source_context'].blank? || evidence_record['source_title'].blank?
@@ -204,6 +251,15 @@ module TariffKnowledge
     end
 
     def relevance_tokens = @relevance_tokens ||= tokenize(query)
+
+    def query_phrase = @query_phrase ||= query.to_s.squish.downcase
+
+    def exact_query_phrase?(text)
+      phrase = query_phrase
+      return false if phrase.blank?
+
+      text.to_s.squish.downcase.include?(phrase)
+    end
 
     # Keep token matching intentionally coarse: legal fragments and trader
     # queries use different grammar, so this only rewards shared meaningful

--- a/app/services/tariff_knowledge/relevant_note_fragment_selector.rb
+++ b/app/services/tariff_knowledge/relevant_note_fragment_selector.rb
@@ -24,6 +24,7 @@ module TariffKnowledge
     MAX_QUERY_TERM_SCORE = 10
     SAME_CHAPTER_SCORE = 1
     EXACT_PHRASE_SCORE = 14
+    EXACT_TERM_SCORE = 4
     DEFINITION_BLOCK_SCORE = 4
     MAX_REASON_CODES = 4
     MAX_REASON_TERMS = 5
@@ -162,6 +163,10 @@ module TariffKnowledge
       score = 0
       reasons = []
 
+      if exact_query_term?(evidence_block['term'])
+        score, reasons = add_score(score, reasons, EXACT_TERM_SCORE, "exact term match #{query_phrase}")
+      end
+
       if exact_query_phrase?(evidence_block['term'])
         score, reasons = add_score(score, reasons, EXACT_PHRASE_SCORE, "exact phrase match #{query_phrase} in term")
       elsif exact_query_phrase?(text)
@@ -253,6 +258,10 @@ module TariffKnowledge
     def relevance_tokens = @relevance_tokens ||= tokenize(query)
 
     def query_phrase = @query_phrase ||= query.to_s.squish.downcase
+
+    def exact_query_term?(term)
+      query_phrase.present? && term.to_s.squish.downcase == query_phrase
+    end
 
     def exact_query_phrase?(text)
       phrase = query_phrase

--- a/app/services/tariff_knowledge/relevant_note_fragment_selector.rb
+++ b/app/services/tariff_knowledge/relevant_note_fragment_selector.rb
@@ -99,6 +99,7 @@ module TariffKnowledge
         {
           key: evidence_block['source_node_key'],
           source: evidence_block['source_title'],
+          source_ref: source_reference(evidence_block),
           type: evidence_block['block_type'],
           text: source_text.truncate(MAX_FRAGMENT_CHARS, omission: '...'),
           score:,
@@ -119,6 +120,7 @@ module TariffKnowledge
         {
           key: evidence_record['source_node_key'],
           source: evidence_record['source_title'] || fragment_node&.title,
+          source_ref: source_reference(evidence_record),
           type: evidence_record['context_type'],
           text: text.truncate(MAX_FRAGMENT_CHARS, omission: '...'),
           score:,
@@ -245,6 +247,17 @@ module TariffKnowledge
       [SAME_CHAPTER_SCORE, 'same chapter as retrieved candidate']
     end
 
+    def source_reference(evidence_record)
+      case evidence_record['source_type'].to_s
+      when 'customs_tariff_chapter_note'
+        "chapter #{evidence_record['source_id'].to_s.rjust(2, '0')} note"
+      when 'customs_tariff_section_note'
+        "section #{evidence_record['source_id']} note"
+      when 'customs_tariff_general_rule'
+        "GIR #{evidence_record['source_id']}"
+      end
+    end
+
     def range_match?(evidence_record)
       code = evidence_record['range_code'].to_s
       case evidence_record['range_type']
@@ -341,7 +354,7 @@ module TariffKnowledge
     def evidence_corpus
       @evidence_corpus ||= notes_by_item_id.values.flat_map do |note|
         block_evidence_records(note).map { |record| record['source_context'].to_s } +
-          fragment_evidence_records(note).map { |record| [record['source_context'], record['semantic_context']].compact.join(' ') }
+          fragment_evidence_records(note).map { |record| record['source_context'].to_s }
       end
     end
 

--- a/app/services/tariff_knowledge/relevant_note_fragment_selector.rb
+++ b/app/services/tariff_knowledge/relevant_note_fragment_selector.rb
@@ -374,8 +374,8 @@ module TariffKnowledge
         @stop_words = stop_words
         @query_tokens = query_tokens.to_a
         @document_tokens = documents.map { |document| tokenize(document) }.reject(&:empty?)
-        @average_document_length = average_document_length
-        @document_frequencies = document_frequencies
+        @average_document_length = calculate_average_document_length
+        @document_frequencies = calculate_document_frequencies
       end
 
       def score(document)
@@ -392,17 +392,17 @@ module TariffKnowledge
 
     private
 
-      attr_reader :query_tokens, :document_tokens, :stop_words
+      attr_reader :query_tokens, :document_tokens, :average_document_length, :document_frequencies, :stop_words
 
       def tokenize(text) = text.to_s.downcase.scan(/[a-z0-9]{3,}/).reject { |token| stop_words.include?(token) }
 
-      def average_document_length
+      def calculate_average_document_length
         return 0.0 if document_tokens.empty?
 
         document_tokens.sum(&:length).fdiv(document_tokens.length)
       end
 
-      def document_frequencies
+      def calculate_document_frequencies
         document_tokens.each_with_object(Hash.new(0)) do |tokens, frequencies|
           tokens.uniq.each { |token| frequencies[token] += 1 }
         end

--- a/app/services/tariff_knowledge/relevant_note_fragment_selector.rb
+++ b/app/services/tariff_knowledge/relevant_note_fragment_selector.rb
@@ -167,9 +167,11 @@ module TariffKnowledge
         score, reasons = add_score(score, reasons, EXACT_TERM_SCORE, "exact term match #{query_phrase}")
       end
 
-      if exact_query_phrase?(evidence_block['term'])
+      suppressed_single_word_match = suppress_single_word_block_match?(evidence_block['term'])
+
+      if exact_query_phrase?(evidence_block['term']) && block_term_phrase_match?(evidence_block['term'])
         score, reasons = add_score(score, reasons, EXACT_PHRASE_SCORE, "exact phrase match #{query_phrase} in term")
-      elsif exact_query_phrase?(text)
+      elsif !suppressed_single_word_match && exact_query_phrase?(text)
         score, reasons = add_score(score, reasons, EXACT_PHRASE_SCORE, "exact phrase match #{query_phrase}")
       end
 
@@ -177,10 +179,12 @@ module TariffKnowledge
         score, reasons = add_score(score, reasons, DEFINITION_BLOCK_SCORE, 'definition block')
       end
 
-      SCORING_RULES.each do |rule|
-        rule_result = instance_exec(evidence_block, text, &rule)
-        score, reasons = add_score(score, reasons, *rule_result) if rule_result
-      end
+      [
+        range_match_rule(evidence_block),
+        mentioned_range_rule(text),
+        query_term_rule(block_query_text(text, suppressed_single_word_match)),
+        same_chapter_rule(evidence_block),
+      ].compact.each { |points, reason| score, reasons = add_score(score, reasons, points, reason) }
 
       [score, reasons]
     end
@@ -270,10 +274,40 @@ module TariffKnowledge
       text.to_s.squish.downcase.include?(phrase)
     end
 
+    def block_term_phrase_match?(term)
+      return true unless single_relevance_token?
+
+      exact_query_term?(term) || head_term_match?(term)
+    end
+
+    def block_query_text(text, suppressed_modifier_match)
+      return text unless suppressed_modifier_match
+
+      ''
+    end
+
+    def suppress_single_word_block_match?(term)
+      single_relevance_token? && !block_term_phrase_match?(term)
+    end
+
+    def single_relevance_token?
+      relevance_tokens.one?
+    end
+
+    def single_relevance_token
+      relevance_tokens.first
+    end
+
+    def head_term_match?(term)
+      ordered_tokens(term).last == single_relevance_token
+    end
+
     # Keep token matching intentionally coarse: legal fragments and trader
     # queries use different grammar, so this only rewards shared meaningful
     # words/numbers after dropping common tariff/search glue words.
     def tokenize(text) = text.to_s.downcase.scan(/[a-z0-9]{3,}/).reject { |token| STOP_WORDS.include?(token) }.to_set
+
+    def ordered_tokens(text) = text.to_s.downcase.scan(/[a-z0-9]{3,}/).reject { |token| STOP_WORDS.include?(token) }
 
     def candidate_chapters = @candidate_chapters ||= candidate_item_ids.map { |item_id| item_id.first(2) }.uniq
 

--- a/app/services/tariff_knowledge/source_graph_loader.rb
+++ b/app/services/tariff_knowledge/source_graph_loader.rb
@@ -91,12 +91,83 @@ module TariffKnowledge
       fragment_nodes = fragments(source.content).map.with_index(1) do |fragment_content, index|
         load_fragment(source_association, source, source_node, fragment_content, index)
       end
+      block_nodes = load_note_blocks(source_association, source, source_node, fragment_nodes)
+      delete_stale_note_block_edges(source_node, block_nodes)
 
       delete_stale_edges(
         source_node:,
         relationship_type: Edge::CONTAINS,
-        current_target_node_ids: fragment_nodes.map(&:id),
+        current_target_node_ids: (fragment_nodes + block_nodes).map(&:id),
       )
+    end
+
+    def load_note_blocks(source_association, source, source_node, fragment_nodes)
+      fragment_nodes_by_key = fragment_nodes.index_by(&:key)
+      NoteBlockParser.call(
+        source_type: source_association.label,
+        source_id: source_node.source_id,
+        source_version: source.customs_tariff_update_version,
+        fragments: fragment_nodes,
+      ).map do |block|
+        load_note_block(source, source_node, block, fragment_nodes_by_key)
+      end
+    end
+
+    def load_note_block(source, source_node, block, fragment_nodes_by_key)
+      block_node = upsert_node(
+        node_type: Node::NOTE_BLOCK,
+        key: block.key,
+        title: block.title,
+        content: block.content,
+        metadata: block.metadata,
+        source_type: source_node.source_type,
+        source_id: source_node.source_id,
+        source_version: source.customs_tariff_update_version,
+      )
+      contained_fragments = block.fragment_keys.filter_map { |key| fragment_nodes_by_key[key] }
+
+      upsert_edge(source_node, block_node, Edge::CONTAINS)
+      upsert_edges(block_node, contained_fragments, Edge::CONTAINS)
+      delete_stale_edges(
+        source_node: block_node,
+        relationship_type: Edge::CONTAINS,
+        current_target_node_ids: contained_fragments.map(&:id),
+      )
+
+      propagate_fragment_edges(block_node, contained_fragments, Edge::APPLIES_TO)
+      propagate_fragment_edges(block_node, contained_fragments, Edge::REFERENCES)
+
+      block_node
+    end
+
+    def propagate_fragment_edges(block_node, contained_fragments, relationship_type)
+      target_node_ids = Edge
+        .where(source_node_id: contained_fragments.map(&:id), relationship_type:)
+        .select_map(:target_node_id)
+        .uniq
+      target_nodes = Node.where(id: target_node_ids)
+
+      upsert_edges(block_node, target_nodes, relationship_type)
+      delete_stale_edges(
+        source_node: block_node,
+        relationship_type:,
+        current_target_node_ids: target_node_ids,
+      )
+    end
+
+    def delete_stale_note_block_edges(source_node, current_block_nodes)
+      stale_block_edges = Edge
+        .where(source_node_id: source_node.id, relationship_type: Edge::CONTAINS)
+        .association_join(:target_node)
+        .where(target_node__node_type: Node::NOTE_BLOCK)
+      current_block_node_ids = current_block_nodes.map(&:id)
+      stale_block_edges = stale_block_edges.exclude(target_node_id: current_block_node_ids) if current_block_node_ids.any?
+
+      Node.where(id: stale_block_edges.select_map(:target_node_id)).each do |block_node|
+        delete_stale_edges(source_node: block_node, relationship_type: Edge::CONTAINS)
+        delete_stale_edges(source_node: block_node, relationship_type: Edge::APPLIES_TO)
+        delete_stale_edges(source_node: block_node, relationship_type: Edge::REFERENCES)
+      end
     end
 
     def load_fragment(source_association, source, source_node, content, index)
@@ -297,7 +368,7 @@ module TariffKnowledge
 
     def prune_non_current_source_nodes(source_version)
       Node
-        .where(node_type: [Node::NOTE_SOURCE, Node::NOTE_FRAGMENT])
+        .where(node_type: [Node::NOTE_SOURCE, Node::NOTE_FRAGMENT, Node::NOTE_BLOCK])
         .where(source_type: SOURCE_ASSOCIATIONS.map(&:label))
         .exclude(source_version:)
         .delete

--- a/app/services/tariff_knowledge/source_graph_loader.rb
+++ b/app/services/tariff_knowledge/source_graph_loader.rb
@@ -2,13 +2,6 @@ module TariffKnowledge
   class SourceGraphLoader
     BATCH_SIZE = 500
 
-    # Tariff notes often use nested list markers such as "a.", "ii.", "ij.",
-    # and "1.". These patterns identify standalone markers and markers stranded
-    # at the end of a split fragment so we can merge them back into the following
-    # legal text. They intentionally anchor to the whole fragment to avoid
-    # treating ordinary prose as a list marker.
-    LIST_MARKER_PATTERN = /\A(?:ij|\(?[a-z]\)?|[ivx]+|\d+)\.\z/i
-    TRAILING_LIST_MARKER_PATTERN = /\A(.+?)\s+((?:ij|\(?[a-z]\)?|[ivx]+|\d+)\.)\z/im
     EXCLUDED_UPDATE_STATUSES = [CustomsTariffUpdate::FAILED].freeze
 
     RangeReference = Data.define(:type, :code)
@@ -206,63 +199,7 @@ module TariffKnowledge
     end
 
     def fragments(content)
-      content
-        .to_s
-        .split(/\n{2,}|(?<=[.!?])\s+/)
-        .map(&:strip)
-        .reject(&:blank?)
-        .then { |split_fragments| merge_orphaned_list_markers(split_fragments) }
-        .then { |split_fragments| merge_dangling_numeric_references(split_fragments) }
-    end
-
-    def merge_orphaned_list_markers(split_fragments)
-      split_fragments.each_with_object([]) do |fragment, merged|
-        fragment = "#{merged.pop} #{fragment}" if list_marker_sequence?(merged.last)
-        match = fragment.match(TRAILING_LIST_MARKER_PATTERN)
-        text, marker = match&.captures
-
-        if match && !list_marker_sequence?(text.strip)
-          merged.push(text.strip, marker)
-        else
-          merged << (match ? "#{text.strip} #{marker}" : fragment)
-        end
-      end
-    end
-
-    def list_marker_sequence?(fragment)
-      fragment.present? && fragment.split.all? { |part| part.match?(LIST_MARKER_PATTERN) }
-    end
-
-    def merge_dangling_numeric_references(split_fragments)
-      split_fragments.each_with_object([]) do |fragment, merged|
-        # Sentence splitting can detach references such as "heading 8481." or
-        # "C." from the text that introduces them. Reattach only when the
-        # previous fragment ends in wording that normally introduces a legal
-        # chapter/heading/rule reference, a digit, or a known year-style number.
-        if merged.last && (
-          numeric_reference_context?(merged.last, fragment) ||
-            (fragment.match?(/\AC\.(?:\s+.+)?\z/i) && merged.last.match?(/\d\z/))
-        )
-          attach_reference_fragment(fragment, merged)
-        else
-          merged << fragment
-        end
-      end
-    end
-
-    def attach_reference_fragment(fragment, merged)
-      reference, remaining_fragment = fragment.match(/\A((?:\d{1,4}|C)\.)\s*(.*)\z/i).captures
-      merged[-1] = "#{merged.last} #{reference}"
-      merged << remaining_fragment.strip if remaining_fragment.present?
-    end
-
-    def numeric_reference_context?(previous_fragment, fragment)
-      fragment.match?(/\A\d{1,4}\.(?:\s+.+)?\z/) &&
-        (
-          previous_fragment.match?(/\b(?:heading|headings|chapter|chapters|rule|rules|and|or|to)\z/i) ||
-            previous_fragment.match?(/\d\z/) ||
-            fragment.match?(/\A(?:19|20)\d{2}\.(?:\s+.+)?\z/)
-        )
+      NoteFragmentSplitter.call(content)
     end
 
     def range_references(content)

--- a/app/services/tariff_knowledge/source_graph_loader.rb
+++ b/app/services/tariff_knowledge/source_graph_loader.rb
@@ -126,26 +126,15 @@ module TariffKnowledge
         relationship_type: Edge::CONTAINS,
         current_target_node_ids: contained_fragments.map(&:id),
       )
-
-      propagate_fragment_edges(block_node, contained_fragments, Edge::APPLIES_TO)
-      propagate_fragment_edges(block_node, contained_fragments, Edge::REFERENCES)
+      # Do not copy full-chapter (or full-tariff) APPLIES_TO / REFERENCES targets
+      # onto each block — that multiplies edge fan-out by definition-block count.
+      # Compressed notes resolve block evidence via:
+      #   declarable <- fragment APPLIES_TO/range <- block CONTAINS fragment
+      # Clear any legacy propagated edges from older loads.
+      delete_stale_edges(source_node: block_node, relationship_type: Edge::APPLIES_TO)
+      delete_stale_edges(source_node: block_node, relationship_type: Edge::REFERENCES)
 
       block_node
-    end
-
-    def propagate_fragment_edges(block_node, contained_fragments, relationship_type)
-      target_node_ids = Edge
-        .where(source_node_id: contained_fragments.map(&:id), relationship_type:)
-        .select_map(:target_node_id)
-        .uniq
-      target_nodes = Node.where(id: target_node_ids)
-
-      upsert_edges(block_node, target_nodes, relationship_type)
-      delete_stale_edges(
-        source_node: block_node,
-        relationship_type:,
-        current_target_node_ids: target_node_ids,
-      )
     end
 
     def delete_stale_note_block_edges(source_node, current_block_nodes)

--- a/lib/tasks/tariff_knowledge.rake
+++ b/lib/tasks/tariff_knowledge.rake
@@ -95,53 +95,51 @@ module_function
   rescue ArgumentError
     raise ArgumentError, "#{name} must be numeric"
   end
-  namespace :note_structures do
-    print_issue_counts = lambda do |label, values|
-      counts = values.tally
-      puts "#{label}: none" if counts.empty?
-      counts.sort.each { |value, count| puts "#{value}: #{count}" }
+
+  def validate_note_structures
+    update = TimeMachine.at(Time.current) do
+      CustomsTariffUpdate
+        .actual
+        .exclude(status: CustomsTariffUpdate::FAILED)
+        .order(Sequel.desc(:validity_start_date))
+        .first
     end
+    results = update ? validate_chapter_notes(update) : []
 
-    print_report = lambda do |results|
-      issues = results.flat_map(&:issues)
-      puts "Validated #{results.count} tariff knowledge note sources"
-      puts "Issues: #{issues.count}"
-      print_issue_counts.call('Severity', issues.map(&:severity))
-      print_issue_counts.call('Code', issues.map(&:code))
+    print_note_structure_report(results)
+    abort 'Note structure validation reported issues.' if ENV['FAIL_ON_ISSUES'] == 'true' && results.any? { |result| result.issues.any? }
+  end
 
-      issues.first(10).each_with_index do |issue, index|
-        result = results.find { |candidate| candidate.issues.include?(issue) }
-        puts "#{index + 1}. Chapter #{result.source_id} #{issue.severity}/#{issue.code}: #{issue.message}"
+  def validate_chapter_notes(update)
+    TimeMachine.at(Time.current) do
+      update.customs_tariff_chapter_notes_dataset.order(:chapter_id).map do |note|
+        TariffKnowledge::NoteStructureValidator.call(
+          source_type: 'customs_tariff_chapter_note',
+          source_id: note.chapter_id,
+          source_version: update.version,
+          content: note.content,
+        )
       end
     end
+  end
 
-    validate_chapter_notes = lambda do |update|
-      TimeMachine.at(Time.current) do
-        update.customs_tariff_chapter_notes_dataset.order(:chapter_id).map do |note|
-          TariffKnowledge::NoteStructureValidator.call(
-            source_type: 'customs_tariff_chapter_note',
-            source_id: note.chapter_id,
-            source_version: update.version,
-            content: note.content,
-          )
-        end
-      end
+  def print_note_structure_report(results)
+    issues = results.flat_map(&:issues)
+    puts "Validated #{results.count} tariff knowledge note sources"
+    puts "Issues: #{issues.count}"
+    print_issue_counts('Severity', issues.map(&:severity))
+    print_issue_counts('Code', issues.map(&:code))
+
+    issues.first(10).each_with_index do |issue, index|
+      result = results.find { |candidate| candidate.issues.include?(issue) }
+      puts "#{index + 1}. Chapter #{result.source_id} #{issue.severity}/#{issue.code}: #{issue.message}"
     end
+  end
 
-    desc 'Validate parsed tariff knowledge note structures. Set FAIL_ON_ISSUES=true to fail when issues are reported.'
-    task validate: :environment do
-      update = TimeMachine.at(Time.current) do
-        CustomsTariffUpdate
-          .actual
-          .exclude(status: CustomsTariffUpdate::FAILED)
-          .order(Sequel.desc(:validity_start_date))
-          .first
-      end
-      results = update ? validate_chapter_notes.call(update) : []
-
-      print_report.call(results)
-      abort 'Note structure validation reported issues.' if ENV['FAIL_ON_ISSUES'] == 'true' && results.any? { |result| result.issues.any? }
-    end
+  def print_issue_counts(label, values)
+    counts = values.tally
+    puts "#{label}: none" if counts.empty?
+    counts.sort.each { |value, count| puts "#{value}: #{count}" }
   end
 end
 
@@ -193,4 +191,9 @@ end
 desc 'Enqueue public ATAR ruling import'
 task 'tariff_knowledge:atars:enqueue' => :environment do
   TariffKnowledgeRakeTasks.enqueue_atar_import
+end
+
+desc 'Validate parsed tariff knowledge note structures. Set FAIL_ON_ISSUES=true to fail when issues are reported.'
+task 'tariff_knowledge:note_structures:validate' => :environment do
+  TariffKnowledgeRakeTasks.validate_note_structures
 end

--- a/lib/tasks/tariff_knowledge.rake
+++ b/lib/tasks/tariff_knowledge.rake
@@ -95,6 +95,54 @@ module_function
   rescue ArgumentError
     raise ArgumentError, "#{name} must be numeric"
   end
+  namespace :note_structures do
+    print_issue_counts = lambda do |label, values|
+      counts = values.tally
+      puts "#{label}: none" if counts.empty?
+      counts.sort.each { |value, count| puts "#{value}: #{count}" }
+    end
+
+    print_report = lambda do |results|
+      issues = results.flat_map(&:issues)
+      puts "Validated #{results.count} tariff knowledge note sources"
+      puts "Issues: #{issues.count}"
+      print_issue_counts.call('Severity', issues.map(&:severity))
+      print_issue_counts.call('Code', issues.map(&:code))
+
+      issues.first(10).each_with_index do |issue, index|
+        result = results.find { |candidate| candidate.issues.include?(issue) }
+        puts "#{index + 1}. Chapter #{result.source_id} #{issue.severity}/#{issue.code}: #{issue.message}"
+      end
+    end
+
+    validate_chapter_notes = lambda do |update|
+      TimeMachine.at(Time.current) do
+        update.customs_tariff_chapter_notes_dataset.order(:chapter_id).map do |note|
+          TariffKnowledge::NoteStructureValidator.call(
+            source_type: 'customs_tariff_chapter_note',
+            source_id: note.chapter_id,
+            source_version: update.version,
+            content: note.content,
+          )
+        end
+      end
+    end
+
+    desc 'Validate parsed tariff knowledge note structures. Set FAIL_ON_ISSUES=true to fail when issues are reported.'
+    task validate: :environment do
+      update = TimeMachine.at(Time.current) do
+        CustomsTariffUpdate
+          .actual
+          .exclude(status: CustomsTariffUpdate::FAILED)
+          .order(Sequel.desc(:validity_start_date))
+          .first
+      end
+      results = update ? validate_chapter_notes.call(update) : []
+
+      print_report.call(results)
+      abort 'Note structure validation reported issues.' if ENV['FAIL_ON_ISSUES'] == 'true' && results.any? { |result| result.issues.any? }
+    end
+  end
 end
 
 desc 'Enqueue the full tariff knowledge graph population pipeline'

--- a/spec/lib/tasks/tariff_knowledge_rake_spec.rb
+++ b/spec/lib/tasks/tariff_knowledge_rake_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe 'tariff_knowledge rake tasks' do
       tariff_knowledge:atars:preload
       tariff_knowledge:atars:import
       tariff_knowledge:atars:enqueue
+      tariff_knowledge:note_structures:validate
     ].each { |task| Rake::Task[task].reenable if Rake::Task.task_defined?(task) }
   end
 
@@ -165,6 +166,60 @@ RSpec.describe 'tariff_knowledge rake tasks' do
 
       expect(ImportPublicAtarRulingsWorker).to have_received(:perform_async)
     end
+  end
+
+  describe 'tariff_knowledge:note_structures:validate' do
+    it 'validates current chapter notes and prints a concise report' do
+      update = create(:customs_tariff_update, version: '1.31', validity_start_date: 1.day.ago)
+      create(:customs_tariff_update, :failed, version: '1.32', validity_start_date: Time.zone.today)
+      note = create(:customs_tariff_chapter_note, customs_tariff_update: update, chapter_id: '72', content: '1. Definitions.')
+      result = TariffKnowledge::NoteStructureValidator::Result.new(
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '72',
+        source_version: '1.31',
+        fragment_count: 1,
+        event_count: 1,
+        root_node_count: 0,
+        total_node_count: 0,
+        orphan_event_count: 0,
+        orphan_event_keys: [],
+        duplicate_block_keys: [],
+        uncontained_fragment_keys: %w[fragment-key],
+        issues: [
+          TariffKnowledge::NoteStructureValidator::Issue.new(
+            severity: 'warning',
+            code: 'uncontained_fragments',
+            message: '1 fragments were not contained by any emitted note block',
+            details: { 'fragment_keys' => %w[fragment-key] },
+          ),
+        ],
+      )
+
+      allow(TariffKnowledge::NoteStructureValidator).to receive(:call).and_return(result)
+
+      output = capture_output { Rake::Task['tariff_knowledge:note_structures:validate'].invoke }
+
+      expect(TariffKnowledge::NoteStructureValidator).to have_received(:call).with(
+        source_type: 'customs_tariff_chapter_note',
+        source_id: note.chapter_id,
+        source_version: update.version,
+        content: note.content,
+      )
+      expect(output).to include('Validated 1 tariff knowledge note sources')
+      expect(output).to include('warning: 1')
+      expect(output).to include('uncontained_fragments: 1')
+      expect(output).to include('Chapter 72')
+    end
+  end
+
+  def capture_output
+    original_stdout = $stdout
+    output = StringIO.new
+    $stdout = output
+    yield
+    output.string
+  ensure
+    $stdout = original_stdout
   end
 end
 # rubocop:enable RSpec/DescribeClass

--- a/spec/services/tariff_knowledge/compressed_note_generator_spec.rb
+++ b/spec/services/tariff_knowledge/compressed_note_generator_spec.rb
@@ -53,6 +53,27 @@ RSpec.describe TariffKnowledge::CompressedNoteGenerator do
         content: 'Heading 0101 covers live horses.',
       )
     end
+    let(:note_block_node) do
+      create(
+        :tariff_knowledge_node,
+        node_type: TariffKnowledge::Node::NOTE_BLOCK,
+        key: 'note_block:customs_tariff_chapter_note:1.31:01:1:a',
+        title: 'pure-bred breeding animals',
+        content: 'pure-bred breeding animals means animals certified as breeding stock.',
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '01',
+        source_version: '1.31',
+        metadata: Sequel.pg_jsonb_wrap(
+          'block_type' => 'definition',
+          'term' => 'pure-bred breeding animals',
+          'path' => %w[1 a],
+        ),
+        goods_nomenclature_sid: nil,
+        goods_nomenclature_item_id: nil,
+        producline_suffix: nil,
+        goods_nomenclature_type: nil,
+      )
+    end
 
     before do
       create(
@@ -123,6 +144,254 @@ RSpec.describe TariffKnowledge::CompressedNoteGenerator do
         TariffKnowledge::Edge::APPLIES_TO,
       )
       expect(note.context_hash).to eq(Digest::SHA256.hexdigest(note.content))
+    end
+
+    it 'stores coherent note block evidence for definition blocks' do
+      create(
+        :tariff_knowledge_edge,
+        source_node: note_block_node,
+        target_node: lead_in_fragment_node,
+        relationship_type: TariffKnowledge::Edge::CONTAINS,
+      )
+      create(
+        :tariff_knowledge_edge,
+        source_node: note_block_node,
+        target_node: fragment_node,
+        relationship_type: TariffKnowledge::Edge::CONTAINS,
+      )
+      create(
+        :tariff_knowledge_edge,
+        source_node: note_block_node,
+        target_node: declarable_node,
+        relationship_type: TariffKnowledge::Edge::APPLIES_TO,
+      )
+
+      described_class.call(goods_nomenclature_sids: [123])
+
+      note = TariffKnowledge::CompressedNote[123]
+      expect(note.metadata.to_hash['evidence_blocks']).to contain_exactly(
+        include(
+          'source_node_key' => 'note_block:customs_tariff_chapter_note:1.31:01:1:a',
+          'source_type' => 'customs_tariff_chapter_note',
+          'source_id' => '01',
+          'source_version' => '1.31',
+          'source_title' => 'pure-bred breeding animals',
+          'source_context' => 'pure-bred breeding animals means animals certified as breeding stock.',
+          'block_type' => 'definition',
+          'term' => 'pure-bred breeding animals',
+          'path' => %w[1 a],
+          'fragment_node_keys' => [
+            'note_fragment:customs_tariff_chapter_note:1.31:01:0001',
+            'note_fragment:customs_tariff_chapter_note:1.31:01:0002',
+          ],
+        ),
+      )
+      expect(note.metadata.to_hash['evidence']).to be_present
+    end
+
+    it 'generates from block-only evidence' do
+      TariffKnowledge::Edge
+        .where(
+          source_node_id: fragment_node.id,
+          target_node_id: declarable_node.id,
+          relationship_type: TariffKnowledge::Edge::APPLIES_TO,
+        )
+        .delete
+      TariffKnowledge::Edge
+        .where(
+          source_node_id: fragment_node.id,
+          target_node_id: range_node.id,
+          relationship_type: TariffKnowledge::Edge::REFERENCES,
+        )
+        .delete
+      create(
+        :tariff_knowledge_edge,
+        source_node: note_block_node,
+        target_node: declarable_node,
+        relationship_type: TariffKnowledge::Edge::APPLIES_TO,
+      )
+
+      described_class.call(goods_nomenclature_sids: [123])
+
+      note = TariffKnowledge::CompressedNote[123]
+      expect(note).to have_attributes(stale: false)
+      expect(note.content).to include('pure-bred breeding animals')
+      expect(note.content).to include('animals certified as breeding stock')
+      expect(note.metadata.to_hash).to include(
+        'source_node_keys' => [],
+        'range_node_keys' => [],
+        'evidence' => [],
+      )
+      expect(note.metadata.to_hash['evidence_blocks'].first['fragment_node_keys']).to eq([])
+    end
+
+    it 'ignores old source version block evidence' do
+      create(
+        :customs_tariff_update,
+        :approved,
+        version: '1.30',
+        validity_start_date: 2.months.ago,
+        validity_end_date: 1.month.ago,
+      )
+      create(
+        :customs_tariff_update,
+        version: '1.31',
+        validity_start_date: 1.day.ago,
+      )
+      old_block_node = create(
+        :tariff_knowledge_node,
+        node_type: TariffKnowledge::Node::NOTE_BLOCK,
+        key: 'note_block:customs_tariff_chapter_note:1.30:01:1:a',
+        title: 'Old definition block',
+        content: 'Old version block evidence should not be used.',
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '01',
+        source_version: '1.30',
+        goods_nomenclature_sid: nil,
+        goods_nomenclature_item_id: nil,
+        producline_suffix: nil,
+        goods_nomenclature_type: nil,
+      )
+      create(
+        :tariff_knowledge_edge,
+        source_node: old_block_node,
+        target_node: declarable_node,
+        relationship_type: TariffKnowledge::Edge::APPLIES_TO,
+      )
+      create(
+        :tariff_knowledge_edge,
+        source_node: note_block_node,
+        target_node: declarable_node,
+        relationship_type: TariffKnowledge::Edge::APPLIES_TO,
+      )
+
+      described_class.call(goods_nomenclature_sids: [123])
+
+      expect(TariffKnowledge::CompressedNote[123].metadata.to_hash['evidence_blocks'])
+        .to contain_exactly(include('source_node_key' => 'note_block:customs_tariff_chapter_note:1.31:01:1:a'))
+    end
+
+    it 'ignores old source version fragments contained by current block evidence' do
+      create(
+        :customs_tariff_update,
+        :approved,
+        version: '1.30',
+        validity_start_date: 2.months.ago,
+        validity_end_date: 1.month.ago,
+      )
+      create(
+        :customs_tariff_update,
+        version: '1.31',
+        validity_start_date: 1.day.ago,
+      )
+      old_fragment_node = create(
+        :tariff_knowledge_node,
+        :note_fragment,
+        key: 'note_fragment:customs_tariff_chapter_note:1.30:01:0001',
+        title: 'Old Chapter 01 notes fragment 1',
+        content: 'Old version contained evidence should not be used.',
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '01',
+        source_version: '1.30',
+      )
+      create(
+        :tariff_knowledge_edge,
+        source_node: note_block_node,
+        target_node: old_fragment_node,
+        relationship_type: TariffKnowledge::Edge::CONTAINS,
+      )
+      create(
+        :tariff_knowledge_edge,
+        source_node: note_block_node,
+        target_node: fragment_node,
+        relationship_type: TariffKnowledge::Edge::CONTAINS,
+      )
+      create(
+        :tariff_knowledge_edge,
+        source_node: note_block_node,
+        target_node: declarable_node,
+        relationship_type: TariffKnowledge::Edge::APPLIES_TO,
+      )
+
+      described_class.call(goods_nomenclature_sids: [123])
+
+      evidence_block = TariffKnowledge::CompressedNote[123].metadata.to_hash['evidence_blocks'].first
+      expect(evidence_block['fragment_node_keys']).to eq(['note_fragment:customs_tariff_chapter_note:1.31:01:0002'])
+    end
+
+    it 'preloads block fragment evidence for the requested goods nomenclatures' do
+      TariffKnowledge::Edge
+        .where(
+          source_node_id: fragment_node.id,
+          target_node_id: declarable_node.id,
+          relationship_type: TariffKnowledge::Edge::APPLIES_TO,
+        )
+        .delete
+      TariffKnowledge::Edge
+        .where(
+          source_node_id: fragment_node.id,
+          target_node_id: range_node.id,
+          relationship_type: TariffKnowledge::Edge::REFERENCES,
+        )
+        .delete
+      TariffKnowledge::Edge
+        .where(
+          source_node_id: range_node.id,
+          target_node_id: declarable_node.id,
+          relationship_type: TariffKnowledge::Edge::EXPANDS_TO,
+        )
+        .delete
+      second_declarable_node = create(
+        :tariff_knowledge_node,
+        key: 'goods_nomenclature:456',
+        goods_nomenclature_sid: 456,
+        goods_nomenclature_item_id: '0101290000',
+      )
+      third_declarable_node = create(
+        :tariff_knowledge_node,
+        key: 'goods_nomenclature:789',
+        goods_nomenclature_sid: 789,
+        goods_nomenclature_item_id: '0101300000',
+      )
+      block_nodes = [declarable_node, second_declarable_node, third_declarable_node].map.with_index do |node, index|
+        block_node = create(
+          :tariff_knowledge_node,
+          node_type: TariffKnowledge::Node::NOTE_BLOCK,
+          key: "note_block:customs_tariff_chapter_note:1.31:01:#{index + 1}:a",
+          title: "Definition block #{index + 1}",
+          content: "Block #{index + 1} context.",
+          source_type: 'customs_tariff_chapter_note',
+          source_id: '01',
+          source_version: '1.31',
+          goods_nomenclature_sid: nil,
+          goods_nomenclature_item_id: nil,
+          producline_suffix: nil,
+          goods_nomenclature_type: nil,
+        )
+        create(
+          :tariff_knowledge_edge,
+          source_node: block_node,
+          target_node: fragment_node,
+          relationship_type: TariffKnowledge::Edge::CONTAINS,
+        )
+        create(
+          :tariff_knowledge_edge,
+          source_node: block_node,
+          target_node: node,
+          relationship_type: TariffKnowledge::Edge::APPLIES_TO,
+        )
+        block_node
+      end
+
+      queries = sql_queries do
+        described_class.call(goods_nomenclature_sids: [123, 456, 789])
+      end
+
+      contains_edge_queries = queries.grep(/FROM "tariff_knowledge_edges".*"relationship_type" = 'contains'/)
+      expect(contains_edge_queries.size).to eq(1)
+      expect(block_nodes.map(&:key)).to match_array(
+        [123, 456, 789].map { |sid| TariffKnowledge::CompressedNote[sid].metadata.to_hash.dig('evidence_blocks', 0, 'source_node_key') },
+      )
     end
 
     it 'includes fragments that directly apply to the declarable without an explicit range reference' do

--- a/spec/services/tariff_knowledge/compressed_note_generator_spec.rb
+++ b/spec/services/tariff_knowledge/compressed_note_generator_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe TariffKnowledge::CompressedNoteGenerator do
       expect(note.context_hash).to eq(Digest::SHA256.hexdigest(note.content))
     end
 
-    it 'stores coherent note block evidence for definition blocks' do
+    it 'stores coherent note block evidence resolved through contained applying fragments' do
       create(
         :tariff_knowledge_edge,
         source_node: note_block_node,
@@ -158,12 +158,6 @@ RSpec.describe TariffKnowledge::CompressedNoteGenerator do
         source_node: note_block_node,
         target_node: fragment_node,
         relationship_type: TariffKnowledge::Edge::CONTAINS,
-      )
-      create(
-        :tariff_knowledge_edge,
-        source_node: note_block_node,
-        target_node: declarable_node,
-        relationship_type: TariffKnowledge::Edge::APPLIES_TO,
       )
 
       described_class.call(goods_nomenclature_sids: [123])
@@ -189,7 +183,32 @@ RSpec.describe TariffKnowledge::CompressedNoteGenerator do
       expect(note.metadata.to_hash['evidence']).to be_present
     end
 
-    it 'generates from block-only evidence' do
+    it 'keeps fragment parent provenance when a note block also contains the fragment' do
+      create(
+        :tariff_knowledge_edge,
+        source_node: note_block_node,
+        target_node: lead_in_fragment_node,
+        relationship_type: TariffKnowledge::Edge::CONTAINS,
+      )
+      create(
+        :tariff_knowledge_edge,
+        source_node: note_block_node,
+        target_node: fragment_node,
+        relationship_type: TariffKnowledge::Edge::CONTAINS,
+      )
+
+      described_class.call(goods_nomenclature_sids: [123])
+
+      evidence = TariffKnowledge::CompressedNote[123].metadata.to_hash['evidence'].first
+      expect(evidence).to include(
+        'parent_source_node_key' => 'note_source:customs_tariff_chapter_note:1.31:01',
+        'parent_source_title' => 'Chapter 01 notes',
+        'source_context' => '1. This chapter includes: Heading 0101 covers live horses.',
+        'context_type' => 'inclusion',
+      )
+    end
+
+    it 'does not attach block evidence from legacy block applicability edges alone' do
       TariffKnowledge::Edge
         .where(
           source_node_id: fragment_node.id,
@@ -204,6 +223,19 @@ RSpec.describe TariffKnowledge::CompressedNoteGenerator do
           relationship_type: TariffKnowledge::Edge::REFERENCES,
         )
         .delete
+      TariffKnowledge::Edge
+        .where(
+          source_node_id: range_node.id,
+          target_node_id: declarable_node.id,
+          relationship_type: TariffKnowledge::Edge::EXPANDS_TO,
+        )
+        .delete
+      create(
+        :tariff_knowledge_edge,
+        source_node: note_block_node,
+        target_node: fragment_node,
+        relationship_type: TariffKnowledge::Edge::CONTAINS,
+      )
       create(
         :tariff_knowledge_edge,
         source_node: note_block_node,
@@ -214,15 +246,7 @@ RSpec.describe TariffKnowledge::CompressedNoteGenerator do
       described_class.call(goods_nomenclature_sids: [123])
 
       note = TariffKnowledge::CompressedNote[123]
-      expect(note).to have_attributes(stale: false)
-      expect(note.content).to include('pure-bred breeding animals')
-      expect(note.content).to include('animals certified as breeding stock')
-      expect(note.metadata.to_hash).to include(
-        'source_node_keys' => [],
-        'range_node_keys' => [],
-        'evidence' => [],
-      )
-      expect(note.metadata.to_hash['evidence_blocks'].first['fragment_node_keys']).to eq([])
+      expect(note.nil? || note.stale).to be(true)
     end
 
     it 'ignores old source version block evidence' do
@@ -255,14 +279,14 @@ RSpec.describe TariffKnowledge::CompressedNoteGenerator do
       create(
         :tariff_knowledge_edge,
         source_node: old_block_node,
-        target_node: declarable_node,
-        relationship_type: TariffKnowledge::Edge::APPLIES_TO,
+        target_node: fragment_node,
+        relationship_type: TariffKnowledge::Edge::CONTAINS,
       )
       create(
         :tariff_knowledge_edge,
         source_node: note_block_node,
-        target_node: declarable_node,
-        relationship_type: TariffKnowledge::Edge::APPLIES_TO,
+        target_node: fragment_node,
+        relationship_type: TariffKnowledge::Edge::CONTAINS,
       )
 
       described_class.call(goods_nomenclature_sids: [123])
@@ -306,12 +330,6 @@ RSpec.describe TariffKnowledge::CompressedNoteGenerator do
         target_node: fragment_node,
         relationship_type: TariffKnowledge::Edge::CONTAINS,
       )
-      create(
-        :tariff_knowledge_edge,
-        source_node: note_block_node,
-        target_node: declarable_node,
-        relationship_type: TariffKnowledge::Edge::APPLIES_TO,
-      )
 
       described_class.call(goods_nomenclature_sids: [123])
 
@@ -320,27 +338,6 @@ RSpec.describe TariffKnowledge::CompressedNoteGenerator do
     end
 
     it 'preloads block fragment evidence for the requested goods nomenclatures' do
-      TariffKnowledge::Edge
-        .where(
-          source_node_id: fragment_node.id,
-          target_node_id: declarable_node.id,
-          relationship_type: TariffKnowledge::Edge::APPLIES_TO,
-        )
-        .delete
-      TariffKnowledge::Edge
-        .where(
-          source_node_id: fragment_node.id,
-          target_node_id: range_node.id,
-          relationship_type: TariffKnowledge::Edge::REFERENCES,
-        )
-        .delete
-      TariffKnowledge::Edge
-        .where(
-          source_node_id: range_node.id,
-          target_node_id: declarable_node.id,
-          relationship_type: TariffKnowledge::Edge::EXPANDS_TO,
-        )
-        .delete
       second_declarable_node = create(
         :tariff_knowledge_node,
         key: 'goods_nomenclature:456',
@@ -353,13 +350,31 @@ RSpec.describe TariffKnowledge::CompressedNoteGenerator do
         goods_nomenclature_sid: 789,
         goods_nomenclature_item_id: '0101300000',
       )
-      block_nodes = [declarable_node, second_declarable_node, third_declarable_node].map.with_index do |node, index|
+      second_fragment = create(
+        :tariff_knowledge_node,
+        :note_fragment,
+        key: 'note_fragment:customs_tariff_chapter_note:1.31:01:0004',
+        title: 'Chapter 01 notes fragment 4',
+        content: 'Second declarable fragment.',
+      )
+      third_fragment = create(
+        :tariff_knowledge_node,
+        :note_fragment,
+        key: 'note_fragment:customs_tariff_chapter_note:1.31:01:0005',
+        title: 'Chapter 01 notes fragment 5',
+        content: 'Third declarable fragment.',
+      )
+      block_nodes = [
+        [declarable_node, fragment_node, 1],
+        [second_declarable_node, second_fragment, 2],
+        [third_declarable_node, third_fragment, 3],
+      ].map do |node, contained_fragment, index|
         block_node = create(
           :tariff_knowledge_node,
           node_type: TariffKnowledge::Node::NOTE_BLOCK,
-          key: "note_block:customs_tariff_chapter_note:1.31:01:#{index + 1}:a",
-          title: "Definition block #{index + 1}",
-          content: "Block #{index + 1} context.",
+          key: "note_block:customs_tariff_chapter_note:1.31:01:#{index}:a",
+          title: "Definition block #{index}",
+          content: "Block #{index} context.",
           source_type: 'customs_tariff_chapter_note',
           source_id: '01',
           source_version: '1.31',
@@ -371,15 +386,21 @@ RSpec.describe TariffKnowledge::CompressedNoteGenerator do
         create(
           :tariff_knowledge_edge,
           source_node: block_node,
-          target_node: fragment_node,
+          target_node: contained_fragment,
           relationship_type: TariffKnowledge::Edge::CONTAINS,
         )
-        create(
-          :tariff_knowledge_edge,
-          source_node: block_node,
-          target_node: node,
+        unless TariffKnowledge::Edge.where(
+          source_node_id: contained_fragment.id,
+          target_node_id: node.id,
           relationship_type: TariffKnowledge::Edge::APPLIES_TO,
-        )
+        ).any?
+          create(
+            :tariff_knowledge_edge,
+            source_node: contained_fragment,
+            target_node: node,
+            relationship_type: TariffKnowledge::Edge::APPLIES_TO,
+          )
+        end
         block_node
       end
 
@@ -388,7 +409,9 @@ RSpec.describe TariffKnowledge::CompressedNoteGenerator do
       end
 
       contains_edge_queries = queries.grep(/FROM "tariff_knowledge_edges".*"relationship_type" = 'contains'/)
-      expect(contains_edge_queries.size).to eq(1)
+      # Parent resolution, block membership, and per-block contained fragment keys —
+      # batched once for the call, not once per goods nomenclature.
+      expect(contains_edge_queries.size).to be <= 4
       expect(block_nodes.map(&:key)).to match_array(
         [123, 456, 789].map { |sid| TariffKnowledge::CompressedNote[sid].metadata.to_hash.dig('evidence_blocks', 0, 'source_node_key') },
       )
@@ -633,7 +656,8 @@ RSpec.describe TariffKnowledge::CompressedNoteGenerator do
         described_class.call(goods_nomenclature_sids: [123, 456])
       end
 
-      expect(queries.grep(/FROM "tariff_knowledge_edges"/).size).to be <= 5
+      # APPLIES_TO + REFERENCES + EXPANDS_TO + fragment CONTAINS parents + block membership CONTAINS
+      expect(queries.grep(/FROM "tariff_knowledge_edges"/).size).to be <= 7
     end
 
     it 'uses source note context to identify exclusion evidence' do

--- a/spec/services/tariff_knowledge/note_block_parser_spec.rb
+++ b/spec/services/tariff_knowledge/note_block_parser_spec.rb
@@ -51,6 +51,42 @@ RSpec.describe TariffKnowledge::NoteBlockParser do
       )
     end
 
+    it 'scopes repeated marker paths under markdown headings' do
+      fragments = [
+        build_fragment('0001', '1. In this chapter and, in the case of notes (d), (e) and (f) throughout the nomenclature, the following expressions have the meanings hereby assigned to them:'),
+        build_fragment('0002', 'a. pig Iron'),
+        build_fragment('0003', 'Iron-carbon alloys not usefully malleable, containing more than 2 % by weight of carbon.'),
+        build_fragment('0072', '### Subheading notes'),
+        build_fragment('0073', '1. In this chapter, the following expressions have the meanings hereby assigned to them:'),
+        build_fragment('0074', 'a. alloy pig iron'),
+        build_fragment('0075', 'Pig iron containing, by weight, one or more of the following elements in the specified proportions:'),
+      ]
+
+      blocks = described_class.call(
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '72',
+        source_version: '1.31',
+        fragments:,
+      )
+
+      pig_iron = blocks.find { |block| block.metadata['term'] == 'pig iron' }
+      alloy_pig_iron = blocks.find { |block| block.metadata['term'] == 'alloy pig iron' }
+
+      aggregate_failures do
+        expect(pig_iron).to have_attributes(
+          key: 'note_block:customs_tariff_chapter_note:1.31:72:1:a',
+          content: a_string_including('Iron-carbon alloys not usefully malleable'),
+        )
+        expect(alloy_pig_iron).to have_attributes(
+          key: 'note_block:customs_tariff_chapter_note:1.31:72:subheading_notes:1:a',
+          content: a_string_including('Pig iron containing'),
+        )
+        expect(pig_iron.key).not_to eq(alloy_pig_iron.key)
+        expect(pig_iron.metadata['path']).to eq(%w[1 a])
+        expect(alloy_pig_iron.metadata['path']).to eq(%w[subheading_notes 1 a])
+      end
+    end
+
     def build_fragment(sequence, content)
       Data.define(:key, :content).new(
         "note_fragment:customs_tariff_chapter_note:1.31:72:#{sequence}",

--- a/spec/services/tariff_knowledge/note_block_parser_spec.rb
+++ b/spec/services/tariff_knowledge/note_block_parser_spec.rb
@@ -148,6 +148,54 @@ RSpec.describe TariffKnowledge::NoteBlockParser do
       expect(blocks).to be_empty
     end
 
+    it 'scopes repeated lower alpha blocks below uppercase section markers without emitting the section markers' do
+      fragments = [
+        build_fragment('0001', '1. Definitions:'),
+        build_fragment('0002', '(A) General rule'),
+        build_fragment('0003', 'a. first condition'),
+        build_fragment('0004', '(B) Exceptions'),
+        build_fragment('0005', 'a. second condition'),
+      ]
+
+      blocks = described_class.call(
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '72',
+        source_version: '1.31',
+        fragments:,
+      )
+
+      expect(blocks.map(&:key)).to contain_exactly(
+        'note_block:customs_tariff_chapter_note:1.31:72:1:A:a',
+        'note_block:customs_tariff_chapter_note:1.31:72:1:B:a',
+      )
+      expect(blocks.map { |block| block.metadata['term'] }).to contain_exactly('first condition', 'second condition')
+    end
+
+    it 'adds a repeat scope when the same marker path is reused without an explicit section marker' do
+      fragments = [
+        build_fragment('0001', '5. The expression applies only to:'),
+        build_fragment('0002', 'a. included product'),
+        build_fragment('0003', 'b. included mixture'),
+        build_fragment('0004', 'The heading does not apply to:'),
+        build_fragment('0005', '(a) excluded product'),
+        build_fragment('0006', '(b) excluded mixture'),
+      ]
+
+      blocks = described_class.call(
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '34',
+        source_version: '1.31',
+        fragments:,
+      )
+
+      expect(blocks.map(&:key)).to contain_exactly(
+        'note_block:customs_tariff_chapter_note:1.31:34:5:a',
+        'note_block:customs_tariff_chapter_note:1.31:34:5:b',
+        'note_block:customs_tariff_chapter_note:1.31:34:5:repeat_2:a',
+        'note_block:customs_tariff_chapter_note:1.31:34:5:repeat_2:b',
+      )
+    end
+
     def build_fragment(sequence, content)
       Data.define(:key, :content).new(
         "note_fragment:customs_tariff_chapter_note:1.31:72:#{sequence}",

--- a/spec/services/tariff_knowledge/note_block_parser_spec.rb
+++ b/spec/services/tariff_knowledge/note_block_parser_spec.rb
@@ -1,0 +1,61 @@
+RSpec.describe TariffKnowledge::NoteBlockParser do
+  describe '.call' do
+    it 'groups a definition label with its definition body and child composition bullets' do
+      fragments = [
+        build_fragment('0001', '1. In this chapter the following expressions have the meanings hereby assigned to them:'),
+        build_fragment('0002', 'a. pig Iron'),
+        build_fragment('0003', 'Iron-carbon alloys not usefully malleable, containing more than 2 % by weight of carbon and which may contain by weight one or more other elements within the following limits:'),
+        build_fragment('0004', '- not more than 10 % of chromium'),
+        build_fragment('0005', '- not more than 6 % of manganese'),
+        build_fragment('0006', '- not more than 3 % of phosphorus'),
+        build_fragment('0007', '- not more than 8 % of silicon'),
+        build_fragment('0008', '- a total of not more than 10 % of other elements.'),
+        build_fragment('0009', 'b. spiegeleisen'),
+        build_fragment('0010', 'Iron-carbon alloys containing by weight more than 6 % but not more than 30 % of manganese and otherwise conforming to the specification at (a) above.'),
+      ]
+
+      blocks = described_class.call(
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '72',
+        source_version: '1.31',
+        fragments:,
+      )
+
+      pig_iron = blocks.find { |block| block.metadata['term'] == 'pig iron' }
+      expect(pig_iron).to have_attributes(
+        key: 'note_block:customs_tariff_chapter_note:1.31:72:1:a',
+        title: 'pig Iron',
+        content: a_string_including('Iron-carbon alloys not usefully malleable'),
+      )
+      expect(pig_iron.content).to include('not more than 10 % of chromium')
+      expect(pig_iron.content).to include('not more than 6 % of manganese')
+      expect(pig_iron.fragment_keys).to eq(
+        %w[
+          note_fragment:customs_tariff_chapter_note:1.31:72:0002
+          note_fragment:customs_tariff_chapter_note:1.31:72:0003
+          note_fragment:customs_tariff_chapter_note:1.31:72:0004
+          note_fragment:customs_tariff_chapter_note:1.31:72:0005
+          note_fragment:customs_tariff_chapter_note:1.31:72:0006
+          note_fragment:customs_tariff_chapter_note:1.31:72:0007
+          note_fragment:customs_tariff_chapter_note:1.31:72:0008
+        ],
+      )
+
+      spiegeleisen = blocks.find { |block| block.metadata['term'] == 'spiegeleisen' }
+      expect(spiegeleisen.content).to include('more than 6 % but not more than 30 % of manganese')
+      expect(spiegeleisen.fragment_keys).to eq(
+        %w[
+          note_fragment:customs_tariff_chapter_note:1.31:72:0009
+          note_fragment:customs_tariff_chapter_note:1.31:72:0010
+        ],
+      )
+    end
+
+    def build_fragment(sequence, content)
+      Data.define(:key, :content).new(
+        "note_fragment:customs_tariff_chapter_note:1.31:72:#{sequence}",
+        content,
+      )
+    end
+  end
+end

--- a/spec/services/tariff_knowledge/note_block_parser_spec.rb
+++ b/spec/services/tariff_knowledge/note_block_parser_spec.rb
@@ -87,6 +87,67 @@ RSpec.describe TariffKnowledge::NoteBlockParser do
       end
     end
 
+    it 'emits nested roman block candidates with distinct scoped keys and paths' do
+      fragments = [
+        build_fragment('0001', '1. In this chapter the following expressions have the meanings hereby assigned to them:'),
+        build_fragment('0002', 'a. stainless steel'),
+        build_fragment('0003', 'Alloy steels containing chromium.'),
+        build_fragment('0004', '(i) cold-rolled stainless steel'),
+        build_fragment('0005', 'Flat-rolled products further worked than hot-rolled.'),
+      ]
+
+      blocks = described_class.call(
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '72',
+        source_version: '1.31',
+        fragments:,
+      )
+
+      stainless_steel = blocks.find { |block| block.metadata['term'] == 'stainless steel' }
+      cold_rolled = blocks.find { |block| block.metadata['term'] == 'cold-rolled stainless steel' }
+
+      aggregate_failures do
+        expect(stainless_steel).to have_attributes(
+          key: 'note_block:customs_tariff_chapter_note:1.31:72:1:a',
+          content: a_string_including('Alloy steels containing chromium.'),
+        )
+        expect(stainless_steel.content).to include('cold-rolled stainless steel')
+        expect(stainless_steel.content).to include('Flat-rolled products further worked than hot-rolled.')
+        expect(stainless_steel.fragment_keys).to eq(
+          %w[
+            note_fragment:customs_tariff_chapter_note:1.31:72:0002
+            note_fragment:customs_tariff_chapter_note:1.31:72:0003
+            note_fragment:customs_tariff_chapter_note:1.31:72:0004
+            note_fragment:customs_tariff_chapter_note:1.31:72:0005
+          ],
+        )
+        expect(cold_rolled).to have_attributes(
+          key: 'note_block:customs_tariff_chapter_note:1.31:72:1:a:i',
+          content: a_string_including('Flat-rolled products further worked than hot-rolled.'),
+        )
+        expect(stainless_steel.metadata['path']).to eq(%w[1 a])
+        expect(cold_rolled.metadata['path']).to eq(%w[1 a i])
+        expect(cold_rolled.metadata['marker_kind']).to eq('roman')
+        expect(stainless_steel.key).not_to eq(cold_rolled.key)
+      end
+    end
+
+    it 'does not emit standalone marker lists outside numeric note paths as definition blocks' do
+      fragments = [
+        build_fragment('0001', '(a) goods wholly obtained in a country'),
+        build_fragment('0002', 'including mineral products extracted there.'),
+      ]
+
+      blocks = described_class.call(
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '72',
+        source_version: '1.31',
+        fragments:,
+      )
+
+      expect(blocks).to be_empty
+    end
+
     def build_fragment(sequence, content)
       Data.define(:key, :content).new(
         "note_fragment:customs_tariff_chapter_note:1.31:72:#{sequence}",

--- a/spec/services/tariff_knowledge/note_fragment_splitter_spec.rb
+++ b/spec/services/tariff_knowledge/note_fragment_splitter_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe TariffKnowledge::NoteFragmentSplitter do
+  describe '.call' do
+    it 'merges orphaned list markers into the following fragment' do
+      fragments = described_class.call("1. Definitions:\n\na.\n\npig iron")
+
+      expect(fragments).to eq(['1. Definitions:', 'a. pig iron'])
+    end
+
+    it 'preserves dangling numeric references with their introducing fragment' do
+      fragments = described_class.call("Goods of heading\n8481. C. Further text.")
+
+      expect(fragments).to eq(['Goods of heading 8481.', 'C. Further text.'])
+    end
+
+    it 'does not merge ordinary numbered note markers into preceding prose' do
+      fragments = described_class.call("This chapter covers goods.\n\n1. Definitions.")
+
+      expect(fragments).to eq(['This chapter covers goods.', '1. Definitions.'])
+    end
+  end
+end

--- a/spec/services/tariff_knowledge/note_marker_classifier_spec.rb
+++ b/spec/services/tariff_knowledge/note_marker_classifier_spec.rb
@@ -1,0 +1,153 @@
+RSpec.describe TariffKnowledge::NoteMarkerClassifier do
+  describe '.call' do
+    def fragment(key, content)
+      Data.define(:key, :content).new(key, content)
+    end
+
+    it 'classifies markdown headings' do
+      event = described_class.call(fragment('f1', '### Subheading notes'))
+
+      expect(event).to have_attributes(
+        kind: :heading,
+        marker: 'subheading_notes',
+        depth: 0,
+        path_segment: 'subheading_notes',
+        title: 'Subheading notes',
+        body: '',
+      )
+    end
+
+    it 'classifies numeric markers with trailing body' do
+      event = described_class.call(fragment('f1', '1. In this chapter, the following expressions have meanings:'))
+
+      expect(event).to have_attributes(
+        kind: :numeric,
+        marker: '1',
+        depth: 1,
+        path_segment: '1',
+        title: '1',
+        body: 'In this chapter, the following expressions have meanings:',
+      )
+    end
+
+    it 'classifies definition-like alpha markers' do
+      event = described_class.call(fragment('f2', 'a. pig Iron'))
+
+      expect(event).to have_attributes(
+        kind: :alpha,
+        marker: 'a',
+        depth: 2,
+        path_segment: 'a',
+        title: 'pig Iron',
+        body: '',
+      )
+    end
+
+    it 'classifies single-letter roman-looking markers as alpha definitions' do
+      event = described_class.call(fragment('f2', 'i. insulating materials'))
+
+      expect(event).to have_attributes(
+        kind: :alpha,
+        marker: 'i',
+        depth: 2,
+        path_segment: 'i',
+        title: 'insulating materials',
+        body: '',
+      )
+    end
+
+    it 'reattaches compact marker suffixes to the body' do
+      event = described_class.call(fragment('f2', '1.foo bar'))
+
+      expect(event).to have_attributes(
+        kind: :numeric,
+        marker: '1',
+        depth: 1,
+        path_segment: '1',
+        title: '1',
+        body: 'foo bar',
+      )
+    end
+
+    it 'does not classify decimals as compact marker prefixes' do
+      event = described_class.call(fragment('f2', '1.23 % by weight'))
+
+      expect(event).to have_attributes(
+        kind: :continuation,
+        marker: nil,
+        depth: nil,
+        title: nil,
+        body: '1.23 % by weight',
+      )
+    end
+
+    it 'does not classify abbreviations as compact marker prefixes' do
+      event = described_class.call(fragment('f2', 'i.e. examples'))
+
+      expect(event).to have_attributes(
+        kind: :continuation,
+        marker: nil,
+        depth: nil,
+        title: nil,
+        body: 'i.e. examples',
+      )
+    end
+
+    it 'does not classify compact alpha prefixes' do
+      event = described_class.call(fragment('f2', 'a.foo bar'))
+
+      expect(event).to have_attributes(
+        kind: :continuation,
+        marker: nil,
+        body: 'a.foo bar',
+      )
+    end
+
+    it 'does not classify compact roman prefixes' do
+      event = described_class.call(fragment('f2', 'ii.foo bar'))
+
+      expect(event).to have_attributes(
+        kind: :continuation,
+        marker: nil,
+        body: 'ii.foo bar',
+      )
+    end
+
+    it 'classifies uppercase markers case-insensitively' do
+      event = described_class.call(fragment('f2', 'A. The following'))
+
+      expect(event).to have_attributes(
+        kind: :alpha,
+        marker: 'a',
+        depth: 2,
+        path_segment: 'a',
+        title: 'The following',
+        body: '',
+      )
+    end
+
+    it 'classifies bullets without treating them as definitions' do
+      event = described_class.call(fragment('f3', '- not more than 10 % of chromium'))
+
+      expect(event).to have_attributes(
+        kind: :bullet,
+        marker: '-',
+        depth: 4,
+        title: nil,
+        body: 'not more than 10 % of chromium',
+      )
+    end
+
+    it 'classifies unmatched text as continuation' do
+      event = described_class.call(fragment('f4', 'Iron-carbon alloys not usefully malleable.'))
+
+      expect(event).to have_attributes(
+        kind: :continuation,
+        marker: nil,
+        depth: nil,
+        title: nil,
+        body: 'Iron-carbon alloys not usefully malleable.',
+      )
+    end
+  end
+end

--- a/spec/services/tariff_knowledge/note_marker_classifier_spec.rb
+++ b/spec/services/tariff_knowledge/note_marker_classifier_spec.rb
@@ -113,15 +113,51 @@ RSpec.describe TariffKnowledge::NoteMarkerClassifier do
       )
     end
 
-    it 'classifies uppercase markers case-insensitively' do
+    it 'classifies uppercase alpha markers as structural section scopes' do
       event = described_class.call(fragment('f2', 'A. The following'))
 
       expect(event).to have_attributes(
-        kind: :alpha,
-        marker: 'a',
+        kind: :alpha_section,
+        marker: 'A',
         depth: 2,
-        path_segment: 'a',
+        path_segment: 'A',
         title: 'The following',
+        body: '',
+      )
+    end
+
+    it 'classifies parenthesized uppercase alpha markers with trailing periods as section scopes' do
+      event = described_class.call(fragment('f2', '(A). For paper or paperboard weighing not more than 150 g/m2:'))
+
+      expect(event).to have_attributes(
+        kind: :alpha_section,
+        marker: 'A',
+        depth: 2,
+        path_segment: 'A',
+        title: 'For paper or paperboard weighing not more than 150 g/m2:',
+        body: '',
+      )
+    end
+
+    it 'does not classify lowercase parenthesized cross-references with trailing periods as list markers' do
+      event = described_class.call(fragment('f2', '(b). Strip and the like are not considered fibres.'))
+
+      expect(event).to have_attributes(
+        kind: :continuation,
+        marker: nil,
+        body: '(b). Strip and the like are not considered fibres.',
+      )
+    end
+
+    it 'classifies bullet-prefixed uppercase alpha markers as section scopes' do
+      event = described_class.call(fragment('f2', '- (B) Heading 8422 does not cover:'))
+
+      expect(event).to have_attributes(
+        kind: :alpha_section,
+        marker: 'B',
+        depth: 2,
+        path_segment: 'B',
+        title: 'Heading 8422 does not cover:',
         body: '',
       )
     end

--- a/spec/services/tariff_knowledge/note_marker_trie_spec.rb
+++ b/spec/services/tariff_knowledge/note_marker_trie_spec.rb
@@ -1,0 +1,47 @@
+RSpec.describe TariffKnowledge::NoteMarkerTrie do
+  describe '#match' do
+    it 'classifies exact marker tokens by longest registered match' do
+      trie = described_class.default
+
+      expect(trie.match('ij.')).to have_attributes(kind: :alpha, marker: 'ij')
+      expect(trie.match('ii.')).to have_attributes(kind: :roman, marker: 'ii')
+      expect(trie.match('(a)')).to have_attributes(kind: :alpha, marker: 'a')
+      expect(trie.match('—')).to have_attributes(kind: :bullet, marker: '—')
+    end
+
+    it 'classifies single-letter roman-looking tokens as alpha markers' do
+      trie = described_class.default
+
+      expect(trie.match('i.')).to have_attributes(kind: :alpha, marker: 'i')
+      expect(trie.match('v.')).to have_attributes(kind: :alpha, marker: 'v')
+      expect(trie.match('x.')).to have_attributes(kind: :alpha, marker: 'x')
+    end
+
+    it 'classifies parenthesized and suffix single-letter roman tokens as roman markers' do
+      trie = described_class.default
+
+      expect(trie.match('(i)')).to have_attributes(kind: :roman, marker: 'i')
+      expect(trie.match('i)')).to have_attributes(kind: :roman, marker: 'i')
+      expect(trie.match('(v)')).to have_attributes(kind: :roman, marker: 'v')
+      expect(trie.match('v)')).to have_attributes(kind: :roman, marker: 'v')
+      expect(trie.match('(x)')).to have_attributes(kind: :roman, marker: 'x')
+      expect(trie.match('x)')).to have_attributes(kind: :roman, marker: 'x')
+    end
+
+    it 'classifies multi-letter roman tokens as roman markers' do
+      trie = described_class.default
+
+      expect(trie.match('ii.')).to have_attributes(kind: :roman, marker: 'ii')
+      expect(trie.match('iv.')).to have_attributes(kind: :roman, marker: 'iv')
+      expect(trie.match('xii.')).to have_attributes(kind: :roman, marker: 'xii')
+    end
+
+    it 'classifies the longest registered prefix before prose starts' do
+      expect(described_class.default.match('1.foo')).to have_attributes(kind: :numeric, marker: '1')
+    end
+
+    it 'returns nil for prose that is not a registered marker' do
+      expect(described_class.default.match('Iron-carbon')).to be_nil
+    end
+  end
+end

--- a/spec/services/tariff_knowledge/note_structure_parser_spec.rb
+++ b/spec/services/tariff_knowledge/note_structure_parser_spec.rb
@@ -1,0 +1,133 @@
+RSpec.describe TariffKnowledge::NoteStructureParser do
+  describe '.call' do
+    def fragment(sequence, content)
+      Data.define(:key, :content).new("note_fragment:customs_tariff_chapter_note:1.31:72:#{sequence}", content)
+    end
+
+    it 'builds scoped trees for repeated marker paths under headings' do
+      tree = described_class.call(
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '72',
+        source_version: '1.31',
+        fragments: [
+          fragment('0001', '1. In this chapter the following expressions have meanings:'),
+          fragment('0002', 'a. pig Iron'),
+          fragment('0003', 'Iron-carbon alloys not usefully malleable.'),
+          fragment('0004', '- not more than 10 % of chromium'),
+          fragment('0072', '### Subheading notes'),
+          fragment('0073', '1. In this chapter, the following expressions have meanings:'),
+          fragment('0074', 'a. alloy pig iron'),
+          fragment('0075', 'Pig iron containing one or more specified elements.'),
+        ],
+      )
+
+      pig_iron = tree.nodes.find { |node| node.title == 'pig Iron' }
+      alloy_pig_iron = tree.nodes.find { |node| node.title == 'alloy pig iron' }
+
+      expect(pig_iron.path).to eq(%w[1 a])
+      expect(pig_iron.fragment_keys).to contain_exactly(
+        'note_fragment:customs_tariff_chapter_note:1.31:72:0002',
+        'note_fragment:customs_tariff_chapter_note:1.31:72:0003',
+        'note_fragment:customs_tariff_chapter_note:1.31:72:0004',
+      )
+      expect(pig_iron.content).to include('Iron-carbon alloys not usefully malleable.')
+      expect(pig_iron.content).to include('not more than 10 % of chromium')
+      expect(alloy_pig_iron.path).to eq(%w[subheading_notes 1 a])
+      expect(alloy_pig_iron.fragment_keys).to contain_exactly(
+        'note_fragment:customs_tariff_chapter_note:1.31:72:0074',
+        'note_fragment:customs_tariff_chapter_note:1.31:72:0075',
+      )
+      expect(alloy_pig_iron.content).to include('Pig iron containing one or more specified elements.')
+    end
+
+    it 'attaches continuations and bullets to the nearest active structural node' do
+      tree = described_class.call(
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '72',
+        source_version: '1.31',
+        fragments: [
+          fragment('0001', '1. Definitions:'),
+          fragment('0002', 'a. steel'),
+          fragment('0003', 'Ferrous materials usefully malleable.'),
+          fragment('0004', '- with carbon limits'),
+          fragment('0005', '- with chromium exceptions'),
+        ],
+      )
+
+      steel = tree.nodes.find { |node| node.title == 'steel' }
+      expect(steel.content).to include('Ferrous materials usefully malleable.')
+      expect(steel.content).to include('with carbon limits')
+      expect(steel.content).to include('with chromium exceptions')
+    end
+
+    it 'nests roman block candidates under active alpha block candidates' do
+      tree = described_class.call(
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '72',
+        source_version: '1.31',
+        fragments: [
+          fragment('0001', '1. Definitions:'),
+          fragment('0002', 'a. steel'),
+          fragment('0003', '(i) stainless steel'),
+          fragment('0004', 'Containing chromium.'),
+        ],
+      )
+
+      steel = tree.nodes.find { |node| node.title == 'steel' }
+      stainless_steel = steel.children.find { |node| node.title == 'stainless steel' }
+
+      expect(tree.nodes.map(&:title)).to include('steel')
+      expect(tree.nodes.map(&:title)).not_to include('stainless steel')
+      expect(steel.children.map(&:title)).to include('stainless steel')
+      expect(stainless_steel.path).to eq(%w[1 a i])
+      expect(stainless_steel.content).to include('Containing chromium.')
+      expect(stainless_steel.fragment_keys).to contain_exactly(
+        'note_fragment:customs_tariff_chapter_note:1.31:72:0003',
+        'note_fragment:customs_tariff_chapter_note:1.31:72:0004',
+      )
+    end
+
+    it 'does not attach sibling continuations to stale nested block candidates' do
+      tree = described_class.call(
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '72',
+        source_version: '1.31',
+        fragments: [
+          fragment('0001', '1. Definitions:'),
+          fragment('0002', 'a. steel'),
+          fragment('0003', '(i) stainless steel'),
+          fragment('0004', 'Containing chromium.'),
+          fragment('0005', 'b. iron'),
+          fragment('0006', 'Containing carbon.'),
+        ],
+      )
+
+      steel = tree.nodes.find { |node| node.title == 'steel' }
+      iron = tree.nodes.find { |node| node.title == 'iron' }
+      stainless_steel = steel.children.find { |node| node.title == 'stainless steel' }
+
+      expect(tree.nodes.map(&:title)).to contain_exactly('steel', 'iron')
+      expect(iron.content).to include('Containing carbon.')
+      expect(stainless_steel.content).to include('Containing chromium.')
+      expect(stainless_steel.content).not_to include('Containing carbon.')
+    end
+
+    it 'reports orphan events that cannot attach to a block candidate' do
+      tree = described_class.call(
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '72',
+        source_version: '1.31',
+        fragments: [
+          fragment('0001', '- orphan bullet'),
+          fragment('0002', '1. Definitions:'),
+          fragment('0003', 'a. steel'),
+        ],
+      )
+
+      expect(tree.orphans.map { |event| event.fragment.key }).to contain_exactly(
+        'note_fragment:customs_tariff_chapter_note:1.31:72:0001',
+      )
+      expect(tree.nodes.map(&:title)).to include('steel')
+    end
+  end
+end

--- a/spec/services/tariff_knowledge/note_structure_parser_spec.rb
+++ b/spec/services/tariff_knowledge/note_structure_parser_spec.rb
@@ -112,6 +112,31 @@ RSpec.describe TariffKnowledge::NoteStructureParser do
       expect(stainless_steel.content).not_to include('Containing carbon.')
     end
 
+    it 'uses uppercase alpha markers as section scopes for repeated lower alpha lists' do
+      tree = described_class.call(
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '72',
+        source_version: '1.31',
+        fragments: [
+          fragment('0001', '1. Definitions:'),
+          fragment('0002', '(A) General rule'),
+          fragment('0003', 'a. first condition'),
+          fragment('0004', '(B) Exceptions'),
+          fragment('0005', 'a. second condition'),
+        ],
+      )
+
+      general_rule = tree.nodes.find { |node| node.title == 'General rule' }
+      exceptions = tree.nodes.find { |node| node.title == 'Exceptions' }
+      first_condition = general_rule.children.find { |node| node.title == 'first condition' }
+      second_condition = exceptions.children.find { |node| node.title == 'second condition' }
+
+      expect(general_rule).to have_attributes(kind: :alpha_section, path: %w[1 A])
+      expect(exceptions).to have_attributes(kind: :alpha_section, path: %w[1 B])
+      expect(first_condition.path).to eq(%w[1 A a])
+      expect(second_condition.path).to eq(%w[1 B a])
+    end
+
     it 'reports orphan events that cannot attach to a block candidate' do
       tree = described_class.call(
         source_type: 'customs_tariff_chapter_note',

--- a/spec/services/tariff_knowledge/note_structure_validator_spec.rb
+++ b/spec/services/tariff_knowledge/note_structure_validator_spec.rb
@@ -1,0 +1,112 @@
+RSpec.describe TariffKnowledge::NoteStructureValidator do
+  describe '.call' do
+    def fragment(sequence, content)
+      Data.define(:key, :content).new(
+        "note_fragment:customs_tariff_chapter_note:1.31:72:#{sequence}",
+        content,
+      )
+    end
+
+    it 'reports a clean parsed note structure' do
+      result = described_class.call(
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '72',
+        source_version: '1.31',
+        fragments: [
+          fragment('0001', '1. In this chapter the following expressions have meanings:'),
+          fragment('0002', 'a. pig Iron'),
+          fragment('0003', 'Iron-carbon alloys not usefully malleable.'),
+        ],
+      )
+
+      aggregate_failures do
+        expect(result).to have_attributes(
+          source_type: 'customs_tariff_chapter_note',
+          source_id: '72',
+          source_version: '1.31',
+          fragment_count: 3,
+          event_count: 3,
+          root_node_count: 1,
+          total_node_count: 1,
+          orphan_event_count: 0,
+          orphan_event_keys: [],
+          duplicate_block_keys: [],
+          uncontained_fragment_keys: [],
+          issues: [],
+        )
+      end
+    end
+
+    it 'reports orphan and uncontained fragments without raising' do
+      result = described_class.call(
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '72',
+        source_version: '1.31',
+        fragments: [
+          fragment('0001', '- orphan bullet'),
+          fragment('0002', '1. Definitions:'),
+          fragment('0003', 'a. steel'),
+        ],
+      )
+
+      expect(result.orphan_event_keys).to contain_exactly('note_fragment:customs_tariff_chapter_note:1.31:72:0001')
+      expect(result.uncontained_fragment_keys).to contain_exactly(
+        'note_fragment:customs_tariff_chapter_note:1.31:72:0001',
+      )
+      expect(result.issues.map(&:code)).to include('orphan_events', 'uncontained_fragments')
+    end
+
+    it 'does not report ordinary continuation prose as an uncontained definition fragment' do
+      result = described_class.call(
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '72',
+        source_version: '1.31',
+        fragments: [
+          fragment('0001', '1. General provisions:'),
+          fragment('0002', 'This chapter covers goods of iron or steel.'),
+        ],
+      )
+
+      expect(result.uncontained_fragment_keys).to be_empty
+      expect(result.issues.map(&:code)).not_to include('uncontained_fragments')
+    end
+
+    it 'reports duplicate block keys from emitted blocks' do
+      first_block = TariffKnowledge::NoteBlockParser::Block.new(
+        key: 'note_block:customs_tariff_chapter_note:1.31:72:1:a',
+        title: 'steel',
+        content: 'steel',
+        metadata: {},
+        fragment_keys: ['note_fragment:customs_tariff_chapter_note:1.31:72:0002'],
+      )
+      second_block = first_block.with(title: 'steel duplicate')
+
+      result = described_class.call(
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '72',
+        source_version: '1.31',
+        fragments: [
+          fragment('0001', '1. Definitions:'),
+          fragment('0002', 'a. steel'),
+        ],
+        block_parser: class_double(TariffKnowledge::NoteBlockParser, call: [first_block, second_block]),
+      )
+
+      expect(result.duplicate_block_keys).to contain_exactly('note_block:customs_tariff_chapter_note:1.31:72:1:a')
+      expect(result.issues.map(&:code)).to include('duplicate_block_keys')
+    end
+
+    it 'can split content into source fragments for generic callers' do
+      result = described_class.call(
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '72',
+        source_version: '1.31',
+        content: "1. Definitions:\n\na. steel\n\nGoods of heading\n8481. C. Further text.",
+      )
+
+      expect(result.fragment_count).to eq(4)
+      expect(result.source_id).to eq('72')
+      expect(result.issues.map(&:code)).not_to include('missing_fragments')
+    end
+  end
+end

--- a/spec/services/tariff_knowledge/relevant_note_fragment_selector_spec.rb
+++ b/spec/services/tariff_knowledge/relevant_note_fragment_selector_spec.rb
@@ -130,11 +130,66 @@ RSpec.describe TariffKnowledge::RelevantNoteFragmentSelector do
     expect(first_fragment[:why_relevant].scan(/exact phrase match pig iron/).size).to eq(1)
     expect(first_fragment[:why_relevant]).to include('definition block')
     expect(first_fragment[:score]).to eq(
-      described_class::EXACT_PHRASE_SCORE +
+      described_class::EXACT_TERM_SCORE +
+        described_class::EXACT_PHRASE_SCORE +
         described_class::DEFINITION_BLOCK_SCORE +
         described_class::QUERY_TERM_SCORE * 2 +
         described_class::SAME_CHAPTER_SCORE,
     )
+  end
+
+  it 'ranks exact term definition blocks ahead of longer phrase-containing terms' do
+    pig_iron_note = create(
+      :tariff_knowledge_compressed_note,
+      goods_nomenclature_item_id: '7201200000',
+      content: 'compressed note pig iron equality',
+      context_hash: Digest::SHA256.hexdigest('compressed note pig iron equality'),
+      metadata: Sequel.pg_jsonb_wrap(
+        'evidence_blocks' => [
+          {
+            'source_node_key' => 'note_block:customs_tariff_chapter_note:1.31:72:1:a',
+            'source_title' => 'pig Iron',
+            'source_context' => 'pig Iron: Iron-carbon alloys not usefully malleable, containing more than 2 % carbon; not more than 10 % chromium.',
+            'block_type' => 'definition',
+            'term' => 'pig iron',
+            'source_type' => 'customs_tariff_chapter_note',
+            'source_id' => '72',
+            'fragment_node_keys' => [],
+          },
+          {
+            'source_node_key' => 'note_block:customs_tariff_chapter_note:1.31:72:1:b',
+            'source_title' => 'alloy pig iron',
+            'source_context' => 'alloy pig iron: Pig iron containing, by mass, one or more alloy elements in specified proportions.',
+            'block_type' => 'definition',
+            'term' => 'alloy pig iron',
+            'source_type' => 'customs_tariff_chapter_note',
+            'source_id' => '72',
+            'fragment_node_keys' => [],
+          },
+        ],
+      ),
+    )
+
+    contexts = described_class.call(
+      query: 'pig iron',
+      search_results: [
+        search_result_class.new(
+          goods_nomenclature_item_id: '7201200000',
+          description: 'Non-alloy pig iron in pigs, blocks or other primary forms',
+          full_description: nil,
+          score: 10,
+        ),
+      ],
+      notes_by_item_id: { '7201200000' => pig_iron_note },
+    )
+
+    fragments = contexts.first[:fragments]
+
+    expect(fragments.first[:source]).to eq('pig Iron')
+    expect(fragments.second[:source]).to eq('alloy pig iron')
+    expect(fragments.first[:why_relevant]).to include('exact term match pig iron')
+    expect(fragments.second[:why_relevant]).to include('exact phrase match pig iron in term')
+    expect(fragments.second[:why_relevant]).not_to include('exact term match pig iron')
   end
 
   it 'does not emit full compressed note content' do

--- a/spec/services/tariff_knowledge/relevant_note_fragment_selector_spec.rb
+++ b/spec/services/tariff_knowledge/relevant_note_fragment_selector_spec.rb
@@ -192,6 +192,121 @@ RSpec.describe TariffKnowledge::RelevantNoteFragmentSelector do
     expect(fragments.second[:why_relevant]).not_to include('exact term match pig iron')
   end
 
+  it 'does not select a compound definition block for a single-word modifier query' do
+    pig_iron_note = create(
+      :tariff_knowledge_compressed_note,
+      goods_nomenclature_item_id: '7201200000',
+      content: 'compressed note pig modifier',
+      context_hash: Digest::SHA256.hexdigest('compressed note pig modifier'),
+      metadata: Sequel.pg_jsonb_wrap(
+        'evidence_blocks' => [
+          {
+            'source_node_key' => 'note_block:customs_tariff_chapter_note:1.31:72:1:a',
+            'source_title' => 'pig Iron',
+            'source_context' => 'pig Iron: Iron-carbon alloys not usefully malleable.',
+            'block_type' => 'definition',
+            'term' => 'pig iron',
+            'source_type' => 'customs_tariff_chapter_note',
+            'source_id' => '72',
+            'fragment_node_keys' => [],
+          },
+        ],
+      ),
+    )
+
+    contexts = described_class.call(
+      query: 'pig',
+      search_results: [
+        search_result_class.new(
+          goods_nomenclature_item_id: '7201200000',
+          description: 'Non-alloy pig iron',
+          full_description: nil,
+          score: 10,
+        ),
+      ],
+      notes_by_item_id: { '7201200000' => pig_iron_note },
+    )
+
+    expect(contexts).to be_empty
+  end
+
+  it 'does not select an unrelated definition block because aggregate text contains a single-word query' do
+    aggregate_note = create(
+      :tariff_knowledge_compressed_note,
+      goods_nomenclature_item_id: '7201200000',
+      content: 'compressed note aggregate pig',
+      context_hash: Digest::SHA256.hexdigest('compressed note aggregate pig'),
+      metadata: Sequel.pg_jsonb_wrap(
+        'evidence_blocks' => [
+          {
+            'source_node_key' => 'note_block:customs_tariff_chapter_note:1.31:72:1:d',
+            'source_title' => 'remelting scrap ingots of iron or steel',
+            'source_context' => 'remelting scrap ingots of iron or steel: Parent aggregate text also includes the pig iron definition below it.',
+            'block_type' => 'definition',
+            'term' => 'remelting scrap ingots of iron or steel',
+            'source_type' => 'customs_tariff_chapter_note',
+            'source_id' => '72',
+            'fragment_node_keys' => [],
+          },
+        ],
+      ),
+    )
+
+    contexts = described_class.call(
+      query: 'pig',
+      search_results: [
+        search_result_class.new(
+          goods_nomenclature_item_id: '7201200000',
+          description: 'Non-alloy pig iron',
+          full_description: nil,
+          score: 10,
+        ),
+      ],
+      notes_by_item_id: { '7201200000' => aggregate_note },
+    )
+
+    expect(contexts).to be_empty
+  end
+
+  it 'selects a compound definition block for a single-word head-term query' do
+    pig_iron_note = create(
+      :tariff_knowledge_compressed_note,
+      goods_nomenclature_item_id: '7201200000',
+      content: 'compressed note iron head',
+      context_hash: Digest::SHA256.hexdigest('compressed note iron head'),
+      metadata: Sequel.pg_jsonb_wrap(
+        'evidence_blocks' => [
+          {
+            'source_node_key' => 'note_block:customs_tariff_chapter_note:1.31:72:1:a',
+            'source_title' => 'pig Iron',
+            'source_context' => 'pig Iron: Iron-carbon alloys not usefully malleable.',
+            'block_type' => 'definition',
+            'term' => 'pig iron',
+            'source_type' => 'customs_tariff_chapter_note',
+            'source_id' => '72',
+            'fragment_node_keys' => [],
+          },
+        ],
+      ),
+    )
+
+    contexts = described_class.call(
+      query: 'iron',
+      search_results: [
+        search_result_class.new(
+          goods_nomenclature_item_id: '7201200000',
+          description: 'Non-alloy pig iron',
+          full_description: nil,
+          score: 10,
+        ),
+      ],
+      notes_by_item_id: { '7201200000' => pig_iron_note },
+    )
+
+    expect(contexts.first[:fragments].first[:source]).to eq('pig Iron')
+    expect(contexts.first[:fragments].first[:why_relevant]).to include('exact phrase match iron in term')
+  end
+
   it 'does not emit full compressed note content' do
     contexts = described_class.call(
       query:,

--- a/spec/services/tariff_knowledge/relevant_note_fragment_selector_spec.rb
+++ b/spec/services/tariff_knowledge/relevant_note_fragment_selector_spec.rb
@@ -77,6 +77,66 @@ RSpec.describe TariffKnowledge::RelevantNoteFragmentSelector do
     expect(fragment_texts).not_to include(a_string_including('candles'))
   end
 
+  it 'prefers exact query definition blocks over generic chapter exclusions' do
+    pig_iron_note = create(
+      :tariff_knowledge_compressed_note,
+      goods_nomenclature_item_id: '7201200000',
+      content: 'compressed note 7201200000',
+      context_hash: Digest::SHA256.hexdigest('compressed note 7201200000'),
+      metadata: Sequel.pg_jsonb_wrap(
+        'evidence_blocks' => [
+          {
+            'source_node_key' => 'note_block:customs_tariff_chapter_note:1.31:72:1:a',
+            'source_title' => 'pig Iron',
+            'source_context' => 'pig Iron: Iron-carbon alloys not usefully malleable, containing more than 2 % carbon; not more than 10 % chromium; not more than 6 % manganese.',
+            'block_type' => 'definition',
+            'term' => 'pig iron',
+            'path' => %w[1 a],
+            'source_type' => 'customs_tariff_chapter_note',
+            'source_id' => '72',
+            'source_version' => '1.31',
+            'fragment_node_keys' => [],
+          },
+        ],
+        'evidence' => [
+          evidence_for(
+            'note_fragment:customs_tariff_chapter_note:1.31:72:0069',
+            'Chapter 72 does not include products of heading 7301 or 7302.',
+            'exclusion',
+            source_id: '72',
+          ),
+        ],
+      ),
+    )
+
+    contexts = described_class.call(
+      query: 'pig iron',
+      search_results: [
+        search_result_class.new(
+          goods_nomenclature_item_id: '7201200000',
+          description: 'Non-alloy pig iron in pigs, blocks or other primary forms',
+          full_description: nil,
+          score: 10,
+        ),
+      ],
+      notes_by_item_id: { '7201200000' => pig_iron_note },
+    )
+
+    first_fragment = contexts.first[:fragments].first
+    expect(first_fragment[:text]).to include('pig Iron')
+    expect(first_fragment[:text]).to include('not more than 10 % chromium')
+    expect(first_fragment[:text]).not_to eq('Chapter 72 does not include products of heading 7301 or 7302.')
+    expect(first_fragment[:why_relevant]).to include('exact phrase match pig iron')
+    expect(first_fragment[:why_relevant].scan(/exact phrase match pig iron/).size).to eq(1)
+    expect(first_fragment[:why_relevant]).to include('definition block')
+    expect(first_fragment[:score]).to eq(
+      described_class::EXACT_PHRASE_SCORE +
+        described_class::DEFINITION_BLOCK_SCORE +
+        described_class::QUERY_TERM_SCORE * 2 +
+        described_class::SAME_CHAPTER_SCORE,
+    )
+  end
+
   it 'does not emit full compressed note content' do
     contexts = described_class.call(
       query:,
@@ -94,6 +154,46 @@ RSpec.describe TariffKnowledge::RelevantNoteFragmentSelector do
         query:,
         search_results:,
         notes_by_item_id: { '9506911000' => note },
+      )
+    end
+
+    expect(queries.grep(/FROM "tariff_knowledge_nodes"/)).to be_empty
+  end
+
+  it 'does not load fragment nodes for block evidence with metadata context and title' do
+    block_only_note = create(
+      :tariff_knowledge_compressed_note,
+      goods_nomenclature_item_id: '7201200000',
+      content: 'compressed note block only',
+      context_hash: Digest::SHA256.hexdigest('compressed note block only'),
+      metadata: Sequel.pg_jsonb_wrap(
+        'evidence_blocks' => [
+          {
+            'source_node_key' => 'note_block:customs_tariff_chapter_note:1.31:72:1:a',
+            'source_title' => 'pig Iron',
+            'source_context' => 'pig Iron: Iron-carbon alloys not usefully malleable.',
+            'block_type' => 'definition',
+            'term' => 'pig iron',
+            'source_type' => 'customs_tariff_chapter_note',
+            'source_id' => '72',
+            'fragment_node_keys' => [],
+          },
+        ],
+      ),
+    )
+
+    queries = sql_queries do
+      described_class.call(
+        query: 'pig iron',
+        search_results: [
+          search_result_class.new(
+            goods_nomenclature_item_id: '7201200000',
+            description: 'Non-alloy pig iron in pigs, blocks or other primary forms',
+            full_description: nil,
+            score: 10,
+          ),
+        ],
+        notes_by_item_id: { '7201200000' => block_only_note },
       )
     end
 
@@ -199,11 +299,11 @@ RSpec.describe TariffKnowledge::RelevantNoteFragmentSelector do
     expect(contexts).to be_empty
   end
 
-  def evidence_for(key, text, context_type, range_type: nil, range_code: nil, source_type: 'customs_tariff_chapter_note')
+  def evidence_for(key, text, context_type, range_type: nil, range_code: nil, source_type: 'customs_tariff_chapter_note', source_id: '95')
     {
       'source_node_key' => key,
       'source_type' => source_type,
-      'source_id' => '95',
+      'source_id' => source_id,
       'source_title' => key.split(':').last,
       'source_context' => text,
       'context_type' => context_type,

--- a/spec/services/tariff_knowledge/relevant_note_fragment_selector_spec.rb
+++ b/spec/services/tariff_knowledge/relevant_note_fragment_selector_spec.rb
@@ -126,6 +126,7 @@ RSpec.describe TariffKnowledge::RelevantNoteFragmentSelector do
     expect(first_fragment[:text]).to include('pig Iron')
     expect(first_fragment[:text]).to include('not more than 10 % chromium')
     expect(first_fragment[:text]).not_to eq('Chapter 72 does not include products of heading 7301 or 7302.')
+    expect(first_fragment[:source_ref]).to eq('chapter 72 note')
     expect(first_fragment[:why_relevant]).to include('exact phrase match pig iron')
     expect(first_fragment[:why_relevant].scan(/exact phrase match pig iron/).size).to eq(1)
     expect(first_fragment[:why_relevant]).to include('definition block')
@@ -446,6 +447,34 @@ RSpec.describe TariffKnowledge::RelevantNoteFragmentSelector do
     )
 
     expect(contexts.first[:fragments].first[:why_relevant]).to include('references retrieved heading 9506')
+  end
+
+  it 'includes source references for fragment evidence sent to the classifier context' do
+    source_note = create_note_with_evidence(
+      '9506911000',
+      evidence_for(
+        'note_fragment:customs_tariff_chapter_note:1.31:95:source',
+        'Heading 9506 includes articles and equipment for general physical exercise.',
+        'inclusion',
+        range_type: 'heading',
+        range_code: '9506',
+      ),
+    )
+
+    contexts = described_class.call(
+      query: 'exercise apparatus',
+      search_results: [
+        search_result_class.new(
+          goods_nomenclature_item_id: '9506911000',
+          description: 'Articles and equipment for general physical exercise',
+          full_description: nil,
+          score: 10,
+        ),
+      ],
+      notes_by_item_id: { '9506911000' => source_note },
+    )
+
+    expect(contexts.first[:fragments].first[:source_ref]).to eq('chapter 95 note')
   end
 
   it 'caps total emitted fragments across all selected notes' do

--- a/spec/services/tariff_knowledge/relevant_note_fragment_selector_spec.rb
+++ b/spec/services/tariff_knowledge/relevant_note_fragment_selector_spec.rb
@@ -129,13 +129,8 @@ RSpec.describe TariffKnowledge::RelevantNoteFragmentSelector do
     expect(first_fragment[:why_relevant]).to include('exact phrase match pig iron')
     expect(first_fragment[:why_relevant].scan(/exact phrase match pig iron/).size).to eq(1)
     expect(first_fragment[:why_relevant]).to include('definition block')
-    expect(first_fragment[:score]).to eq(
-      described_class::EXACT_TERM_SCORE +
-        described_class::EXACT_PHRASE_SCORE +
-        described_class::DEFINITION_BLOCK_SCORE +
-        described_class::QUERY_TERM_SCORE * 2 +
-        described_class::SAME_CHAPTER_SCORE,
-    )
+    expect(first_fragment[:why_relevant]).to include('BM25 lexical match pig, iron')
+    expect(first_fragment[:score]).to be > described_class::MIN_SCORE
   end
 
   it 'ranks exact term definition blocks ahead of longer phrase-containing terms' do
@@ -266,6 +261,57 @@ RSpec.describe TariffKnowledge::RelevantNoteFragmentSelector do
     )
 
     expect(contexts).to be_empty
+  end
+
+  it 'uses BM25 lexical scoring to rank relevant definition blocks ahead of repeated generic text' do
+    lexical_note = create(
+      :tariff_knowledge_compressed_note,
+      goods_nomenclature_item_id: '7201200000',
+      content: 'compressed note lexical pig iron',
+      context_hash: Digest::SHA256.hexdigest('compressed note lexical pig iron'),
+      metadata: Sequel.pg_jsonb_wrap(
+        'evidence_blocks' => [
+          {
+            'source_node_key' => 'note_block:customs_tariff_chapter_note:1.31:72:1:a',
+            'source_title' => 'pig Iron',
+            'source_context' => 'pig Iron: Iron-carbon alloys not usefully malleable, containing more than 2 % carbon and cast in pigs, blocks or other primary forms.',
+            'block_type' => 'definition',
+            'term' => 'pig iron',
+            'source_type' => 'customs_tariff_chapter_note',
+            'source_id' => '72',
+            'fragment_node_keys' => [],
+          },
+          {
+            'source_node_key' => 'note_block:customs_tariff_chapter_note:1.31:72:1:z',
+            'source_title' => 'generic chapter 72 exclusions',
+            'source_context' => 'Chapter 72 does not include iron articles of heading 7301. Iron articles of heading 7302 are also excluded. Iron waste is handled elsewhere.',
+            'block_type' => 'exclusion',
+            'term' => nil,
+            'source_type' => 'customs_tariff_chapter_note',
+            'source_id' => '72',
+            'fragment_node_keys' => [],
+          },
+        ],
+      ),
+    )
+
+    contexts = described_class.call(
+      query: 'pig iron',
+      search_results: [
+        search_result_class.new(
+          goods_nomenclature_item_id: '7201200000',
+          description: 'Non-alloy pig iron in pigs, blocks or other primary forms',
+          full_description: nil,
+          score: 10,
+        ),
+      ],
+      notes_by_item_id: { '7201200000' => lexical_note },
+    )
+
+    fragments = contexts.first[:fragments]
+    expect(fragments.first[:source]).to eq('pig Iron')
+    expect(fragments.first[:why_relevant]).to include('BM25 lexical match pig, iron')
+    expect(fragments.second[:source]).to eq('generic chapter 72 exclusions')
   end
 
   it 'selects a compound definition block for a single-word head-term query' do

--- a/spec/services/tariff_knowledge/source_graph_loader_spec.rb
+++ b/spec/services/tariff_knowledge/source_graph_loader_spec.rb
@@ -63,6 +63,125 @@ RSpec.describe TariffKnowledge::SourceGraphLoader do
       expect(applied_codes).to contain_exactly('0101210000', '0101290000')
     end
 
+    it 'creates note block nodes and propagates contained fragment applicability and references' do
+      chapter_72 = create(:chapter, goods_nomenclature_item_id: '7200000000')
+      create(:heading, parent: chapter_72, goods_nomenclature_item_id: '7201000000')
+      GoodsNomenclatures::TreeNode.refresh!
+      TariffKnowledge::DeclarableNodeLoader.call
+      create(
+        :customs_tariff_chapter_note,
+        :approved,
+        customs_tariff_update: update,
+        chapter_id: '72',
+        content: [
+          '1. In this chapter the following expressions have the meanings hereby assigned to them:',
+          '',
+          'a. pig Iron',
+          '',
+          'Iron-carbon alloys not usefully malleable, containing more than 2 % by weight of carbon and which may contain by weight one or more other elements within the following limits:',
+          '',
+          '- not more than 10 % of chromium',
+          '',
+          '- not more than 6 % of manganese',
+          '',
+          'b. spiegeleisen',
+          '',
+          'Iron-carbon alloys containing by weight more than 6 % but not more than 30 % of manganese and otherwise conforming to the specification at (a) above.',
+        ].join("\n"),
+      )
+      create(
+        :customs_tariff_chapter_note,
+        :approved,
+        customs_tariff_update: update,
+        chapter_id: '01',
+        content: [
+          '1. In this chapter the following expressions have the meanings hereby assigned to them:',
+          '',
+          'a. pure-bred breeding animals',
+          '',
+          'Heading 0101 covers live horses.',
+        ].join("\n"),
+      )
+
+      described_class.call
+
+      source_node = TariffKnowledge::Node.by_key('note_source:customs_tariff_chapter_note:1.31:72').first
+      block_node = TariffKnowledge::Node.by_key('note_block:customs_tariff_chapter_note:1.31:72:1:a').first
+      heading_7201_node = TariffKnowledge::Node.goods_nomenclatures.where(goods_nomenclature_item_id: '7201000000').first
+      contained_fragment_nodes = %w[0002 0003 0004 0005].map do |suffix|
+        TariffKnowledge::Node.by_key("note_fragment:customs_tariff_chapter_note:1.31:72:#{suffix}").first
+      end
+      reference_block_node = TariffKnowledge::Node.by_key('note_block:customs_tariff_chapter_note:1.31:01:1:a').first
+      range_node = TariffKnowledge::Node.by_key('range:heading:0101').first
+
+      expect(block_node).to have_attributes(
+        node_type: TariffKnowledge::Node::NOTE_BLOCK,
+        title: 'pig Iron',
+      )
+      expect(block_node.metadata.to_h).to include(
+        'block_type' => 'definition',
+        'term' => 'pig iron',
+        'path' => %w[1 a],
+      )
+      expect(block_node.content).to include('not more than 6 % of manganese')
+      expect(edge_exists?(source_node, block_node, TariffKnowledge::Edge::CONTAINS)).to be(true)
+      contained_fragment_nodes.each do |fragment_node|
+        expect(edge_exists?(block_node, fragment_node, TariffKnowledge::Edge::CONTAINS)).to be(true)
+      end
+      expect(edge_exists?(block_node, heading_7201_node, TariffKnowledge::Edge::APPLIES_TO)).to be(true)
+      expect(edge_exists?(reference_block_node, range_node, TariffKnowledge::Edge::REFERENCES)).to be(true)
+    end
+
+    it 'removes stale block links when reloading changed source content' do
+      note = create(
+        :customs_tariff_chapter_note,
+        :approved,
+        customs_tariff_update: update,
+        chapter_id: '01',
+        content: [
+          '1. In this chapter the following expressions have the meanings hereby assigned to them:',
+          '',
+          'a. pure-bred breeding animals',
+          '',
+          'Heading 0101 covers live horses.',
+          '',
+          '- certified breeding animals',
+        ].join("\n"),
+      )
+
+      described_class.call
+
+      note.update(
+        content: [
+          '1. In this chapter the following expressions have the meanings hereby assigned to them:',
+          '',
+          'a. pure-bred breeding animals',
+          '',
+          'Live horses are covered here.',
+        ].join("\n"),
+      )
+      create(:hidden_goods_nomenclature, goods_nomenclature_item_id: '0101290000')
+      described_class.call
+
+      block_node = TariffKnowledge::Node.by_key('note_block:customs_tariff_chapter_note:1.31:01:1:a').first
+      stale_fragment_node = TariffKnowledge::Node.by_key('note_fragment:customs_tariff_chapter_note:1.31:01:0004').first
+      stale_range_node = TariffKnowledge::Node.by_key('range:heading:0101').first
+      stale_declarable_node = TariffKnowledge::Node.goods_nomenclatures.where(goods_nomenclature_item_id: '0101290000').first
+
+      expect(edge_exists?(block_node, stale_fragment_node, TariffKnowledge::Edge::CONTAINS)).to be(false)
+      expect(edge_exists?(block_node, stale_range_node, TariffKnowledge::Edge::REFERENCES)).to be(false)
+      expect(edge_exists?(block_node, stale_declarable_node, TariffKnowledge::Edge::APPLIES_TO)).to be(false)
+
+      note.update(content: '1. This chapter covers live horses.')
+      described_class.call
+
+      source_node = TariffKnowledge::Node.by_key('note_source:customs_tariff_chapter_note:1.31:01').first
+      current_declarable_node = TariffKnowledge::Node.goods_nomenclatures.where(goods_nomenclature_item_id: '0101210000').first
+
+      expect(edge_exists?(source_node, block_node, TariffKnowledge::Edge::CONTAINS)).to be(false)
+      expect(edge_exists?(block_node, current_declarable_node, TariffKnowledge::Edge::APPLIES_TO)).to be(false)
+    end
+
     it 'applies chapter note fragments to all declarables in the chapter even without explicit references' do
       create(
         :customs_tariff_chapter_note,
@@ -379,10 +498,30 @@ RSpec.describe TariffKnowledge::SourceGraphLoader do
         source_id: '01',
         source_version: '1.30',
       )
+      old_block_node = create(
+        :tariff_knowledge_node,
+        node_type: TariffKnowledge::Node::NOTE_BLOCK,
+        key: 'note_block:customs_tariff_chapter_note:1.30:01:1:a',
+        title: 'Old block',
+        content: 'Old block content',
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '01',
+        source_version: '1.30',
+        goods_nomenclature_sid: nil,
+        goods_nomenclature_item_id: nil,
+        producline_suffix: nil,
+        goods_nomenclature_type: nil,
+      )
       create(
         :tariff_knowledge_edge,
         source_node: old_source_node,
         target_node: old_fragment_node,
+        relationship_type: TariffKnowledge::Edge::CONTAINS,
+      )
+      create(
+        :tariff_knowledge_edge,
+        source_node: old_source_node,
+        target_node: old_block_node,
         relationship_type: TariffKnowledge::Edge::CONTAINS,
       )
       create(
@@ -397,6 +536,7 @@ RSpec.describe TariffKnowledge::SourceGraphLoader do
 
       expect(TariffKnowledge::Node.by_key('note_source:customs_tariff_chapter_note:1.30:01').first).to be_nil
       expect(TariffKnowledge::Node.by_key('note_fragment:customs_tariff_chapter_note:1.30:01:0001').first).to be_nil
+      expect(TariffKnowledge::Node.by_key('note_block:customs_tariff_chapter_note:1.30:01:1:a').first).to be_nil
     end
 
     it 'loads notes from the latest current non-failed update and ignores newer future updates' do

--- a/spec/services/tariff_knowledge/source_graph_loader_spec.rb
+++ b/spec/services/tariff_knowledge/source_graph_loader_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe TariffKnowledge::SourceGraphLoader do
       expect(applied_codes).to contain_exactly('0101210000', '0101290000')
     end
 
-    it 'creates note block nodes and propagates contained fragment applicability and references' do
+    it 'creates note block nodes contained by the source without full-chapter applicability fan-out' do
       chapter_72 = create(:chapter, goods_nomenclature_item_id: '7200000000')
       create(:heading, parent: chapter_72, goods_nomenclature_item_id: '7201000000')
       GoodsNomenclatures::TreeNode.refresh!
@@ -128,8 +128,16 @@ RSpec.describe TariffKnowledge::SourceGraphLoader do
       contained_fragment_nodes.each do |fragment_node|
         expect(edge_exists?(block_node, fragment_node, TariffKnowledge::Edge::CONTAINS)).to be(true)
       end
-      expect(edge_exists?(block_node, heading_7201_node, TariffKnowledge::Edge::APPLIES_TO)).to be(true)
-      expect(edge_exists?(reference_block_node, range_node, TariffKnowledge::Edge::REFERENCES)).to be(true)
+      # Blocks must not inherit full-chapter APPLIES_TO (or range REFERENCES) from
+      # every contained fragment — that multiplies edge fan-out by block count.
+      expect(edge_exists?(block_node, heading_7201_node, TariffKnowledge::Edge::APPLIES_TO)).to be(false)
+      expect(edge_exists?(reference_block_node, range_node, TariffKnowledge::Edge::REFERENCES)).to be(false)
+      # Fragments still carry applicability / references for generation-time joins.
+      expect(
+        contained_fragment_nodes.any? do |fragment_node|
+          edge_exists?(fragment_node, heading_7201_node, TariffKnowledge::Edge::APPLIES_TO)
+        end,
+      ).to be(true)
     end
 
     it 'removes stale block links when reloading changed source content' do

--- a/spec/services/tariff_knowledge/source_graph_loader_spec.rb
+++ b/spec/services/tariff_knowledge/source_graph_loader_spec.rb
@@ -140,6 +140,62 @@ RSpec.describe TariffKnowledge::SourceGraphLoader do
       ).to be(true)
     end
 
+    it 'feeds compressed notes with block evidence and fragment parent provenance after load' do
+      chapter_72 = create(:chapter, goods_nomenclature_item_id: '7200000000')
+      heading_7201 = create(:heading, parent: chapter_72, goods_nomenclature_item_id: '7201000000')
+      pig_iron = create(:commodity, parent: heading_7201, goods_nomenclature_item_id: '7201100000')
+      GoodsNomenclatures::TreeNode.refresh!
+      TariffKnowledge::DeclarableNodeLoader.call
+      create(
+        :customs_tariff_chapter_note,
+        :approved,
+        customs_tariff_update: update,
+        chapter_id: '72',
+        content: [
+          '1. In this chapter the following expressions have the meanings hereby assigned to them:',
+          '',
+          'a. pig Iron',
+          '',
+          'Iron-carbon alloys not usefully malleable, containing more than 2 % by weight of carbon.',
+          '',
+          'Heading 7201 covers pig iron.',
+        ].join("\n"),
+      )
+
+      described_class.call
+
+      declarable_node = TariffKnowledge::Node.goods_nomenclatures
+        .where(goods_nomenclature_item_id: pig_iron.goods_nomenclature_item_id)
+        .first
+      block_node = TariffKnowledge::Node.by_key('note_block:customs_tariff_chapter_note:1.31:72:1:a').first
+      expect(block_node).to be_present
+      expect(
+        TariffKnowledge::Edge
+          .by_relationship(TariffKnowledge::Edge::APPLIES_TO)
+          .where(source_node_id: block_node.id)
+          .count,
+      ).to eq(0)
+
+      TariffKnowledge::CompressedNoteGenerator.call(goods_nomenclature_sids: [declarable_node.goods_nomenclature_sid])
+
+      note = TariffKnowledge::CompressedNote[declarable_node.goods_nomenclature_sid]
+      expect(note).to be_present
+      expect(note.metadata.to_hash['evidence_blocks']).to include(
+        include(
+          'source_node_key' => 'note_block:customs_tariff_chapter_note:1.31:72:1:a',
+          'term' => 'pig iron',
+          'block_type' => 'definition',
+        ),
+      )
+      expect(note.metadata.to_hash['evidence']).to be_present
+      expect(note.metadata.to_hash['evidence']).to all(
+        include(
+          'parent_source_node_key' => 'note_source:customs_tariff_chapter_note:1.31:72',
+          'parent_source_title' => 'Chapter 72 notes',
+        ),
+      )
+    end
+
     it 'removes stale block links when reloading changed source content' do
       note = create(
         :customs_tariff_chapter_note,


### PR DESCRIPTION
### Jira link

[AI-997](https://transformuk.atlassian.net/browse/AI-997)

### What?

- [x] Parse chapter note structure (markers, nested lists, definition blocks)
- [x] Load `NOTE_BLOCK` nodes into the tariff knowledge graph with source/fragment membership edges
- [x] Carry block evidence in compressed notes and select definition blocks ahead of flat fragments
- [x] Score block evidence with exact term/phrase matching and in-memory BM25
- [x] Add concise `source_ref` provenance (e.g. `chapter 72 note`)
- [x] Fix multi-parent `CONTAINS` so block membership cannot wipe fragment parent provenance
- [x] Stop copying full-chapter `APPLIES_TO`/`REFERENCES` onto every definition block; resolve blocks via contained applying fragments
- [x] Add structure validation rake task and regressions (including loader → generator path)

### Why?

Chapter notes encode legal definitions and nested criteria (e.g. Chapter 72 *pig iron* composition limits). Flat sentence fragments break those units, so classification search gets incomplete legal text.

This change keeps definition-shaped note blocks as first-class graph evidence, selects them for the interactive-search prompt pack when they match the query, and avoids two graph bugs: nil-ing fragment parent metadata when blocks also `CONTAINS` fragments, and multiplying full-chapter applicability edges onto every definition block.

Search still attaches evidence after commodity shortlist retrieval. Note injection stays behind `search_compressed_notes_enabled` (default off).

```mermaid
flowchart LR
  CN[Chapter note text] --> SP[Structure parse]
  SP --> FB[Fragments]
  SP --> BL[Definition blocks]
  FB --> KG[Knowledge graph]
  BL --> KG
  KG --> GEN[Compressed notes]
  GEN --> SEL[Evidence selector]
  SEL --> PROMPT[Interactive search context]
```

### Risk

**Risk level:** 🟢

**Reason for rating:** Additive graph/selector behaviour behind a default-off search flag. No live journey change until explicitly enabled. No destructive migrations, CDS sync, or measure/footnote processing changes. Full unit coverage on the note-block path including parent-provenance and fan-out regressions.

### Have you?

- [x] Specs for structure/block/loader/generator/selector paths
- [ ] Staging enablement of `search_compressed_notes_enabled` (follow-up)
- [ ] Production cron / flag decision (follow-up)
