### PR TITLE
Classify search request source in analytics

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -49,7 +49,8 @@ class ApplicationController < ActionController::API
   def append_info_to_payload(payload)
     super
     payload[:request_id] = logged_request_id
-    payload[:user_agent] = request.headers['HTTP_X_ORIGINAL_USER_AGENT'].presence || request.env['HTTP_USER_AGENT']
+    payload[:user_agent] = request_user_agent
+    payload[:request_source] = TradeTariffRequest.request_source
     payload[:client_id] = request.headers['HTTP_X_CLIENT_ID']
   end
 
@@ -126,6 +127,7 @@ class ApplicationController < ActionController::API
 
   def set_trade_tariff_request_id
     TradeTariffRequest.request_id = params[:request_id].presence || request.request_id
+    TradeTariffRequest.request_source = TradeTariffRequest.request_source_for_user_agent(request_user_agent)
   end
 
   def set_api_docs_link_header
@@ -134,5 +136,9 @@ class ApplicationController < ActionController::API
 
   def logged_request_id
     (TradeTariffRequest.request_id.presence || request.request_id).to_s.first(MAX_LOGGED_REQUEST_ID_LENGTH)
+  end
+
+  def request_user_agent
+    request.headers['HTTP_X_ORIGINAL_USER_AGENT'].presence || request.env['HTTP_USER_AGENT']
   end
 end

--- a/app/lib/search/instrumentation.rb
+++ b/app/lib/search/instrumentation.rb
@@ -9,7 +9,7 @@ module Search
     EVALUATION_TRACE_VERSION = 'classification_evaluation_trace.v1'.freeze
 
     def instrument(event_name, payload = {}, &block)
-      ActiveSupport::Notifications.instrument("#{event_name}.search", with_request_id(payload), &block)
+      ActiveSupport::Notifications.instrument("#{event_name}.search", with_request_context(payload), &block)
     end
 
     def search_started(request_id:, query:, search_type:)
@@ -363,10 +363,18 @@ module Search
       }
     end
 
-    def with_request_id(payload)
+    def with_request_context(payload)
       return payload unless payload.key?(:request_id)
 
-      payload.merge(request_id: payload[:request_id].presence || TradeTariffRequest.request_id.presence || SecureRandom.uuid)
+      payload
+        .merge(request_id: payload[:request_id].presence || TradeTariffRequest.request_id.presence || SecureRandom.uuid)
+        .merge(request_source_payload)
+    end
+
+    def request_source_payload
+      return {} if TradeTariffRequest.request_source.blank?
+
+      { request_source: TradeTariffRequest.request_source }
     end
 
     def summarize_classic_fuzzy_results(results)

--- a/app/lib/search/logger.rb
+++ b/app/lib/search/logger.rb
@@ -3,16 +3,16 @@ require 'active_support/log_subscriber'
 module Search
   class Logger < ActiveSupport::LogSubscriber
     def search_started(event)
-      info log_entry(
+      info log_entry({
         event: 'search_started',
         request_id: event.payload[:request_id],
         query: event.payload[:query],
         search_type: event.payload[:search_type],
-      )
+      }, event)
     end
 
     def query_expanded(event)
-      info log_entry(
+      info log_entry({
         event: 'query_expanded',
         request_id: event.payload[:request_id],
         search_type: event.payload[:search_type],
@@ -20,11 +20,11 @@ module Search
         expanded_query: event.payload[:expanded_query],
         reason: event.payload[:reason],
         duration_ms: event.payload[:duration_ms],
-      )
+      }, event)
     end
 
     def query_refined(event)
-      info log_entry(
+      info log_entry({
         event: 'query_refined',
         request_id: event.payload[:request_id],
         search_type: event.payload[:search_type],
@@ -35,11 +35,11 @@ module Search
         answer_count: event.payload[:answer_count],
         added_answers: event.payload[:added_answers],
         iteration: event.payload[:iteration],
-      )
+      }, event)
     end
 
     def query_expansion_decided(event)
-      info log_entry(
+      info log_entry({
         event: 'query_expansion_decided',
         request_id: event.payload[:request_id],
         search_type: event.payload[:search_type],
@@ -48,7 +48,7 @@ module Search
         reason: event.payload[:reason],
         result_count: event.payload[:result_count],
         max_score: event.payload[:max_score],
-      )
+      }, event)
     end
 
     def api_call_completed(event)
@@ -65,11 +65,11 @@ module Search
         operation: event.payload[:operation],
       }
       add_error_fields!(data, event)
-      info log_entry(data)
+      info log_entry(data, event)
     end
 
     def exact_match_selected(event)
-      info log_entry(
+      info log_entry({
         event: 'exact_match_selected',
         request_id: event.payload[:request_id],
         search_type: event.payload[:search_type],
@@ -82,32 +82,32 @@ module Search
         goods_nomenclature_item_id: event.payload[:goods_nomenclature_item_id],
         goods_nomenclature_sid: event.payload[:goods_nomenclature_sid],
         details: event.payload[:details],
-      )
+      }, event)
     end
 
     def fuzzy_results_returned(event)
-      info log_entry(
+      info log_entry({
         event: 'fuzzy_results_returned',
         request_id: event.payload[:request_id],
         search_type: event.payload[:search_type],
         query: event.payload[:query],
         result_count: event.payload[:result_count],
         details: event.payload[:details],
-      )
+      }, event)
     end
 
     def interactive_configuration_used(event)
-      info log_entry(
+      info log_entry({
         event: 'interactive_configuration_used',
         request_id: event.payload[:request_id],
         search_type: event.payload[:search_type],
         query: event.payload[:query],
         details: event.payload[:details],
-      )
+      }, event)
     end
 
     def retrieval_results_returned(event)
-      info log_entry(
+      info log_entry({
         event: 'retrieval_results_returned',
         request_id: event.payload[:request_id],
         search_type: event.payload[:search_type],
@@ -119,7 +119,7 @@ module Search
         iteration: event.payload[:iteration],
         result_count: event.payload[:result_count],
         details: event.payload[:details],
-      )
+      }, event)
     end
 
     def question_returned(event)
@@ -133,7 +133,7 @@ module Search
         effective_query: event.payload[:effective_query],
       }
       data[:details] = event.payload[:details] if event.payload[:details]
-      info log_entry(data)
+      info log_entry(data, event)
     end
 
     def answer_returned(event)
@@ -148,11 +148,11 @@ module Search
         effective_query: event.payload[:effective_query],
       }
       data[:details] = event.payload[:details] if event.payload[:details]
-      info log_entry(data)
+      info log_entry(data, event)
     end
 
     def evaluation_trace_returned(event)
-      info log_entry(
+      info log_entry({
         event: 'evaluation_trace_returned',
         request_id: event.payload[:request_id],
         search_type: event.payload[:search_type],
@@ -180,11 +180,11 @@ module Search
         error_message: event.payload[:error_message],
         error_message_truncated: event.payload[:error_message_truncated],
         details: event.payload[:details],
-      )
+      }, event)
     end
 
     def duplicate_question_guard_checked(event)
-      info log_entry(
+      info log_entry({
         event: 'duplicate_question_guard_checked',
         request_id: event.payload[:request_id],
         search_type: event.payload[:search_type],
@@ -199,7 +199,7 @@ module Search
         reason_truncated: event.payload[:reason_truncated],
         duplicate_of_question: event.payload[:duplicate_of_question],
         duplicate_of_answer: event.payload[:duplicate_of_answer],
-      )
+      }, event)
     end
 
     def description_intercept_checked(event)
@@ -208,7 +208,7 @@ module Search
                        request_id: event.payload[:request_id],
                        search_type: event.payload[:search_type],
                        query: event.payload[:query],
-                     ))
+                     ), event)
     end
 
     def search_completed(event)
@@ -227,7 +227,7 @@ module Search
       data[:max_score] = event.payload[:max_score] if event.payload[:max_score]
       add_description_intercept_fields!(data, event)
       add_error_fields!(data, event)
-      info log_entry(data)
+      info log_entry(data, event)
     end
 
     def retrieval_leg_completed(event)
@@ -241,16 +241,16 @@ module Search
         status: event.payload[:status],
       }
       add_error_fields!(data, event)
-      info log_entry(data)
+      info log_entry(data, event)
     end
 
     def result_selected(event)
-      info log_entry(
+      info log_entry({
         event: 'result_selected',
         request_id: event.payload[:request_id],
         goods_nomenclature_item_id: event.payload[:goods_nomenclature_item_id],
         goods_nomenclature_class: event.payload[:goods_nomenclature_class],
-      )
+      }, event)
     end
 
     def search_failed(event)
@@ -261,16 +261,18 @@ module Search
         search_type: event.payload[:search_type],
       }
       add_error_fields!(data, event)
-      error log_entry(data)
+      error log_entry(data, event)
     end
 
     private
 
-    def log_entry(data)
-      data.merge(
+    def log_entry(data, event)
+      entry = data.merge(
         service: 'search',
         timestamp: Time.current.iso8601,
-      ).to_json
+      )
+      entry[:request_source] = event.payload[:request_source] if event.payload[:request_source].present?
+      entry.to_json
     end
 
     def add_description_intercept_fields!(data, event)

--- a/app/lib/trade_tariff_request.rb
+++ b/app/lib/trade_tariff_request.rb
@@ -1,6 +1,11 @@
 class TradeTariffRequest < ActiveSupport::CurrentAttributes
+  FRONTEND_USER_AGENT_PREFIX = 'TradeTariffFrontend/'.freeze
+  FRONTEND_REQUEST_SOURCE = 'frontend'.freeze
+  BACKEND_ONLY_REQUEST_SOURCE = 'backend_only'.freeze
+
   attribute :whodunnit,
             :request_id,
+            :request_source,
             :green_lanes,
             :time_machine_now,
             # Controls how TimeMachine filters associated records in queries.
@@ -13,4 +18,12 @@ class TradeTariffRequest < ActiveSupport::CurrentAttributes
             # Controls whether label fields (known_brands, colloquial_terms, synonyms)
             # are included in search suggestion queries
             :search_labels_enabled
+
+  def self.request_source_for_user_agent(user_agent)
+    if user_agent.to_s.start_with?(FRONTEND_USER_AGENT_PREFIX)
+      FRONTEND_REQUEST_SOURCE
+    else
+      BACKEND_ONLY_REQUEST_SOURCE
+    end
+  end
 end

--- a/app/serializers/api/admin/search_analytics_serializer.rb
+++ b/app/serializers/api/admin/search_analytics_serializer.rb
@@ -11,7 +11,7 @@ module Api
       attribute(:generated_at) { |snapshot| snapshot.generated_at.iso8601 }
       attribute(:data_through) { |snapshot| snapshot.data_through.iso8601 }
 
-      %w[summary summary_statuses trends comparisons].each do |name|
+      %w[summary summary_statuses trends comparisons request_sources].each do |name|
         attribute(name.to_sym) { |snapshot| snapshot.payload.fetch(name, {}) }
       end
 

--- a/app/services/search_analytics/cloudwatch_snapshot_query.rb
+++ b/app/services/search_analytics/cloudwatch_snapshot_query.rb
@@ -12,6 +12,7 @@ module SearchAnalytics
       'internal' => %w[interactive internal],
     }.freeze
     VIEWS = %w[all classic internal].freeze
+    REQUEST_SOURCES = %w[frontend backend_only unknown].freeze
     QueryError = Class.new(StandardError)
 
     def self.call(period:, client: self.client, now: Time.current) = new(period:, client:, now:).call
@@ -29,8 +30,10 @@ module SearchAnalytics
         period:,
         volume_rows: run_query(volume_query),
         zero_result_rows: run_query(zero_result_query),
-        all_latency_rows: run_query(all_latency_query),
-        view_latency_rows: run_query(view_latency_query),
+        summary_all_latency_rows: run_query(summary_all_latency_query),
+        summary_view_latency_rows: run_query(summary_view_latency_query),
+        source_all_latency_rows: run_query(source_all_latency_query),
+        source_view_latency_rows: run_query(source_view_latency_query),
         selection_rows: selection_queries.flat_map { |view, query| run_query(query).map { |row| row.merge('selectable_search_type' => view) } },
         selection_trend_rows: selection_trend_queries.flat_map { |view, query| run_query(query).map { |row| row.merge('selectable_search_type' => view) } },
         improvement_term_rows: improvement_term_queries.flat_map { |term_type, query| run_query(query).map { |row| row.merge('term_type' => term_type) } },
@@ -89,23 +92,25 @@ module SearchAnalytics
 
     def volume_query
       <<~QUERY
-        fields @timestamp, event, search_type
+        fields @timestamp, event, search_type, request_source
         | #{log_stream_filter}
         | #{base_search_filter}
-        | stats count(*) as searches by #{bucket_expression}, search_type, event
+        | fields if(ispresent(request_source), request_source, "unknown") as request_source
+        | stats count(*) as searches by #{bucket_expression}, search_type, event, request_source
       QUERY
     end
 
     def zero_result_query
       <<~QUERY
-        fields @timestamp, event, search_type, result_count
+        fields @timestamp, event, search_type, result_count, request_source
         | #{log_stream_filter}
         | filter service = "search" and event = "search_completed" and result_count = 0
-        | stats count(*) as zero_results by #{bucket_expression}, search_type
+        | fields if(ispresent(request_source), request_source, "unknown") as request_source
+        | stats count(*) as zero_results by #{bucket_expression}, search_type, request_source
       QUERY
     end
 
-    def all_latency_query
+    def summary_all_latency_query
       <<~QUERY
         fields event, total_duration_ms
         | #{log_stream_filter}
@@ -114,12 +119,32 @@ module SearchAnalytics
       QUERY
     end
 
-    def view_latency_query
+    def summary_view_latency_query
       <<~QUERY
         fields event, search_type, total_duration_ms
         | #{log_stream_filter}
         | #{base_search_filter} and ispresent(total_duration_ms)
         | stats pct(total_duration_ms, 90) as p90_latency_ms by search_type
+      QUERY
+    end
+
+    def source_all_latency_query
+      <<~QUERY
+        fields event, total_duration_ms, request_source
+        | #{log_stream_filter}
+        | #{base_search_filter} and ispresent(total_duration_ms)
+        | fields if(ispresent(request_source), request_source, "unknown") as request_source
+        | stats pct(total_duration_ms, 90) as p90_latency_ms by request_source
+      QUERY
+    end
+
+    def source_view_latency_query
+      <<~QUERY
+        fields event, search_type, total_duration_ms, request_source
+        | #{log_stream_filter}
+        | #{base_search_filter} and ispresent(total_duration_ms)
+        | fields if(ispresent(request_source), request_source, "unknown") as request_source
+        | stats pct(total_duration_ms, 90) as p90_latency_ms by search_type, request_source
       QUERY
     end
 
@@ -132,15 +157,17 @@ module SearchAnalytics
 
     def selection_query(selectable_condition)
       <<~QUERY
-        fields request_id, event, search_type, result_count, results_type
+        fields request_id, event, search_type, result_count, results_type, request_source
         | #{log_stream_filter}
         | filter service = "search" and ispresent(request_id) and (event = "result_selected" or (event = "search_completed" and result_count > 0 and #{selectable_condition}))
         | fields if(event = "result_selected", 1, 0) as result_selection_marker
         | fields if(event = "search_completed" and result_count > 0 and #{selectable_condition}, 1, 0) as selectable_search_marker
+        | fields if(ispresent(request_source), request_source, "unknown") as request_source
         | stats sum(result_selection_marker) as result_selections,
-            sum(selectable_search_marker) as selectable_searches by request_id
+            sum(selectable_search_marker) as selectable_searches,
+            earliest(request_source) as request_source by request_id
         | filter selectable_searches > 0
-        | stats sum(result_selections) as selected, sum(selectable_searches) as selectable
+        | stats sum(result_selections) as selected, sum(selectable_searches) as selectable by request_source
       QUERY
     end
 
@@ -148,11 +175,11 @@ module SearchAnalytics
       selection_queries.transform_values do |query|
         query
           .sub(
-            'sum(selectable_search_marker) as selectable_searches by request_id',
-            'sum(selectable_search_marker) as selectable_searches, max(@timestamp) as @t by request_id',
+            'earliest(request_source) as request_source by request_id',
+            'earliest(request_source) as request_source, max(@timestamp) as @t by request_id',
           )
           .sub(
-            '| stats sum(result_selections) as selected, sum(selectable_searches) as selectable',
+            '| stats sum(result_selections) as selected, sum(selectable_searches) as selectable by request_source',
             "| stats sum(result_selections) as selected by datefloor(@t, #{bucket_period}) as @timestamp",
           )
       end
@@ -182,12 +209,14 @@ module SearchAnalytics
     end
 
     class Aggregate
-      def initialize(period:, volume_rows:, zero_result_rows:, all_latency_rows:, view_latency_rows:, selection_rows:, selection_trend_rows:, improvement_term_rows:)
+      def initialize(period:, volume_rows:, zero_result_rows:, summary_all_latency_rows:, summary_view_latency_rows:, source_all_latency_rows:, source_view_latency_rows:, selection_rows:, selection_trend_rows:, improvement_term_rows:)
         @period = period
         @volume_rows = volume_rows
         @zero_result_rows = zero_result_rows
-        @all_latency_rows = all_latency_rows
-        @view_latency_rows = view_latency_rows
+        @summary_all_latency_rows = summary_all_latency_rows
+        @summary_view_latency_rows = summary_view_latency_rows
+        @source_all_latency_rows = source_all_latency_rows
+        @source_view_latency_rows = source_view_latency_rows
         @selection_rows = selection_rows
         @selection_trend_rows = selection_trend_rows
         @improvement_term_rows = improvement_term_rows
@@ -199,13 +228,14 @@ module SearchAnalytics
           'summary_statuses' => summary_statuses(view),
           'trends' => trends(view),
           'comparisons' => comparisons,
+          'request_sources' => request_sources(view),
           'improvement_terms' => improvement_terms(view),
         }
       end
 
       private
 
-      attr_reader :period, :volume_rows, :zero_result_rows, :all_latency_rows, :view_latency_rows, :selection_rows, :selection_trend_rows, :improvement_term_rows
+      attr_reader :period, :volume_rows, :zero_result_rows, :summary_all_latency_rows, :summary_view_latency_rows, :source_all_latency_rows, :source_view_latency_rows, :selection_rows, :selection_trend_rows, :improvement_term_rows
 
       def summary(view)
         searches = search_count(view)
@@ -235,6 +265,9 @@ module SearchAnalytics
             'all' => bucket_search_count(bucket, 'all'),
             'classic' => bucket_search_count(bucket, 'classic'),
             'internal' => bucket_search_count(bucket, 'internal'),
+            'frontend' => bucket_search_count(bucket, 'all', request_source: 'frontend'),
+            'backend_only' => bucket_search_count(bucket, 'all', request_source: 'backend_only'),
+            'unknown' => bucket_search_count(bucket, 'all', request_source: 'unknown'),
           }
         end
       end
@@ -258,16 +291,21 @@ module SearchAnalytics
         }
       end
 
-      def comparison_for(view)
-        searches = search_count(view)
-        completed = completed_count(view)
-        zero_results = zero_result_count(view)
+      def request_sources(view)
+        REQUEST_SOURCES.index_with { |source| comparison_for(view, request_source: source) }
+      end
+
+      def comparison_for(view, request_source: nil)
+        searches = search_count(view, request_source:)
+        completed = completed_count(view, request_source:)
+        zero_results = zero_result_count(view, request_source:)
 
         {
           'searches' => searches,
+          'failure_rate' => rate(failed_count(view, request_source:), searches),
           'zero_result_rate' => rate(zero_results, completed),
-          'selection_rate' => rate(selection_count(view), selectable_count(view)),
-          'p90_latency_ms' => latency_for(view),
+          'selection_rate' => rate(selection_count(view, request_source:), selectable_count(view, request_source:)),
+          'p90_latency_ms' => latency_for(view, request_source:),
         }
       end
 
@@ -351,30 +389,42 @@ module SearchAnalytics
         end
       end
 
-      def search_count(view) = filtered_rows(volume_rows, view).sum { |row| integer(row['searches']) }
+      def search_count(view, request_source: nil) = filtered_rows(volume_rows, view, request_source:).sum { |row| integer(row['searches']) }
 
-      def failed_count(view)
-        filtered_rows(volume_rows, view).sum { |row| row['event'] == 'search_failed' ? integer(row['searches']) : 0 }
+      def failed_count(view, request_source: nil)
+        filtered_rows(volume_rows, view, request_source:).sum { |row| row['event'] == 'search_failed' ? integer(row['searches']) : 0 }
       end
 
-      def completed_count(view)
-        filtered_rows(volume_rows, view).sum { |row| row['event'] == 'search_completed' ? integer(row['searches']) : 0 }
+      def completed_count(view, request_source: nil)
+        filtered_rows(volume_rows, view, request_source:).sum { |row| row['event'] == 'search_completed' ? integer(row['searches']) : 0 }
       end
 
-      def zero_result_count(view) = filtered_rows(zero_result_rows, view).sum { |row| integer(row['zero_results']) }
+      def zero_result_count(view, request_source: nil) = filtered_rows(zero_result_rows, view, request_source:).sum { |row| integer(row['zero_results']) }
 
-      def selection_count(view) = filtered_rows(selection_rows, view).sum { |row| integer(row['selected']) }
+      def selection_count(view, request_source: nil) = filtered_rows(selection_rows, view, request_source:).sum { |row| integer(row['selected']) }
 
-      def selectable_count(view) = filtered_rows(selection_rows, view).sum { |row| integer(row['selectable']) }
+      def selectable_count(view, request_source: nil) = filtered_rows(selection_rows, view, request_source:).sum { |row| integer(row['selectable']) }
 
-      def latency_for(view)
-        return integer(all_latency_rows.first&.fetch('p90_latency_ms', nil)) if view == 'all'
+      def latency_for(view, request_source: nil)
+        rows = latency_rows_for(view, request_source:)
 
-        filtered_rows(view_latency_rows, view).map { |row| integer(row['p90_latency_ms']) }.max || 0
+        rows.map { |row| integer(row['p90_latency_ms']) }.max || 0
       end
 
-      def bucket_search_count(bucket, view)
-        filtered_rows(volume_rows, view).sum { |row| iso8601(row['@timestamp']) == bucket ? integer(row['searches']) : 0 }
+      def latency_rows_for(view, request_source: nil)
+        if request_source
+          return filtered_rows(source_all_latency_rows, view, request_source:) if view == 'all'
+
+          filtered_rows(source_view_latency_rows, view, request_source:)
+        elsif view == 'all'
+          summary_all_latency_rows
+        else
+          filtered_rows(summary_view_latency_rows, view)
+        end
+      end
+
+      def bucket_search_count(bucket, view, request_source: nil)
+        filtered_rows(volume_rows, view, request_source:).sum { |row| iso8601(row['@timestamp']) == bucket ? integer(row['searches']) : 0 }
       end
 
       def bucket_event_count(bucket, view, event)
@@ -398,11 +448,15 @@ module SearchAnalytics
           .sort
       end
 
-      def filtered_rows(rows, view)
+      def filtered_rows(rows, view, request_source: nil)
+        rows = rows.select { |row| source_key(row) == request_source } if request_source
+
         return rows if view == 'all'
 
         rows.select { |row| row_matches_view?(row, view) }
       end
+
+      def source_key(row) = row['request_source'].presence || 'unknown'
 
       def row_matches_view?(row, view) = VIEW_SEARCH_TYPES.fetch(view, [view]).include?(row_search_type(row))
 

--- a/spec/lib/search/instrumentation_spec.rb
+++ b/spec/lib/search/instrumentation_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Search::Instrumentation do
+  before { TradeTariffRequest.request_source = nil }
+
   describe '.search_started' do
     it 'instruments the search_started event' do
       allow(ActiveSupport::Notifications).to receive(:instrument)
@@ -24,6 +26,21 @@ RSpec.describe Search::Instrumentation do
         request_id: 'current-request-id',
         query: 'horses',
         search_type: 'interactive',
+      )
+    end
+
+    it 'adds the current request source to the search event payload' do
+      allow(ActiveSupport::Notifications).to receive(:instrument)
+      TradeTariffRequest.request_source = 'frontend'
+
+      described_class.search_started(request_id: 'req-1', query: 'horses', search_type: 'interactive')
+
+      expect(ActiveSupport::Notifications).to have_received(:instrument).with(
+        'search_started.search',
+        request_id: 'req-1',
+        query: 'horses',
+        search_type: 'interactive',
+        request_source: 'frontend',
       )
     end
   end

--- a/spec/lib/search/logger_spec.rb
+++ b/spec/lib/search/logger_spec.rb
@@ -33,6 +33,15 @@ RSpec.describe Search::Logger do
       expect(json['service']).to eq('search')
       expect(json['timestamp']).to be_present
     end
+
+    it 'uses the event payload request source when present' do
+      TradeTariffRequest.request_source = 'backend_only'
+      logger_instance.public_send(method_name, build_event(event_name, payload.merge(request_source: 'frontend')))
+      json = parsed_log_output
+      expect(json['request_source']).to eq('frontend')
+    ensure
+      TradeTariffRequest.request_source = nil
+    end
   end
 
   describe '#search_started' do
@@ -48,6 +57,16 @@ RSpec.describe Search::Logger do
       expect(json['request_id']).to eq('req-1')
       expect(json['query']).to eq('horses')
       expect(json['search_type']).to eq('interactive')
+    end
+
+    it 'preserves nil logged fields when request source is absent' do
+      TradeTariffRequest.request_source = nil
+
+      logger_instance.search_started(build_event('search_started', payload.merge(query: nil)))
+
+      json = parsed_log_output
+      expect(json).to include('query' => nil)
+      expect(json).not_to have_key('request_source')
     end
   end
 

--- a/spec/requests/api/admin/search_analytics_controller_spec.rb
+++ b/spec/requests/api/admin/search_analytics_controller_spec.rb
@@ -24,6 +24,11 @@ RSpec.describe Api::Admin::SearchAnalyticsController do
         'comparisons' => {
           'classic' => { 'searches' => 710 },
         },
+        'request_sources' => {
+          'frontend' => { 'searches' => 920 },
+          'backend_only' => { 'searches' => 320 },
+          'unknown' => { 'searches' => 5 },
+        },
         'improvement_terms' => [
           { 'query' => 'trainers', 'zero_results' => 18 },
         ],
@@ -83,6 +88,17 @@ RSpec.describe Api::Admin::SearchAnalyticsController do
             comparisons: {
               classic: {
                 searches: 710,
+              },
+            },
+            request_sources: {
+              frontend: {
+                searches: 920,
+              },
+              backend_only: {
+                searches: 320,
+              },
+              unknown: {
+                searches: 5,
               },
             },
             improvement_terms: [

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -78,13 +78,13 @@ RSpec.describe ApplicationController, type: :request do
     end
 
     context 'with request logging payload' do
-      def process_action_payload_for(params:)
+      def process_action_payload_for(params:, headers: {})
         events = []
         subscriber = ActiveSupport::Notifications.subscribe('process_action.action_controller') do |*args|
           events << ActiveSupport::Notifications::Event.new(*args)
         end
 
-        api_get('/uk/api/healthcheck', params:)
+        api_get('/uk/api/healthcheck', params:, headers:)
 
         events.last.payload
       ensure
@@ -109,6 +109,49 @@ RSpec.describe ApplicationController, type: :request do
 
         expect(payload[:request_id]).to be_present
         expect(payload[:request_id].length).to be <= ApplicationController::MAX_LOGGED_REQUEST_ID_LENGTH
+      end
+
+      it 'classifies requests from the frontend user agent' do
+        payload = process_action_payload_for(
+          params: { request_id: 'search-request-id' },
+          headers: { 'HTTP_USER_AGENT' => 'TradeTariffFrontend/a4d021c2' },
+        )
+
+        expect(payload[:request_source]).to eq('frontend')
+      end
+
+      it 'classifies non-frontend requests as backend_only' do
+        payload = process_action_payload_for(
+          params: { request_id: 'search-request-id' },
+          headers: { 'HTTP_USER_AGENT' => 'curl/8.0.1' },
+        )
+
+        expect(payload[:request_source]).to eq('backend_only')
+      end
+
+      it 'prefers the original user agent header for request source classification' do
+        payload = process_action_payload_for(
+          params: { request_id: 'search-request-id' },
+          headers: {
+            'HTTP_X_ORIGINAL_USER_AGENT' => 'TradeTariffFrontend/a4d021c2',
+            'HTTP_USER_AGENT' => 'curl/8.0.1',
+          },
+        )
+
+        expect(payload[:user_agent]).to eq('TradeTariffFrontend/a4d021c2')
+        expect(payload[:request_source]).to eq('frontend')
+      end
+
+      it 'classifies blank user agents as backend_only' do
+        payload = process_action_payload_for(
+          params: { request_id: 'search-request-id' },
+          headers: {
+            'HTTP_X_ORIGINAL_USER_AGENT' => '',
+            'HTTP_USER_AGENT' => '',
+          },
+        )
+
+        expect(payload[:request_source]).to eq('backend_only')
       end
     end
   end

--- a/spec/services/search_analytics/cloudwatch_snapshot_query_spec.rb
+++ b/spec/services/search_analytics/cloudwatch_snapshot_query_spec.rb
@@ -14,8 +14,10 @@ RSpec.describe SearchAnalytics::CloudwatchSnapshotQuery do
     allow(client).to receive(:start_query).and_return(
       start_query_response('volume'),
       start_query_response('zero'),
-      start_query_response('latency_all'),
-      start_query_response('latency_by_view'),
+      start_query_response('summary_latency_all'),
+      start_query_response('summary_latency_by_view'),
+      start_query_response('source_latency_all'),
+      start_query_response('source_latency_by_view'),
       start_query_response('classic_selections'),
       start_query_response('internal_selections'),
       start_query_response('classic_selection_trend'),
@@ -25,22 +27,41 @@ RSpec.describe SearchAnalytics::CloudwatchSnapshotQuery do
     )
     allow(client).to receive(:get_query_results).and_return(
       complete_response(
-        result_row('@timestamp' => '2026-06-10 09:00:00.000', 'search_type' => 'classic', 'event' => 'search_completed', 'searches' => '42'),
-        result_row('@timestamp' => '2026-06-10 09:00:00.000', 'search_type' => 'interactive', 'event' => 'search_completed', 'searches' => '8'),
-        result_row('@timestamp' => '2026-06-10 09:00:00.000', 'search_type' => 'classic', 'event' => 'search_failed', 'searches' => '2'),
+        result_row('@timestamp' => '2026-06-10 09:00:00.000', 'search_type' => 'classic', 'event' => 'search_completed', 'request_source' => 'frontend', 'searches' => '35'),
+        result_row('@timestamp' => '2026-06-10 09:00:00.000', 'search_type' => 'classic', 'event' => 'search_completed', 'request_source' => 'backend_only', 'searches' => '7'),
+        result_row('@timestamp' => '2026-06-10 09:00:00.000', 'search_type' => 'classic', 'event' => 'search_completed', 'searches' => '5'),
+        result_row('@timestamp' => '2026-06-10 09:00:00.000', 'search_type' => 'interactive', 'event' => 'search_completed', 'request_source' => 'frontend', 'searches' => '8'),
+        result_row('@timestamp' => '2026-06-10 09:00:00.000', 'search_type' => 'classic', 'event' => 'search_failed', 'request_source' => 'frontend', 'searches' => '2'),
       ),
       complete_response(
-        result_row('@timestamp' => '2026-06-10 09:00:00.000', 'search_type' => 'classic', 'zero_results' => '4'),
-        result_row('@timestamp' => '2026-06-10 09:00:00.000', 'search_type' => 'interactive', 'zero_results' => '1'),
+        result_row('@timestamp' => '2026-06-10 09:00:00.000', 'search_type' => 'classic', 'request_source' => 'frontend', 'zero_results' => '3'),
+        result_row('@timestamp' => '2026-06-10 09:00:00.000', 'search_type' => 'classic', 'request_source' => 'backend_only', 'zero_results' => '1'),
+        result_row('@timestamp' => '2026-06-10 09:00:00.000', 'search_type' => 'classic', 'zero_results' => '1'),
+        result_row('@timestamp' => '2026-06-10 09:00:00.000', 'search_type' => 'interactive', 'request_source' => 'frontend', 'zero_results' => '1'),
       ),
-      complete_response(result_row('p90_latency_ms' => '1200.0')),
+      complete_response(result_row('p90_latency_ms' => '1000.0')),
       complete_response(
-        result_row('search_type' => 'classic', 'p90_latency_ms' => '900'),
+        result_row('search_type' => 'classic', 'p90_latency_ms' => '700'),
         result_row('search_type' => 'interactive', 'p90_latency_ms' => '2100'),
       ),
-      complete_response(result_row('selected' => '3', 'selectable' => '42')),
-      complete_response(result_row('selected' => '2', 'selectable' => '8')),
-      complete_response(result_row('@timestamp' => '2026-06-10 09:00:00.000', 'selected' => '3')),
+      complete_response(
+        result_row('request_source' => 'frontend', 'p90_latency_ms' => '1200.0'),
+        result_row('request_source' => 'backend_only', 'p90_latency_ms' => '800.0'),
+        result_row('p90_latency_ms' => '600.0'),
+      ),
+      complete_response(
+        result_row('search_type' => 'classic', 'request_source' => 'frontend', 'p90_latency_ms' => '900'),
+        result_row('search_type' => 'classic', 'request_source' => 'backend_only', 'p90_latency_ms' => '800'),
+        result_row('search_type' => 'classic', 'p90_latency_ms' => '600'),
+        result_row('search_type' => 'interactive', 'request_source' => 'frontend', 'p90_latency_ms' => '2100'),
+      ),
+      complete_response(
+        result_row('request_source' => 'frontend', 'selected' => '2', 'selectable' => '35'),
+        result_row('request_source' => 'backend_only', 'selected' => '1', 'selectable' => '7'),
+        result_row('selected' => '1', 'selectable' => '5'),
+      ),
+      complete_response(result_row('request_source' => 'frontend', 'selected' => '2', 'selectable' => '8')),
+      complete_response(result_row('@timestamp' => '2026-06-10 09:00:00.000', 'selected' => '4')),
       complete_response(result_row('@timestamp' => '2026-06-10 09:00:00.000', 'selected' => '2')),
       complete_response(
         result_row('query' => 'scarf', 'search_type' => 'classic', 'zero_results' => '5'),
@@ -66,7 +87,7 @@ RSpec.describe SearchAnalytics::CloudwatchSnapshotQuery do
       hash_including(
         query_string: a_string_including('filter @logStream like "ecs/backend-uk/"'),
       ),
-    ).exactly(10).times
+    ).exactly(12).times
     expect(client).not_to have_received(:start_query).with(
       hash_including(query_string: a_string_including('sort bin(')),
     )
@@ -92,9 +113,24 @@ RSpec.describe SearchAnalytics::CloudwatchSnapshotQuery do
     ).twice
     expect(client).to have_received(:start_query).with(
       hash_including(
+        query_string: a_string_including('earliest(request_source) as request_source'),
+      ),
+    ).exactly(4).times
+    expect(client).to have_received(:start_query).with(
+      hash_including(
         query_string: a_string_including('datefloor(@t, 1h) as @timestamp'),
       ),
     ).twice
+    expect(client).to have_received(:start_query).with(
+      hash_including(
+        query_string: a_string_matching(/stats pct\(total_duration_ms, 90\) as p90_latency_ms\s*$/),
+      ),
+    ).once
+    expect(client).to have_received(:start_query).with(
+      hash_including(
+        query_string: a_string_including('stats pct(total_duration_ms, 90) as p90_latency_ms by request_source'),
+      ),
+    ).once
     expect(client).not_to have_received(:start_query).with(
       hash_including(
         query_string: a_string_including('selected_count'),
@@ -111,7 +147,7 @@ RSpec.describe SearchAnalytics::CloudwatchSnapshotQuery do
       hash_including(
         query_string: a_string_including('filter @logStream like "ecs/backend-xi/"'),
       ),
-    ).exactly(10).times
+    ).exactly(12).times
   end
 
   it 'raises terminal unknown CloudWatch query statuses immediately' do
@@ -134,37 +170,62 @@ RSpec.describe SearchAnalytics::CloudwatchSnapshotQuery do
   it 'builds all dashboard views without raw search rows', :aggregate_failures do
     expect(payloads.keys).to contain_exactly('all', 'classic', 'internal')
     expect(payloads.dig('all', 'summary')).to include(
-      'searches' => 52,
+      'searches' => 57,
       'failure_rate' => 0.04,
-      'zero_result_rate' => 0.1,
-      'selection_rate' => 0.1,
-      'p90_latency_ms' => 1200,
+      'zero_result_rate' => 0.11,
+      'selection_rate' => 0.11,
+      'p90_latency_ms' => 1000,
     )
     expect(payloads.dig('all', 'comparisons', 'classic')).to include(
-      'searches' => 44,
-      'zero_result_rate' => 0.1,
+      'searches' => 49,
+      'zero_result_rate' => 0.11,
+      'p90_latency_ms' => 700,
+    )
+    expect(payloads.dig('all', 'request_sources', 'frontend')).to include(
+      'searches' => 45,
+      'failure_rate' => 0.04,
+      'zero_result_rate' => 0.09,
+      'selection_rate' => 0.09,
+      'p90_latency_ms' => 1200,
+    )
+    expect(payloads.dig('all', 'request_sources', 'backend_only')).to include(
+      'searches' => 7,
+      'failure_rate' => 0.0,
+      'zero_result_rate' => 0.14,
+      'selection_rate' => 0.14,
+      'p90_latency_ms' => 800,
+    )
+    expect(payloads.dig('all', 'request_sources', 'unknown')).to include(
+      'searches' => 5,
+      'failure_rate' => 0.0,
+      'zero_result_rate' => 0.2,
+      'selection_rate' => 0.2,
+      'p90_latency_ms' => 600,
     )
     expect(payloads.dig('all', 'trends', 'volume')).to contain_exactly(
       {
         'bucket' => '2026-06-10T09:00:00Z',
-        'all' => 52,
-        'classic' => 44,
+        'all' => 57,
+        'classic' => 49,
         'internal' => 8,
+        'frontend' => 45,
+        'backend_only' => 7,
+        'unknown' => 5,
       },
     )
     expect(payloads.dig('all', 'trends', 'outcomes')).to contain_exactly(
       {
         'bucket' => '2026-06-10T09:00:00Z',
-        'completed' => 50,
+        'completed' => 55,
         'failed' => 2,
-        'zero_result' => 5,
-        'selected' => 5,
+        'zero_result' => 6,
+        'selected' => 6,
       },
     )
     expect(payloads.dig('classic', 'trends', 'outcomes')).to contain_exactly(
       include(
         'bucket' => '2026-06-10T09:00:00Z',
-        'selected' => 3,
+        'selected' => 4,
       ),
     )
     expect(payloads.dig('all', 'improvement_terms')).to include(

--- a/terraform/modules/search_dashboard/main.tf
+++ b/terraform/modules/search_dashboard/main.tf
@@ -40,13 +40,14 @@ resource "aws_cloudwatch_dashboard" "search" {
           width  = 6
           height = 6
           properties = {
-            title  = "Total Searches"
+            title  = "Search Volume by Request Source and Outcome"
             region = var.region
             view   = "timeSeries"
             query  = <<-EOT
               ${local.source}
-              | ${local.service_filter} and event = "search_completed"
-              | stats count(*) as searches by bin(1d)
+              | ${local.service_filter} and event in ["search_completed", "search_failed"]
+              | fields if(ispresent(request_source), request_source, "unknown") as request_source
+              | stats count(*) as searches by request_source, event, bin(1d)
             EOT
           }
         },

--- a/terraform/modules/search_operations_dashboard/main.tf
+++ b/terraform/modules/search_operations_dashboard/main.tf
@@ -237,7 +237,7 @@ resource "aws_cloudwatch_dashboard" "search_operations" {
               ${local.source}
               | ${local.service_filter} and event in ["search_failed", "search_completed"]
               | filter event = "search_failed" or final_result_type = "error"
-              | fields @timestamp, event, search_type, error_type, final_result_type, error_message, request_id
+              | fields @timestamp, event, request_source, search_type, error_type, final_result_type, error_message, request_id
               | sort @timestamp desc
               | limit 20
             EOT
@@ -255,7 +255,7 @@ resource "aws_cloudwatch_dashboard" "search_operations" {
             query  = <<-EOT
               ${local.source}
               | ${local.service_filter} and event = "search_started"
-              | fields @timestamp, query, search_type, request_id
+              | fields @timestamp, query, request_source, search_type, request_id
               | sort @timestamp desc
               | limit 30
             EOT
@@ -352,7 +352,7 @@ resource "aws_cloudwatch_dashboard" "search_operations" {
             query  = <<-EOT
               ${local.source}
               | ${local.service_filter} and event = "search_completed"
-              | fields @timestamp, search_type, total_duration_ms, result_count, final_result_type, request_id
+              | fields @timestamp, request_source, search_type, total_duration_ms, result_count, final_result_type, request_id
               | sort @timestamp desc
               | limit 30
             EOT

--- a/terraform/modules/search_quality_dashboard/main.tf
+++ b/terraform/modules/search_quality_dashboard/main.tf
@@ -131,7 +131,7 @@ resource "aws_cloudwatch_dashboard" "search_quality" {
             query  = <<-EOT
               ${local.source}
               | ${local.service_filter} and event = "search_completed" and result_count = 0
-              | fields @timestamp, query, search_type, request_id
+              | fields @timestamp, query, request_source, search_type, request_id
               | sort @timestamp desc
               | limit 30
             EOT


### PR DESCRIPTION
### Jira link

N/A

### What?

- [x] Classify backend requests as `frontend` when the user agent starts with `TradeTariffFrontend/`
- [x] Add `request_source` to request/search instrumentation and search logs
- [x] Split cached search analytics and Terraform dashboard queries by request source, including an `unknown` bucket for legacy rows
- [x] Expose `request_sources` through the admin search analytics API response
- [x] Preserve existing aggregate p90 latency semantics while adding source-specific p90s

### Why?

Search dashboards need to distinguish frontend-routed traffic from direct backend / non-frontend traffic so operators can isolate behaviour and volume by caller. This is an observability signal based on the reported user agent, not an authentication or access-control signal.

### Risk

**Risk level:** 🟢

**Reason for rating:** Additive observability/dashboard change for currently unused search analytics surfaces, with focused request, instrumentation, analytics, serializer, and Terraform validation coverage.