### PR TITLE
Guard database replication restore failures

### DIFF
--- a/bin/db-replicate
+++ b/bin/db-replicate
@@ -2,11 +2,13 @@
 
 [[ "$TRACE" ]] && set -o xtrace
 set -o errexit
+set -o errtrace
 set -o nounset
 set -o pipefail
 set -o noclobber
 
 START_TIME=$(date +%s)
+SERVICES_STOPPED=false
 
 declare -A SERVICE_COUNTS
 declare -A ACCOUNT_IDS=(
@@ -38,6 +40,34 @@ set_desired_count_for_service_to() {
         --desired-count "$desired_count" > /dev/null
 }
 
+restore_file_url() {
+  echo "$DB_DUMP_SERVER""$RESTORE_FILE"
+}
+
+validate_restore_file() {
+  local sample_file
+  sample_file=$(mktemp)
+
+  if ! curl --fail --silent --show-error --location \
+    --user "$DB_DUMP_USER":"$DB_DUMP_PASSWORD" \
+    --range 0-1 \
+    --output "$sample_file" \
+    "$(restore_file_url)"; then
+    rm -f "$sample_file"
+    echo "Unable to read restore file: $(restore_file_url)" >&2
+    exit 1
+  fi
+
+  local magic
+  magic=$(od -An -tx1 -N2 "$sample_file" | tr -d '[:space:]')
+  rm -f "$sample_file"
+
+  if [ "$magic" != "1f8b" ]; then
+    echo "Restore file is not a gzip stream: $(restore_file_url)" >&2
+    exit 1
+  fi
+}
+
 stop_services() {
   for service in $SERVICES; do
       SERVICE_COUNTS[$service]=$(get_desired_count_for_service "$service")
@@ -49,7 +79,9 @@ stop_services() {
 }
 
 restore_database() {
-  curl --silent -u "$DB_DUMP_USER":"$DB_DUMP_PASSWORD" "$DB_DUMP_SERVER""$RESTORE_FILE" | gzip -d | psql "$DATABASE_URL"
+  curl --fail --silent --show-error --location \
+    --user "$DB_DUMP_USER":"$DB_DUMP_PASSWORD" \
+    "$(restore_file_url)" | gzip -d | psql "$DATABASE_URL"
 }
 
 start_services() {
@@ -63,6 +95,20 @@ start_services() {
 
       set_desired_count_for_service_to "$service" "$desired_count"
   done
+
+  SERVICES_STOPPED=false
+}
+
+restart_services_on_error() {
+  local exit_code=$?
+  trap - ERR
+
+  if [ "$SERVICES_STOPPED" = true ]; then
+    echo "Replication failed after services were stopped; restarting services $SERVICES" >&2
+    start_services
+  fi
+
+  exit "$exit_code"
 }
 
 lookup_persistence_bucket() {
@@ -81,8 +127,12 @@ sync_buckets() {
   aws s3 sync "$source_bucket/data/exchange_rates/" "$target_bucket/data/exchange_rates/"
 }
 
+validate_restore_file
+
 echo "Stopping services $SERVICES"
 stop_services
+SERVICES_STOPPED=true
+trap restart_services_on_error ERR
 
 restore_database
 
@@ -90,6 +140,7 @@ echo "SQL backup restored successfully"
 
 echo "Starting services  $SERVICES"
 start_services
+trap - ERR
 
 echo "Syncing exchange rates"
 

--- a/spec/bin/db_replicate_spec.rb
+++ b/spec/bin/db_replicate_spec.rb
@@ -1,0 +1,155 @@
+require 'fileutils'
+require 'open3'
+require 'tmpdir'
+
+RSpec.describe 'bin/db-replicate' do # rubocop:disable RSpec/DescribeClass
+  let(:repo_root) { File.expand_path('../..', __dir__) }
+  let(:script) { File.join(repo_root, 'bin/db-replicate') }
+
+  def write_executable(path, content)
+    File.write(path, content)
+    FileUtils.chmod('+x', path)
+  end
+
+  it 'does not stop services when the restore file is not a gzip stream' do
+    Dir.mktmpdir do |dir|
+      bin_dir = File.join(dir, 'bin')
+      calls_log = File.join(dir, 'aws-calls.log')
+      FileUtils.mkdir_p(bin_dir)
+
+      write_executable(
+        File.join(bin_dir, 'aws'),
+        <<~BASH,
+          #!/usr/bin/env bash
+          echo "$*" >> "#{calls_log}"
+          if [[ "$*" == *"describe-services"* ]]; then
+            echo 2
+          fi
+        BASH
+      )
+
+      write_executable(
+        File.join(bin_dir, 'curl'),
+        <<~BASH,
+          #!/usr/bin/env bash
+          output=''
+          while [[ "$#" -gt 0 ]]; do
+            if [[ "$1" == "--output" ]]; then
+              output="$2"
+              shift 2
+            else
+              shift
+            fi
+          done
+
+          if [[ -n "$output" ]]; then
+            printf '<html>Forbidden</html>' > "$output"
+          else
+            printf '<html>Forbidden</html>'
+          fi
+        BASH
+      )
+
+      stdout, stderr, status = Open3.capture3(
+        {
+          'PATH' => "#{bin_dir}:#{ENV.fetch('PATH')}",
+          'ENVIRONMENT' => 'staging',
+          'CLUSTER_NAME' => 'trade-tariff-cluster-staging',
+          'SERVICES' => 'backend-uk worker-uk',
+          'DB_DUMP_USER' => 'tariff',
+          'DB_DUMP_PASSWORD' => 'secret',
+          'DB_DUMP_SERVER' => 'https://dumps.example.test/',
+          'RESTORE_FILE' => 'tariff-merged-production.sql.gz',
+          'DATABASE_URL' => 'postgres://example',
+        },
+        script,
+      )
+
+      calls = File.exist?(calls_log) ? File.read(calls_log) : ''
+
+      expect(status).not_to be_success
+      expect(stdout).not_to include('Stopping services')
+      expect(stderr).to include('Restore file is not a gzip stream')
+      expect(calls).not_to include('update-service')
+    end
+  end
+
+  it 'restarts services when restore fails after services are stopped' do
+    Dir.mktmpdir do |dir|
+      bin_dir = File.join(dir, 'bin')
+      calls_log = File.join(dir, 'aws-calls.log')
+      sql_file = File.join(dir, 'dump.sql')
+      gzip_file = File.join(dir, 'dump.sql.gz')
+      FileUtils.mkdir_p(bin_dir)
+      File.write(sql_file, 'SELECT 1;')
+      system('gzip', '-c', sql_file, out: gzip_file)
+
+      write_executable(
+        File.join(bin_dir, 'aws'),
+        <<~BASH,
+          #!/usr/bin/env bash
+          echo "$*" >> "#{calls_log}"
+          if [[ "$*" == *"describe-services"* ]]; then
+            echo 2
+          fi
+        BASH
+      )
+
+      write_executable(
+        File.join(bin_dir, 'curl'),
+        <<~BASH,
+          #!/usr/bin/env bash
+          output=''
+          while [[ "$#" -gt 0 ]]; do
+            if [[ "$1" == "--output" ]]; then
+              output="$2"
+              shift 2
+            else
+              shift
+            fi
+          done
+
+          if [[ -n "$output" ]]; then
+            head -c 2 "#{gzip_file}" > "$output"
+          else
+            cat "#{gzip_file}"
+          fi
+        BASH
+      )
+
+      write_executable(
+        File.join(bin_dir, 'psql'),
+        <<~BASH,
+          #!/usr/bin/env bash
+          cat >/dev/null
+          exit 42
+        BASH
+      )
+
+      _stdout, _stderr, status = Open3.capture3(
+        {
+          'PATH' => "#{bin_dir}:#{ENV.fetch('PATH')}",
+          'ENVIRONMENT' => 'staging',
+          'CLUSTER_NAME' => 'trade-tariff-cluster-staging',
+          'SERVICES' => 'backend-uk worker-uk',
+          'DB_DUMP_USER' => 'tariff',
+          'DB_DUMP_PASSWORD' => 'secret',
+          'DB_DUMP_SERVER' => 'https://dumps.example.test/',
+          'RESTORE_FILE' => 'tariff-merged-production.sql.gz',
+          'DATABASE_URL' => 'postgres://example',
+        },
+        script,
+      )
+
+      update_calls = File.readlines(calls_log).grep(/update-service/)
+
+      expect(status.exitstatus).to eq(42)
+      expect(update_calls).to contain_exactly(
+        a_string_including('--service backend-uk --desired-count 0'),
+        a_string_including('--service worker-uk --desired-count 0'),
+        a_string_including('--service backend-uk --desired-count 2'),
+        a_string_including('--service worker-uk --desired-count 2'),
+      )
+    end
+  end
+end


### PR DESCRIPTION
## What:
Adds safeguards to `bin/db-replicate` so staging/development database replication validates the restore dump before stopping ECS services, and restarts services if a later restore step fails after they have been stopped.

## Why:
The scheduled staging replication stopped backend/worker services, then failed with `gzip: invalid magic` because the configured dump URL returned HTML instead of a gzip stream. Since the script exited before `start_services`, backend services stayed at desired count zero.

This change prevents that class of failure by checking the restore file is readable and begins with gzip magic bytes before `stop_services`, and adds an ERR trap to restart services after any post-stop failure.

## Ticket:
N/A

## Risk:
**Risk level:** 🟠

**Reason for rating:**
Low risk because its only replicating into non-production environment