### PR TITLE
HMRC-2429: Add scheduled ECS scaling for predictable overnight traffic peaks

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -79,9 +79,8 @@ Terraform to deploy the service into AWS.
 
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
-| <a name="input_backend_uk_min_capacity"></a> [backend\_uk\_min\_capacity](#input\_backend\_uk\_min\_capacity) | Smallest number of tasks the backend-uk service can scale-in to. | `number` | `1` | no |
-| <a name="input_backend_uk_scheduled_scaling_actions"></a> [backend\_uk\_scheduled\_scaling\_actions](#input\_backend\_uk\_scheduled\_scaling\_actions) | Map of scheduled scaling actions keyed by a unique name. Each value must include:<br/>- schedule     : AWS cron expression in UTC, e.g. 'cron(0 7 ? * MON-FRI *)'<br/>- min\_capacity : minimum desired tasks at schedule time<br/>- max\_capacity : maximum desired tasks at schedule time | <pre>map(object({<br/>    schedule     = string<br/>    min_capacity = number<br/>    max_capacity = number<br/>  }))</pre> | `{}` | no |
-| <a name="input_backend_xi_min_capacity"></a> [backend\_xi\_min\_capacity](#input\_backend\_xi\_min\_capacity) | Smallest number of tasks the backend-xi service can scale-in to. | `number` | `1` | no |
+| <a name="input_backend_uk_scheduled_scaling_actions"></a> [backend\_uk\_scheduled\_scaling\_actions](#input\_backend\_uk\_scheduled\_scaling\_actions) | Map of scheduled scaling actions keyed by a unique name. Each value must include:<br/>  - schedule     : AWS cron expression in UTC, e.g. 'cron(0 7 ? * MON-FRI *)'<br/>  - min\_capacity : minimum desired tasks at schedule time<br/>  - max\_capacity : maximum desired tasks at schedule time | <pre>map(object({<br/>    schedule     = string<br/>    min_capacity = number<br/>    max_capacity = number<br/>  }))</pre> | `{}` | no |
+| <a name="input_backend_xi_scheduled_scaling_actions"></a> [backend\_xi\_scheduled\_scaling\_actions](#input\_backend\_xi\_scheduled\_scaling\_actions) | n/a | <pre>map(object({<br/>    schedule     = string<br/>    min_capacity = number<br/>    max_capacity = number<br/>  }))</pre> | `{}` | no |
 | <a name="input_cpu"></a> [cpu](#input\_cpu) | CPU units to use. | `number` | n/a | yes |
 | <a name="input_docker_tag"></a> [docker\_tag](#input\_docker\_tag) | Image tag to use. | `string` | n/a | yes |
 | <a name="input_enable_alarms"></a> [enable\_alarms](#input\_enable\_alarms) | Whether to enable CloudWatch alarms for the service. | `bool` | `false` | no |
@@ -90,10 +89,11 @@ Terraform to deploy the service into AWS.
 | <a name="input_environment"></a> [environment](#input\_environment) | Deployment environment. | `string` | n/a | yes |
 | <a name="input_max_capacity"></a> [max\_capacity](#input\_max\_capacity) | Largest number of tasks the service can scale-out to. | `number` | `5` | no |
 | <a name="input_memory"></a> [memory](#input\_memory) | Memory to allocate in MB. Powers of 2 only. | `number` | n/a | yes |
+| <a name="input_min_capacity"></a> [min\_capacity](#input\_min\_capacity) | Smallest number of tasks the backend-xi service can scale-in to. | `number` | `1` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS region to use. | `string` | n/a | yes |
 | <a name="input_scale_in_cooldown"></a> [scale\_in\_cooldown](#input\_scale\_in\_cooldown) | Prevents aggressive scale-in by enforcing a waiting period after tasks are removed. | `number` | `300` | no |
 | <a name="input_scale_out_cooldown"></a> [scale\_out\_cooldown](#input\_scale\_out\_cooldown) | Minimum time to wait after a scale-out before allowing another scale-out, giving new tasks time to start contributing capacity. | `number` | `60` | no |
-| <a name="input_service_count"></a> [service\_count](#input\_service\_count) | Number of services to use. | `number` | `2` | no |
+| <a name="input_service_count"></a> [service\_count](#input\_service\_count) | Number of services to use. | `number` | `1` | no |
 
 ## Outputs
 

--- a/terraform/backend_uk.tf
+++ b/terraform/backend_uk.tf
@@ -32,7 +32,7 @@ module "backend_uk" {
   enable_ecs_exec = true
 
   has_autoscaler     = local.has_autoscaler
-  min_capacity       = var.backend_uk_min_capacity
+  min_capacity       = var.min_capacity
   max_capacity       = var.max_capacity
   scale_in_cooldown  = var.scale_in_cooldown
   scale_out_cooldown = var.scale_out_cooldown

--- a/terraform/backend_xi.tf
+++ b/terraform/backend_xi.tf
@@ -32,7 +32,7 @@ module "backend_xi" {
   enable_ecs_exec = true
 
   has_autoscaler     = local.has_autoscaler
-  min_capacity       = var.backend_xi_min_capacity
+  min_capacity       = var.min_capacity
   max_capacity       = var.max_capacity
   scale_in_cooldown  = var.scale_in_cooldown
   scale_out_cooldown = var.scale_out_cooldown
@@ -47,6 +47,9 @@ module "backend_xi" {
       target_value = 70
     }
   }
+
+  scheduled_actions_enabled = length(var.backend_xi_scheduled_scaling_actions) > 0
+  scheduled_scaling_actions = var.backend_xi_scheduled_scaling_actions
 
   enable_alarms       = var.enable_alarms
   cpu_alarm_threshold = 85 # Temporarily set higher to avoid alarm noise during load testing, will be adjusted based on observed metrics after testing is complete.

--- a/terraform/config_development.tfvars
+++ b/terraform/config_development.tfvars
@@ -1,9 +1,8 @@
-region                  = "eu-west-2"
-environment             = "development"
-cpu                     = 1024
-memory                  = 2048
-backend_uk_min_capacity = 1
-backend_xi_min_capacity = 1
-max_capacity            = 1
+region       = "eu-west-2"
+environment  = "development"
+cpu          = 1024
+memory       = 2048
+min_capacity = 1
+max_capacity = 1
 
 enable_database_replication = true

--- a/terraform/config_production.tfvars
+++ b/terraform/config_production.tfvars
@@ -1,11 +1,10 @@
-region                  = "eu-west-2"
-environment             = "production"
-cpu                     = 2048
-memory                  = 4096
-service_count           = 3
-backend_uk_min_capacity = 3
-backend_xi_min_capacity = 2
-max_capacity            = 16
+region        = "eu-west-2"
+environment   = "production"
+cpu           = 2048
+memory        = 4096
+service_count = 3
+min_capacity  = 2
+max_capacity  = 16
 
 enable_alarms               = true
 enable_observability_alerts = true
@@ -20,7 +19,7 @@ backend_uk_scheduled_scaling_actions = {
 
   midnight_scale_down = {
     schedule     = "cron(40 0 * * ? *)"
-    min_capacity = 3
+    min_capacity = 2
     max_capacity = 16
   }
 
@@ -32,7 +31,7 @@ backend_uk_scheduled_scaling_actions = {
 
   threeam_scale_down = {
     schedule     = "cron(40 3 * * ? *)"
-    min_capacity = 3
+    min_capacity = 2
     max_capacity = 16
   }
 
@@ -44,7 +43,34 @@ backend_uk_scheduled_scaling_actions = {
 
   fiveam_scale_down = {
     schedule     = "cron(0 7 * * ? *)"
-    min_capacity = 3
+    min_capacity = 2
+    max_capacity = 16
+  }
+}
+
+backend_xi_scheduled_scaling_actions = {
+
+  midnight_scale_up = {
+    schedule     = "cron(0 0 * * ? *)"
+    min_capacity = 4
+    max_capacity = 16
+  }
+
+  midnight_scale_down = {
+    schedule     = "cron(45 0 * * ? *)"
+    min_capacity = 2
+    max_capacity = 16
+  }
+
+  threeam_scale_up = {
+    schedule     = "cron(50 2 * * ? *)"
+    min_capacity = 5
+    max_capacity = 16
+  }
+
+  threeam_scale_down = {
+    schedule     = "cron(15 4 * * ? *)"
+    min_capacity = 2
     max_capacity = 16
   }
 }

--- a/terraform/config_staging.tfvars
+++ b/terraform/config_staging.tfvars
@@ -1,8 +1,7 @@
-region                  = "eu-west-2"
-environment             = "staging"
-cpu                     = 1024
-memory                  = 2048
-service_count           = 4
-backend_uk_min_capacity = 2
-backend_xi_min_capacity = 2
-max_capacity            = 8
+region        = "eu-west-2"
+environment   = "staging"
+cpu           = 1024
+memory        = 2048
+service_count = 4
+min_capacity  = 2
+max_capacity  = 8

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -16,16 +16,10 @@ variable "docker_tag" {
 variable "service_count" {
   description = "Number of services to use."
   type        = number
-  default     = 2
-}
-
-variable "backend_uk_min_capacity" {
-  description = "Smallest number of tasks the backend-uk service can scale-in to."
-  type        = number
   default     = 1
 }
 
-variable "backend_xi_min_capacity" {
+variable "min_capacity" {
   description = "Smallest number of tasks the backend-xi service can scale-in to."
   type        = number
   default     = 1
@@ -78,11 +72,11 @@ variable "scale_out_cooldown" {
 
 variable "backend_uk_scheduled_scaling_actions" {
   description = <<EOT
-Map of scheduled scaling actions keyed by a unique name. Each value must include:
-- schedule     : AWS cron expression in UTC, e.g. 'cron(0 7 ? * MON-FRI *)'
-- min_capacity : minimum desired tasks at schedule time
-- max_capacity : maximum desired tasks at schedule time
-EOT
+  Map of scheduled scaling actions keyed by a unique name. Each value must include:
+  - schedule     : AWS cron expression in UTC, e.g. 'cron(0 7 ? * MON-FRI *)'
+  - min_capacity : minimum desired tasks at schedule time
+  - max_capacity : maximum desired tasks at schedule time
+  EOT
   type = map(object({
     schedule     = string
     min_capacity = number
@@ -95,5 +89,21 @@ EOT
       action.min_capacity >= 0 && action.max_capacity >= 0 && action.min_capacity <= action.max_capacity
     ])
     error_message = "Each backend_uk_scheduled_scaling_actions entry must have non-negative min_capacity/max_capacity and min_capacity must be <= max_capacity."
+  }
+}
+
+variable "backend_xi_scheduled_scaling_actions" {
+  type = map(object({
+    schedule     = string
+    min_capacity = number
+    max_capacity = number
+  }))
+  default = {}
+  validation {
+    condition = alltrue([
+      for _, action in var.backend_xi_scheduled_scaling_actions :
+      action.min_capacity >= 0 && action.max_capacity >= 0 && action.min_capacity <= action.max_capacity
+    ])
+    error_message = "Each backend_xi_scheduled_scaling_actions entry must have non-negative min_capacity/max_capacity and min_capacity must be <= max_capacity."
   }
 }


### PR DESCRIPTION
## What:
- Reduce backend-uk ECS service baseline capacity from 3 to 2 tasks.
- Add scheduled scaling actions to temporarily increase the minimum task count from 2 to 4/5 during recurring overnight traffic peaks for backend-xi.


## Why:
Analysis of RequestCountPerTarget and CPU metrics shows recurring traffic and CPU increases around 00:00 and 03:00 UTC. Scheduled scaling proactively increases capacity ahead of these predictable peaks while allowing a lower baseline capacity for the rest of the day. Existing target-tracking autoscaling remains responsible for handling unexpected traffic increases.

## Ticket:

[HMRC-2429](https://transformuk.atlassian.net/browse/HMRC-2429)

## Risk:
**Risk level:** 🟢 

**Reason for rating:**

- Existing autoscaling policies remain unchanged.
- Maximum capacity is unchanged.
- Scheduled actions only adjust the minimum capacity during known peak windows.
- Baseline capacity for `backend-uk` is reduced conservatively from 3 to 2 tasks 