### PR TITLE
BAU: log Accept header in lograge for API version tracking

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -68,6 +68,7 @@ Rails.application.configure do
       request_id: event.payload[:request_id],
       auth_type: event.payload[:auth_type],
       client_id: event.payload[:client_id],
+      accept: event.payload[:headers]['HTTP_ACCEPT'],
       exception_class: exception&.class&.name || exception_class,
       params: event.payload[:params].except('controller', 'action', 'format', 'utf8'),
       user_agent: event.payload[:user_agent],

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -68,7 +68,7 @@ Rails.application.configure do
       request_id: event.payload[:request_id],
       auth_type: event.payload[:auth_type],
       client_id: event.payload[:client_id],
-      accept: event.payload[:headers]['HTTP_ACCEPT'],
+      accept: event.payload[:headers]&.[]('HTTP_ACCEPT'),
       exception_class: exception&.class&.name || exception_class,
       params: event.payload[:params].except('controller', 'action', 'format', 'utf8'),
       user_agent: event.payload[:user_agent],


### PR DESCRIPTION
## What:
Add the `Accept` request header to lograge's custom options so it is included in every production log entry.

## Why:
The backend serves V1 and V2 API traffic on the same URL path (`/uk/api`, `/xi/api`), with version negotiated entirely via the `Accept` header (`application/vnd.hmrc.1.0+json` vs `2.0`). Without logging this header, it is impossible to split V1 vs V2 traffic in CloudWatch Logs Insights on `platform-logs-production`.

Once deployed, the following query will give a per-day breakdown:

```
fields @timestamp, accept
| filter accept like /vnd.hmrc/
| stats count_if(accept like /1\.0/) as v1_requests,
        count_if(accept like /2\.0/) as v2_requests
  by bin(1d)
```

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Additive observability change only — adds a new field to log output, no behaviour change. Safe default (nil compacted away if header absent).