### PR TITLE
AI-994: Capture AI token usage and cost telemetry

### DIFF
--- a/app/lib/ai_usage.rb
+++ b/app/lib/ai_usage.rb
@@ -1,0 +1,112 @@
+module AiUsage
+  LOG_FIELDS = %i[provider model event_kind input_tokens output_tokens total_tokens input_cost_usd output_cost_usd total_cost_usd pricing_known].freeze
+  Metadata = Data.define(*LOG_FIELDS)
+
+  module_function
+
+  def metadata_for(model:, event_kind:, usage:)
+    usage = normalize_usage(usage)
+    pricing = pricing_for(model)
+    input_price = price_for(pricing, 'input_per_million_tokens')
+    output_price = price_for(pricing, 'output_per_million_tokens')
+    input_tokens = usage[:input_tokens]
+    output_tokens = usage[:output_tokens]
+    input_cost = cost_for(input_tokens, input_price)
+    output_cost = cost_for(output_tokens, output_price)
+
+    Metadata.new(
+      provider: 'openai',
+      model:,
+      event_kind:,
+      input_tokens:,
+      output_tokens:,
+      total_tokens: usage[:total_tokens] || [input_tokens, output_tokens].compact.sum,
+      input_cost_usd: input_cost,
+      output_cost_usd: output_cost,
+      total_cost_usd: [input_cost, output_cost].compact.then { |costs| costs.sum if costs.any? },
+      pricing_known: pricing_known?(pricing, input_tokens:, output_tokens:, input_price:, output_price:),
+    )
+  end
+
+  def attach_metadata(result, metadata)
+    return result unless metadata && (result.is_a?(Array) || result.is_a?(Hash) || result.is_a?(String))
+
+    result.define_singleton_method(:ai_usage) { metadata }
+    result
+  rescue TypeError
+    result
+  end
+
+  def metadata_from(object)
+    object.ai_usage if object.respond_to?(:ai_usage)
+  end
+
+  def payload_from(object) = metadata_from(object)&.to_h&.compact || {}
+
+  def payload_from_error(error) = error.respond_to?(:ai_usage) && error.ai_usage ? error.ai_usage.to_h.compact : {}
+
+  def safe_error_message(error)
+    return "OpenAI API error status=#{error.status}" if error.is_a?(OpenaiClient::ApiError)
+
+    error.message.to_s.truncate(500)
+  end
+
+  def add_log_fields!(data, event)
+    LOG_FIELDS.each { |key| data[key] = event.payload[key] if event.payload.key?(key) }
+    data
+  end
+
+  def merge_metadata(left, right)
+    left = metadata_from(left) || left
+    right = metadata_from(right) || right
+    return left unless right
+    return right unless left
+
+    Metadata.new(
+      provider: left.provider,
+      model: left.model,
+      event_kind: left.event_kind || right.event_kind,
+      input_tokens: [left.input_tokens, right.input_tokens].compact.sum,
+      output_tokens: [left.output_tokens, right.output_tokens].compact.sum,
+      total_tokens: [left.total_tokens, right.total_tokens].compact.sum,
+      input_cost_usd: sum_cost(left.input_cost_usd, right.input_cost_usd),
+      output_cost_usd: sum_cost(left.output_cost_usd, right.output_cost_usd),
+      total_cost_usd: sum_cost(left.total_cost_usd, right.total_cost_usd),
+      pricing_known: left.pricing_known && right.pricing_known,
+    )
+  end
+
+  def normalize_usage(usage)
+    usage = usage.respond_to?(:to_h) ? usage.to_h : {}
+    {
+      input_tokens: integer_value(usage['prompt_tokens'] || usage[:prompt_tokens] || usage['input_tokens'] || usage[:input_tokens]),
+      output_tokens: integer_value(usage['completion_tokens'] || usage[:completion_tokens] || usage['output_tokens'] || usage[:output_tokens]),
+      total_tokens: integer_value(usage['total_tokens'] || usage[:total_tokens]),
+    }
+  end
+
+  def pricing_for(model)
+    pricing = TradeTariffBackend.openai_model_pricing
+    pricing.is_a?(Hash) ? pricing.fetch(model.to_s, {}) : {}
+  end
+
+  def price_for(pricing, key)
+    Float(pricing[key], exception: false) if pricing.is_a?(Hash)
+  end
+
+  def cost_for(tokens, per_million_tokens)
+    tokens * per_million_tokens / 1_000_000.0 if tokens && per_million_tokens
+  end
+
+  def pricing_known?(pricing, input_tokens:, output_tokens:, input_price:, output_price:)
+    !!(pricing.present? && pricing.is_a?(Hash) &&
+      (input_tokens.to_i <= 0 || input_price) &&
+      (output_tokens.to_i <= 0 || output_price))
+  end
+
+  def sum_cost(left, right) = [left, right].compact.then { |costs| costs.sum if costs.any? }
+
+  def integer_value(value)
+    Integer(value, exception: false) unless value.nil?
+  end
+end

--- a/app/lib/ai_usage/instrumentation.rb
+++ b/app/lib/ai_usage/instrumentation.rb
@@ -1,0 +1,64 @@
+require 'active_support/notifications'
+require_relative 'logger'
+
+module AiUsage
+  module Instrumentation
+    module_function
+
+    def instrument(event_name, payload = {}, &block)
+      ActiveSupport::Notifications.instrument("#{event_name}.ai_usage", payload, &block)
+    end
+
+    def api_call(event_kind:, model:, batch_size: nil, &block)
+      call('api_call', event_kind:, batch_size:, model:, &block)
+    end
+
+    def embedding_api_call(event_kind:, batch_size:, model:, &block)
+      call('embedding_api_call', event_kind:, batch_size:, model:, &block)
+    end
+
+    def embedding_api_retry(event_kind:, batch_size:, model:, attempt:, delay:, error:)
+      instrument(
+        'embedding_api_retry',
+        event_kind:,
+        batch_size:,
+        model:,
+        attempt:,
+        delay:,
+        error_class: error.class.name,
+        error_message: AiUsage.safe_error_message(error),
+      )
+    end
+
+    def call(event_prefix, event_kind:, batch_size:, model:)
+      start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      result = yield
+      duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
+
+      instrument(
+        "#{event_prefix}_completed",
+        event_payload(event_kind:, batch_size:, model:, duration:).merge(AiUsage.payload_from(result)),
+      )
+      result
+    rescue StandardError => e
+      duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
+      instrument(
+        "#{event_prefix}_failed",
+        event_payload(event_kind:, batch_size:, model:, duration:).merge(
+          error_class: e.class.name,
+          error_message: AiUsage.safe_error_message(e),
+        ).merge(AiUsage.payload_from_error(e)),
+      )
+      raise
+    end
+
+    def event_payload(event_kind:, batch_size:, model:, duration:)
+      {
+        event_kind:,
+        batch_size:,
+        model:,
+        duration_ms: (duration * 1000).round(2),
+      }
+    end
+  end
+end

--- a/app/lib/ai_usage/logger.rb
+++ b/app/lib/ai_usage/logger.rb
@@ -1,0 +1,44 @@
+require 'active_support/log_subscriber'
+
+module AiUsage
+  class Logger < ActiveSupport::LogSubscriber
+    %w[api_call_completed embedding_api_call_completed].each do |event_name|
+      define_method(event_name) { |event| info log_entry(base_payload(event_name, event)) }
+    end
+
+    %w[api_call_failed embedding_api_call_failed].each do |event_name|
+      define_method(event_name) { |event| error log_entry(error_payload(event_name, event)) }
+    end
+
+  private
+
+    def error_payload(event_name, event)
+      base_payload(event_name, event).merge(
+        error_class: event.payload[:error_class],
+        error_message: event.payload[:error_message],
+      )
+    end
+
+    def base_payload(event_name, event)
+      data = {
+        event: event_name,
+        event_kind: event.payload[:event_kind],
+        batch_size: event.payload[:batch_size],
+        model: event.payload[:model],
+        duration_ms: event.payload[:duration_ms],
+      }
+      add_ai_usage_fields!(data, event)
+      data
+    end
+
+    def log_entry(data)
+      data.merge(service: 'ai_usage', timestamp: Time.current.iso8601).to_json
+    end
+
+    def add_ai_usage_fields!(data, event)
+      AiUsage.add_log_fields!(data, event)
+    end
+  end
+end
+
+AiUsage::Logger.attach_to :ai_usage unless Rails.env.test?

--- a/app/lib/embedding_service.rb
+++ b/app/lib/embedding_service.rb
@@ -27,11 +27,14 @@ class EmbeddingService
   class ServerError < ApiError; end
   class ClientError < ApiError; end
 
-  def embed(text)
-    embed_batch([text]).first
+  def embed(text, event_kind: nil)
+    embeddings = embed_batch([text], event_kind:)
+    embedding = embeddings.first
+    AiUsage.attach_metadata(embedding, AiUsage.metadata_from(embeddings)) if embedding
+    embedding
   end
 
-  def embed_batch(texts)
+  def embed_batch(texts, event_kind: nil)
     present_indices = []
     filtered_texts = []
 
@@ -45,9 +48,10 @@ class EmbeddingService
     return Array.new(texts.size) if filtered_texts.empty?
 
     embeddings = Array.new(texts.size)
+    usage = nil
 
     filtered_texts.each_slice(BATCH_SIZE).each_with_index do |batch, slice_index|
-      response = with_retry do
+      response = with_retry(event_kind:, batch_size: batch.size) do
         resp = client.post('embeddings', { model: MODEL, input: batch }.to_json)
 
         if RETRYABLE_HTTP_STATUSES.include?(resp.status)
@@ -58,6 +62,8 @@ class EmbeddingService
       end
 
       if response.success?
+        usage = AiUsage.merge_metadata(usage, usage_metadata(response.body, event_kind:))
+
         batch_embeddings = response.body['data']
           .sort_by { |d| d['index'] }
           .map { |d| d['embedding'] }
@@ -71,12 +77,20 @@ class EmbeddingService
       end
     end
 
-    embeddings
+    AiUsage.attach_metadata(embeddings, usage)
   end
 
   private
 
-  def with_retry
+  def usage_metadata(body, event_kind:)
+    usage = body.to_h['usage']
+    return unless usage
+
+    usage = usage.to_h.merge('completion_tokens' => 0) unless usage.to_h.key?('completion_tokens')
+    AiUsage.metadata_for(model: MODEL, event_kind:, usage:)
+  end
+
+  def with_retry(event_kind:, batch_size:)
     attempts = 0
 
     begin
@@ -85,7 +99,14 @@ class EmbeddingService
     rescue *RETRYABLE_ERRORS, ServerError => e
       if attempts < MAX_RETRIES
         delay = RETRY_DELAY * (2**(attempts - 1))
-        SelfTextGenerator::Instrumentation.embedding_api_retry(attempt: attempts, delay:, error: e)
+        AiUsage::Instrumentation.embedding_api_retry(
+          event_kind:,
+          batch_size:,
+          model: MODEL,
+          attempt: attempts,
+          delay:,
+          error: e,
+        )
         Kernel.sleep delay
         retry
       else

--- a/app/lib/label_generator/instrumentation.rb
+++ b/app/lib/label_generator/instrumentation.rb
@@ -46,11 +46,14 @@ module LabelGenerator
 
       instrument(
         'api_call_completed',
-        batch_size:,
-        model:,
-        page_number:,
-        results_count:,
-        duration_ms: (duration * 1000).round(2),
+        {
+          batch_size:,
+          model:,
+          page_number:,
+          results_count:,
+          duration_ms: (duration * 1000).round(2),
+          event_kind: 'label_generation',
+        }.merge(AiUsage.payload_from(result)),
       )
 
       result
@@ -58,12 +61,15 @@ module LabelGenerator
       duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
       instrument(
         'api_call_failed',
-        batch_size:,
-        model:,
-        page_number:,
-        error_class: e.class.name,
-        error_message: e.message,
-        duration_ms: (duration * 1000).round(2),
+        {
+          batch_size:,
+          model:,
+          page_number:,
+          error_class: e.class.name,
+          error_message: AiUsage.safe_error_message(e),
+          duration_ms: (duration * 1000).round(2),
+          event_kind: 'label_generation',
+        }.merge(AiUsage.payload_from_error(e)),
       )
       raise
     end
@@ -124,9 +130,12 @@ module LabelGenerator
 
       instrument(
         'embedding_api_call_completed',
-        batch_size:,
-        model:,
-        duration_ms: (duration * 1000).round(2),
+        {
+          batch_size:,
+          model:,
+          duration_ms: (duration * 1000).round(2),
+          event_kind: 'label_scoring_embedding',
+        }.merge(AiUsage.payload_from(result)),
       )
 
       result
@@ -136,12 +145,15 @@ module LabelGenerator
 
       instrument(
         'embedding_api_call_failed',
-        batch_size:,
-        model:,
-        error_class: e.class.name,
-        error_message: e.message,
-        duration_ms: (duration * 1000).round(2),
-        http_status:,
+        {
+          batch_size:,
+          model:,
+          error_class: e.class.name,
+          error_message: AiUsage.safe_error_message(e),
+          duration_ms: (duration * 1000).round(2),
+          http_status:,
+          event_kind: 'label_scoring_embedding',
+        }.merge(AiUsage.payload_from_error(e)),
       )
       raise
     end

--- a/app/lib/label_generator/logger.rb
+++ b/app/lib/label_generator/logger.rb
@@ -58,18 +58,20 @@ module LabelGenerator
     end
 
     def api_call_completed(event)
-      info log_entry(
+      data = {
         event: 'api_call_completed',
         page_number: event.payload[:page_number],
         batch_size: event.payload[:batch_size],
         results_count: event.payload[:results_count],
         model: event.payload[:model],
         duration_ms: event.payload[:duration_ms],
-      )
+      }
+      add_ai_usage_fields!(data, event)
+      info log_entry(data)
     end
 
     def api_call_failed(event)
-      error log_entry(
+      data = {
         event: 'api_call_failed',
         page_number: event.payload[:page_number],
         batch_size: event.payload[:batch_size],
@@ -77,7 +79,9 @@ module LabelGenerator
         error_class: event.payload[:error_class],
         error_message: event.payload[:error_message],
         duration_ms: event.payload[:duration_ms],
-      )
+      }
+      add_ai_usage_fields!(data, event)
+      error log_entry(data)
     end
 
     def label_saved(event)
@@ -143,16 +147,18 @@ module LabelGenerator
     end
 
     def embedding_api_call_completed(event)
-      info log_entry(
+      data = {
         event: 'embedding_api_call_completed',
         batch_size: event.payload[:batch_size],
         model: event.payload[:model],
         duration_ms: event.payload[:duration_ms],
-      )
+      }
+      add_ai_usage_fields!(data, event)
+      info log_entry(data)
     end
 
     def embedding_api_call_failed(event)
-      error log_entry(
+      data = {
         event: 'embedding_api_call_failed',
         batch_size: event.payload[:batch_size],
         model: event.payload[:model],
@@ -160,7 +166,9 @@ module LabelGenerator
         error_message: event.payload[:error_message],
         duration_ms: event.payload[:duration_ms],
         http_status: event.payload[:http_status],
-      )
+      }
+      add_ai_usage_fields!(data, event)
+      error log_entry(data)
     end
 
     private
@@ -170,6 +178,10 @@ module LabelGenerator
         service: 'label_generator',
         timestamp: Time.current.iso8601,
       ).to_json
+    end
+
+    def add_ai_usage_fields!(data, event)
+      AiUsage.add_log_fields!(data, event)
     end
   end
 end

--- a/app/lib/openai_client.rb
+++ b/app/lib/openai_client.rb
@@ -1,20 +1,21 @@
 class OpenaiClient
   class ApiError < StandardError
-    attr_reader :status, :body
+    attr_reader :status, :body, :ai_usage
 
-    def initialize(status:, body:)
+    def initialize(status:, body:, ai_usage: nil)
       @status = status
       @body = body
-      super("OpenAI API error (HTTP #{status}): #{body}")
+      @ai_usage = ai_usage
+      super("OpenAI API error status=#{status}")
     end
   end
 
   class RateLimitError < ApiError
     attr_reader :retry_after
 
-    def initialize(status:, body:, retry_after: nil)
+    def initialize(status:, body:, retry_after: nil, ai_usage: nil)
       @retry_after = retry_after&.to_f
-      super(status: status, body: body)
+      super(status: status, body: body, ai_usage:)
     end
   end
 
@@ -30,7 +31,7 @@ class OpenaiClient
     Net::OpenTimeout,
   ].freeze
 
-  def call(context, model: nil, reasoning_effort: nil)
+  def call(context, model: nil, reasoning_effort: nil, event_kind: nil)
     messages = if context.is_a?(Array)
                  context
                else
@@ -51,27 +52,42 @@ class OpenaiClient
     with_retry do
       response = self.class.client.post('chat/completions', body)
 
-      raise_on_error!(response) unless response.success?
+      raise_on_error!(response, model:, event_kind:) unless response.success?
 
       json = response.body.dig('choices', 0, 'message', 'content') || ''
 
-      begin
+      result = begin
         JSON.parse(json)
       rescue StandardError
         json
       end
+
+      AiUsage.attach_metadata(result, usage_metadata(response.body, model:, event_kind:))
     end
   end
 
   private
 
-  def raise_on_error!(response)
+  def raise_on_error!(response, model: nil, event_kind: nil)
+    ai_usage = usage_metadata(response.body, model:, event_kind:)
+
     if response.status == 429
       retry_after = response.headers['Retry-After'] || response.headers['retry-after']
-      raise RateLimitError.new(status: response.status, body: response.body, retry_after: retry_after)
+      raise RateLimitError.new(status: response.status, body: response.body, retry_after: retry_after, ai_usage:)
     end
 
-    raise ApiError.new(status: response.status, body: response.body)
+    raise ApiError.new(status: response.status, body: response.body, ai_usage:)
+  end
+
+  def usage_metadata(body, model:, event_kind:)
+    return unless body.respond_to?(:to_h)
+
+    body = body.to_h
+    error = body['error']
+    usage = body['usage'] || (error['usage'] if error.is_a?(Hash))
+    return unless usage
+
+    AiUsage.metadata_for(model:, event_kind:, usage:)
   end
 
   def with_retry
@@ -104,9 +120,9 @@ class OpenaiClient
   end
 
   class << self
-    def call(context, model: nil, reasoning_effort: nil)
+    def call(context, model: nil, reasoning_effort: nil, event_kind: nil)
       instrument do
-        new.call(context, model: model, reasoning_effort: reasoning_effort)
+        new.call(context, model: model, reasoning_effort: reasoning_effort, event_kind:)
       end
     end
 

--- a/app/lib/search/instrumentation.rb
+++ b/app/lib/search/instrumentation.rb
@@ -87,7 +87,8 @@ module Search
           iteration:,
           effective_query:,
           operation:,
-        }.merge(error_payload_for_result(result)),
+          event_kind: operation,
+        }.merge(error_payload_for_result(result)).merge(AiUsage.payload_from(result)),
       )
 
       result
@@ -105,9 +106,10 @@ module Search
           iteration:,
           effective_query:,
           operation:,
-        }.merge(truncate_error_payload(e.message)),
+          event_kind: operation,
+        }.merge(truncate_error_payload(AiUsage.safe_error_message(e))).merge(AiUsage.payload_from_error(e)),
       )
-      search_failed(request_id:, error_type: e.class.name, error_message: e.message, search_type: 'interactive') if emit_search_failed
+      search_failed(request_id:, error_type: e.class.name, error_message: AiUsage.safe_error_message(e), search_type: 'interactive') if emit_search_failed
       raise
     end
 

--- a/app/lib/search/logger.rb
+++ b/app/lib/search/logger.rb
@@ -64,6 +64,7 @@ module Search
         effective_query: event.payload[:effective_query],
         operation: event.payload[:operation],
       }
+      add_ai_usage_fields!(data, event)
       add_error_fields!(data, event)
       info log_entry(data, event)
     end
@@ -295,6 +296,10 @@ module Search
 
       data[:error_message] = event.payload[:error_message]
       data[:error_message_truncated] = event.payload[:error_message_truncated]
+    end
+
+    def add_ai_usage_fields!(data, event)
+      AiUsage.add_log_fields!(data, event)
     end
   end
 end

--- a/app/lib/self_text_generator/instrumentation.rb
+++ b/app/lib/self_text_generator/instrumentation.rb
@@ -34,7 +34,7 @@ module SelfTextGenerator
       )
     end
 
-    def api_call(batch_size:, model:, chapter_code:)
+    def api_call(batch_size:, model:, chapter_code:, event_kind: 'self_text_generation_ai')
       instrument('api_call_started', batch_size:, model:, chapter_code:)
 
       start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
@@ -43,10 +43,13 @@ module SelfTextGenerator
 
       instrument(
         'api_call_completed',
-        batch_size:,
-        model:,
-        chapter_code:,
-        duration_ms: (duration * 1000).round(2),
+        {
+          batch_size:,
+          model:,
+          chapter_code:,
+          duration_ms: (duration * 1000).round(2),
+          event_kind:,
+        }.merge(AiUsage.payload_from(result)),
       )
 
       result
@@ -60,13 +63,16 @@ module SelfTextGenerator
 
       instrument(
         'api_call_failed',
-        batch_size:,
-        model:,
-        chapter_code:,
-        error_class: e.class.name,
-        error_message: e.message,
-        duration_ms: (duration * 1000).round(2),
-        http_status:,
+        {
+          batch_size:,
+          model:,
+          chapter_code:,
+          error_class: e.class.name,
+          error_message: AiUsage.safe_error_message(e),
+          duration_ms: (duration * 1000).round(2),
+          http_status:,
+          event_kind:,
+        }.merge(AiUsage.payload_from_error(e)),
       )
       raise
     end
@@ -105,10 +111,13 @@ module SelfTextGenerator
 
       instrument(
         'embedding_api_call_completed',
-        batch_size:,
-        model:,
-        chapter_code:,
-        duration_ms: (duration * 1000).round(2),
+        {
+          batch_size:,
+          model:,
+          chapter_code:,
+          duration_ms: (duration * 1000).round(2),
+          event_kind: 'self_text_scoring_embedding',
+        }.merge(AiUsage.payload_from(result)),
       )
 
       result
@@ -122,13 +131,16 @@ module SelfTextGenerator
 
       instrument(
         'embedding_api_call_failed',
-        batch_size:,
-        model:,
-        chapter_code:,
-        error_class: e.class.name,
-        error_message: e.message,
-        duration_ms: (duration * 1000).round(2),
-        http_status:,
+        {
+          batch_size:,
+          model:,
+          chapter_code:,
+          error_class: e.class.name,
+          error_message: AiUsage.safe_error_message(e),
+          duration_ms: (duration * 1000).round(2),
+          http_status:,
+          event_kind: 'self_text_scoring_embedding',
+        }.merge(AiUsage.payload_from_error(e)),
       )
       raise
     end

--- a/app/lib/self_text_generator/logger.rb
+++ b/app/lib/self_text_generator/logger.rb
@@ -54,17 +54,19 @@ module SelfTextGenerator
     end
 
     def api_call_completed(event)
-      info log_entry(
+      data = {
         event: 'api_call_completed',
         batch_size: event.payload[:batch_size],
         model: event.payload[:model],
         chapter_code: event.payload[:chapter_code],
         duration_ms: event.payload[:duration_ms],
-      )
+      }
+      add_ai_usage_fields!(data, event)
+      info log_entry(data)
     end
 
     def api_call_failed(event)
-      error log_entry(
+      data = {
         event: 'api_call_failed',
         batch_size: event.payload[:batch_size],
         model: event.payload[:model],
@@ -73,7 +75,9 @@ module SelfTextGenerator
         error_message: event.payload[:error_message],
         duration_ms: event.payload[:duration_ms],
         http_status: event.payload[:http_status],
-      )
+      }
+      add_ai_usage_fields!(data, event)
+      error log_entry(data)
     end
 
     def scoring_started(event)
@@ -115,17 +119,19 @@ module SelfTextGenerator
     end
 
     def embedding_api_call_completed(event)
-      info log_entry(
+      data = {
         event: 'embedding_api_call_completed',
         batch_size: event.payload[:batch_size],
         model: event.payload[:model],
         chapter_code: event.payload[:chapter_code],
         duration_ms: event.payload[:duration_ms],
-      )
+      }
+      add_ai_usage_fields!(data, event)
+      info log_entry(data)
     end
 
     def embedding_api_call_failed(event)
-      error log_entry(
+      data = {
         event: 'embedding_api_call_failed',
         batch_size: event.payload[:batch_size],
         model: event.payload[:model],
@@ -134,7 +140,9 @@ module SelfTextGenerator
         error_message: event.payload[:error_message],
         duration_ms: event.payload[:duration_ms],
         http_status: event.payload[:http_status],
-      )
+      }
+      add_ai_usage_fields!(data, event)
+      error log_entry(data)
     end
 
     def embedding_api_retry(event)
@@ -161,6 +169,10 @@ module SelfTextGenerator
         service: 'self_text_generator',
         timestamp: Time.current.iso8601,
       ).to_json
+    end
+
+    def add_ai_usage_fields!(data, event)
+      AiUsage.add_log_fields!(data, event)
     end
   end
 end

--- a/app/lib/trade_tariff_backend/config.rb
+++ b/app/lib/trade_tariff_backend/config.rb
@@ -276,6 +276,10 @@ module TradeTariffBackend
       ENV.fetch('OPENAI_API_OPEN_TIMEOUT', '60').to_i
     end
 
+    def openai_model_pricing
+      Rails.application.config.x.openai_model_pricing || {}
+    end
+
     # Goods nomenclature
     def goods_nomenclature_label_page_size
       ENV.fetch('GOODS_NOMENCLATURE_LABEL_PAGE_SIZE', '10').to_i

--- a/app/models/goods_nomenclature_self_text.rb
+++ b/app/models/goods_nomenclature_self_text.rb
@@ -136,7 +136,11 @@ class GoodsNomenclatureSelfText < Sequel::Model
 
       records.each_slice(EmbeddingService::BATCH_SIZE) do |batch|
         texts = batch.map { |r| composite_texts[r.goods_nomenclature_sid] }
-        embeddings = embedding_service.embed_batch(texts)
+        embeddings = AiUsage::Instrumentation.embedding_api_call(
+          event_kind: 'composite_search_embedding',
+          batch_size: texts.size,
+          model: EmbeddingService::MODEL,
+        ) { embedding_service.embed_batch(texts, event_kind: 'composite_search_embedding') }
         bulk_update_embeddings(batch, composite_texts, embeddings)
       end
     end

--- a/app/services/expand_search_query_service.rb
+++ b/app/services/expand_search_query_service.rb
@@ -37,7 +37,20 @@ class ExpandSearchQueryService
     cached = Rails.cache.read(cache_key)
     return Result.new(**cached.symbolize_keys) if cached
 
-    response = OpenaiClient.call(context_for(query), model: configured_model, reasoning_effort: configured_reasoning_effort)
+    response = Search::Instrumentation.api_call(
+      request_id: nil,
+      model: configured_model,
+      attempt_number: 1,
+      operation: 'search_query_expansion',
+      emit_search_failed: false,
+    ) do
+      OpenaiClient.call(
+        context_for(query),
+        model: configured_model,
+        reasoning_effort: configured_reasoning_effort,
+        event_kind: 'search_query_expansion',
+      )
+    end
 
     if response.is_a?(Hash) && response['expanded_query'].present?
       result_hash = { expanded_query: response['expanded_query'], reason: response['reason'] }

--- a/app/services/generate_self_text/base_self_text_builder.rb
+++ b/app/services/generate_self_text/base_self_text_builder.rb
@@ -90,7 +90,8 @@ module GenerateSelfText
         batch_size: batch.size,
         model: model,
         chapter_code: chapter.short_code,
-      ) { TradeTariffBackend.ai_client.call(messages, model: model, reasoning_effort: reasoning_effort) }
+        event_kind: self_text_event_kind,
+      ) { TradeTariffBackend.ai_client.call(messages, model: model, reasoning_effort: reasoning_effort, event_kind: self_text_event_kind) }
 
       descriptions = parse_response(response)
 
@@ -124,6 +125,10 @@ module GenerateSelfText
       end
 
       ScoreSelfTextBatchWorker.perform_async(batch_sids, chapter.short_code) if batch_sids.any?
+    end
+
+    def self_text_event_kind
+      'self_text_generation_ai'
     end
 
     def build_messages(batch)

--- a/app/services/generate_self_text/non_other_self_text_builder.rb
+++ b/app/services/generate_self_text/non_other_self_text_builder.rb
@@ -7,6 +7,7 @@ module GenerateSelfText
     end
 
     def generation_type = 'ai_non_other'
+    def self_text_event_kind = 'self_text_generation_ai_non_other'
     def system_prompt_config_key = 'non_other_self_text_context'
     def model_config_key = 'non_other_self_text_model'
     def batch_size_config_key = 'non_other_self_text_batch_size'

--- a/app/services/interactive_search/duplicate_question_guard.rb
+++ b/app/services/interactive_search/duplicate_question_guard.rb
@@ -126,6 +126,7 @@ module InteractiveSearch
           validator_prompt,
           model: model_config[:selected],
           reasoning_effort: model_config[:sub_values]['reasoning_effort'],
+          event_kind: 'duplicate_question_validator',
         )
       end
       parsed = ExtractBottomJson.call(response)

--- a/app/services/interactive_search_service.rb
+++ b/app/services/interactive_search_service.rb
@@ -251,7 +251,7 @@ class InteractiveSearchService
       iteration: attempt,
       effective_query: expanded_query,
       operation: operation,
-    ) { OpenaiClient.call(context, model: configured_model, reasoning_effort: configured_reasoning_effort) }
+    ) { OpenaiClient.call(context, model: configured_model, reasoning_effort: configured_reasoning_effort, event_kind: operation) }
 
     ExtractBottomJson.call(response)
   end

--- a/app/services/label_confidence_scorer.rb
+++ b/app/services/label_confidence_scorer.rb
@@ -115,7 +115,7 @@ class LabelConfidenceScorer
       batch_embeddings = LabelGenerator::Instrumentation.embedding_api_call(
         batch_size: batch.size,
         model: EmbeddingService::MODEL,
-      ) { embedding_service.embed_batch(batch) }
+      ) { embedding_service.embed_batch(batch, event_kind: 'label_scoring_embedding') }
 
       all_embeddings.concat(batch_embeddings)
     end

--- a/app/services/label_service.rb
+++ b/app/services/label_service.rb
@@ -14,7 +14,12 @@ class LabelService
     result = nil
 
     LabelGenerator::Instrumentation.api_call(batch_size: batch.size, model:, page_number:) do
-      result = TradeTariffBackend.ai_client.call(context_for(batch), model: model, reasoning_effort: reasoning_effort)
+      result = TradeTariffBackend.ai_client.call(
+        context_for(batch),
+        model: model,
+        reasoning_effort: reasoning_effort,
+        event_kind: 'label_generation',
+      )
       result
     end
 

--- a/app/services/self_text_confidence_scorer.rb
+++ b/app/services/self_text_confidence_scorer.rb
@@ -97,7 +97,7 @@ class SelfTextConfidenceScorer
         batch_size: texts.size,
         model: EmbeddingService::MODEL,
         chapter_code: @chapter_code,
-      ) { embedding_service.embed_batch(texts) }
+      ) { embedding_service.embed_batch(texts, event_kind: 'self_text_scoring_embedding') }
 
       pairs = batch.zip(embeddings).select { |_record, embedding| embedding }
       next if pairs.empty?
@@ -135,7 +135,7 @@ class SelfTextConfidenceScorer
         batch_size: ancestor_texts.size,
         model: EmbeddingService::MODEL,
         chapter_code: @chapter_code,
-      ) { embedding_service.embed_batch(ancestor_texts) }
+      ) { embedding_service.embed_batch(ancestor_texts, event_kind: 'self_text_scoring_embedding') }
 
       pairs = batch.zip(ancestor_embeddings).select { |_record, embedding| embedding }
       next if pairs.empty?

--- a/app/services/tariff_knowledge/public_atar_fact_generator.rb
+++ b/app/services/tariff_knowledge/public_atar_fact_generator.rb
@@ -33,7 +33,10 @@ module TariffKnowledge
     end
 
     def call
-      response = ai_client.call(messages, model:, reasoning_effort:)
+      response = AiUsage::Instrumentation.api_call(
+        event_kind: 'atar_fact_extraction',
+        model: model,
+      ) { ai_client.call(messages, model:, reasoning_effort:, event_kind: 'atar_fact_extraction') }
       facts_from(response)
     rescue *OpenaiClient::RETRYABLE_ERRORS => e
       Rails.logger.warn("Public ATAR fact generation failed for ATAR #{ruling.ref}: #{failure_log_context(e)}")

--- a/app/services/vector_retrieval_service.rb
+++ b/app/services/vector_retrieval_service.rb
@@ -10,7 +10,11 @@ class VectorRetrievalService
   end
 
   def call
-    query_embedding = embedding_service.embed(@query)
+    query_embedding = AiUsage::Instrumentation.embedding_api_call(
+      event_kind: 'vector_search_query_embedding',
+      batch_size: 1,
+      model: EmbeddingService::MODEL,
+    ) { embedding_service.embed(@query, event_kind: 'vector_search_query_embedding') }
     vector_literal = "'[#{query_embedding.join(',')}]'::vector"
 
     ranked_rows = fetch_ranked_sids(vector_literal)

--- a/config/initializers/openai_model_pricing.rb
+++ b/config/initializers/openai_model_pricing.rb
@@ -1,0 +1,5 @@
+Rails.application.config.x.openai_model_pricing = Rails.application
+  .config_for(:openai_model_pricing)
+  .to_h
+  .deep_stringify_keys
+  .freeze

--- a/config/openai_model_pricing.yml
+++ b/config/openai_model_pricing.yml
@@ -1,0 +1,13 @@
+# Prices are USD per 1M tokens. This is not secret material; keep changes reviewed in git.
+#
+# Models missing from this file are still reported with token usage and
+# pricing_known=false so they remain visible in the AI costs dashboard.
+development: &pricing
+  text-embedding-3-small:
+    input_per_million_tokens: 0.02
+
+test:
+  <<: *pricing
+
+production:
+  <<: *pricing

--- a/docs/generated-classification-content-lifecycle.md
+++ b/docs/generated-classification-content-lifecycle.md
@@ -135,6 +135,17 @@ There are two search paths affected by content changes:
 
 Content-changing actions must keep both paths in sync. Lifecycle-only actions do not need search updates.
 
+AI token and cost telemetry is emitted for generated content calls that use OpenAI:
+
+- Self-text generation emits `self_text_generation_ai` or `self_text_generation_ai_non_other`.
+- Label generation emits `label_generation`.
+- Label scoring embeddings emit `label_scoring_embedding`.
+- Self-text scoring embeddings emit `self_text_scoring_embedding`.
+- Composite search embedding refresh emits `composite_search_embedding`.
+- Public ATAR fact extraction emits `atar_fact_extraction`.
+
+Chapter-note source graph loading and chapter-note expression handling are deterministic parsing and graph-loading paths. They do not call OpenAI directly; their AI cost exposure is limited to downstream generated-content or composite embedding refreshes that include chapter-note-derived context.
+
 | Action | Changes content? | Refresh OpenSearch document? | Refresh composite embedding? |
 | --- | --- | --- | --- |
 | Mark needs review | No | No | No |

--- a/lib/tasks/self_texts.rake
+++ b/lib/tasks/self_texts.rake
@@ -116,7 +116,11 @@ namespace :self_texts do
 
     generate_texts.each_slice(EmbeddingService::BATCH_SIZE).with_index do |batch, i|
       texts = batch.map(&:self_text)
-      embeddings = service.embed_batch(texts)
+      embeddings = AiUsage::Instrumentation.embedding_api_call(
+        event_kind: 'self_text_embedding_backfill',
+        batch_size: texts.size,
+        model: EmbeddingService::MODEL,
+      ) { service.embed_batch(texts, event_kind: 'self_text_embedding_backfill') }
 
       batch.zip(embeddings).each do |record, embedding|
         update_dataset = GoodsNomenclatureSelfText.where(goods_nomenclature_sid: record.goods_nomenclature_sid)
@@ -139,7 +143,11 @@ namespace :self_texts do
 
     eu_texts.each_slice(EmbeddingService::BATCH_SIZE).with_index do |batch, i|
       texts = batch.map(&:eu_self_text)
-      embeddings = service.embed_batch(texts)
+      embeddings = AiUsage::Instrumentation.embedding_api_call(
+        event_kind: 'eu_self_text_embedding_backfill',
+        batch_size: texts.size,
+        model: EmbeddingService::MODEL,
+      ) { service.embed_batch(texts, event_kind: 'eu_self_text_embedding_backfill') }
 
       batch.zip(embeddings).each do |record, embedding|
         update_dataset = GoodsNomenclatureSelfText.where(goods_nomenclature_sid: record.goods_nomenclature_sid)

--- a/spec/lib/ai_usage/instrumentation_spec.rb
+++ b/spec/lib/ai_usage/instrumentation_spec.rb
@@ -1,0 +1,25 @@
+RSpec.describe AiUsage::Instrumentation do
+  describe '.api_call' do
+    it 'redacts provider response bodies from failure instrumentation' do
+      events = []
+      subscriber = ActiveSupport::Notifications.subscribe('api_call_failed.ai_usage') do |*args|
+        events << ActiveSupport::Notifications::Event.new(*args)
+      end
+
+      error = OpenaiClient::ApiError.new(status: 500, body: { prompt: 'do not log this' })
+
+      expect {
+        described_class.api_call(event_kind: 'atar_fact_extraction', model: 'gpt-test') { raise error }
+      }.to raise_error(OpenaiClient::ApiError)
+
+      expect(events.size).to eq(1)
+      expect(events.first.payload).to include(
+        error_class: 'OpenaiClient::ApiError',
+        error_message: 'OpenAI API error status=500',
+      )
+      expect(events.first.payload[:error_message]).not_to include('do not log this')
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+    end
+  end
+end

--- a/spec/lib/ai_usage_spec.rb
+++ b/spec/lib/ai_usage_spec.rb
@@ -1,0 +1,145 @@
+RSpec.describe AiUsage do
+  describe '.metadata_for' do
+    before do
+      allow(TradeTariffBackend).to receive(:openai_model_pricing).and_return({
+        'gpt-test' => { 'input_per_million_tokens' => 2.0, 'output_per_million_tokens' => 8.0 },
+      })
+    end
+
+    it 'calculates chat completion costs from configured model pricing' do
+      usage = described_class.metadata_for(
+        model: 'gpt-test',
+        event_kind: 'interactive_search',
+        usage: { 'prompt_tokens' => 1_000, 'completion_tokens' => 250, 'total_tokens' => 1_250 },
+      )
+
+      expect(usage.to_h).to include(
+        provider: 'openai',
+        model: 'gpt-test',
+        event_kind: 'interactive_search',
+        input_tokens: 1_000,
+        output_tokens: 250,
+        total_tokens: 1_250,
+        input_cost_usd: 0.002,
+        output_cost_usd: 0.002,
+        total_cost_usd: 0.004,
+        pricing_known: true,
+      )
+    end
+
+    it 'marks unknown model pricing without treating it as zero-cost' do
+      usage = described_class.metadata_for(
+        model: 'unpriced-model',
+        event_kind: 'label_generation',
+        usage: { 'prompt_tokens' => 100, 'completion_tokens' => 50, 'total_tokens' => 150 },
+      )
+
+      expect(usage.to_h).to include(
+        model: 'unpriced-model',
+        input_tokens: 100,
+        output_tokens: 50,
+        total_tokens: 150,
+        input_cost_usd: nil,
+        output_cost_usd: nil,
+        total_cost_usd: nil,
+        pricing_known: false,
+      )
+    end
+
+    it 'marks chat completion pricing unknown when output token pricing is missing' do
+      allow(TradeTariffBackend).to receive(:openai_model_pricing).and_return({
+        'partial-model' => { 'input_per_million_tokens' => 2.0 },
+      })
+
+      usage = described_class.metadata_for(
+        model: 'partial-model',
+        event_kind: 'interactive_search',
+        usage: { 'prompt_tokens' => 100, 'completion_tokens' => 50, 'total_tokens' => 150 },
+      )
+
+      expect(usage.to_h).to include(
+        input_cost_usd: 0.0002,
+        output_cost_usd: nil,
+        total_cost_usd: 0.0002,
+        pricing_known: false,
+      )
+    end
+
+    it 'marks pricing unknown when configured prices are invalid' do
+      allow(TradeTariffBackend).to receive(:openai_model_pricing).and_return({
+        'invalid-model' => { 'input_per_million_tokens' => 'not-a-number', 'output_per_million_tokens' => 8.0 },
+      })
+
+      usage = described_class.metadata_for(
+        model: 'invalid-model',
+        event_kind: 'interactive_search',
+        usage: { 'prompt_tokens' => 100, 'completion_tokens' => 50, 'total_tokens' => 150 },
+      )
+
+      expect(usage.to_h).to include(
+        input_cost_usd: nil,
+        output_cost_usd: 0.0004,
+        total_cost_usd: 0.0004,
+        pricing_known: false,
+      )
+    end
+
+    it 'ignores unexpected usage shapes without failing the AI call' do
+      usage = described_class.metadata_for(
+        model: 'gpt-test',
+        event_kind: 'interactive_search',
+        usage: 'unexpected',
+      )
+
+      expect(usage.to_h).to include(
+        input_tokens: nil,
+        output_tokens: nil,
+        total_tokens: 0,
+        total_cost_usd: nil,
+      )
+    end
+  end
+
+  describe '.attach_metadata' do
+    let(:metadata) do
+      described_class::Metadata.new(
+        provider: 'openai',
+        model: 'gpt-test',
+        event_kind: 'search_query_expansion',
+        input_tokens: 10,
+        output_tokens: 5,
+        total_tokens: 15,
+        input_cost_usd: nil,
+        output_cost_usd: nil,
+        total_cost_usd: nil,
+        pricing_known: false,
+      )
+    end
+
+    it 'attaches usage metadata without changing the returned object shape' do
+      response = { 'expanded_query' => 'horses' }
+
+      result = described_class.attach_metadata(response, metadata)
+
+      expect(result).to equal(response)
+      expect(result).to eq('expanded_query' => 'horses')
+      expect(described_class.metadata_from(result)).to eq(metadata)
+    end
+
+    it 'does not fail when the parsed response is a scalar JSON value' do
+      expect(described_class.attach_metadata(1, metadata)).to eq(1)
+      expect(described_class.attach_metadata(true, metadata)).to be(true)
+      expect(described_class.attach_metadata(nil, metadata)).to be_nil
+    end
+
+    it 'attaches usage metadata to string responses without changing the returned value' do
+      response = 'not json'
+
+      result = described_class.attach_metadata(response, metadata)
+
+      expect(result).to equal(response)
+      expect(result).to eq('not json')
+      expect(described_class.metadata_from(result)).to eq(metadata)
+    end
+  end
+end

--- a/spec/lib/embedding_service_spec.rb
+++ b/spec/lib/embedding_service_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe EmbeddingService do
     let(:response_body) do
       {
         'data' => [{ 'index' => 0, 'embedding' => embedding }],
+        'usage' => {
+          'prompt_tokens' => 42,
+          'total_tokens' => 42,
+        },
       }
     end
 
@@ -36,6 +40,25 @@ RSpec.describe EmbeddingService do
       expect(WebMock).to have_requested(:post, "#{api_base_url}/embeddings")
         .with(body: hash_including('input' => ['Live horses']))
     end
+
+    it 'attaches embedding token usage and cost metadata to the returned vector' do
+      allow(TradeTariffBackend).to receive(:openai_model_pricing).and_return({
+        'text-embedding-3-small' => { 'input_per_million_tokens' => 0.02 },
+      })
+
+      result = service.embed('Live horses', event_kind: 'label_scoring_embedding')
+
+      expect(AiUsage.metadata_from(result).to_h).to include(
+        model: 'text-embedding-3-small',
+        event_kind: 'label_scoring_embedding',
+        input_tokens: 42,
+        output_tokens: 0,
+        total_tokens: 42,
+        input_cost_usd: 0.00000084,
+        total_cost_usd: 0.00000084,
+        pricing_known: true,
+      )
+    end
   end
 
   describe '#embed_batch' do
@@ -44,6 +67,10 @@ RSpec.describe EmbeddingService do
       let(:response_body) do
         {
           'data' => embeddings.each_with_index.map { |emb, i| { 'index' => i, 'embedding' => emb } },
+          'usage' => {
+            'prompt_tokens' => 9,
+            'total_tokens' => 9,
+          },
         }
       end
 
@@ -60,6 +87,17 @@ RSpec.describe EmbeddingService do
       it 'preserves order based on index' do
         result = service.embed_batch(%w[one two three])
         expect(result).to eq(embeddings)
+      end
+
+      it 'attaches batch usage metadata to the returned embeddings array' do
+        result = service.embed_batch(%w[one two three], event_kind: 'self_text_scoring_embedding')
+
+        expect(AiUsage.metadata_from(result).to_h).to include(
+          event_kind: 'self_text_scoring_embedding',
+          input_tokens: 9,
+          output_tokens: 0,
+          total_tokens: 9,
+        )
       end
     end
 
@@ -126,6 +164,26 @@ RSpec.describe EmbeddingService do
         result = service.embed_batch(%w[test])
         expect(result).to eq([embedding])
         expect(WebMock).to have_requested(:post, "#{api_base_url}/embeddings").times(2)
+      end
+
+      it 'emits retry instrumentation with the embedding event kind' do
+        events = []
+        subscriber = ActiveSupport::Notifications.subscribe('embedding_api_retry.ai_usage') do |*args|
+          events << ActiveSupport::Notifications::Event.new(*args)
+        end
+
+        service.embed_batch(%w[test], event_kind: 'label_scoring_embedding')
+
+        expect(events.size).to eq(1)
+        expect(events.first.payload).to include(
+          event_kind: 'label_scoring_embedding',
+          batch_size: 1,
+          model: 'text-embedding-3-small',
+          attempt: 1,
+          error_class: 'EmbeddingService::ServerError',
+        )
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
       end
     end
 

--- a/spec/lib/label_generator/instrumentation_spec.rb
+++ b/spec/lib/label_generator/instrumentation_spec.rb
@@ -1,0 +1,100 @@
+RSpec.describe LabelGenerator::Instrumentation do
+  describe '.api_call' do
+    it 'emits label generation event kind and AI usage metadata' do
+      events = []
+      subscriber = ActiveSupport::Notifications.subscribe('api_call_completed.label_generator') do |*args|
+        events << ActiveSupport::Notifications::Event.new(*args)
+      end
+
+      response = AiUsage.attach_metadata(
+        { 'data' => [{ 'commodity_code' => '0101210000' }] },
+        AiUsage::Metadata.new(
+          provider: 'openai',
+          model: 'gpt-5.2',
+          event_kind: 'label_generation',
+          input_tokens: 100,
+          output_tokens: 50,
+          total_tokens: 150,
+          input_cost_usd: nil,
+          output_cost_usd: nil,
+          total_cost_usd: nil,
+          pricing_known: false,
+        ),
+      )
+
+      described_class.api_call(batch_size: 1, model: 'gpt-5.2', page_number: 2) { response }
+
+      expect(events.size).to eq(1)
+      expect(events.first.payload).to include(
+        event_kind: 'label_generation',
+        input_tokens: 100,
+        output_tokens: 50,
+        total_tokens: 150,
+        pricing_known: false,
+      )
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+    end
+
+    it 'redacts OpenAI provider response bodies from failure instrumentation' do
+      events = []
+      subscriber = ActiveSupport::Notifications.subscribe('api_call_failed.label_generator') do |*args|
+        events << ActiveSupport::Notifications::Event.new(*args)
+      end
+
+      error = OpenaiClient::ApiError.new(status: 500, body: { prompt: 'do not log this' })
+
+      expect {
+        described_class.api_call(batch_size: 1, model: 'gpt-5.2', page_number: 2) { raise error }
+      }.to raise_error(OpenaiClient::ApiError)
+
+      expect(events.size).to eq(1)
+      expect(events.first.payload).to include(
+        error_class: 'OpenaiClient::ApiError',
+        error_message: 'OpenAI API error status=500',
+      )
+      expect(events.first.payload[:error_message]).not_to include('do not log this')
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+    end
+  end
+
+  describe '.embedding_api_call' do
+    it 'emits label scoring embedding event kind and AI usage metadata' do
+      events = []
+      subscriber = ActiveSupport::Notifications.subscribe('embedding_api_call_completed.label_generator') do |*args|
+        events << ActiveSupport::Notifications::Event.new(*args)
+      end
+
+      embeddings = AiUsage.attach_metadata(
+        [[0.1, 0.2]],
+        AiUsage::Metadata.new(
+          provider: 'openai',
+          model: 'text-embedding-3-small',
+          event_kind: 'label_scoring_embedding',
+          input_tokens: 20,
+          output_tokens: 0,
+          total_tokens: 20,
+          input_cost_usd: 0.0000004,
+          output_cost_usd: nil,
+          total_cost_usd: 0.0000004,
+          pricing_known: true,
+        ),
+      )
+
+      described_class.embedding_api_call(batch_size: 1, model: 'text-embedding-3-small') { embeddings }
+
+      expect(events.size).to eq(1)
+      expect(events.first.payload).to include(
+        event_kind: 'label_scoring_embedding',
+        input_tokens: 20,
+        output_tokens: 0,
+        total_tokens: 20,
+        total_cost_usd: 0.0000004,
+        pricing_known: true,
+      )
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+    end
+  end
+end

--- a/spec/lib/openai_client_spec.rb
+++ b/spec/lib/openai_client_spec.rb
@@ -9,6 +9,11 @@ RSpec.describe OpenaiClient do
           },
         },
       ],
+      'usage' => {
+        'prompt_tokens' => 1_000,
+        'completion_tokens' => 250,
+        'total_tokens' => 1_250,
+      },
     }
   end
 
@@ -26,6 +31,24 @@ RSpec.describe OpenaiClient do
       it 'returns the parsed JSON response' do
         result = client.call(context)
         expect(result).to eq('capital' => 'Paris')
+      end
+
+      it 'attaches token usage and cost metadata to the parsed response' do
+        allow(TradeTariffBackend).to receive(:openai_model_pricing).and_return({
+          TradeTariffBackend.ai_model => { 'input_per_million_tokens' => 2.0, 'output_per_million_tokens' => 8.0 },
+        })
+
+        result = client.call(context, event_kind: 'search_query_expansion')
+
+        expect(AiUsage.metadata_from(result).to_h).to include(
+          model: TradeTariffBackend.ai_model,
+          event_kind: 'search_query_expansion',
+          input_tokens: 1_000,
+          output_tokens: 250,
+          total_tokens: 1_250,
+          total_cost_usd: 0.004,
+          pricing_known: true,
+        )
       end
 
       it 'sends the context as a user message' do
@@ -90,17 +113,44 @@ RSpec.describe OpenaiClient do
     end
 
     context 'when the API returns a 500 error response' do
+      let(:error_body) do
+        {
+          error: 'Internal Server Error',
+          usage: {
+            prompt_tokens: 20,
+            completion_tokens: 0,
+            total_tokens: 20,
+          },
+        }
+      end
+
       before do
         allow(Kernel).to receive(:sleep)
 
         stub_request(:post, "#{api_base_url}/chat/completions")
-          .to_return(status: 500, body: { error: 'Internal Server Error' }.to_json, headers: { 'Content-Type' => 'application/json' })
+          .to_return(status: 500, body: error_body.to_json, headers: { 'Content-Type' => 'application/json' })
       end
 
       it 'raises an ApiError' do
         expect { client.call('test') }.to raise_error(OpenaiClient::ApiError) do |error|
           expect(error.status).to eq(500)
+          expect(error.message).to eq('OpenAI API error status=500')
+          expect(error.message).not_to include('Internal Server Error')
+          expect(error.body['error']).to eq('Internal Server Error')
+          expect(error.body.dig('usage', 'prompt_tokens')).to eq(20)
         end
+      end
+
+      it 'attaches usage metadata to ApiError when the provider returns usage' do
+        expect { client.call('test', model: 'gpt-test', event_kind: 'interactive_search') }
+          .to raise_error(OpenaiClient::ApiError) { |error|
+            expect(error.ai_usage.to_h).to include(
+              model: 'gpt-test',
+              event_kind: 'interactive_search',
+              input_tokens: 20,
+              total_tokens: 20,
+            )
+          }
       end
     end
 
@@ -130,6 +180,11 @@ RSpec.describe OpenaiClient do
               },
             },
           ],
+          'usage' => {
+            'prompt_tokens' => 10,
+            'completion_tokens' => 5,
+            'total_tokens' => 15,
+          },
         }
       end
 
@@ -141,6 +196,17 @@ RSpec.describe OpenaiClient do
       it 'returns the raw string' do
         result = client.call('test')
         expect(result).to eq('not valid json')
+      end
+
+      it 'attaches usage metadata to the raw string response' do
+        result = client.call('test', event_kind: 'label_generation')
+
+        expect(AiUsage.metadata_from(result).to_h).to include(
+          event_kind: 'label_generation',
+          input_tokens: 10,
+          output_tokens: 5,
+          total_tokens: 15,
+        )
       end
     end
 

--- a/spec/lib/search/instrumentation_spec.rb
+++ b/spec/lib/search/instrumentation_spec.rb
@@ -253,6 +253,46 @@ RSpec.describe Search::Instrumentation do
           attempt_number: 1,
           duration_ms: a_kind_of(Float),
           operation: 'interactive_search',
+          event_kind: 'interactive_search',
+        ),
+      )
+    end
+
+    it 'includes AI usage and cost metadata from the response' do
+      allow(ActiveSupport::Notifications).to receive(:instrument)
+      response = AiUsage.attach_metadata(
+        { 'answer' => 'ai response' },
+        AiUsage::Metadata.new(
+          provider: 'openai',
+          model: 'gpt-4',
+          event_kind: 'interactive_search_final_answer',
+          input_tokens: 1_000,
+          output_tokens: 200,
+          total_tokens: 1_200,
+          input_cost_usd: 0.002,
+          output_cost_usd: 0.0016,
+          total_cost_usd: 0.0036,
+          pricing_known: true,
+        ),
+      )
+
+      described_class.api_call(
+        request_id: 'req-1',
+        model: 'gpt-4',
+        attempt_number: 1,
+        operation: 'interactive_search_final_answer',
+      ) { response }
+
+      expect(ActiveSupport::Notifications).to have_received(:instrument).with(
+        'api_call_completed.search',
+        hash_including(
+          provider: 'openai',
+          event_kind: 'interactive_search_final_answer',
+          input_tokens: 1_000,
+          output_tokens: 200,
+          total_tokens: 1_200,
+          total_cost_usd: 0.0036,
+          pricing_known: true,
         ),
       )
     end
@@ -271,6 +311,48 @@ RSpec.describe Search::Instrumentation do
       expect(ActiveSupport::Notifications).to have_received(:instrument).with(
         'search_failed.search',
         hash_including(error_type: 'Faraday::TimeoutError'),
+      )
+    end
+
+    it 'includes AI usage metadata on failed provider calls when available' do
+      allow(ActiveSupport::Notifications).to receive(:instrument)
+      error = OpenaiClient::ApiError.new(
+        status: 500,
+        body: { 'usage' => { 'prompt_tokens' => 75, 'completion_tokens' => 0, 'total_tokens' => 75 } },
+        ai_usage: AiUsage::Metadata.new(
+          provider: 'openai',
+          model: 'gpt-4',
+          event_kind: 'interactive_search',
+          input_tokens: 75,
+          output_tokens: 0,
+          total_tokens: 75,
+          input_cost_usd: nil,
+          output_cost_usd: nil,
+          total_cost_usd: nil,
+          pricing_known: false,
+        ),
+      )
+
+      expect {
+        described_class.api_call(request_id: 'req-1', model: 'gpt-4', attempt_number: 1) { raise error }
+      }.to raise_error(OpenaiClient::ApiError)
+
+      expect(ActiveSupport::Notifications).to have_received(:instrument).with(
+        'api_call_completed.search',
+        hash_including(
+          response_type: 'error',
+          error_message: 'OpenAI API error status=500',
+          provider: 'openai',
+          event_kind: 'interactive_search',
+          input_tokens: 75,
+          total_tokens: 75,
+          pricing_known: false,
+        ),
+      )
+
+      expect(ActiveSupport::Notifications).not_to have_received(:instrument).with(
+        anything,
+        hash_including(error_message: a_string_including('usage')),
       )
     end
 

--- a/spec/lib/self_text_generator/instrumentation_spec.rb
+++ b/spec/lib/self_text_generator/instrumentation_spec.rb
@@ -112,12 +112,48 @@ RSpec.describe SelfTextGenerator::Instrumentation do
       ActiveSupport::Notifications.unsubscribe('api_call_started.self_text_generator')
       ActiveSupport::Notifications.unsubscribe('api_call_completed.self_text_generator')
     end
+
+    it 'emits self-text generation event kind and AI usage metadata' do
+      events = []
+      subscriber = ActiveSupport::Notifications.subscribe('api_call_completed.self_text_generator') do |*args|
+        events << ActiveSupport::Notifications::Event.new(*args)
+      end
+
+      response = AiUsage.attach_metadata(
+        [{ 'sid' => 1, 'contextualised_description' => 'Live horses' }],
+        AiUsage::Metadata.new(
+          provider: 'openai',
+          model: 'gpt-5.2',
+          event_kind: 'self_text_generation_ai',
+          input_tokens: 120,
+          output_tokens: 30,
+          total_tokens: 150,
+          input_cost_usd: nil,
+          output_cost_usd: nil,
+          total_cost_usd: nil,
+          pricing_known: false,
+        ),
+      )
+
+      described_class.api_call(batch_size: 1, model: 'gpt-5.2', chapter_code: '01', event_kind: 'self_text_generation_ai') { response }
+
+      expect(events.size).to eq(1)
+      expect(events.first.payload).to include(
+        event_kind: 'self_text_generation_ai',
+        input_tokens: 120,
+        output_tokens: 30,
+        total_tokens: 150,
+        pricing_known: false,
+      )
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+    end
   end
 
   describe '.api_call on failure' do
     it 'instruments failure and re-raises' do
       failed_events = []
-      ActiveSupport::Notifications.subscribe('api_call_failed.self_text_generator') do |*args|
+      subscriber = ActiveSupport::Notifications.subscribe('api_call_failed.self_text_generator') do |*args|
         failed_events << ActiveSupport::Notifications::Event.new(*args)
       end
 
@@ -131,7 +167,29 @@ RSpec.describe SelfTextGenerator::Instrumentation do
         error_message: 'timeout',
       )
     ensure
-      ActiveSupport::Notifications.unsubscribe('api_call_failed.self_text_generator')
+      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+    end
+
+    it 'redacts OpenAI provider response bodies from failure instrumentation' do
+      failed_events = []
+      subscriber = ActiveSupport::Notifications.subscribe('api_call_failed.self_text_generator') do |*args|
+        failed_events << ActiveSupport::Notifications::Event.new(*args)
+      end
+
+      error = OpenaiClient::ApiError.new(status: 500, body: { prompt: 'do not log this' })
+
+      expect {
+        described_class.api_call(batch_size: 5, model: 'gpt-4', chapter_code: '01') { raise error }
+      }.to raise_error(OpenaiClient::ApiError)
+
+      expect(failed_events.size).to eq(1)
+      expect(failed_events.first.payload).to include(
+        error_class: 'OpenaiClient::ApiError',
+        error_message: 'OpenAI API error status=500',
+      )
+      expect(failed_events.first.payload[:error_message]).not_to include('do not log this')
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
     end
   end
 
@@ -162,6 +220,45 @@ RSpec.describe SelfTextGenerator::Instrumentation do
       expect(events.size).to eq(1)
     ensure
       ActiveSupport::Notifications.unsubscribe('reindex_completed.self_text_generator')
+    end
+  end
+
+  describe '.embedding_api_call' do
+    it 'emits self-text scoring embedding event kind and AI usage metadata' do
+      events = []
+      subscriber = ActiveSupport::Notifications.subscribe('embedding_api_call_completed.self_text_generator') do |*args|
+        events << ActiveSupport::Notifications::Event.new(*args)
+      end
+
+      embeddings = AiUsage.attach_metadata(
+        [[0.1, 0.2]],
+        AiUsage::Metadata.new(
+          provider: 'openai',
+          model: 'text-embedding-3-small',
+          event_kind: 'self_text_scoring_embedding',
+          input_tokens: 20,
+          output_tokens: 0,
+          total_tokens: 20,
+          input_cost_usd: 0.0000004,
+          output_cost_usd: nil,
+          total_cost_usd: 0.0000004,
+          pricing_known: true,
+        ),
+      )
+
+      described_class.embedding_api_call(batch_size: 1, model: 'text-embedding-3-small', chapter_code: '01') { embeddings }
+
+      expect(events.size).to eq(1)
+      expect(events.first.payload).to include(
+        event_kind: 'self_text_scoring_embedding',
+        input_tokens: 20,
+        output_tokens: 0,
+        total_tokens: 20,
+        total_cost_usd: 0.0000004,
+        pricing_known: true,
+      )
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
     end
   end
 end

--- a/spec/lib/tasks/self_texts_rake_spec.rb
+++ b/spec/lib/tasks/self_texts_rake_spec.rb
@@ -139,6 +139,24 @@ RSpec.describe 'self_texts rake tasks' do
 
       expect(WebMock).to have_requested(:post, "#{api_base_url}/embeddings").at_least_once
     end
+
+    it 'instruments generated and EU embedding backfill batches with event kinds' do
+      create(:goods_nomenclature_self_text, self_text: 'Live horses')
+      create(:goods_nomenclature_self_text, self_text: 'Pure-bred horses', eu_self_text: 'EU pure-bred horses')
+      events = []
+      subscriber = ActiveSupport::Notifications.subscribe('embedding_api_call_completed.ai_usage') do |*args|
+        events << ActiveSupport::Notifications::Event.new(*args)
+      end
+
+      generate_embeddings
+
+      expect(events.map { |event| event.payload[:event_kind] }).to include(
+        'self_text_embedding_backfill',
+        'eu_self_text_embedding_backfill',
+      )
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+    end
   end
 end
 # rubocop:enable RSpec/DescribeClass

--- a/spec/lib/trade_tariff_backend/config_spec.rb
+++ b/spec/lib/trade_tariff_backend/config_spec.rb
@@ -394,6 +394,16 @@ RSpec.describe TradeTariffBackend::Config do
         expect(config.openai_api_base_url).to eq('https://api.openai.com/v1')
       end
     end
+
+    describe '.openai_model_pricing' do
+      it 'loads reviewed model pricing from application config' do
+        expect(config.openai_model_pricing).to include(
+          'text-embedding-3-small' => {
+            'input_per_million_tokens' => 0.02,
+          },
+        )
+      end
+    end
   end
 
   describe 'goods nomenclature config' do

--- a/spec/models/goods_nomenclature_self_text_spec.rb
+++ b/spec/models/goods_nomenclature_self_text_spec.rb
@@ -260,7 +260,7 @@ RSpec.describe GoodsNomenclatureSelfText do
 
     before do
       allow(EmbeddingService).to receive(:new).and_return(embedding_service)
-      allow(embedding_service).to receive(:embed_batch) { |texts| texts.map { Array.new(1536, 0.0) } }
+      allow(embedding_service).to receive(:embed_batch) { |texts, **_kwargs| texts.map { Array.new(1536, 0.0) } }
     end
 
     it 'updates search_text and search_embedding for records with self_text' do
@@ -271,6 +271,29 @@ RSpec.describe GoodsNomenclatureSelfText do
       record.reload
       expect(record.search_text).to be_present
       expect(record.search_embedding).to be_present
+    end
+
+    it 'instruments composite search embedding generation with an event kind' do
+      record = create(:goods_nomenclature_self_text, self_text: 'Widgets for manufacturing')
+      events = []
+      subscriber = ActiveSupport::Notifications.subscribe('embedding_api_call_completed.ai_usage') do |*args|
+        events << ActiveSupport::Notifications::Event.new(*args)
+      end
+
+      described_class.regenerate_search_embeddings([record.goods_nomenclature_sid])
+
+      expect(embedding_service).to have_received(:embed_batch).with(
+        [a_string_including('Widgets for manufacturing')],
+        event_kind: 'composite_search_embedding',
+      )
+      expect(events.size).to eq(1)
+      expect(events.first.payload).to include(
+        event_kind: 'composite_search_embedding',
+        batch_size: 1,
+        model: EmbeddingService::MODEL,
+      )
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
     end
 
     it 'skips embedding when composite text matches stored search_text' do

--- a/spec/services/expand_search_query_service_spec.rb
+++ b/spec/services/expand_search_query_service_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe ExpandSearchQueryService do
           a_string_including('laptop'),
           model: 'gpt-4.1-mini-2025-04-14',
           reasoning_effort: nil,
+          event_kind: 'search_query_expansion',
         )
       end
     end
@@ -184,6 +185,7 @@ RSpec.describe ExpandSearchQueryService do
           anything,
           model: 'gpt-4.1-mini-2025-04-14',
           reasoning_effort: nil,
+          event_kind: 'search_query_expansion',
         )
       end
     end
@@ -202,6 +204,7 @@ RSpec.describe ExpandSearchQueryService do
           'Custom prompt for: laptop',
           model: 'gpt-4.1-mini-2025-04-14',
           reasoning_effort: nil,
+          event_kind: 'search_query_expansion',
         )
       end
     end

--- a/spec/services/generate_self_text/non_other_self_text_builder_spec.rb
+++ b/spec/services/generate_self_text/non_other_self_text_builder_spec.rb
@@ -98,6 +98,17 @@ RSpec.describe GenerateSelfText::NonOtherSelfTextBuilder do
       expect(result[:processed]).to eq(2)
     end
 
+    it 'passes the non-Other AI event kind to the AI client' do
+      result
+
+      expect(ai_client).to have_received(:call).with(
+        anything,
+        model: 'gpt-5.2',
+        reasoning_effort: 'low',
+        event_kind: 'self_text_generation_ai_non_other',
+      )
+    end
+
     context 'when eu_self_text is available' do
       before do
         allow(SelfTextLookupService).to receive(:lookup)

--- a/spec/services/generate_self_text/other_self_text_builder_spec.rb
+++ b/spec/services/generate_self_text/other_self_text_builder_spec.rb
@@ -339,6 +339,7 @@ RSpec.describe GenerateSelfText::OtherSelfTextBuilder do
           anything,
           model: 'gpt-4.1-mini-2025-04-14',
           reasoning_effort: nil,
+          event_kind: 'self_text_generation_ai',
         )
       end
 
@@ -371,6 +372,7 @@ RSpec.describe GenerateSelfText::OtherSelfTextBuilder do
           anything,
           model: TradeTariffBackend.ai_model,
           reasoning_effort: nil,
+          event_kind: 'self_text_generation_ai',
         )
       end
     end

--- a/spec/services/interactive_search/duplicate_question_guard_spec.rb
+++ b/spec/services/interactive_search/duplicate_question_guard_spec.rb
@@ -76,6 +76,7 @@ RSpec.describe InteractiveSearch::DuplicateQuestionGuard do
       anything,
       model: 'gpt-5-nano-2025-08-07',
       reasoning_effort: 'low',
+      event_kind: 'duplicate_question_validator',
     )
   end
 
@@ -148,6 +149,7 @@ RSpec.describe InteractiveSearch::DuplicateQuestionGuard do
       ),
       model: 'gpt-5-nano-2025-08-07',
       reasoning_effort: 'low',
+      event_kind: 'duplicate_question_validator',
     )
   end
 

--- a/spec/services/interactive_search_service_spec.rb
+++ b/spec/services/interactive_search_service_spec.rb
@@ -138,6 +138,7 @@ RSpec.describe InteractiveSearchService do
           a_string_including('you MUST now provide your best answer'),
           model: anything,
           reasoning_effort: anything,
+          event_kind: 'interactive_search_final_answer',
         )
       end
 
@@ -281,6 +282,7 @@ RSpec.describe InteractiveSearchService do
           a_string_including('The previous candidate question repeated'),
           model: 'gpt-5.4',
           reasoning_effort: 'medium',
+          event_kind: 'duplicate_question_retry',
         )
         expect(Search::Instrumentation).to have_received(:api_call).with(
           request_id: request_id,
@@ -449,6 +451,7 @@ RSpec.describe InteractiveSearchService do
           a_string_including('Leather'),
           model: 'gpt-5.4',
           reasoning_effort: 'medium',
+          event_kind: 'interactive_search',
         )
       end
 
@@ -887,6 +890,7 @@ RSpec.describe InteractiveSearchService do
           anything,
           model: 'gpt-4.1-mini-2025-04-14',
           reasoning_effort: nil,
+          event_kind: 'interactive_search',
         )
       end
     end

--- a/spec/services/label_confidence_scorer_spec.rb
+++ b/spec/services/label_confidence_scorer_spec.rb
@@ -73,6 +73,7 @@ RSpec.describe LabelConfidenceScorer do
         # 1 description + 2 synonyms + 1 colloquial term = 4 texts
         expect(embedding_service).to have_received(:embed_batch).with(
           ['Live horses for breeding', 'stallions', 'mares', 'stud horses'],
+          event_kind: 'label_scoring_embedding',
         )
       end
     end

--- a/spec/services/tariff_knowledge/public_atar_fact_generator_spec.rb
+++ b/spec/services/tariff_knowledge/public_atar_fact_generator_spec.rb
@@ -84,6 +84,7 @@ RSpec.describe TariffKnowledge::PublicAtarFactGenerator do
       ),
       model: 'gpt-5.5',
       reasoning_effort: 'high',
+      event_kind: 'atar_fact_extraction',
     )
   end
 

--- a/spec/services/vector_retrieval_service_spec.rb
+++ b/spec/services/vector_retrieval_service_spec.rb
@@ -6,14 +6,32 @@ RSpec.describe VectorRetrievalService do
 
   before do
     allow(EmbeddingService).to receive(:new).and_return(embedding_service)
-    allow(embedding_service).to receive(:embed).with('live horses').and_return(query_embedding)
+    allow(embedding_service).to receive(:embed).with('live horses', event_kind: 'vector_search_query_embedding').and_return(query_embedding)
   end
 
   describe '#call' do
     it 'embeds the query text' do
       service.call
 
-      expect(embedding_service).to have_received(:embed).with('live horses')
+      expect(embedding_service).to have_received(:embed).with('live horses', event_kind: 'vector_search_query_embedding')
+    end
+
+    it 'instruments the query embedding call with AI usage metadata' do
+      events = []
+      subscriber = ActiveSupport::Notifications.subscribe('embedding_api_call_completed.ai_usage') do |*args|
+        events << ActiveSupport::Notifications::Event.new(*args)
+      end
+
+      service.call
+
+      expect(events.size).to eq(1)
+      expect(events.first.payload).to include(
+        event_kind: 'vector_search_query_embedding',
+        batch_size: 1,
+        model: EmbeddingService::MODEL,
+      )
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
     end
 
     it 'returns results with ORM-derived fields', :aggregate_failures do

--- a/spec/terraform/ai_costs_dashboard_spec.rb
+++ b/spec/terraform/ai_costs_dashboard_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+RSpec.describe 'AI costs dashboard Terraform' do # rubocop:disable RSpec/DescribeClass
+  let(:dashboards_tf) { Rails.root.join('terraform/dashboards.tf').read }
+
+  it 'wires the AI costs dashboard into the dashboard stack' do
+    expect(dashboards_tf).to include('resource "aws_cloudwatch_dashboard" "ai_costs"')
+    expect(dashboards_tf).to include('dashboard_name = "AICosts-${var.environment}"')
+  end
+
+  it 'groups costs and tokens by low-cardinality event kind' do
+    expect(dashboards_tf).to include('api_call_failed')
+    expect(dashboards_tf).to include('embedding_api_call_failed')
+    expect(dashboards_tf).to include('stats sum(total_cost_usd) as total_cost_usd by event_kind')
+    expect(dashboards_tf).to include('stats sum(input_tokens) as input_tokens, sum(output_tokens) as output_tokens, sum(total_tokens) as total_tokens by event_kind')
+  end
+
+  it 'keeps unknown model pricing visible instead of counting it as zero' do
+    expect(dashboards_tf).to include('filter pricing_known = false or not ispresent(total_cost_usd)')
+    expect(dashboards_tf).to include('Unknown or High-Cost Events')
+  end
+
+  it 'includes recent high-cost event detail' do
+    expect(dashboards_tf).to include('fields @timestamp, service, event, event_kind, model, total_tokens, total_cost_usd, pricing_known')
+    expect(dashboards_tf).to include('sort total_cost_usd desc, total_tokens desc')
+  end
+end

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -37,6 +37,7 @@ Terraform to deploy the service into AWS.
 
 | Name | Type |
 | ---- | ---- |
+| [aws_cloudwatch_dashboard.ai_costs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_dashboard) | resource |
 | [aws_cloudwatch_event_rule.database_backup](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_rule.database_backup_freshness_check](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_rule.database_replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |

--- a/terraform/dashboards.tf
+++ b/terraform/dashboards.tf
@@ -1,3 +1,36 @@
+locals {
+  ai_cost_events = "filter event in [\"api_call_completed\", \"embedding_api_call_completed\", \"api_call_failed\", \"embedding_api_call_failed\"] and ispresent(event_kind)"
+}
+
+resource "aws_cloudwatch_dashboard" "ai_costs" {
+  dashboard_name = "AICosts-${var.environment}"
+  dashboard_body = jsonencode({
+    widgets = [
+      {
+        type = "log", x = 0, y = 0, width = 12, height = 6
+        properties = {
+          title = "Total Cost by Event Kind", region = var.region, view = "bar"
+          query = "SOURCE 'platform-logs-${var.environment}' | ${local.ai_cost_events} | filter pricing_known = true | stats sum(total_cost_usd) as total_cost_usd by event_kind | sort total_cost_usd desc"
+        }
+      },
+      {
+        type = "log", x = 12, y = 0, width = 12, height = 6
+        properties = {
+          title = "Token Totals by Event Kind", region = var.region, view = "bar"
+          query = "SOURCE 'platform-logs-${var.environment}' | ${local.ai_cost_events} | stats sum(input_tokens) as input_tokens, sum(output_tokens) as output_tokens, sum(total_tokens) as total_tokens by event_kind | sort total_tokens desc"
+        }
+      },
+      {
+        type = "log", x = 0, y = 6, width = 24, height = 8
+        properties = {
+          title = "Unknown or High-Cost Events", region = var.region
+          query = "SOURCE 'platform-logs-${var.environment}' | ${local.ai_cost_events} | fields @timestamp, service, event, event_kind, model, total_tokens, total_cost_usd, pricing_known | filter pricing_known = false or not ispresent(total_cost_usd) or total_cost_usd > 0 | sort total_cost_usd desc, total_tokens desc | limit 50"
+        }
+      },
+    ]
+  })
+}
+
 module "label_generator_dashboard" {
   source = "./modules/label_generator_dashboard"
 


### PR DESCRIPTION
## What:
- [x] Add AI usage metadata extraction and pricing for chat completions and embeddings
- [x] Emit token and cost fields through search, label, self-text, ATAR, vector, and composite embedding instrumentation
- [x] Add an AI costs CloudWatch dashboard module and wire it into Terraform
- [x] Document deterministic chapter-note paths and downstream AI cost exposure
- [x] Add coverage for usage extraction, event-kind propagation, failure redaction, and dashboard query shape

## Why:
Operators need AI spend visibility by capability so token usage, cost estimates, unknown pricing, and high-cost events can be monitored before the generated-classification work is live.

## Ticket:
https://transformuk.atlassian.net/browse/AI-994

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Low-risk read-only observability for a non-live feature. It adds structured telemetry and dashboards without changing trader-facing tariff behaviour.