### PR TITLE
Remove redundant replication ECS permissions

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -87,22 +87,6 @@ data "aws_iam_policy_document" "task" {
   statement {
     effect = "Allow"
     actions = [
-      "ecs:DescribeServices",
-      "ecs:UpdateService",
-    ]
-    resources = [
-      "arn:aws:ecs:${var.region}:${local.account_id}:service/trade-tariff-cluster-${var.environment}/*",
-    ]
-    condition {
-      test     = "ArnEquals"
-      variable = "ecs:cluster"
-      values   = [data.aws_ecs_cluster.this.arn]
-    }
-  }
-
-  statement {
-    effect = "Allow"
-    actions = [
       "s3:ListBucket",
       "s3:GetObject",
       "s3:GetObjectTagging",


### PR DESCRIPTION
## What:
Removed the explicit `ecs:DescribeServices` and `ecs:UpdateService` permissions added to the backend task policy for the database replication job.

## Why:
The ECS service module already attaches ECS permissions to the task role, so this policy block duplicates permissions managed by the module.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Low-risk Terraform cleanup that removes redundant IAM policy entries without changing the replication script behaviour or public API behaviour.