### PR TITLE
AI-943 Include public ATAR keywords in hybrid search

### DIFF
--- a/app/indexes/search/goods_nomenclature_index.rb
+++ b/app/indexes/search/goods_nomenclature_index.rb
@@ -30,6 +30,7 @@ module Search
               type: 'text',
               analyzer: 'snowball',
             },
+            atar_keywords: { type: 'text', analyzer: 'snowball' },
             labels: {
               properties: {
                 description: { type: 'text', analyzer: 'snowball' },
@@ -55,6 +56,7 @@ module Search
         :goods_nomenclature_descriptions,
         :goods_nomenclature_label,
         :goods_nomenclature_self_text,
+        :public_atar_rulings,
         :search_references,
         { ancestors: %i[goods_nomenclature_descriptions search_references] },
         { heading: [:goods_nomenclature_descriptions] },

--- a/app/queries/search/goods_nomenclature_query.rb
+++ b/app/queries/search/goods_nomenclature_query.rb
@@ -126,6 +126,7 @@ module Search
       fields = %w[
         search_references^5
         description^3
+        atar_keywords^2
         ancestor_descriptions
       ]
 

--- a/app/serializers/search/goods_nomenclature_serializer.rb
+++ b/app/serializers/search/goods_nomenclature_serializer.rb
@@ -23,6 +23,7 @@ module Search
         description:,
         ancestor_descriptions:,
         search_references: search_references_part,
+        atar_keywords: atar_keywords_part,
         labels: labels_part,
       }.compact
     end
@@ -74,6 +75,11 @@ module Search
         colloquial_terms: labels['colloquial_terms'],
         synonyms: labels['synonyms'],
       }.compact_blank
+    end
+
+    def atar_keywords_part
+      keywords = public_atar_rulings.flat_map(&:keywords).compact_blank.uniq
+      keywords.presence
     end
   end
 end

--- a/app/services/composite_search_text_builder.rb
+++ b/app/services/composite_search_text_builder.rb
@@ -1,8 +1,9 @@
 class CompositeSearchTextBuilder
-  def initialize(self_text_record, labels: nil, search_references: nil)
+  def initialize(self_text_record, labels: nil, search_references: nil, atar_keywords: nil)
     @self_text_record = self_text_record
     @labels = labels
     @search_references = search_references
+    @atar_keywords = atar_keywords
   end
 
   def call
@@ -10,6 +11,7 @@ class CompositeSearchTextBuilder
     sections << also_known_as_section if also_known_as.any?
     sections << brands_section if brands.any?
     sections << references_section if reference_titles.any?
+    sections << atar_keywords_section if normalized_atar_keywords.any?
     sections.join("\n")
   end
 
@@ -21,10 +23,19 @@ class CompositeSearchTextBuilder
     return {} if self_text_records.empty?
 
     sids = self_text_records.map(&:goods_nomenclature_sid)
+    goods_nomenclature_item_ids = self_text_records.map(&:goods_nomenclature_item_id).compact
 
     labels_by_sid = GoodsNomenclatureLabel
       .where(goods_nomenclature_sid: sids)
       .as_hash(:goods_nomenclature_sid)
+
+    atar_keywords_by_item_id = TariffKnowledge::PublicAtarRuling
+      .actual
+      .where(goods_nomenclature_item_id: goods_nomenclature_item_ids)
+      .select(:goods_nomenclature_item_id, :keywords)
+      .all
+      .group_by(&:goods_nomenclature_item_id)
+      .transform_values { |rulings| rulings.flat_map(&:keywords).compact_blank.uniq }
 
     gns_by_sid = GoodsNomenclature
       .where(goods_nomenclature_sid: sids)
@@ -40,6 +51,7 @@ class CompositeSearchTextBuilder
         record,
         labels: labels_by_sid[sid],
         search_references: all_refs,
+        atar_keywords: atar_keywords_by_item_id[record.goods_nomenclature_item_id],
       )
       hash[sid] = builder.call
     end
@@ -47,7 +59,7 @@ class CompositeSearchTextBuilder
 
   private
 
-  attr_reader :self_text_record, :labels, :search_references
+  attr_reader :self_text_record, :labels, :search_references, :atar_keywords
 
   def description_section
     self_text_record.self_text
@@ -63,6 +75,10 @@ class CompositeSearchTextBuilder
 
   def references_section
     "References: #{reference_titles.join(', ')}"
+  end
+
+  def atar_keywords_section
+    "ATAR keywords: #{normalized_atar_keywords.join(', ')}"
   end
 
   def also_known_as
@@ -87,5 +103,9 @@ class CompositeSearchTextBuilder
 
   def reference_titles
     @reference_titles ||= (search_references || []).filter_map { |r| r.title.presence }.uniq
+  end
+
+  def normalized_atar_keywords
+    @normalized_atar_keywords ||= Array(atar_keywords).compact_blank.uniq
   end
 end

--- a/app/services/tariff_knowledge/public_atar_ruling_importer.rb
+++ b/app/services/tariff_knowledge/public_atar_ruling_importer.rb
@@ -2,7 +2,8 @@ require 'json'
 
 module TariffKnowledge
   class PublicAtarRulingImporter
-    Result = Data.define(:seen_count, :created_count, :updated_count, :failed_count)
+    Result = Data.define(:seen_count, :created_count, :updated_count, :failed_count, :refresh_goods_nomenclature_item_ids)
+    UpsertResult = Data.define(:action, :refresh_goods_nomenclature_item_ids)
 
     DEFAULT_PRELOAD_PATH = Rails.root.join('db/tariff_knowledge/public_atar_rulings_preload.json')
 
@@ -25,6 +26,7 @@ module TariffKnowledge
       created_count = 0
       updated_count = 0
       failed_count = 0
+      refresh_goods_nomenclature_item_ids = []
       remaining = limit
 
       (1..max_pages).each do |page|
@@ -35,9 +37,10 @@ module TariffKnowledge
         seen_count += refs.size
 
         refs.each do |ref|
-          action = upsert_ruling(sync_source.ruling_for_ref(ref))
-          created_count += 1 if action == :created
-          updated_count += 1 if action == :updated
+          upsert_result = upsert_ruling(sync_source.ruling_for_ref(ref))
+          created_count += 1 if upsert_result.action == :created
+          updated_count += 1 if upsert_result.action == :updated
+          refresh_goods_nomenclature_item_ids.concat(upsert_result.refresh_goods_nomenclature_item_ids)
         rescue StandardError => e
           failed_count += 1
           Rails.logger.warn("Failed to import public ATAR #{ref}: #{e.class}: #{e.message}")
@@ -49,26 +52,28 @@ module TariffKnowledge
         end
       end
 
-      Result.new(seen_count:, created_count:, updated_count:, failed_count:)
+      Result.new(seen_count:, created_count:, updated_count:, failed_count:, refresh_goods_nomenclature_item_ids: refresh_goods_nomenclature_item_ids.uniq)
     end
 
     def import_file(path: DEFAULT_PRELOAD_PATH)
       created_count = 0
       updated_count = 0
       failed_count = 0
+      refresh_goods_nomenclature_item_ids = []
       rows = JSON.parse(File.read(path))
 
       rows.each do |attributes|
         ruling = ruling_from_hash(attributes)
-        action = upsert_ruling(ruling)
-        created_count += 1 if action == :created
-        updated_count += 1 if action == :updated
+        upsert_result = upsert_ruling(ruling)
+        created_count += 1 if upsert_result.action == :created
+        updated_count += 1 if upsert_result.action == :updated
+        refresh_goods_nomenclature_item_ids.concat(upsert_result.refresh_goods_nomenclature_item_ids)
       rescue StandardError => e
         failed_count += 1
         Rails.logger.warn("Failed to import public ATAR #{attributes['ref'] || 'unknown'}: #{e.class}: #{e.message}")
       end
 
-      Result.new(seen_count: rows.size, created_count:, updated_count:, failed_count:)
+      Result.new(seen_count: rows.size, created_count:, updated_count:, failed_count:, refresh_goods_nomenclature_item_ids: refresh_goods_nomenclature_item_ids.uniq)
     end
 
   private
@@ -79,12 +84,20 @@ module TariffKnowledge
       existing = PublicAtarRuling.by_ref(ruling.ref).first
       now = Time.zone.now
       action = existing ? :updated : :created
+      row = row_for(ruling, existing:, now:)
+      refresh_goods_nomenclature_item_ids = search_refresh_item_ids(existing, row)
 
       PublicAtarRuling.dataset
                        .insert_conflict(target: :ref, update: update_values)
-                       .insert(row_for(ruling, existing:, now:))
+                       .insert(row)
 
-      action
+      UpsertResult.new(action:, refresh_goods_nomenclature_item_ids:)
+    end
+
+    def search_refresh_item_ids(existing, row)
+      return [row[:goods_nomenclature_item_id]] unless existing
+
+      [existing.goods_nomenclature_item_id, row[:goods_nomenclature_item_id]].compact.uniq
     end
 
     def row_for(ruling, existing:, now:)

--- a/app/services/tariff_knowledge/public_atar_search_refresh.rb
+++ b/app/services/tariff_knowledge/public_atar_search_refresh.rb
@@ -1,0 +1,46 @@
+module TariffKnowledge
+  class PublicAtarSearchRefresh
+    BATCH_SIZE = 500
+
+    def self.call(...) = new(...).call
+
+    def initialize(goods_nomenclature_item_ids)
+      @goods_nomenclature_item_ids = Array(goods_nomenclature_item_ids).compact_blank.uniq
+    end
+
+    def call
+      return [] if goods_nomenclature_item_ids.empty?
+
+      goods_nomenclatures = matching_goods_nomenclatures
+      goods_nomenclatures.each { |goods_nomenclature| reindex(goods_nomenclature) }
+
+      sids = goods_nomenclatures.map(&:goods_nomenclature_sid)
+      sids.each_slice(BATCH_SIZE) { |batch| ScoreLabelBatchWorker.perform_async(batch) }
+      sids
+    end
+
+  private
+
+    attr_reader :goods_nomenclature_item_ids
+
+    def matching_goods_nomenclatures
+      TimeMachine.now do
+        index = Search::GoodsNomenclatureIndex.new
+
+        GoodsNomenclature
+          .actual
+          .with_leaf_column
+          .where(goods_nomenclatures__goods_nomenclature_item_id: goods_nomenclature_item_ids)
+          .eager(index.eager_load)
+          .all
+      end
+    end
+
+    def reindex(goods_nomenclature)
+      TradeTariffBackend.search_client.index(
+        Search::GoodsNomenclatureIndex,
+        goods_nomenclature,
+      )
+    end
+  end
+end

--- a/app/workers/import_public_atar_rulings_worker.rb
+++ b/app/workers/import_public_atar_rulings_worker.rb
@@ -10,6 +10,8 @@ class ImportPublicAtarRulingsWorker
     end
 
     result = TariffKnowledge::PublicAtarRulingImporter.call(**options.symbolize_keys)
+    refreshed_sids = TariffKnowledge::PublicAtarSearchRefresh.call(result.refresh_goods_nomenclature_item_ids)
     Rails.logger.info("Public ATAR import complete: #{result.seen_count} seen, #{result.created_count} created, #{result.updated_count} updated, #{result.failed_count} failed")
+    Rails.logger.info("Public ATAR search refresh complete: #{refreshed_sids.size} goods nomenclatures refreshed or queued")
   end
 end

--- a/lib/tasks/tariff_knowledge.rake
+++ b/lib/tasks/tariff_knowledge.rake
@@ -79,7 +79,9 @@ namespace :tariff_knowledge do
       next unless ensure_uk_service.call
 
       result = TariffKnowledge::PublicAtarRulingImporter.import_file
+      refreshed_sids = TariffKnowledge::PublicAtarSearchRefresh.call(result.refresh_goods_nomenclature_item_ids)
       puts "Public ATAR preload complete: #{result.seen_count} seen, #{result.created_count} created, #{result.updated_count} updated, #{result.failed_count} failed."
+      puts "Public ATAR search refresh complete: #{refreshed_sids.size} goods nomenclatures refreshed or queued."
     end
 
     desc 'Import public ATAR rulings from tax.service.gov.uk'
@@ -92,7 +94,9 @@ namespace :tariff_knowledge do
         request_delay: float_env.call('ATAR_REQUEST_DELAY', TariffKnowledge::PublicAtarRulingSource::DEFAULT_REQUEST_DELAY),
         max_retries: integer_env.call('ATAR_MAX_RETRIES', TariffKnowledge::PublicAtarRulingSource::DEFAULT_MAX_RETRIES),
       )
+      refreshed_sids = TariffKnowledge::PublicAtarSearchRefresh.call(result.refresh_goods_nomenclature_item_ids)
       puts "Public ATAR import complete: #{result.seen_count} seen, #{result.created_count} created, #{result.updated_count} updated, #{result.failed_count} failed."
+      puts "Public ATAR search refresh complete: #{refreshed_sids.size} goods nomenclatures refreshed or queued."
     end
 
     desc 'Enqueue public ATAR ruling import'

--- a/spec/indexes/search/goods_nomenclature_index_spec.rb
+++ b/spec/indexes/search/goods_nomenclature_index_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe Search::GoodsNomenclatureIndex do
       expect(properties[:description]).to eq(type: 'text', analyzer: 'snowball')
       expect(properties[:ancestor_descriptions]).to eq(type: 'text', analyzer: 'snowball')
       expect(properties[:search_references]).to eq(type: 'text', analyzer: 'snowball')
+      expect(properties[:atar_keywords]).to eq(type: 'text', analyzer: 'snowball')
     end
 
     it 'includes labels mapping' do
@@ -50,6 +51,7 @@ RSpec.describe Search::GoodsNomenclatureIndex do
         :goods_nomenclature_indents,
         :goods_nomenclature_descriptions,
         :goods_nomenclature_label,
+        :public_atar_rulings,
         :search_references,
       )
     end

--- a/spec/lib/tasks/tariff_knowledge_rake_spec.rb
+++ b/spec/lib/tasks/tariff_knowledge_rake_spec.rb
@@ -94,31 +94,37 @@ RSpec.describe 'tariff_knowledge rake tasks' do
   describe 'tariff_knowledge:atars:preload' do
     it 'imports the public ATAR preload file' do
       allow(TariffKnowledge::PublicAtarRulingImporter).to receive(:import_file)
-        .and_return(TariffKnowledge::PublicAtarRulingImporter::Result.new(seen_count: 2, created_count: 2, updated_count: 0, failed_count: 0))
+        .and_return(TariffKnowledge::PublicAtarRulingImporter::Result.new(seen_count: 2, created_count: 2, updated_count: 0, failed_count: 0, refresh_goods_nomenclature_item_ids: %w[6302100000]))
+      allow(TariffKnowledge::PublicAtarSearchRefresh).to receive(:call).and_return([1])
 
       suppress_output { Rake::Task['tariff_knowledge:atars:preload'].invoke }
 
       expect(TariffKnowledge::PublicAtarRulingImporter).to have_received(:import_file)
+      expect(TariffKnowledge::PublicAtarSearchRefresh).to have_received(:call).with(%w[6302100000])
     end
 
     it 'skips outside UK service mode' do
       allow(TradeTariffBackend).to receive(:service).and_return('xi')
       allow(TariffKnowledge::PublicAtarRulingImporter).to receive(:import_file)
+      allow(TariffKnowledge::PublicAtarSearchRefresh).to receive(:call)
 
       suppress_output { Rake::Task['tariff_knowledge:atars:preload'].invoke }
 
       expect(TariffKnowledge::PublicAtarRulingImporter).not_to have_received(:import_file)
+      expect(TariffKnowledge::PublicAtarSearchRefresh).not_to have_received(:call)
     end
   end
 
   describe 'tariff_knowledge:atars:import' do
     it 'imports public ATAR rulings inline' do
       allow(TariffKnowledge::PublicAtarRulingImporter).to receive(:call)
-        .and_return(TariffKnowledge::PublicAtarRulingImporter::Result.new(seen_count: 2, created_count: 1, updated_count: 1, failed_count: 0))
+        .and_return(TariffKnowledge::PublicAtarRulingImporter::Result.new(seen_count: 2, created_count: 1, updated_count: 1, failed_count: 0, refresh_goods_nomenclature_item_ids: %w[6302100000]))
+      allow(TariffKnowledge::PublicAtarSearchRefresh).to receive(:call).and_return([1])
 
       suppress_output { Rake::Task['tariff_knowledge:atars:import'].invoke }
 
       expect(TariffKnowledge::PublicAtarRulingImporter).to have_received(:call)
+      expect(TariffKnowledge::PublicAtarSearchRefresh).to have_received(:call).with(%w[6302100000])
     end
 
     it 'rejects invalid numeric options' do

--- a/spec/models/goods_nomenclature_self_text_spec.rb
+++ b/spec/models/goods_nomenclature_self_text_spec.rb
@@ -298,6 +298,27 @@ RSpec.describe GoodsNomenclatureSelfText do
       expect(embedding_service).to have_received(:embed_batch).twice
     end
 
+    it 're-embeds when public ATAR keywords change the composite search text' do
+      commodity = create(:commodity, :with_description, :declarable, goods_nomenclature_item_id: '6302100000')
+      record = create(:goods_nomenclature_self_text,
+                      goods_nomenclature: commodity,
+                      goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
+                      self_text: 'Bed linen')
+
+      described_class.regenerate_search_embeddings([record.goods_nomenclature_sid])
+      expect(embedding_service).to have_received(:embed_batch).once
+
+      create(:tariff_knowledge_public_atar_ruling,
+             commodity_code: '630210',
+             goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
+             keywords: Sequel.pg_array(['cotton sheets'], :text))
+
+      described_class.regenerate_search_embeddings([record.goods_nomenclature_sid])
+
+      expect(embedding_service).to have_received(:embed_batch).twice
+      expect(record.reload.search_text).to include('ATAR keywords: cotton sheets')
+    end
+
     it 're-embeds when search_embedding is nil even if search_text matches' do
       record = create(:goods_nomenclature_self_text, self_text: 'Widgets for manufacturing')
 

--- a/spec/queries/search/goods_nomenclature_query_spec.rb
+++ b/spec/queries/search/goods_nomenclature_query_spec.rb
@@ -48,6 +48,10 @@ RSpec.describe Search::GoodsNomenclatureQuery do
           expect(multi_match[:fields]).to include('search_references^5')
           expect(multi_match[:fields]).to include('ancestor_descriptions')
         end
+
+        it 'searches public ATAR keywords' do
+          expect(multi_match[:fields]).to include('atar_keywords^2')
+        end
       end
     end
 

--- a/spec/serializers/search/goods_nomenclature_serializer_spec.rb
+++ b/spec/serializers/search/goods_nomenclature_serializer_spec.rb
@@ -89,6 +89,20 @@ RSpec.describe Search::GoodsNomenclatureSerializer do
       end
     end
 
+    context 'with public ATAR rulings' do
+      before do
+        create(:tariff_knowledge_public_atar_ruling,
+               commodity_code: '0101210000',
+               goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
+               keywords: Sequel.pg_array(['riding horses', 'show ponies', '', 'riding horses'], :text))
+        commodity.reload
+      end
+
+      it 'includes unique nonblank ATAR keywords for OpenSearch' do
+        expect(result[:atar_keywords]).to eq(['riding horses', 'show ponies'])
+      end
+    end
+
     context 'without labels' do
       it 'does not include labels key' do
         expect(result[:labels]).to be_nil

--- a/spec/services/composite_search_text_builder_spec.rb
+++ b/spec/services/composite_search_text_builder_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe CompositeSearchTextBuilder do
-  subject(:builder) { described_class.new(self_text_record, labels: label, search_references: refs) }
+  subject(:builder) { described_class.new(self_text_record, labels: label, search_references: refs, atar_keywords: atar_keywords) }
 
   let(:self_text_record) do
     build(:goods_nomenclature_self_text,
@@ -9,6 +9,7 @@ RSpec.describe CompositeSearchTextBuilder do
 
   let(:label) { nil }
   let(:refs) { nil }
+  let(:atar_keywords) { nil }
 
   describe '#call' do
     context 'with only a self-text description' do
@@ -72,6 +73,16 @@ RSpec.describe CompositeSearchTextBuilder do
       end
     end
 
+    context 'with public ATAR keywords' do
+      let(:atar_keywords) { ['riding horses', 'show ponies', '', 'riding horses'] }
+
+      it 'includes unique nonblank ATAR keywords' do
+        result = builder.call
+
+        expect(result).to include('ATAR keywords: riding horses, show ponies')
+      end
+    end
+
     context 'with all data present' do
       let(:label) do
         build(:goods_nomenclature_label,
@@ -90,6 +101,8 @@ RSpec.describe CompositeSearchTextBuilder do
         [build(:search_reference, title: 'horses')]
       end
 
+      let(:atar_keywords) { ['equestrian sports'] }
+
       it 'assembles all sections in order' do
         result = builder.call
         lines = result.split("\n")
@@ -98,6 +111,7 @@ RSpec.describe CompositeSearchTextBuilder do
         expect(lines[1]).to eq('Also known as: ponies, equines')
         expect(lines[2]).to eq('Brands: Thoroughbred')
         expect(lines[3]).to eq('References: horses')
+        expect(lines[4]).to eq('ATAR keywords: equestrian sports')
       end
     end
 
@@ -192,6 +206,23 @@ RSpec.describe CompositeSearchTextBuilder do
       result = described_class.batch([self_text])
 
       expect(result[commodity.goods_nomenclature_sid]).to include('References: fridges')
+    end
+
+    it 'includes public ATAR keywords for the matching goods nomenclature item id' do
+      commodity = create(:commodity, :with_description, :declarable,
+                         goods_nomenclature_item_id: '6302100000')
+      self_text = create(:goods_nomenclature_self_text,
+                         goods_nomenclature_sid: commodity.goods_nomenclature_sid,
+                         goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
+                         self_text: 'Bed linen commodity')
+      create(:tariff_knowledge_public_atar_ruling,
+             commodity_code: '630210',
+             goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
+             keywords: Sequel.pg_array(['cotton sheets', 'bed linen'], :text))
+
+      result = described_class.batch([self_text])
+
+      expect(result[commodity.goods_nomenclature_sid]).to include('ATAR keywords: cotton sheets, bed linen')
     end
   end
 end

--- a/spec/services/tariff_knowledge/public_atar_ruling_importer_spec.rb
+++ b/spec/services/tariff_knowledge/public_atar_ruling_importer_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe TariffKnowledge::PublicAtarRulingImporter do
 
       ruling = TariffKnowledge::PublicAtarRuling.by_ref('600015804').first
       expect(result.created_count).to eq(1)
+      expect(result.refresh_goods_nomenclature_item_ids).to eq(%w[9705100074])
       expect(ruling.commodity_code).to eq('9705100074')
       expect(ruling.goods_nomenclature_item_id).to eq('9705100074')
       expect(ruling.keywords).to eq(['CEILING LIGHTS', 'OF GLASS'])
@@ -107,6 +108,21 @@ RSpec.describe TariffKnowledge::PublicAtarRulingImporter do
       expect(updated.first_seen_at).to eq(first_seen_at)
       expect(updated.last_seen_at).to eq(Time.zone.now)
       expect(updated.fetched_at).to eq(Time.zone.now)
+      expect(result.refresh_goods_nomenclature_item_ids).to contain_exactly('9705100074')
+    end
+
+    it 'keeps unchanged existing rulings in the refresh list so retries remain safe' do
+      path = Rails.root.join('tmp/public_atar_rulings_preload_spec.json')
+      File.write(path, JSON.pretty_generate([ruling_hash(ref: '600015804', keywords: ['CEILING LIGHTS'])]))
+      importer = described_class.new
+
+      importer.import_file(path:)
+      result = importer.import_file(path:)
+
+      expect(result.updated_count).to eq(1)
+      expect(result.refresh_goods_nomenclature_item_ids).to eq(%w[9705100074])
+    ensure
+      FileUtils.rm_f(path)
     end
 
     it 'continues past already imported listing pages' do

--- a/spec/services/tariff_knowledge/public_atar_search_refresh_spec.rb
+++ b/spec/services/tariff_knowledge/public_atar_search_refresh_spec.rb
@@ -1,0 +1,42 @@
+RSpec.describe TariffKnowledge::PublicAtarSearchRefresh do
+  describe '.call' do
+    let(:search_client) { instance_double(TradeTariffBackend::SearchClient, index: true) }
+
+    before do
+      allow(TradeTariffBackend).to receive(:search_client).and_return(search_client)
+      allow(ScoreLabelBatchWorker).to receive(:perform_async)
+    end
+
+    it 'indexes matching goods nomenclatures and queues embedding regeneration' do
+      commodity = create(:commodity, :with_description, :declarable, goods_nomenclature_item_id: '6302100000')
+      create(:goods_nomenclature_self_text,
+             goods_nomenclature: commodity,
+             goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
+             self_text: 'Bed linen')
+
+      result = described_class.call(%w[6302100000])
+
+      expect(result).to eq([commodity.goods_nomenclature_sid])
+      expect(search_client).to have_received(:index).with(Search::GoodsNomenclatureIndex, have_attributes(goods_nomenclature_sid: commodity.goods_nomenclature_sid))
+      expect(ScoreLabelBatchWorker).to have_received(:perform_async).with([commodity.goods_nomenclature_sid])
+    end
+
+    it 'does nothing when no goods nomenclatures match' do
+      result = described_class.call(%w[9999999999])
+
+      expect(result).to eq([])
+      expect(search_client).not_to have_received(:index)
+      expect(ScoreLabelBatchWorker).not_to have_received(:perform_async)
+    end
+
+    it 'deduplicates blank and repeated item ids before refreshing' do
+      commodity = create(:commodity, :with_description, :declarable, goods_nomenclature_item_id: '6302100000')
+
+      result = described_class.call(['6302100000', '', nil, '6302100000'])
+
+      expect(result).to eq([commodity.goods_nomenclature_sid])
+      expect(search_client).to have_received(:index).once
+      expect(ScoreLabelBatchWorker).to have_received(:perform_async).with([commodity.goods_nomenclature_sid])
+    end
+  end
+end

--- a/spec/workers/import_public_atar_rulings_worker_spec.rb
+++ b/spec/workers/import_public_atar_rulings_worker_spec.rb
@@ -2,23 +2,39 @@ RSpec.describe ImportPublicAtarRulingsWorker, type: :worker do
   describe '#perform' do
     it 'delegates to the public ATAR importer' do
       allow(TariffKnowledge::PublicAtarRulingImporter).to receive(:call)
-        .and_return(TariffKnowledge::PublicAtarRulingImporter::Result.new(seen_count: 1, created_count: 1, updated_count: 0, failed_count: 0))
+        .and_return(TariffKnowledge::PublicAtarRulingImporter::Result.new(seen_count: 1, created_count: 1, updated_count: 0, failed_count: 0, refresh_goods_nomenclature_item_ids: []))
       allow(Rails.logger).to receive(:info)
+      allow(TariffKnowledge::PublicAtarSearchRefresh).to receive(:call).and_return([])
 
       described_class.new.perform('max_pages' => 1, 'request_delay' => 0)
 
       expect(TariffKnowledge::PublicAtarRulingImporter).to have_received(:call).with(max_pages: 1, request_delay: 0)
+      expect(TariffKnowledge::PublicAtarSearchRefresh).to have_received(:call).with([])
       expect(Rails.logger).to have_received(:info).with(/Public ATAR import complete/)
+    end
+
+    it 'refreshes search surfaces for changed ATAR goods nomenclature item ids' do
+      allow(TariffKnowledge::PublicAtarRulingImporter).to receive(:call)
+        .and_return(TariffKnowledge::PublicAtarRulingImporter::Result.new(seen_count: 1, created_count: 0, updated_count: 1, failed_count: 0, refresh_goods_nomenclature_item_ids: %w[6302100000]))
+      allow(TariffKnowledge::PublicAtarSearchRefresh).to receive(:call).and_return([1])
+      allow(Rails.logger).to receive(:info)
+
+      described_class.new.perform
+
+      expect(TariffKnowledge::PublicAtarSearchRefresh).to have_received(:call).with(%w[6302100000])
+      expect(Rails.logger).to have_received(:info).with(/1 goods nomenclatures refreshed or queued/)
     end
 
     it 'does not import public ATAR rulings for XI service mode' do
       allow(TradeTariffBackend).to receive(:service).and_return('xi')
       allow(TariffKnowledge::PublicAtarRulingImporter).to receive(:call)
+      allow(TariffKnowledge::PublicAtarSearchRefresh).to receive(:call)
       allow(Rails.logger).to receive(:info)
 
       described_class.new.perform
 
       expect(TariffKnowledge::PublicAtarRulingImporter).not_to have_received(:call)
+      expect(TariffKnowledge::PublicAtarSearchRefresh).not_to have_received(:call)
       expect(Rails.logger).to have_received(:info).with(/Skipping public ATAR import/)
     end
   end


### PR DESCRIPTION
## What:
- Add public ATAR keywords to the goods nomenclature OpenSearch document as a searchable `atar_keywords` field.
- Include `atar_keywords^2` in goods nomenclature OpenSearch multi-match fields.
- Include public ATAR keywords in the composite search text used to generate pg_vector search embeddings.
- Refresh derived search surfaces after public ATAR imports/preloads by reindexing affected goods nomenclatures and queueing embedding regeneration for affected self-text SIDs.
- Add specs proving OpenSearch serialization/query coverage, pg_vector embedding regeneration, importer refresh IDs, and worker/rake search refresh wiring.

## Why:
Public ATAR rulings are loaded nightly and their mechanically extracted keywords were already stored, but those keywords were not included in hybrid search retrieval inputs. This makes the existing ATAR keyword data available through both hybrid search legs and keeps those derived search surfaces current when ATAR import/preload input is processed.

## Ticket:
https://transformuk.atlassian.net/browse/AI-943

## Risk:
**Risk level:** 🟢

**Reason for rating:**
This is additive use of currently unused public ATAR keyword data. It adds a searchable OpenSearch field and composite embedding text input without changing APIs, database schema, tariff sync semantics, measure logic, duties, quotas, or trader-facing regulatory content generation.

## Verification:
- `bundle exec rubocop app/indexes/search/goods_nomenclature_index.rb app/queries/search/goods_nomenclature_query.rb app/serializers/search/goods_nomenclature_serializer.rb app/services/composite_search_text_builder.rb app/services/tariff_knowledge/public_atar_ruling_importer.rb app/services/tariff_knowledge/public_atar_search_refresh.rb app/workers/import_public_atar_rulings_worker.rb lib/tasks/tariff_knowledge.rake spec/indexes/search/goods_nomenclature_index_spec.rb spec/models/goods_nomenclature_self_text_spec.rb spec/queries/search/goods_nomenclature_query_spec.rb spec/serializers/search/goods_nomenclature_serializer_spec.rb spec/services/composite_search_text_builder_spec.rb spec/services/tariff_knowledge/public_atar_ruling_importer_spec.rb spec/services/tariff_knowledge/public_atar_search_refresh_spec.rb spec/workers/import_public_atar_rulings_worker_spec.rb spec/lib/tasks/tariff_knowledge_rake_spec.rb` - 17 files inspected, no offenses detected.
- `bundle exec rspec spec/serializers/search/goods_nomenclature_serializer_spec.rb spec/indexes/search/goods_nomenclature_index_spec.rb spec/queries/search/goods_nomenclature_query_spec.rb spec/services/composite_search_text_builder_spec.rb spec/models/goods_nomenclature_self_text_spec.rb spec/models/goods_nomenclature_spec.rb spec/models/tariff_knowledge/public_atar_ruling_spec.rb spec/services/tariff_knowledge/public_atar_ruling_importer_spec.rb spec/services/tariff_knowledge/public_atar_ruling_source_spec.rb spec/services/tariff_knowledge/public_atar_search_refresh_spec.rb spec/workers/import_public_atar_rulings_worker_spec.rb spec/lib/tasks/tariff_knowledge_rake_spec.rb` - 258 examples, 0 failures.
- `bundle exec rspec` - 8668 examples, 0 failures, 2 pending.
- Copilot review checked the PR and generated no inline comments; GitHub currently shows no review comments or issue comments requiring action.

## Path to live:
- Standard backend PR review and CI.
- Merge to `main` after review/checks.
- Deploy through the normal backend deployment workflow.
- Rebuild/recreate the goods nomenclature OpenSearch search index once after deploy so the new `atar_keywords` mapping exists and preloaded ATAR data is present in existing indexed documents.
- Run `search_embeddings:generate` once after deploy/reindex so existing pg_vector embeddings include ATAR keyword sections for already-preloaded ATARs.
- ATAR imports/preloads after this change will refresh affected OpenSearch documents and queue embedding regeneration for imported ATAR item IDs.