### PR TITLE
AI-988: Store generated ATAR facts

### DIFF
--- a/app/services/tariff_knowledge/public_atar_ruling_importer.rb
+++ b/app/services/tariff_knowledge/public_atar_ruling_importer.rb
@@ -64,7 +64,7 @@ module TariffKnowledge
 
       rows.each do |attributes|
         ruling = ruling_from_hash(attributes)
-        upsert_result = upsert_ruling(ruling)
+        upsert_result = upsert_ruling(ruling, derived_fact_attributes: derived_fact_attributes_from_hash(attributes))
         created_count += 1 if upsert_result.action == :created
         updated_count += 1 if upsert_result.action == :updated
         refresh_goods_nomenclature_item_ids.concat(upsert_result.refresh_goods_nomenclature_item_ids)
@@ -80,15 +80,15 @@ module TariffKnowledge
 
     attr_reader :source
 
-    def upsert_ruling(ruling)
+    def upsert_ruling(ruling, derived_fact_attributes: nil)
       existing = PublicAtarRuling.by_ref(ruling.ref).first
       now = Time.zone.now
       action = existing ? :updated : :created
-      row = row_for(ruling, existing:, now:)
+      row = row_for(ruling, existing:, now:, derived_fact_attributes:)
       refresh_goods_nomenclature_item_ids = search_refresh_item_ids(existing, row)
 
       PublicAtarRuling.dataset
-                       .insert_conflict(target: :ref, update: update_values)
+                       .insert_conflict(target: :ref, update: update_values(update_derived_facts: derived_fact_attributes.present?))
                        .insert(row)
 
       UpsertResult.new(action:, refresh_goods_nomenclature_item_ids:)
@@ -100,8 +100,8 @@ module TariffKnowledge
       [existing.goods_nomenclature_item_id, row[:goods_nomenclature_item_id]].compact.uniq
     end
 
-    def row_for(ruling, existing:, now:)
-      {
+    def row_for(ruling, existing:, now:, derived_fact_attributes:)
+      row = {
         ref: ruling.ref,
         commodity_code: ruling.commodity_code,
         goods_nomenclature_item_id: ruling.goods_nomenclature_item_id,
@@ -118,10 +118,12 @@ module TariffKnowledge
         created_at: now,
         updated_at: now,
       }
+      row.merge!(derived_fact_attributes) if derived_fact_attributes.present?
+      row
     end
 
-    def update_values
-      {
+    def update_values(update_derived_facts:)
+      values = {
         commodity_code: Sequel[:excluded][:commodity_code],
         goods_nomenclature_item_id: Sequel[:excluded][:goods_nomenclature_item_id],
         description: Sequel[:excluded][:description],
@@ -135,6 +137,10 @@ module TariffKnowledge
         fetched_at: Sequel[:excluded][:fetched_at],
         updated_at: Sequel[:excluded][:updated_at],
       }
+
+      values[:derived_facts] = Sequel[:excluded][:derived_facts] if update_derived_facts
+
+      values
     end
 
     def ruling_from_hash(attributes)
@@ -150,6 +156,17 @@ module TariffKnowledge
         source_url: attributes.fetch('source_url'),
         raw_fields: attributes.fetch('raw_fields'),
       )
+    end
+
+    def derived_fact_attributes_from_hash(attributes)
+      return unless attributes.key?('derived_facts')
+
+      derived_facts = attributes.fetch('derived_facts')
+      return if derived_facts.nil?
+
+      {
+        derived_facts: Sequel.pg_array(Array(derived_facts).compact_blank, :text),
+      }
     end
 
     def parse_date(value)

--- a/db/migrate/20260708130000_add_derived_facts_to_public_atar_rulings.rb
+++ b/db/migrate/20260708130000_add_derived_facts_to_public_atar_rulings.rb
@@ -1,0 +1,15 @@
+Sequel.migration do
+  up do
+    alter_table :tariff_knowledge_public_atar_rulings do
+      add_column :derived_facts, 'text[]', null: false, default: Sequel.pg_array([], :text)
+
+      add_index :derived_facts, type: :gin
+    end
+  end
+
+  down do
+    alter_table :tariff_knowledge_public_atar_rulings do
+      drop_column :derived_facts
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -7983,6 +7983,7 @@ CREATE TABLE uk.tariff_knowledge_public_atar_rulings (
     fetched_at timestamp without time zone NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
+    derived_facts text[] DEFAULT '{}'::text[] NOT NULL,
     CONSTRAINT tariff_knowledge_public_atars_commodity_code_format CHECK ((commodity_code ~ '^[0-9]{6}([0-9]{2}){0,2}$'::text)),
     CONSTRAINT tariff_knowledge_public_atars_goods_nomenclature_item_id_format CHECK (((goods_nomenclature_item_id)::text ~ '^[0-9]{10}$'::text)),
     CONSTRAINT tariff_knowledge_public_atars_normalized_goods_nomenclature_ite CHECK (((goods_nomenclature_item_id)::text = rpad(commodity_code, 10, '0'::text)))
@@ -14290,6 +14291,13 @@ CREATE INDEX tariff_knowledge_public_atar_rulings_keywords_index ON uk.tariff_kn
 
 
 --
+-- Name: tariff_knowledge_public_atar_rulings_derived_facts_index; Type: INDEX; Schema: uk; Owner: -
+--
+
+CREATE INDEX tariff_knowledge_public_atar_rulings_derived_facts_index ON uk.tariff_knowledge_public_atar_rulings USING gin (derived_facts);
+
+
+--
 -- Name: tariff_knowledge_public_atar_rulings_raw_fields_index; Type: INDEX; Schema: uk; Owner: -
 --
 
@@ -14750,3 +14758,4 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20260519120000_add_tariff_
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260609120000_create_tariff_knowledge_graph.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260610100000_create_search_analytics_snapshots.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260626120000_create_tariff_knowledge_public_atar_rulings.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20260708130000_add_derived_facts_to_public_atar_rulings.rb');

--- a/spec/factories/tariff_knowledge_factories.rb
+++ b/spec/factories/tariff_knowledge_factories.rb
@@ -54,6 +54,7 @@ FactoryBot.define do
     description { 'Venini, Cardin lights - Set of five.' }
     keywords { Sequel.pg_array(['CEILING LIGHTS', 'OF GLASS'], :text) }
     justification { 'Classification has been determined in accordance with GIR 1.' }
+    derived_facts { Sequel.pg_array([], :text) }
     validity_start_date { Date.new(2026, 6, 26) }
     validity_end_date { Date.new(2029, 6, 25) }
     source_url { "https://www.tax.service.gov.uk/search-for-advance-tariff-rulings/ruling/#{ref}" }

--- a/spec/models/tariff_knowledge/public_atar_ruling_spec.rb
+++ b/spec/models/tariff_knowledge/public_atar_ruling_spec.rb
@@ -26,6 +26,12 @@ RSpec.describe TariffKnowledge::PublicAtarRuling do
       expect(ruling).to be_valid
     end
 
+    it 'allows rulings with AI-generated derived facts' do
+      ruling = build(:tariff_knowledge_public_atar_ruling, derived_facts: Sequel.pg_array(['Murano glass lighting'], :text))
+
+      expect(ruling).to be_valid
+    end
+
     it 'validates normalized commodity association keys' do
       ruling = build(
         :tariff_knowledge_public_atar_ruling,

--- a/spec/services/tariff_knowledge/public_atar_ruling_importer_spec.rb
+++ b/spec/services/tariff_knowledge/public_atar_ruling_importer_spec.rb
@@ -36,6 +36,32 @@ RSpec.describe TariffKnowledge::PublicAtarRulingImporter do
       FileUtils.rm_f(path)
     end
 
+    it 'imports optional AI-generated derived facts from preload rows' do
+      path = Rails.root.join('tmp/public_atar_rulings_preload_spec.json')
+      importer = described_class.new
+      File.write(
+        path,
+        JSON.pretty_generate([
+          ruling_hash(ref: '600015804').merge(
+            'derived_facts' => ['Murano glass lighting', 'designer ceiling lights'],
+          ),
+        ]),
+      )
+
+      importer.import_file(path:)
+
+      File.write(path, JSON.pretty_generate([ruling_hash(ref: '600015804')]))
+      importer.import_file(path:)
+
+      File.write(path, JSON.pretty_generate([ruling_hash(ref: '600015804').merge('derived_facts' => nil)]))
+      importer.import_file(path:)
+
+      ruling = TariffKnowledge::PublicAtarRuling.by_ref('600015804').first
+      expect(ruling.derived_facts).to eq(['Murano glass lighting', 'designer ceiling lights'])
+    ensure
+      FileUtils.rm_f(path)
+    end
+
     it 'counts malformed preload rows and continues importing valid rows' do
       path = Rails.root.join('tmp/public_atar_rulings_preload_spec.json')
       malformed = ruling_hash(ref: '600015805')


### PR DESCRIPTION
## What:

- [x] Add a `derived_facts` text array column to public ATAR rulings.
- [x] Import optional `derived_facts` values from the public ATAR preload JSON.
- [x] Add the generated ATAR fact strings to the preload file, without prompt/review analysis metadata.
- [x] Preserve existing generated facts when live ATAR imports do not include a facts payload.

## Why:

This prepares the backend for reloading public ATAR rulings with concise AI-generated fact strings that can later be used by embeddings and OpenSearch retrieval. The field is additive and not consumed by live search in this PR, so deploying it should not change current trader-facing behaviour.

## Ticket:

[AI-988](https://transformuk.atlassian.net/browse/AI-988)

## Risk:

**Risk level:** 🟢

**Reason for rating:** Additive, currently unused storage and preload data. Existing live ATAR imports continue to work without generated facts, and search behaviour is unchanged until a later PR explicitly incorporates the facts into retrieval.