### PR TITLE
AI-943 Bulk refresh ATAR search documents

### DIFF
--- a/app/services/tariff_knowledge/public_atar_search_refresh.rb
+++ b/app/services/tariff_knowledge/public_atar_search_refresh.rb
@@ -11,11 +11,18 @@ module TariffKnowledge
     def call
       return [] if goods_nomenclature_item_ids.empty?
 
-      goods_nomenclatures = matching_goods_nomenclatures
-      goods_nomenclatures.each { |goods_nomenclature| reindex(goods_nomenclature) }
+      sids = []
+      goods_nomenclature_item_ids.each_slice(BATCH_SIZE) do |item_id_batch|
+        goods_nomenclatures = matching_goods_nomenclatures(item_id_batch)
+        next if goods_nomenclatures.empty?
 
-      sids = goods_nomenclatures.map(&:goods_nomenclature_sid)
-      sids.each_slice(BATCH_SIZE) { |batch| ScoreLabelBatchWorker.perform_async(batch) }
+        bulk_reindex(goods_nomenclatures)
+
+        sid_batch = goods_nomenclatures.map(&:goods_nomenclature_sid)
+        sids.concat(sid_batch)
+        ScoreLabelBatchWorker.perform_async(sid_batch)
+      end
+
       sids
     end
 
@@ -23,24 +30,34 @@ module TariffKnowledge
 
     attr_reader :goods_nomenclature_item_ids
 
-    def matching_goods_nomenclatures
+    def matching_goods_nomenclatures(item_ids)
       TimeMachine.now do
         index = Search::GoodsNomenclatureIndex.new
 
         GoodsNomenclature
           .actual
           .with_leaf_column
-          .where(goods_nomenclatures__goods_nomenclature_item_id: goods_nomenclature_item_ids)
+          .where(goods_nomenclatures__goods_nomenclature_item_id: item_ids)
           .eager(index.eager_load)
           .all
       end
     end
 
-    def reindex(goods_nomenclature)
-      TradeTariffBackend.search_client.index(
-        Search::GoodsNomenclatureIndex,
-        goods_nomenclature,
+    def bulk_reindex(goods_nomenclatures)
+      index = Search::GoodsNomenclatureIndex.new
+      TradeTariffBackend.search_client.bulk(
+        body: goods_nomenclatures.map { |goods_nomenclature| bulk_operation(index, goods_nomenclature) },
       )
+    end
+
+    def bulk_operation(index, goods_nomenclature)
+      {
+        index: {
+          _index: index.name,
+          _id: index.document_id(goods_nomenclature),
+          data: index.serialize_record(goods_nomenclature),
+        },
+      }
     end
   end
 end

--- a/app/services/tariff_knowledge/public_atar_search_refresh.rb
+++ b/app/services/tariff_knowledge/public_atar_search_refresh.rb
@@ -46,7 +46,9 @@ module TariffKnowledge
     def bulk_reindex(goods_nomenclatures)
       index = Search::GoodsNomenclatureIndex.new
       TradeTariffBackend.search_client.bulk(
-        body: goods_nomenclatures.map { |goods_nomenclature| bulk_operation(index, goods_nomenclature) },
+        {
+          body: goods_nomenclatures.map { |goods_nomenclature| bulk_operation(index, goods_nomenclature) },
+        }.merge(TradeTariffBackend.search_client.search_operation_options),
       )
     end
 

--- a/spec/services/tariff_knowledge/public_atar_search_refresh_spec.rb
+++ b/spec/services/tariff_knowledge/public_atar_search_refresh_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe TariffKnowledge::PublicAtarSearchRefresh do
   describe '.call' do
-    let(:search_client) { object_double(TradeTariffBackend.search_client, bulk: true) }
+    let(:search_client) { object_double(TradeTariffBackend.search_client, bulk: true, search_operation_options: { refresh: true }) }
 
     before do
       allow(TradeTariffBackend).to receive(:search_client).and_return(search_client)
@@ -18,6 +18,7 @@ RSpec.describe TariffKnowledge::PublicAtarSearchRefresh do
 
       expect(result).to eq([commodity.goods_nomenclature_sid])
       expect(search_client).to have_received(:bulk) do |args|
+        expect(args).to include(refresh: true)
         operation = args.fetch(:body).first.fetch(:index)
         expect(operation[:_id]).to eq(commodity.goods_nomenclature_sid)
         expect(operation[:data]).to include('goods_nomenclature_sid' => commodity.goods_nomenclature_sid)

--- a/spec/services/tariff_knowledge/public_atar_search_refresh_spec.rb
+++ b/spec/services/tariff_knowledge/public_atar_search_refresh_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe TariffKnowledge::PublicAtarSearchRefresh do
   describe '.call' do
-    let(:search_client) { instance_double(TradeTariffBackend::SearchClient, index: true) }
+    let(:search_client) { object_double(TradeTariffBackend.search_client, bulk: true) }
 
     before do
       allow(TradeTariffBackend).to receive(:search_client).and_return(search_client)
@@ -17,7 +17,11 @@ RSpec.describe TariffKnowledge::PublicAtarSearchRefresh do
       result = described_class.call(%w[6302100000])
 
       expect(result).to eq([commodity.goods_nomenclature_sid])
-      expect(search_client).to have_received(:index).with(Search::GoodsNomenclatureIndex, have_attributes(goods_nomenclature_sid: commodity.goods_nomenclature_sid))
+      expect(search_client).to have_received(:bulk) do |args|
+        operation = args.fetch(:body).first.fetch(:index)
+        expect(operation[:_id]).to eq(commodity.goods_nomenclature_sid)
+        expect(operation[:data]).to include('goods_nomenclature_sid' => commodity.goods_nomenclature_sid)
+      end
       expect(ScoreLabelBatchWorker).to have_received(:perform_async).with([commodity.goods_nomenclature_sid])
     end
 
@@ -25,7 +29,7 @@ RSpec.describe TariffKnowledge::PublicAtarSearchRefresh do
       result = described_class.call(%w[9999999999])
 
       expect(result).to eq([])
-      expect(search_client).not_to have_received(:index)
+      expect(search_client).not_to have_received(:bulk)
       expect(ScoreLabelBatchWorker).not_to have_received(:perform_async)
     end
 
@@ -35,7 +39,7 @@ RSpec.describe TariffKnowledge::PublicAtarSearchRefresh do
       result = described_class.call(['6302100000', '', nil, '6302100000'])
 
       expect(result).to eq([commodity.goods_nomenclature_sid])
-      expect(search_client).to have_received(:index).once
+      expect(search_client).to have_received(:bulk).once
       expect(ScoreLabelBatchWorker).to have_received(:perform_async).with([commodity.goods_nomenclature_sid])
     end
   end


### PR DESCRIPTION
## What:
- Updates the ATAR search refresh service introduced by AI-943 to bulk-index affected goods nomenclatures in batches instead of issuing one OpenSearch request per goods nomenclature.
- Keeps embedding regeneration queued per refreshed SID batch.
- Updates the refresh service spec to assert the bulk OpenSearch payload.

## Why:
PR #3354 was merged while the final performance review improvement was still local. This follow-up keeps broad ATAR preload/import refreshes efficient for the existing preloaded ATAR volume.

## Ticket:
https://transformuk.atlassian.net/browse/AI-943

## Risk:
**Risk level:** 🟢

**Reason for rating:**
This is a narrow performance improvement to an additive ATAR search refresh path. It does not change APIs, database schema, tariff sync semantics, measure logic, duties, quotas, or trader-facing regulatory content generation.