### PR TITLE
Fix PopulateChangesTableWorker dead job: DateNotSet in DescendantPopulator

### DIFF
--- a/app/lib/changes_table_populator/descendant_populator.rb
+++ b/app/lib/changes_table_populator/descendant_populator.rb
@@ -10,8 +10,8 @@ module ChangesTablePopulator
     end
 
     def build_descendant_change_records(row:, day: Time.zone.today)
-      find_source_and_descendants(row:, day:).map do |descendant|
-        build_change_record(row: descendant, day:, is_end_line: descendant.declarable?)
+      find_source_and_descendants(row:, day:).map do |descendant, declarable|
+        build_change_record(row: descendant, day:, is_end_line: declarable)
       end
     end
   end

--- a/app/lib/changes_table_populator/importer.rb
+++ b/app/lib/changes_table_populator/importer.rb
@@ -105,7 +105,7 @@ module ChangesTablePopulator
              .first
 
       TimeMachine.at(descendants_date(gn, day)) do
-        [gn] + gn.descendants
+        ([gn] + gn.descendants).map { |d| [d, d.declarable?] }
       end
     end
   end


### PR DESCRIPTION
## What:
Fixes a dead Sidekiq job in `PopulateChangesTableWorker` caused by `GoodsNomenclatures::NestedSet::DateNotSet` being raised inside `DescendantPopulator`.

## Why:
`build_descendant_change_records` called `descendant.declarable?` on objects returned from `find_source_and_descendants` after the `TimeMachine.at` block had already closed. When `declarable?` → `leaf?` → `children.empty?` was evaluated, the `children` association guard raised `DateNotSet` because no TimeMachine date was active at that point.

The fix evaluates `declarable?` for every node **inside** the `TimeMachine.at` block in `find_source_and_descendants`, returning `[node, declarable_bool]` pairs. `build_descendant_change_records` destructures those pairs instead of re-calling `declarable?` after the block has closed.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Bug fix with no behaviour change — the `declarable?` result is now computed at the correct point in time (inside the TimeMachine context where descendants were fetched), which is what the original code intended. No API surface, schema, or data flow changes.