### PR TITLE
Detect parent declarability transitions driven by child commodity creation/ending

### DIFF
--- a/app/services/tariff_changes_service.rb
+++ b/app/services/tariff_changes_service.rb
@@ -192,8 +192,8 @@ class TariffChangesService
       goods_nomenclature_sid: parent.goods_nomenclature_sid,
       action:,
       date_of_effect:,
-      validity_start_date: action == BaseChanges::CREATION ? date_of_effect : previous_parent&.validity_start_date&.to_date,
-      validity_end_date: action == BaseChanges::ENDING ? date_of_effect : previous_parent&.validity_end_date&.to_date,
+      validity_start_date: action == BaseChanges::CREATION ? date_of_effect : current_parent&.validity_start_date&.to_date,
+      validity_end_date: action == BaseChanges::ENDING ? date_of_effect : current_parent&.validity_end_date&.to_date,
     }
   end
 

--- a/app/services/tariff_changes_service.rb
+++ b/app/services/tariff_changes_service.rb
@@ -7,6 +7,12 @@
 class TariffChangesService
   FALLBACK_START_DATE = Date.new(2024, 12, 31).freeze
 
+  # Frozen snapshot of a GoodsNomenclature at a specific point in time, used to
+  # capture declarability at the correct TimeMachine date.
+  ParentSnapshot = Data.define(:goods_nomenclature_sid, :goods_nomenclature_item_id, :validity_start_date, :validity_end_date, :declarable) do
+    def declarable? = declarable
+  end
+
   # Generates TariffChange records for the given date.
   # If no date is provided, it generates for all pending changes and all dates since the last change
   def self.generate(date = nil)
@@ -87,6 +93,8 @@ class TariffChangesService
       add_change_record(change, change[:goods_nomenclature_item_id], change[:object_sid])
     end
 
+    add_parent_declarability_transition_records
+
     @changes[:commodity_descriptions].each do |change|
       next if matching_commodity_change?(change[:goods_nomenclature_sid], change[:action])
 
@@ -121,6 +129,95 @@ class TariffChangesService
           declarables_for(goods_nomenclatures[goods_nomenclature_sid])
         end
       end
+    end
+  end
+
+  def add_parent_declarability_transition_records
+    parent_declarability_transition_changes.each do |change|
+      next if matching_commodity_change?(change[:goods_nomenclature_sid], change[:action])
+
+      add_change_record(change, change[:goods_nomenclature_item_id], change[:goods_nomenclature_sid])
+    end
+  end
+
+  def parent_declarability_transition_changes
+    parent_declarability_child_changes.filter_map { |child_change|
+      parent_declarability_transition_for(child_change)
+    }.uniq { |change| [change[:goods_nomenclature_sid], change[:action], change[:date_of_effect]] }
+  end
+
+  def parent_declarability_child_changes
+    @parent_declarability_child_changes ||= GoodsNomenclature.operation_klass
+      .where(operation_date: date)
+      .filter_map do |op_record|
+        next if op_record.record.nil?
+
+        change = TariffChangesService::CommodityChanges.new(op_record.record, date).analyze
+        next if change.nil?
+
+        next unless [BaseChanges::CREATION, BaseChanges::ENDING].include?(change[:action])
+        next if change[:object_sid].blank? || change[:date_of_effect].blank?
+
+        change
+      end
+  end
+
+  def parent_declarability_transition_for(child_change)
+    child_effective_date = child_change[:date_of_effect]
+
+    before_date, after_date =
+      if child_change[:action] == BaseChanges::CREATION
+        [child_effective_date - 1.day, child_effective_date]
+      else
+        [child_effective_date, child_effective_date + 1.day]
+      end
+
+    parent = parent_for_child_at(child_change[:object_sid], child_effective_date)
+    return if parent.nil?
+
+    previous_parent = goods_nomenclature_at(parent.goods_nomenclature_sid, before_date)
+    current_parent = goods_nomenclature_at(parent.goods_nomenclature_sid, after_date)
+
+    previous_declarable = previous_parent&.declarable? || false
+    current_declarable = current_parent&.declarable? || false
+    return if previous_declarable == current_declarable
+
+    action = previous_declarable ? BaseChanges::ENDING : BaseChanges::CREATION
+    date_of_effect = previous_declarable ? before_date : after_date
+
+    {
+      type: 'Commodity',
+      object_sid: parent.goods_nomenclature_sid,
+      goods_nomenclature_item_id: parent.goods_nomenclature_item_id,
+      goods_nomenclature_sid: parent.goods_nomenclature_sid,
+      action:,
+      date_of_effect:,
+      validity_start_date: action == BaseChanges::CREATION ? date_of_effect : previous_parent&.validity_start_date&.to_date,
+      validity_end_date: action == BaseChanges::ENDING ? date_of_effect : previous_parent&.validity_end_date&.to_date,
+    }
+  end
+
+  def parent_for_child_at(child_sid, snapshot_date)
+    TimeMachine.at(snapshot_date) do
+      GoodsNomenclature.where(goods_nomenclature_sid: child_sid).actual.eager(:parent).first&.parent
+    end
+  end
+
+  def goods_nomenclature_at(goods_nomenclature_sid, snapshot_date)
+    TimeMachine.at(snapshot_date) do
+      gn = GoodsNomenclature.where(goods_nomenclature_sid: goods_nomenclature_sid).actual.first
+      next nil if gn.nil?
+
+      # Evaluate declarable? here, inside the TimeMachine block, so that
+      # leaf? -> children.empty? queries at the correct point-in-time snapshot.
+      # Captured in a frozen value object to avoid re-querying outside this block.
+      ParentSnapshot.new(
+        goods_nomenclature_sid: gn.goods_nomenclature_sid,
+        goods_nomenclature_item_id: gn.goods_nomenclature_item_id,
+        validity_start_date: gn.validity_start_date,
+        validity_end_date: gn.validity_end_date,
+        declarable: gn.declarable?,
+      )
     end
   end
 

--- a/app/services/tariff_changes_service.rb
+++ b/app/services/tariff_changes_service.rb
@@ -198,13 +198,21 @@ class TariffChangesService
   end
 
   def parent_for_child_at(child_sid, snapshot_date)
-    TimeMachine.at(snapshot_date) do
+    @parent_for_child_at_cache ||= {}
+    cache_key = [child_sid, snapshot_date.to_date]
+    return @parent_for_child_at_cache[cache_key] if @parent_for_child_at_cache.key?(cache_key)
+
+    @parent_for_child_at_cache[cache_key] = TimeMachine.at(snapshot_date) do
       GoodsNomenclature.where(goods_nomenclature_sid: child_sid).actual.eager(:parent).first&.parent
     end
   end
 
   def goods_nomenclature_at(goods_nomenclature_sid, snapshot_date)
-    TimeMachine.at(snapshot_date) do
+    @goods_nomenclature_at_cache ||= {}
+    cache_key = [goods_nomenclature_sid, snapshot_date.to_date]
+    return @goods_nomenclature_at_cache[cache_key] if @goods_nomenclature_at_cache.key?(cache_key)
+
+    @goods_nomenclature_at_cache[cache_key] = TimeMachine.at(snapshot_date) do
       gn = GoodsNomenclature.where(goods_nomenclature_sid: goods_nomenclature_sid).actual.first
       next nil if gn.nil?
 

--- a/app/services/tariff_changes_service/commodity_changes.rb
+++ b/app/services/tariff_changes_service/commodity_changes.rb
@@ -4,7 +4,9 @@ class TariffChangesService
       GoodsNomenclature.operation_klass
         .where(operation_date: date)
         .map { |op_record|
-          new(op_record.record, date).analyze if op_record.record&.declarable?
+          next unless op_record.record&.declarable?
+
+          new(op_record.record, date).analyze
         }
         .compact
     end

--- a/spec/services/tariff_changes_service/commodity_changes_spec.rb
+++ b/spec/services/tariff_changes_service/commodity_changes_spec.rb
@@ -34,15 +34,16 @@ RSpec.describe TariffChangesService::CommodityChanges do
     end
 
     context 'with declarable and non-declarable goods nomenclatures' do
-      before do
-        create(:commodity, operation_date: date)
-      end
+      let!(:declarable_commodity) { create(:commodity, :declarable, operation_date: date) }
+      let!(:non_declarable_commodity) { create(:commodity, :non_declarable, operation_date: date) }
 
       it 'only analyzes declarable goods nomenclatures' do
         results = described_class.collect(date)
 
-        expect(results.size).to be >= 1
-        expect(results.all? { |result| result[:type] == 'Commodity' }).to be true
+        returned_sids = results.map { |result| result[:goods_nomenclature_sid] }
+
+        expect(returned_sids).to include(declarable_commodity.goods_nomenclature_sid)
+        expect(returned_sids).not_to include(non_declarable_commodity.goods_nomenclature_sid)
       end
     end
   end

--- a/spec/services/tariff_changes_service_spec.rb
+++ b/spec/services/tariff_changes_service_spec.rb
@@ -682,8 +682,8 @@ RSpec.describe TariffChangesService do
         action: TariffChangesService::BaseChanges::CREATION,
         date_of_effect: child_effective_date,
       }
-      previous_parent = instance_double(GoodsNomenclature, declarable?: true, validity_start_date: Date.new(2024, 1, 1), validity_end_date: nil)
-      current_parent = instance_double(GoodsNomenclature, declarable?: false)
+      previous_parent = instance_double(GoodsNomenclature, declarable?: true)
+      current_parent = instance_double(GoodsNomenclature, declarable?: false, validity_start_date: Date.new(2024, 1, 1), validity_end_date: nil)
 
       allow(other_service).to receive(:parent_declarability_child_changes).and_return([child_change])
       allow(other_service).to receive(:parent_for_child_at).with(child_sid, child_effective_date).and_return(parent)
@@ -713,8 +713,8 @@ RSpec.describe TariffChangesService do
         action: TariffChangesService::BaseChanges::ENDING,
         date_of_effect: child_end_date,
       }
-      previous_parent = instance_double(GoodsNomenclature, declarable?: false, validity_start_date: Date.new(2024, 1, 1), validity_end_date: nil)
-      current_parent = instance_double(GoodsNomenclature, declarable?: true)
+      previous_parent = instance_double(GoodsNomenclature, declarable?: false)
+      current_parent = instance_double(GoodsNomenclature, declarable?: true, validity_start_date: Date.new(2024, 1, 1), validity_end_date: nil)
 
       allow(other_service).to receive(:parent_declarability_child_changes).and_return([child_change])
       allow(other_service).to receive(:parent_for_child_at).with(child_sid, child_end_date).and_return(parent)
@@ -748,7 +748,7 @@ RSpec.describe TariffChangesService do
     describe '#parent_for_child_at' do
       context 'when child is imported before its validity starts' do
         let!(:parent_node) do
-          create(:commodity, :declarable, validity_start_date: 2.years.ago.to_date)
+          create(:commodity, :declarable, validity_start_date: operation_date - 2.years)
         end
         let!(:child_node) do
           create(:commodity, :non_declarable,
@@ -774,7 +774,7 @@ RSpec.describe TariffChangesService do
     describe '#parent_declarability_transition_for' do
       context 'when a non-declarable child is imported before its validity starts' do
         let!(:parent_node) do
-          create(:commodity, :declarable, validity_start_date: 2.years.ago.to_date)
+          create(:commodity, :declarable, validity_start_date: operation_date - 2.years)
         end
         let!(:child_node) do
           create(:commodity, :non_declarable,
@@ -804,12 +804,12 @@ RSpec.describe TariffChangesService do
       context 'when child ending makes parent declarable again' do
         let(:child_end_date) { operation_date + 3.days }
         let!(:parent_node) do
-          create(:commodity, :declarable, validity_start_date: 2.years.ago.to_date)
+          create(:commodity, :declarable, validity_start_date: operation_date - 2.years)
         end
         let!(:child_node) do
           create(:commodity, :non_declarable,
                  parent: parent_node,
-                 validity_start_date: 2.years.ago.to_date,
+                 validity_start_date: operation_date - 2.years,
                  validity_end_date: child_end_date)
         end
 

--- a/spec/services/tariff_changes_service_spec.rb
+++ b/spec/services/tariff_changes_service_spec.rb
@@ -453,6 +453,8 @@ RSpec.describe TariffChangesService do
 
     context 'when processing commodity changes' do
       it 'adds change records for each commodity change' do
+        allow(service).to receive(:parent_declarability_transition_changes).and_return([])
+
         service.generate_commodity_change_records
 
         expect(service.tariff_change_records).to include(
@@ -467,6 +469,8 @@ RSpec.describe TariffChangesService do
 
     context 'when processing commodity description changes' do
       it 'adds change records for commodity description changes' do
+        allow(service).to receive(:parent_declarability_transition_changes).and_return([])
+
         service.generate_commodity_change_records
 
         expect(service.tariff_change_records).to include(
@@ -479,6 +483,7 @@ RSpec.describe TariffChangesService do
       end
 
       it 'skips commodity description changes when there is a matching commodity change' do
+        allow(service).to receive(:parent_declarability_transition_changes).and_return([])
         allow(service).to receive(:matching_commodity_change?).with(commodity_description_change[:goods_nomenclature_sid], commodity_description_change[:action]).and_return(true)
 
         service.generate_commodity_change_records
@@ -491,6 +496,7 @@ RSpec.describe TariffChangesService do
     context 'when processing measure changes' do
       context 'when goods nomenclature is not found' do
         it 'does not add measure change records but processes other changes' do
+          allow(service).to receive(:parent_declarability_transition_changes).and_return([])
           # Create a measure change that references a non-existent goods_nomenclature_sid
           service.instance_variable_set(:@changes, {
             commodities: [commodity_change],
@@ -517,7 +523,7 @@ RSpec.describe TariffChangesService do
 
         it 'adds change record for the declarable goods nomenclature' do
           other_service = described_class.new(date)
-          allow(other_service).to receive(:matching_commodity_change?).and_return(false)
+          allow(other_service).to receive_messages(parent_declarability_transition_changes: [], matching_commodity_change?: false)
 
           other_service.instance_variable_set(:@changes, service.instance_variable_get(:@changes))
 
@@ -563,7 +569,7 @@ RSpec.describe TariffChangesService do
         end
 
         it 'loads goods nomenclatures once for the measure batch' do
-          allow(service).to receive(:matching_commodity_change?).and_return(false)
+          allow(service).to receive_messages(parent_declarability_transition_changes: [], matching_commodity_change?: false)
           allow(GoodsNomenclature).to receive(:where).and_call_original
 
           service.generate_commodity_change_records
@@ -593,7 +599,7 @@ RSpec.describe TariffChangesService do
         it 'adds change records for declarable descendants' do
           other_service = described_class.new(date)
           other_service.instance_variable_set(:@changes, service.instance_variable_get(:@changes))
-          allow(other_service).to receive(:matching_commodity_change?).and_return(false)
+          allow(other_service).to receive_messages(parent_declarability_transition_changes: [], matching_commodity_change?: false)
 
           other_service.generate_commodity_change_records
 
@@ -615,11 +621,215 @@ RSpec.describe TariffChangesService do
         it 'does not add a change record' do
           other_service = described_class.new(date)
           other_service.instance_variable_set(:@changes, service.instance_variable_get(:@changes))
+          allow(other_service).to receive(:parent_declarability_transition_changes).and_return([])
           allow(other_service).to receive(:matching_commodity_change?).and_return(false, true)
 
           other_service.generate_commodity_change_records
 
           expect(other_service.tariff_change_records).not_to include(hash_including(type: 'Measure', goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid))
+        end
+      end
+
+      context 'when parent declarability transitions are present' do
+        let(:transition_change) do
+          {
+            type: 'Commodity',
+            object_sid: 78_901,
+            goods_nomenclature_item_id: '0202000000',
+            goods_nomenclature_sid: 78_901,
+            action: 'ending',
+            date_of_effect: date,
+            validity_start_date: date - 1.year,
+            validity_end_date: date,
+          }
+        end
+
+        it 'adds parent transition records before non-commodity changes' do
+          allow(service).to receive(:parent_declarability_transition_changes).and_return([transition_change])
+
+          service.generate_commodity_change_records
+
+          expect(service.tariff_change_records).to include(
+            hash_including(
+              type: 'Commodity',
+              goods_nomenclature_sid: transition_change[:goods_nomenclature_sid],
+              action: 'ending',
+            ),
+          )
+        end
+      end
+    end
+  end
+
+  describe '#parent_declarability_transition_changes' do
+    let(:date) { Date.new(2025, 1, 15) }
+    let(:other_service) { described_class.new(date) }
+    let(:parent_sid) { 90_001 }
+    let(:parent) do
+      instance_double(
+        GoodsNomenclature,
+        goods_nomenclature_sid: parent_sid,
+        goods_nomenclature_item_id: '2202000000',
+      )
+    end
+
+    it 'creates an ending change when creation causes declarability to switch from true to false' do
+      child_effective_date = date + 2.days
+      child_sid = 91_001
+      child_change = {
+        type: 'Commodity',
+        object_sid: child_sid,
+        action: TariffChangesService::BaseChanges::CREATION,
+        date_of_effect: child_effective_date,
+      }
+      previous_parent = instance_double(GoodsNomenclature, declarable?: true, validity_start_date: Date.new(2024, 1, 1), validity_end_date: nil)
+      current_parent = instance_double(GoodsNomenclature, declarable?: false)
+
+      allow(other_service).to receive(:parent_declarability_child_changes).and_return([child_change])
+      allow(other_service).to receive(:parent_for_child_at).with(child_sid, child_effective_date).and_return(parent)
+      allow(other_service).to receive(:goods_nomenclature_at).with(parent_sid, child_effective_date - 1.day).and_return(previous_parent)
+      allow(other_service).to receive(:goods_nomenclature_at).with(parent_sid, child_effective_date).and_return(current_parent)
+
+      result = other_service.parent_declarability_transition_changes
+
+      expect(result).to include(
+        hash_including(
+          type: 'Commodity',
+          goods_nomenclature_sid: parent_sid,
+          action: TariffChangesService::BaseChanges::ENDING,
+          date_of_effect: child_effective_date - 1.day,
+          validity_start_date: Date.new(2024, 1, 1),
+          validity_end_date: child_effective_date - 1.day,
+        ),
+      )
+    end
+
+    it 'creates a creation change when ending causes declarability to switch from false to true' do
+      child_end_date = date + 1.day
+      child_sid = 91_002
+      child_change = {
+        type: 'Commodity',
+        object_sid: child_sid,
+        action: TariffChangesService::BaseChanges::ENDING,
+        date_of_effect: child_end_date,
+      }
+      previous_parent = instance_double(GoodsNomenclature, declarable?: false, validity_start_date: Date.new(2024, 1, 1), validity_end_date: nil)
+      current_parent = instance_double(GoodsNomenclature, declarable?: true)
+
+      allow(other_service).to receive(:parent_declarability_child_changes).and_return([child_change])
+      allow(other_service).to receive(:parent_for_child_at).with(child_sid, child_end_date).and_return(parent)
+      allow(other_service).to receive(:goods_nomenclature_at).with(parent_sid, child_end_date).and_return(previous_parent)
+      allow(other_service).to receive(:goods_nomenclature_at).with(parent_sid, child_end_date + 1.day).and_return(current_parent)
+
+      result = other_service.parent_declarability_transition_changes
+
+      expect(result).to include(
+        hash_including(
+          type: 'Commodity',
+          goods_nomenclature_sid: parent_sid,
+          action: TariffChangesService::BaseChanges::CREATION,
+          date_of_effect: child_end_date + 1.day,
+          validity_start_date: child_end_date + 1.day,
+          validity_end_date: nil,
+        ),
+      )
+    end
+  end
+
+  # Integration specs: use real goods nomenclature tree nodes to verify that
+  # parent declarability is resolved at the child's effective date, not the
+  # operation date. This exercises the TimeMachine + nested-set path that
+  # mocked unit specs cannot reach.
+  describe 'parent declarability (integration)' do
+    let(:operation_date) { Date.new(2025, 1, 15) }
+    let(:effective_date) { operation_date + 5.days }
+    let(:int_service) { described_class.new(operation_date) }
+
+    describe '#parent_for_child_at' do
+      context 'when child is imported before its validity starts' do
+        let!(:parent_node) do
+          create(:commodity, :declarable, validity_start_date: 2.years.ago.to_date)
+        end
+        let!(:child_node) do
+          create(:commodity, :non_declarable,
+                 parent: parent_node,
+                 validity_start_date: effective_date)
+        end
+
+        it 'returns nil at operation_date because child not yet valid at that snapshot' do
+          result = int_service.parent_for_child_at(child_node.goods_nomenclature_sid, operation_date)
+
+          expect(result).to be_nil
+        end
+
+        it 'resolves the parent at the child effective_date' do
+          result = int_service.parent_for_child_at(child_node.goods_nomenclature_sid, effective_date)
+
+          expect(result).not_to be_nil
+          expect(result.goods_nomenclature_sid).to eq(parent_node.goods_nomenclature_sid)
+        end
+      end
+    end
+
+    describe '#parent_declarability_transition_for' do
+      context 'when a non-declarable child is imported before its validity starts' do
+        let!(:parent_node) do
+          create(:commodity, :declarable, validity_start_date: 2.years.ago.to_date)
+        end
+        let!(:child_node) do
+          create(:commodity, :non_declarable,
+                 parent: parent_node,
+                 validity_start_date: effective_date)
+        end
+
+        it 'emits an ENDING change for the parent using the child effective date, not operation date' do
+          child_change = {
+            type: 'Commodity',
+            object_sid: child_node.goods_nomenclature_sid,
+            action: TariffChangesService::BaseChanges::CREATION,
+            date_of_effect: effective_date,
+          }
+
+          result = int_service.parent_declarability_transition_for(child_change)
+
+          expect(result).to include(
+            type: 'Commodity',
+            goods_nomenclature_sid: parent_node.goods_nomenclature_sid,
+            action: TariffChangesService::BaseChanges::ENDING,
+            date_of_effect: effective_date - 1.day,
+          )
+        end
+      end
+
+      context 'when child ending makes parent declarable again' do
+        let(:child_end_date) { operation_date + 3.days }
+        let!(:parent_node) do
+          create(:commodity, :declarable, validity_start_date: 2.years.ago.to_date)
+        end
+        let!(:child_node) do
+          create(:commodity, :non_declarable,
+                 parent: parent_node,
+                 validity_start_date: 2.years.ago.to_date,
+                 validity_end_date: child_end_date)
+        end
+
+        it 'emits a CREATION change for the parent the day after the child ends' do
+          child_change = {
+            type: 'Commodity',
+            object_sid: child_node.goods_nomenclature_sid,
+            action: TariffChangesService::BaseChanges::ENDING,
+            date_of_effect: child_end_date,
+          }
+
+          result = int_service.parent_declarability_transition_for(child_change)
+
+          expect(result).to include(
+            type: 'Commodity',
+            goods_nomenclature_sid: parent_node.goods_nomenclature_sid,
+            action: TariffChangesService::BaseChanges::CREATION,
+            date_of_effect: child_end_date + 1.day,
+            validity_start_date: child_end_date + 1.day,
+          )
         end
       end
     end


### PR DESCRIPTION
## What:

Handles cases where a commodity code either becomes declarable, or stops being declarable because of children being added or removed.

- Identifies all commodity changes where the commodity is created or ending.
- For each parent tests if the commodity has changed from declarable to non-declarable or the inverse using TimeMachine.
- If there is a change then a TariffChange record is created

## Why:

Fills a gap in the CCWL data for commodity changes

## Ticket:
[N/A](https://transformuk.atlassian.net/browse/OTTIMP-665)

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Changes declarable goods and commodity watchlist notification logic (the feature that determines which parent commodities gain or lose declarability). Behaviour change is additive for users (new CREATION/ENDING synthetic changes appear where they were previously missed).