### PR TITLE
HMRC-2429: Add scheduled ECS scaling for predictable overnight traffic peaks

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -91,6 +91,8 @@ Terraform to deploy the service into AWS.
 | <a name="input_region"></a> [region](#input\_region) | AWS region to use. | `string` | n/a | yes |
 | <a name="input_scale_in_cooldown"></a> [scale\_in\_cooldown](#input\_scale\_in\_cooldown) | Prevents aggressive scale-in by enforcing a waiting period after tasks are removed. | `number` | `300` | no |
 | <a name="input_scale_out_cooldown"></a> [scale\_out\_cooldown](#input\_scale\_out\_cooldown) | Minimum time to wait after a scale-out before allowing another scale-out, giving new tasks time to start contributing capacity. | `number` | `60` | no |
+| <a name="input_scheduled_actions_enabled"></a> [scheduled\_actions\_enabled](#input\_scheduled\_actions\_enabled) | Enables scheduled scaling to proactively increase or reduce capacity during predictable traffic patterns. | `bool` | `false` | no |
+| <a name="input_scheduled_scaling_actions"></a> [scheduled\_scaling\_actions](#input\_scheduled\_scaling\_actions) | Map of scheduled scaling actions keyed by a unique name. Each value must include:<br/>- schedule     : AWS cron expression in UTC, e.g. 'cron(0 7 ? * MON-FRI *)'<br/>- min\_capacity : minimum desired tasks at schedule time<br/>- max\_capacity : maximum desired tasks at schedule time | <pre>map(object({<br/>    schedule     = string<br/>    min_capacity = number<br/>    max_capacity = number<br/>  }))</pre> | `{}` | no |
 | <a name="input_service_count"></a> [service\_count](#input\_service\_count) | Number of services to use. | `number` | `2` | no |
 
 ## Outputs

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -80,6 +80,7 @@ Terraform to deploy the service into AWS.
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_backend_uk_min_capacity"></a> [backend\_uk\_min\_capacity](#input\_backend\_uk\_min\_capacity) | Smallest number of tasks the backend-uk service can scale-in to. | `number` | `1` | no |
+| <a name="input_backend_uk_scheduled_scaling_actions"></a> [backend\_uk\_scheduled\_scaling\_actions](#input\_backend\_uk\_scheduled\_scaling\_actions) | Map of scheduled scaling actions keyed by a unique name. Each value must include:<br/>- schedule     : AWS cron expression in UTC, e.g. 'cron(0 7 ? * MON-FRI *)'<br/>- min\_capacity : minimum desired tasks at schedule time<br/>- max\_capacity : maximum desired tasks at schedule time | <pre>map(object({<br/>    schedule     = string<br/>    min_capacity = number<br/>    max_capacity = number<br/>  }))</pre> | `{}` | no |
 | <a name="input_backend_xi_min_capacity"></a> [backend\_xi\_min\_capacity](#input\_backend\_xi\_min\_capacity) | Smallest number of tasks the backend-xi service can scale-in to. | `number` | `1` | no |
 | <a name="input_cpu"></a> [cpu](#input\_cpu) | CPU units to use. | `number` | n/a | yes |
 | <a name="input_docker_tag"></a> [docker\_tag](#input\_docker\_tag) | Image tag to use. | `string` | n/a | yes |
@@ -91,8 +92,6 @@ Terraform to deploy the service into AWS.
 | <a name="input_region"></a> [region](#input\_region) | AWS region to use. | `string` | n/a | yes |
 | <a name="input_scale_in_cooldown"></a> [scale\_in\_cooldown](#input\_scale\_in\_cooldown) | Prevents aggressive scale-in by enforcing a waiting period after tasks are removed. | `number` | `300` | no |
 | <a name="input_scale_out_cooldown"></a> [scale\_out\_cooldown](#input\_scale\_out\_cooldown) | Minimum time to wait after a scale-out before allowing another scale-out, giving new tasks time to start contributing capacity. | `number` | `60` | no |
-| <a name="input_scheduled_actions_enabled"></a> [scheduled\_actions\_enabled](#input\_scheduled\_actions\_enabled) | Enables scheduled scaling to proactively increase or reduce capacity during predictable traffic patterns. | `bool` | `false` | no |
-| <a name="input_scheduled_scaling_actions"></a> [scheduled\_scaling\_actions](#input\_scheduled\_scaling\_actions) | Map of scheduled scaling actions keyed by a unique name. Each value must include:<br/>- schedule     : AWS cron expression in UTC, e.g. 'cron(0 7 ? * MON-FRI *)'<br/>- min\_capacity : minimum desired tasks at schedule time<br/>- max\_capacity : maximum desired tasks at schedule time | <pre>map(object({<br/>    schedule     = string<br/>    min_capacity = number<br/>    max_capacity = number<br/>  }))</pre> | `{}` | no |
 | <a name="input_service_count"></a> [service\_count](#input\_service\_count) | Number of services to use. | `number` | `2` | no |
 
 ## Outputs

--- a/terraform/backend_uk.tf
+++ b/terraform/backend_uk.tf
@@ -48,8 +48,8 @@ module "backend_uk" {
     }
   }
 
-  scheduled_actions_enabled = var.scheduled_actions_enabled
-  scheduled_scaling_actions = var.scheduled_scaling_actions
+  scheduled_actions_enabled = length(var.backend_uk_scheduled_scaling_actions) > 0
+  scheduled_scaling_actions = var.backend_uk_scheduled_scaling_actions
 
   enable_alarms       = var.enable_alarms
   cpu_alarm_threshold = 85 # Temporarily set higher to avoid alarm noise during load testing, will be adjusted based on observed metrics after testing is complete.

--- a/terraform/backend_uk.tf
+++ b/terraform/backend_uk.tf
@@ -48,6 +48,9 @@ module "backend_uk" {
     }
   }
 
+  scheduled_actions_enabled = var.scheduled_actions_enabled
+  scheduled_scaling_actions = var.scheduled_scaling_actions
+
   enable_alarms       = var.enable_alarms
   cpu_alarm_threshold = 85 # Temporarily set higher to avoid alarm noise during load testing, will be adjusted based on observed metrics after testing is complete.
 

--- a/terraform/config_production.tfvars
+++ b/terraform/config_production.tfvars
@@ -2,10 +2,50 @@ region                  = "eu-west-2"
 environment             = "production"
 cpu                     = 2048
 memory                  = 4096
-service_count           = 4
-backend_uk_min_capacity = 4
+service_count           = 3
+backend_uk_min_capacity = 3
 backend_xi_min_capacity = 2
 max_capacity            = 16
 
 enable_alarms               = true
 enable_observability_alerts = true
+scheduled_actions_enabled   = true
+
+scheduled_scaling_actions = {
+
+  midnight_scale_up = {
+    schedule     = "cron(55 23 * * ? *)"
+    min_capacity = 4
+    max_capacity = 16
+  }
+
+  midnight_scale_down = {
+    schedule     = "cron(40 0 * * ? *)"
+    min_capacity = 3
+    max_capacity = 16
+  }
+
+  threeam_scale_up = {
+    schedule     = "cron(55 2 * * ? *)"
+    min_capacity = 4
+    max_capacity = 16
+  }
+
+  threeam_scale_down = {
+    schedule     = "cron(40 3 * * ? *)"
+    min_capacity = 3
+    max_capacity = 16
+  }
+
+  fiveam_scale_up = {
+    schedule     = "cron(50 4 * * ? *)"
+    min_capacity = 4
+    max_capacity = 16
+  }
+
+  fiveam_scale_down = {
+    schedule     = "cron(0 7 * * ? *)"
+    min_capacity = 3
+    max_capacity = 16
+  }
+}

--- a/terraform/config_production.tfvars
+++ b/terraform/config_production.tfvars
@@ -9,9 +9,8 @@ max_capacity            = 16
 
 enable_alarms               = true
 enable_observability_alerts = true
-scheduled_actions_enabled   = true
 
-scheduled_scaling_actions = {
+backend_uk_scheduled_scaling_actions = {
 
   midnight_scale_up = {
     schedule     = "cron(55 23 * * ? *)"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -70,13 +70,7 @@ variable "scale_out_cooldown" {
   default     = 60
 }
 
-variable "scheduled_actions_enabled" {
-  description = "Enables scheduled scaling to proactively increase or reduce capacity during predictable traffic patterns."
-  type        = bool
-  default     = false
-}
-
-variable "scheduled_scaling_actions" {
+variable "backend_uk_scheduled_scaling_actions" {
   description = <<EOT
 Map of scheduled scaling actions keyed by a unique name. Each value must include:
 - schedule     : AWS cron expression in UTC, e.g. 'cron(0 7 ? * MON-FRI *)'
@@ -89,4 +83,11 @@ EOT
     max_capacity = number
   }))
   default = {}
+  validation {
+    condition = alltrue([
+      for _, action in var.backend_uk_scheduled_scaling_actions :
+      action.min_capacity >= 0 && action.max_capacity >= 0 && action.min_capacity <= action.max_capacity
+    ])
+    error_message = "Each backend_uk_scheduled_scaling_actions entry must have non-negative min_capacity/max_capacity and min_capacity must be <= max_capacity."
+  }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -69,3 +69,24 @@ variable "scale_out_cooldown" {
   type        = number
   default     = 60
 }
+
+variable "scheduled_actions_enabled" {
+  description = "Enables scheduled scaling to proactively increase or reduce capacity during predictable traffic patterns."
+  type        = bool
+  default     = false
+}
+
+variable "scheduled_scaling_actions" {
+  description = <<EOT
+Map of scheduled scaling actions keyed by a unique name. Each value must include:
+- schedule     : AWS cron expression in UTC, e.g. 'cron(0 7 ? * MON-FRI *)'
+- min_capacity : minimum desired tasks at schedule time
+- max_capacity : maximum desired tasks at schedule time
+EOT
+  type = map(object({
+    schedule     = string
+    min_capacity = number
+    max_capacity = number
+  }))
+  default = {}
+}


### PR DESCRIPTION
## What:

- Reduce ECS service baseline capacity from 4 to 3 tasks.
- Add scheduled scaling actions to temporarily increase the minimum task count from 3 to 4 during recurring overnight traffic peaks.
- No change to maximum autoscaling capacity.

## Why:
Analysis of RequestCountPerTarget and CPU metrics shows recurring traffic and CPU increases around 00:00, 03:00 and 05:00–07:00 UTC. Scheduled scaling proactively increases capacity ahead of these predictable peaks while allowing a lower baseline capacity for the rest of the day. Existing target-tracking autoscaling remains responsible for handling unexpected traffic increases.

## Ticket:
[HMRC-2429](https://transformuk.atlassian.net/browse/HMRC-2429)

## Risk:
**Risk level:** 🟢 

**Reason for rating:**

- Existing autoscaling policies remain unchanged.
- Maximum capacity is unchanged.
- Scheduled actions only adjust the minimum capacity during known peak windows.
- Baseline capacity is reduced conservatively from 4 to 3 tasks rather than directly to 2 due to previous incidents involving task-level spikes.