### PR TITLE
HMRC-2430: Validate live issue commodity codes

### DIFF
--- a/app/controllers/api/admin/live_issues_controller.rb
+++ b/app/controllers/api/admin/live_issues_controller.rb
@@ -22,12 +22,10 @@ module Api
       def update
         live_issue = LiveIssue.with_pk!(params[:id])
 
-        begin
-          live_issue.update(live_issue_params)
-          render json: serialize(live_issue), status: :ok
-        rescue StandardError
-          render json: serialize_errors(live_issue), status: :unprocessable_content
-        end
+        live_issue.update(live_issue_params)
+        render json: serialize(live_issue), status: :ok
+      rescue Sequel::ValidationFailed
+        render json: serialize_errors(live_issue), status: :unprocessable_content
       end
 
       def destroy
@@ -46,16 +44,34 @@ module Api
       end
 
       def live_issue_params
-        params.require(:data).require(:attributes).permit(
+        attributes = params.require(:data).require(:attributes)
+
+        permitted_params = attributes.permit(
           :title,
           :description,
           :suggested_action,
           :status,
           :date_discovered,
           :date_resolved,
-        ).merge(
-          commodities: params[:data][:attributes][:commodities]&.split(' '),
         )
+
+        if attributes.key?(:commodities)
+          permitted_params.merge(commodities: normalized_commodities(attributes[:commodities]))
+        else
+          permitted_params
+        end
+      end
+
+      def normalized_commodities(commodities)
+        return [] if commodities.blank?
+
+        return [nil] unless commodities.is_a?(String) || commodities.is_a?(Array)
+
+        Array(commodities).flat_map do |commodity|
+          return [nil] unless commodity.is_a?(String)
+
+          commodity.split(/[,\s]+/)
+        end
       end
     end
   end

--- a/app/models/live_issue.rb
+++ b/app/models/live_issue.rb
@@ -1,4 +1,6 @@
 class LiveIssue < Sequel::Model(Sequel[:live_issues].qualify(:public))
+  COMMODITY_CODE_PATTERN = /\A\d{10}\z/
+
   plugin :timestamps, update_on_create: true
   plugin :auto_validations, not_null: :presence
 
@@ -6,5 +8,15 @@ class LiveIssue < Sequel::Model(Sequel[:live_issues].qualify(:public))
     super
 
     validates_includes %w[Active Resolved], :status
+    errors.add(:commodities, 'must contain 10 digit commodity codes') if invalid_commodity_codes?
+  end
+
+  private
+
+  def invalid_commodity_codes?
+    return false if commodities.blank?
+    return true if commodities.is_a?(String) || !commodities.respond_to?(:any?)
+
+    commodities.any? { |commodity| !commodity.is_a?(String) || !commodity.match?(COMMODITY_CODE_PATTERN) }
   end
 end

--- a/spec/requests/api/admin/live_issues_controller_spec.rb
+++ b/spec/requests/api/admin/live_issues_controller_spec.rb
@@ -52,6 +52,23 @@ RSpec.describe Api::Admin::LiveIssuesController, :admin do
         expect(json_response).to include('data')
         expect(json_response['data']['attributes'].size).to eq(8)
       end
+
+      it 'removes comma separators from commodity codes before saving' do
+        authenticated_post api_admin_live_issues_path(format: :json),
+                           params: { data: { type: 'live_issues', attributes: live_issue_data.merge(commodities: '3402420090, 7222190000') } }
+
+        expect(response).to have_http_status(:created)
+        expect(json_response.dig('data', 'attributes', 'commodities')).to eq(%w[3402420090 7222190000])
+        expect(LiveIssue.last.commodities).to eq(%w[3402420090 7222190000])
+      end
+
+      it 'accepts comma-separated commodity codes without spaces' do
+        authenticated_post api_admin_live_issues_path(format: :json),
+                           params: { data: { type: 'live_issues', attributes: live_issue_data.merge(commodities: '3402420090,7222190000') } }
+
+        expect(response).to have_http_status(:created)
+        expect(json_response.dig('data', 'attributes', 'commodities')).to eq(%w[3402420090 7222190000])
+      end
     end
 
     context 'when the live issue is invalid' do
@@ -60,6 +77,36 @@ RSpec.describe Api::Admin::LiveIssuesController, :admin do
 
         expect(response).to have_http_status(:unprocessable_content)
         expect(json_response['errors'].first['detail']).to include('Title is not present')
+      end
+
+      it 'returns 422 if a commodity code is not ten digits after normalisation' do
+        expect {
+          authenticated_post api_admin_live_issues_path(format: :json),
+                             params: { data: { type: 'live_issues', attributes: live_issue_data.merge(commodities: '3402420090 BAD') } }
+        }.not_to change(LiveIssue, :count)
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(json_response['errors'].first['detail']).to include('Commodities must contain 10 digit commodity codes')
+      end
+
+      it 'returns 422 if a commodity code contains unexpected characters' do
+        expect {
+          authenticated_post api_admin_live_issues_path(format: :json),
+                             params: { data: { type: 'live_issues', attributes: live_issue_data.merge(commodities: '3402420090abc') } }
+        }.not_to change(LiveIssue, :count)
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(json_response['errors'].first['detail']).to include('Commodities must contain 10 digit commodity codes')
+      end
+
+      it 'returns 422 if commodities are submitted with an unsupported shape' do
+        expect {
+          authenticated_post api_admin_live_issues_path(format: :json),
+                             params: { data: { type: 'live_issues', attributes: live_issue_data.merge(commodities: { code: '3402420090' }) } }
+        }.not_to change(LiveIssue, :count)
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(json_response['errors'].first['detail']).to include('Commodities must contain 10 digit commodity codes')
       end
     end
   end
@@ -89,6 +136,23 @@ RSpec.describe Api::Admin::LiveIssuesController, :admin do
         expect(json_response['data']['attributes'].size).to eq(8)
         expect(json_response['data']['attributes']['status']).to eq('Resolved')
       end
+
+      it 'removes comma separators from commodity codes before saving' do
+        authenticated_patch api_admin_live_issue_path(live_issue.id, format: :json),
+                            params: { data: { type: 'live_issues', attributes: live_issue_data.merge(commodities: '3402420090, 7222190000') } }
+
+        expect(response).to have_http_status(:ok)
+        expect(json_response.dig('data', 'attributes', 'commodities')).to eq(%w[3402420090 7222190000])
+        expect(live_issue.reload.commodities).to eq(%w[3402420090 7222190000])
+      end
+
+      it 'does not clear commodity codes when commodities are omitted' do
+        authenticated_patch api_admin_live_issue_path(live_issue.id, format: :json),
+                            params: { data: { type: 'live_issues', attributes: live_issue_data.except(:commodities) } }
+
+        expect(response).to have_http_status(:ok)
+        expect(live_issue.reload.commodities).to eq(%w[0101000000 0101000090])
+      end
     end
 
     context 'when the live issue is invalid' do
@@ -97,6 +161,15 @@ RSpec.describe Api::Admin::LiveIssuesController, :admin do
 
         expect(response).to have_http_status(:unprocessable_content)
         expect(json_response['errors'].first['detail']).to include('Title is not present')
+      end
+
+      it 'returns 422 if a commodity code is not ten digits after normalisation' do
+        authenticated_patch api_admin_live_issue_path(live_issue.id, format: :json),
+                            params: { data: { type: 'live_issues', attributes: live_issue_data.merge(commodities: '3402420090 BAD') } }
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(json_response['errors'].first['detail']).to include('Commodities must contain 10 digit commodity codes')
+        expect(live_issue.reload.commodities).to eq(%w[0101000000 0101000090])
       end
     end
   end


### PR DESCRIPTION
## What:

<img width="723" height="1056" alt="image" src="https://github.com/user-attachments/assets/e0616a1c-a6d6-48a9-83a0-d01119dcdd13" />

- [x] Strip non-digit characters from submitted live issue commodity tokens in the admin API before saving.
- [x] Validate that saved live issue commodity entries are 10 digit commodity codes.
- [x] Return a clear 422 validation error when a submitted commodity entry cannot be normalised to a valid code.
- [x] Add admin request coverage for create and update paths.

## Why:
A malformed live issue commodity value with a trailing comma was saved by the admin API and later caused the public Live Issues page to fail while generating commodity links. Normalising and validating admin submissions prevents malformed commodity values from being persisted.

## Ticket:
[HMRC-2430](https://transformuk.atlassian.net/browse/HMRC-2430)

## Risk:
**Risk level:** 🟢

**Reason for rating:** Narrow defect fix for admin live issue commodity input, covered by request specs. It prevents malformed commodity entries from being saved and does not change public API shape.
