### PR TITLE
HMRC-2219: Enable ecs autoscaling cooldown configs in prod

### DIFF
--- a/terraform/config_production.tfvars
+++ b/terraform/config_production.tfvars
@@ -6,10 +6,6 @@ service_count           = 4
 backend_uk_min_capacity = 4
 backend_xi_min_capacity = 2
 max_capacity            = 16
-# Temporarily pinned autoscaling cooldown values in Production to preserve existing behaviour while testing changes in dev and staging
-# Can also remove those variables (in variables.tf) if we decide to keep the default cooldown values
-scale_in_cooldown  = 0
-scale_out_cooldown = 0
 
 enable_alarms               = true
 enable_observability_alerts = true

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -58,7 +58,6 @@ variable "enable_observability_alerts" {
   default = false
 }
 
-# Can remove that variable after deploying to P
 variable "scale_in_cooldown" {
   description = "Prevents aggressive scale-in by enforcing a waiting period after tasks are removed."
   type        = number


### PR DESCRIPTION
## What:
Update ECS Service Auto Scaling cooldown settings in Prod from:
  - scale_in_cooldown = 0 → 300
  - scale_out_cooldown = 0 → 60

## Why:
The current configuration allows scaling actions to occur immediately and repeatedly with no stabilisation period, which can lead to:
  - Rapid scale-in/scale-out cycles (service "flapping") during short-lived metric spikes.
  - Unnecessary task launches and terminations, increasing operational churn.
  - Less predictable service capacity and scaling behaviour.
  - Increased load on dependent systems during frequent scaling events.

Introducing cooldown periods will provide time for newly launched tasks to become healthy and for metrics to stabilise before additional scaling decisions are made. The proposed settings balance responsiveness to increased demand (scale_out_cooldown = 60) with a more conservative approach to reducing capacity (scale_in_cooldown = 300) to help maintain service stability.

## Ticket:
[HMRC-2219](https://transformuk.atlassian.net/browse/HMRC-2219)

## Risk:

**Risk level:** 🟢 

**Reason for rating:**

- Scaling out may be slightly less aggressive during sustained traffic increases due to the 60-second cooldown.
- Scaling in will occur more gradually, potentially resulting in a small increase in temporary resource usage.
- No application code, infrastructure architecture, or service functionality is being changed.
- Changes are limited to ECS Auto Scaling policy behaviour and align with common AWS best-practice patterns for preventing scaling oscillation.

Rollback
Revert cooldown values to their previous configuration (scale_in_cooldown = 0, scale_out_cooldown = 0) if unexpected scaling behaviour is observed.