### PR TITLE
AI-988: Include ATAR facts in search text

### DIFF
--- a/app/lib/trade_tariff_backend/search_client.rb
+++ b/app/lib/trade_tariff_backend/search_client.rb
@@ -34,6 +34,8 @@ module TradeTariffBackend
     end
 
     def reindex(index)
+      index = index_instance(index)
+
       drop_index(index)
       create_index(index)
       build_index(index)
@@ -44,6 +46,8 @@ module TradeTariffBackend
     end
 
     def update(index)
+      index = index_instance(index)
+
       create_index(index)
       build_index(index)
     end
@@ -92,6 +96,12 @@ module TradeTariffBackend
         index: index_name,
         id: model_id,
       }.merge(search_operation_options))
+    end
+
+    private
+
+    def index_instance(index)
+      index.is_a?(Class) ? index.new : index
     end
   end
 end

--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -53,8 +53,9 @@ class GoodsNomenclature < Sequel::Model
   one_to_many :public_atar_rulings,
               class: 'TariffKnowledge::PublicAtarRuling',
               key: :goods_nomenclature_item_id,
-              primary_key: :goods_nomenclature_item_id,
-              &:actual
+              primary_key: :goods_nomenclature_item_id do |ds|
+                ds.actual.order(:ref)
+              end
 
   many_to_many :guides, left_key: :goods_nomenclature_sid,
                         left_primary_key: :goods_nomenclature_sid,

--- a/app/models/tariff_knowledge/public_atar_ruling.rb
+++ b/app/models/tariff_knowledge/public_atar_ruling.rb
@@ -39,5 +39,9 @@ module TariffKnowledge
 
       errors.add(:goods_nomenclature_item_id, 'must match the normalized commodity code') if goods_nomenclature_item_id != commodity_code.ljust(10, '0')
     end
+
+    def search_terms
+      (Array(keywords) + Array(derived_facts)).compact_blank.uniq
+    end
   end
 end

--- a/app/serializers/search/goods_nomenclature_serializer.rb
+++ b/app/serializers/search/goods_nomenclature_serializer.rb
@@ -78,7 +78,7 @@ module Search
     end
 
     def atar_keywords_part
-      keywords = public_atar_rulings.flat_map(&:keywords).compact_blank.uniq
+      keywords = public_atar_rulings.flat_map(&:search_terms).compact_blank.uniq
       keywords.presence
     end
   end

--- a/app/services/composite_search_text_builder.rb
+++ b/app/services/composite_search_text_builder.rb
@@ -22,8 +22,8 @@ class CompositeSearchTextBuilder
   def self.batch(self_text_records)
     return {} if self_text_records.empty?
 
-    sids = self_text_records.map(&:goods_nomenclature_sid)
-    goods_nomenclature_item_ids = self_text_records.map(&:goods_nomenclature_item_id).compact
+    sids = self_text_records.map(&:goods_nomenclature_sid).uniq
+    goods_nomenclature_item_ids = self_text_records.filter_map(&:goods_nomenclature_item_id).uniq
 
     labels_by_sid = GoodsNomenclatureLabel
       .where(goods_nomenclature_sid: sids)
@@ -32,10 +32,11 @@ class CompositeSearchTextBuilder
     atar_keywords_by_item_id = TariffKnowledge::PublicAtarRuling
       .actual
       .where(goods_nomenclature_item_id: goods_nomenclature_item_ids)
-      .select(:goods_nomenclature_item_id, :keywords)
+      .select(:goods_nomenclature_item_id, :keywords, :derived_facts)
+      .order(:goods_nomenclature_item_id, :ref)
       .all
       .group_by(&:goods_nomenclature_item_id)
-      .transform_values { |rulings| rulings.flat_map(&:keywords).compact_blank.uniq }
+      .transform_values { |rulings| rulings.flat_map(&:search_terms).compact_blank.uniq }
 
     gns_by_sid = GoodsNomenclature
       .where(goods_nomenclature_sid: sids)

--- a/spec/lib/trade_tariff_backend/search_client_spec.rb
+++ b/spec/lib/trade_tariff_backend/search_client_spec.rb
@@ -57,4 +57,32 @@ RSpec.describe TradeTariffBackend::SearchClient do
       end
     end
   end
+
+  describe '#reindex' do
+    let(:indices) { instance_double(OpenSearch::API::Indices::IndicesClient) }
+    let(:opensearch_client) { instance_double(OpenSearch::Client, indices:) }
+    let(:search_client) { described_class.new(opensearch_client) }
+    let(:index_class) do
+      Class.new do
+        def name = 'tariff-test-index-uk'
+        def name_without_namespace = 'TestIndex'
+        def definition = { mappings: { properties: {} } }
+        def total_pages = 2
+      end
+    end
+
+    before do
+      allow(indices).to receive(:exists).with(index: 'tariff-test-index-uk').and_return(false)
+      allow(indices).to receive(:create)
+      allow(BuildIndexPageWorker).to receive(:perform_async)
+    end
+
+    it 'accepts an index class and reindexes using an index instance' do
+      search_client.reindex(index_class)
+
+      expect(indices).to have_received(:create).with(index: 'tariff-test-index-uk', body: { mappings: { properties: {} } })
+      expect(BuildIndexPageWorker).to have_received(:perform_async).with('search', 'TestIndex', 1)
+      expect(BuildIndexPageWorker).to have_received(:perform_async).with('search', 'TestIndex', 2)
+    end
+  end
 end

--- a/spec/models/goods_nomenclature_spec.rb
+++ b/spec/models/goods_nomenclature_spec.rb
@@ -18,6 +18,15 @@ RSpec.describe GoodsNomenclature do
       expect(commodity.public_atar_rulings_dataset.all).to contain_exactly(ruling)
     end
 
+    it 'orders public ATAR rulings by reference for stable search text' do
+      commodity = create(:commodity, :declarable, goods_nomenclature_item_id: '6302100000')
+      later_ruling = create(:tariff_knowledge_public_atar_ruling, ref: '600015804', commodity_code: '630210', goods_nomenclature_item_id: '6302100000')
+      earlier_ruling = create(:tariff_knowledge_public_atar_ruling, ref: '600004365', commodity_code: '630210', goods_nomenclature_item_id: '6302100000')
+
+      expect(commodity.public_atar_rulings).to eq([earlier_ruling, later_ruling])
+      expect(commodity.public_atar_rulings_dataset.all).to eq([earlier_ruling, later_ruling])
+    end
+
     it 'eager loads public ATAR rulings' do
       commodity = create(:commodity, :declarable, goods_nomenclature_item_id: '6302100000')
       other_commodity = create(:commodity, :declarable, goods_nomenclature_item_id: '6404199000')

--- a/spec/models/tariff_knowledge/public_atar_ruling_spec.rb
+++ b/spec/models/tariff_knowledge/public_atar_ruling_spec.rb
@@ -76,4 +76,16 @@ RSpec.describe TariffKnowledge::PublicAtarRuling do
       end
     end
   end
+
+  describe '#search_terms' do
+    it 'combines keywords and derived facts for search surfaces' do
+      ruling = build(
+        :tariff_knowledge_public_atar_ruling,
+        keywords: Sequel.pg_array(['riding horses', '', 'show ponies'], :text),
+        derived_facts: Sequel.pg_array(['equestrian sports', 'show ponies'], :text),
+      )
+
+      expect(ruling.search_terms).to eq(['riding horses', 'show ponies', 'equestrian sports'])
+    end
+  end
 end

--- a/spec/serializers/search/goods_nomenclature_serializer_spec.rb
+++ b/spec/serializers/search/goods_nomenclature_serializer_spec.rb
@@ -94,12 +94,25 @@ RSpec.describe Search::GoodsNomenclatureSerializer do
         create(:tariff_knowledge_public_atar_ruling,
                commodity_code: '0101210000',
                goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
-               keywords: Sequel.pg_array(['riding horses', 'show ponies', '', 'riding horses'], :text))
+               keywords: Sequel.pg_array(['riding horses', 'show ponies', '', 'riding horses'], :text),
+               derived_facts: Sequel.pg_array(['equestrian sports', 'show ponies', ''], :text))
         commodity.reload
       end
 
-      it 'includes unique nonblank ATAR keywords for OpenSearch' do
-        expect(result[:atar_keywords]).to eq(['riding horses', 'show ponies'])
+      it 'includes unique nonblank ATAR keywords and derived facts for OpenSearch' do
+        expect(result[:atar_keywords]).to eq(['riding horses', 'show ponies', 'equestrian sports'])
+      end
+
+      it 'includes derived facts when no official keywords are present' do
+        TariffKnowledge::PublicAtarRuling.dataset.delete
+        create(:tariff_knowledge_public_atar_ruling,
+               commodity_code: '0101210000',
+               goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
+               keywords: Sequel.pg_array([], :text),
+               derived_facts: Sequel.pg_array(['equestrian sports'], :text))
+        commodity.reload
+
+        expect(result[:atar_keywords]).to eq(['equestrian sports'])
       end
     end
 

--- a/spec/services/composite_search_text_builder_spec.rb
+++ b/spec/services/composite_search_text_builder_spec.rb
@@ -218,11 +218,55 @@ RSpec.describe CompositeSearchTextBuilder do
       create(:tariff_knowledge_public_atar_ruling,
              commodity_code: '630210',
              goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
-             keywords: Sequel.pg_array(['cotton sheets', 'bed linen'], :text))
+             keywords: Sequel.pg_array(['cotton sheets', 'bed linen'], :text),
+             derived_facts: Sequel.pg_array(['hotel bedding', 'bed linen'], :text))
 
       result = described_class.batch([self_text])
 
-      expect(result[commodity.goods_nomenclature_sid]).to include('ATAR keywords: cotton sheets, bed linen')
+      expect(result[commodity.goods_nomenclature_sid]).to include('ATAR keywords: cotton sheets, bed linen, hotel bedding')
+    end
+
+    it 'includes public ATAR derived facts when no official keywords are present' do
+      commodity = create(:commodity, :with_description, :declarable,
+                         goods_nomenclature_item_id: '6302100000')
+      self_text = create(:goods_nomenclature_self_text,
+                         goods_nomenclature_sid: commodity.goods_nomenclature_sid,
+                         goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
+                         self_text: 'Bed linen commodity')
+      create(:tariff_knowledge_public_atar_ruling,
+             commodity_code: '630210',
+             goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
+             keywords: Sequel.pg_array([], :text),
+             derived_facts: Sequel.pg_array(['hotel bedding'], :text))
+
+      result = described_class.batch([self_text])
+
+      expect(result[commodity.goods_nomenclature_sid]).to include('ATAR keywords: hotel bedding')
+    end
+
+    it 'orders public ATAR search terms by ruling reference' do
+      commodity = create(:commodity, :with_description, :declarable,
+                         goods_nomenclature_item_id: '6302100000')
+      self_text = create(:goods_nomenclature_self_text,
+                         goods_nomenclature_sid: commodity.goods_nomenclature_sid,
+                         goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
+                         self_text: 'Bed linen commodity')
+      create(:tariff_knowledge_public_atar_ruling,
+             ref: '600015804',
+             commodity_code: '630210',
+             goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
+             keywords: Sequel.pg_array(['later keyword'], :text),
+             derived_facts: Sequel.pg_array(['later fact'], :text))
+      create(:tariff_knowledge_public_atar_ruling,
+             ref: '600004365',
+             commodity_code: '630210',
+             goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
+             keywords: Sequel.pg_array(['earlier keyword'], :text),
+             derived_facts: Sequel.pg_array(['earlier fact'], :text))
+
+      result = described_class.batch([self_text])
+
+      expect(result[commodity.goods_nomenclature_sid]).to include('ATAR keywords: earlier keyword, earlier fact, later keyword, later fact')
     end
   end
 end


### PR DESCRIPTION
## What:

- [x] Include public ATAR `derived_facts` alongside official ATAR keywords in the OpenSearch `atar_keywords` field.
- [x] Include public ATAR `derived_facts` in the composite search text used for vector embeddings.
- [x] Preserve existing de-duplication and blank filtering for ATAR search terms.

## Why:

The previous PR stores generated ATAR facts, but search still only consumed official ATAR keywords. This wires the stored facts into the same shortlist/search text surfaces so they are available when the ATAR fact capability is preloaded and indexed.

## Ticket:

[AI-988](https://transformuk.atlassian.net/browse/AI-988)

## Risk:

**Risk level:** 🟢

**Reason for rating:** Additive wiring for ATAR fact fields that are not live-used yet. Existing keyword behavior is preserved, generated facts are appended through the same field, and no search query shape or endpoint behavior changes until the fact data is preloaded/reindexed.
