### PR TITLE
chore(terraform): disable staging database replication

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -84,6 +84,7 @@ Terraform to deploy the service into AWS.
 | <a name="input_cpu"></a> [cpu](#input\_cpu) | CPU units to use. | `number` | n/a | yes |
 | <a name="input_docker_tag"></a> [docker\_tag](#input\_docker\_tag) | Image tag to use. | `string` | n/a | yes |
 | <a name="input_enable_alarms"></a> [enable\_alarms](#input\_enable\_alarms) | Whether to enable CloudWatch alarms for the service. | `bool` | `false` | no |
+| <a name="input_enable_database_replication"></a> [enable\_database\_replication](#input\_enable\_database\_replication) | Whether to enable the scheduled database replication job. | `bool` | `false` | no |
 | <a name="input_enable_observability_alerts"></a> [enable\_observability\_alerts](#input\_enable\_observability\_alerts) | n/a | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Deployment environment. | `string` | n/a | yes |
 | <a name="input_max_capacity"></a> [max\_capacity](#input\_max\_capacity) | Largest number of tasks the service can scale-out to. | `number` | `5` | no |

--- a/terraform/backend_job.tf
+++ b/terraform/backend_job.tf
@@ -135,7 +135,7 @@ resource "aws_cloudwatch_metric_alarm" "database_backup_freshness" {
 }
 
 resource "aws_cloudwatch_event_rule" "database_replication" {
-  count = var.environment != "production" ? 1 : 0
+  count = var.enable_database_replication ? 1 : 0
 
   name                = "backend-database-replication-${var.environment}"
   description         = "Triggers weekday database replication for ${var.environment}"
@@ -144,7 +144,7 @@ resource "aws_cloudwatch_event_rule" "database_replication" {
 }
 
 resource "aws_cloudwatch_event_target" "database_replication" {
-  count = var.environment != "production" ? 1 : 0
+  count = var.enable_database_replication ? 1 : 0
 
   rule     = aws_cloudwatch_event_rule.database_replication[0].name
   arn      = data.aws_ecs_cluster.this.arn

--- a/terraform/config_development.tfvars
+++ b/terraform/config_development.tfvars
@@ -5,3 +5,5 @@ memory                  = 2048
 backend_uk_min_capacity = 1
 backend_xi_min_capacity = 1
 max_capacity            = 1
+
+enable_database_replication = true

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -53,6 +53,12 @@ variable "enable_alarms" {
   default     = false
 }
 
+variable "enable_database_replication" {
+  description = "Whether to enable the scheduled database replication job."
+  type        = bool
+  default     = false
+}
+
 variable "enable_observability_alerts" {
   type    = bool
   default = false


### PR DESCRIPTION
## What:
Adds an `enable_database_replication` Terraform variable and uses it directly to gate the scheduled database replication EventBridge rule and target. The flag defaults to `false`, and development explicitly sets it to `true`; staging and production do not opt in, so the scheduled `./bin/db-replicate` trigger is disabled there.

## Why:
The staging replication job needs to be stopped via environment configuration rather than an additional environment-name guard in the resource. Using a default-disabled flag makes opt-in explicit and avoids arbitrary production-specific defensiveness in the resource count expression.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Low risk because this is a narrow Terraform variable gate for a scheduled non-production replication trigger, with the job disabled by default and development explicitly opted in. No application runtime behavior, IAM, networking, data model, or production resource behavior is changed beyond not opting into this schedule.
