### PR TITLE
Add duplicate question guard dashboards

### DIFF
--- a/terraform/modules/search_operations_dashboard/main.tf
+++ b/terraform/modules/search_operations_dashboard/main.tf
@@ -267,6 +267,83 @@ resource "aws_cloudwatch_dashboard" "search_operations" {
           type   = "log"
           x      = 0
           y      = 26
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Duplicate Guard AI Latency"
+            region = var.region
+            view   = "timeSeries"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "api_call_completed" and operation in ["duplicate_question_validator", "duplicate_question_retry"]
+              | stats pct(duration_ms, 50) as p50, pct(duration_ms, 90) as p90, pct(duration_ms, 99) as p99 by operation, bin(1h)
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 8
+          y      = 26
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Duplicate Guard Fail-Open Rate"
+            region = var.region
+            view   = "timeSeries"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "duplicate_question_guard_checked"
+              | stats count(*) as checks,
+                  sum(if(reason = "validator_unparseable", 1, 0)) as fail_open_checks,
+                  round(100 * sum(if(reason = "validator_unparseable", 1, 0)) / count(*), 2) as fail_open_pct
+                by bin(1h)
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 16
+          y      = 26
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Duplicate Retry Volume"
+            region = var.region
+            view   = "timeSeries"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "api_call_completed" and operation = "duplicate_question_retry"
+              | stats count(*) as retries by response_type, bin(1h)
+            EOT
+          }
+        },
+      ],
+      [
+        {
+          type   = "log"
+          x      = 0
+          y      = 32
+          width  = 24
+          height = 6
+          properties = {
+            title  = "Recent Duplicate Guard AI Issues"
+            region = var.region
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter}
+              | filter (event = "api_call_completed" and operation in ["duplicate_question_validator", "duplicate_question_retry"] and response_type = "error") or (event = "duplicate_question_guard_checked" and reason = "validator_unparseable")
+              | fields @timestamp, event, request_id, operation, response_type, reason, error_type, error_message, effective_query, attempt_number
+              | sort @timestamp desc
+              | limit 30
+            EOT
+          }
+        },
+      ],
+      [
+        {
+          type   = "log"
+          x      = 0
+          y      = 38
           width  = 24
           height = 6
           properties = {

--- a/terraform/modules/search_quality_dashboard/main.tf
+++ b/terraform/modules/search_quality_dashboard/main.tf
@@ -305,6 +305,86 @@ resource "aws_cloudwatch_dashboard" "search_quality" {
           type   = "log"
           x      = 0
           y      = 32
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Duplicate Guard Outcomes"
+            region = var.region
+            view   = "pie"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "duplicate_question_guard_checked"
+              | stats count(*) as checks by suspicious, duplicate, allowed
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 8
+          y      = 32
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Duplicate Guard Rates"
+            region = var.region
+            view   = "timeSeries"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "duplicate_question_guard_checked"
+              | stats count(*) as checks,
+                  sum(if(suspicious = true, 1, 0)) as suspicious_checks,
+                  sum(if(duplicate = true, 1, 0)) as duplicate_checks,
+                  round(100 * sum(if(suspicious = true, 1, 0)) / count(*), 2) as suspicious_pct,
+                  round(100 * sum(if(duplicate = true, 1, 0)) / count(*), 2) as duplicate_pct
+                by bin(1h)
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 16
+          y      = 32
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Duplicate Guard Signal Breakdown"
+            region = var.region
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "duplicate_question_guard_checked" and suspicious = true
+              | fields jsonParse(@message) as guard
+              | unnest guard.signals into signal
+              | stats count(*) as checks by signal
+              | sort checks desc
+            EOT
+          }
+        },
+      ],
+      [
+        {
+          type   = "log"
+          x      = 0
+          y      = 38
+          width  = 24
+          height = 6
+          properties = {
+            title  = "Recent Duplicate Guard Decisions"
+            region = var.region
+            query  = <<-EOT
+              ${local.source}
+              | ${local.service_filter} and event = "duplicate_question_guard_checked"
+              | fields @timestamp, request_id, attempt_number, suspicious, duplicate, allowed, signals, reason, duplicate_of_question, duplicate_of_answer
+              | sort @timestamp desc
+              | limit 30
+            EOT
+          }
+        },
+      ],
+      [
+        {
+          type   = "log"
+          x      = 0
+          y      = 44
           width  = 24
           height = 6
           properties = {


### PR DESCRIPTION
## What:
Adds duplicate-question guard observability to the existing split search dashboards:

- Search Quality: guard outcomes, suspicious/duplicate rates, flattened signal breakdown, and recent guard decisions.
- Search Operations: duplicate guard AI latency, fail-open rate, retry volume, and recent validator/fail-open issue drill-down.

## Why:
AI-907 added a hybrid guard for repeated guided-search questions. Since the guard is intentionally fail-open and validator-backed, rollout needs dashboard visibility into whether it is catching duplicates, how noisy the mechanical gate is, and whether validator failures are causing questions to pass through.

Subagent review was incorporated before opening this PR:

- Flattened `signals` with `jsonParse(@message)` and `unnest` instead of grouping by the raw array.
- Added percentage-rate widgets so traffic changes do not make counts misleading.
- Added recent duplicate guard AI issue drill-down because validator failures do not emit hard search failures.
- Renamed validator latency to duplicate guard AI latency because it includes validator and retry calls.

## Ticket:
https://transformuk.atlassian.net/browse/AI-907

## Risk:
**Risk level:** 🟢 Green

**Reason for rating:**
Read-only CloudWatch dashboard changes only. No runtime behaviour, IAM, networking, or data-processing changes.