### PR TITLE
AI-994: Add AI costs dashboard

### DIFF
--- a/spec/terraform/ai_costs_dashboard_spec.rb
+++ b/spec/terraform/ai_costs_dashboard_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'AI costs dashboard Terraform' do # rubocop:disable RSpec/Describ
     expect(module_main_tf).to include('api_call_failed')
     expect(module_main_tf).to include('embedding_api_call_failed')
     expect(aggregate_query).to include('${local.ai_cost_events}')
-    expect(aggregate_query).to include('filter ispresent(total_cost_usd)')
+    expect(aggregate_query).to include('filter pricing_known = true and ispresent(total_cost_usd)')
     expect(aggregate_query).to include('stats sum(total_cost_usd) as total_cost_usd by event_kind')
     expect(aggregate_query).not_to include('bin(')
   end

--- a/spec/terraform/ai_costs_dashboard_spec.rb
+++ b/spec/terraform/ai_costs_dashboard_spec.rb
@@ -2,26 +2,36 @@
 
 RSpec.describe 'AI costs dashboard Terraform' do # rubocop:disable RSpec/DescribeClass
   let(:dashboards_tf) { Rails.root.join('terraform/dashboards.tf').read }
+  let(:module_main_tf) { Rails.root.join('terraform/modules/ai_costs_dashboard/main.tf').read }
 
   it 'wires the AI costs dashboard into the dashboard stack' do
-    expect(dashboards_tf).to include('resource "aws_cloudwatch_dashboard" "ai_costs"')
-    expect(dashboards_tf).to include('dashboard_name = "AICosts-${var.environment}"')
+    expect(dashboards_tf).to include('module "ai_costs_dashboard"')
+    expect(dashboards_tf).to include('source = "./modules/ai_costs_dashboard"')
+    expect(dashboards_tf).to include('output "ai_costs_dashboard_url"')
   end
 
-  it 'groups costs and tokens by low-cardinality event kind' do
-    expect(dashboards_tf).to include('api_call_failed')
-    expect(dashboards_tf).to include('embedding_api_call_failed')
-    expect(dashboards_tf).to include('stats sum(total_cost_usd) as total_cost_usd by event_kind')
-    expect(dashboards_tf).to include('stats sum(input_tokens) as input_tokens, sum(output_tokens) as output_tokens, sum(total_tokens) as total_tokens by event_kind')
+  it 'uses a dedicated dashboard module following the existing dashboard pattern' do
+    expect(module_main_tf).to include('dashboard_name = var.dashboard_name != null ? var.dashboard_name : "AICosts-${var.environment}"')
+    expect(module_main_tf).to include('source         = "SOURCE \'${var.log_group_name}\'"')
+    expect(module_main_tf).to include('resource "aws_cloudwatch_dashboard" "ai_costs"')
+    expect(module_main_tf).to include('## AI Costs')
   end
 
-  it 'keeps unknown model pricing visible instead of counting it as zero' do
-    expect(dashboards_tf).to include('filter pricing_known = false or not ispresent(total_cost_usd)')
-    expect(dashboards_tf).to include('Unknown or High-Cost Events')
+  it 'groups total cost by event kind for the selected dashboard time window' do
+    aggregate_query = module_main_tf[/title\s+= "Total Cost by Event Kind".*?query\s+= <<-EOT(?<query>.*?)EOT/m, :query]
+
+    expect(module_main_tf).to include('api_call_failed')
+    expect(module_main_tf).to include('embedding_api_call_failed')
+    expect(aggregate_query).to include('${local.ai_cost_events}')
+    expect(aggregate_query).to include('filter ispresent(total_cost_usd)')
+    expect(aggregate_query).to include('stats sum(total_cost_usd) as total_cost_usd by event_kind')
+    expect(aggregate_query).not_to include('bin(')
   end
 
-  it 'includes recent high-cost event detail' do
-    expect(dashboards_tf).to include('fields @timestamp, service, event, event_kind, model, total_tokens, total_cost_usd, pricing_known')
-    expect(dashboards_tf).to include('sort total_cost_usd desc, total_tokens desc')
+  it 'keeps token totals and unknown pricing visible for cost interpretation' do
+    expect(module_main_tf).to include('stats sum(input_tokens) as input_tokens, sum(output_tokens) as output_tokens, sum(total_tokens) as total_tokens by event_kind')
+    expect(module_main_tf).to include('filter pricing_known = false or not ispresent(total_cost_usd)')
+    expect(module_main_tf).to include('sum(total_cost_usd) as partial_cost_usd')
+    expect(module_main_tf).to include('Unknown Pricing Events')
   end
 end

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -20,6 +20,7 @@ Terraform to deploy the service into AWS.
 
 | Name | Source | Version |
 | ---- | ------ | ------- |
+| <a name="module_ai_costs_dashboard"></a> [ai\_costs\_dashboard](#module\_ai\_costs\_dashboard) | ./modules/ai_costs_dashboard | n/a |
 | <a name="module_backend-job"></a> [backend-job](#module\_backend-job) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.2.0 |
 | <a name="module_backend_uk"></a> [backend\_uk](#module\_backend\_uk) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.2.0 |
 | <a name="module_backend_xi"></a> [backend\_xi](#module\_backend\_xi) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.2.0 |
@@ -37,7 +38,6 @@ Terraform to deploy the service into AWS.
 
 | Name | Type |
 | ---- | ---- |
-| [aws_cloudwatch_dashboard.ai_costs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_dashboard) | resource |
 | [aws_cloudwatch_event_rule.database_backup](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_rule.database_backup_freshness_check](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_rule.database_replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
@@ -100,6 +100,7 @@ Terraform to deploy the service into AWS.
 
 | Name | Description |
 | ---- | ----------- |
+| <a name="output_ai_costs_dashboard_url"></a> [ai\_costs\_dashboard\_url](#output\_ai\_costs\_dashboard\_url) | URL to the AI Costs CloudWatch dashboard |
 | <a name="output_label_generator_dashboard_url"></a> [label\_generator\_dashboard\_url](#output\_label\_generator\_dashboard\_url) | URL to the Label Generator CloudWatch dashboard |
 | <a name="output_search_dashboard_url"></a> [search\_dashboard\_url](#output\_search\_dashboard\_url) | URL to the Search CloudWatch dashboard |
 | <a name="output_search_operations_dashboard_url"></a> [search\_operations\_dashboard\_url](#output\_search\_operations\_dashboard\_url) | URL to the Search Operations CloudWatch dashboard |

--- a/terraform/dashboards.tf
+++ b/terraform/dashboards.tf
@@ -1,34 +1,14 @@
-locals {
-  ai_cost_events = "filter event in [\"api_call_completed\", \"embedding_api_call_completed\", \"api_call_failed\", \"embedding_api_call_failed\"] and ispresent(event_kind)"
+module "ai_costs_dashboard" {
+  source = "./modules/ai_costs_dashboard"
+
+  environment    = var.environment
+  log_group_name = "platform-logs-${var.environment}"
+  region         = var.region
 }
 
-resource "aws_cloudwatch_dashboard" "ai_costs" {
-  dashboard_name = "AICosts-${var.environment}"
-  dashboard_body = jsonencode({
-    widgets = [
-      {
-        type = "log", x = 0, y = 0, width = 12, height = 6
-        properties = {
-          title = "Total Cost by Event Kind", region = var.region, view = "bar"
-          query = "SOURCE 'platform-logs-${var.environment}' | ${local.ai_cost_events} | filter pricing_known = true | stats sum(total_cost_usd) as total_cost_usd by event_kind | sort total_cost_usd desc"
-        }
-      },
-      {
-        type = "log", x = 12, y = 0, width = 12, height = 6
-        properties = {
-          title = "Token Totals by Event Kind", region = var.region, view = "bar"
-          query = "SOURCE 'platform-logs-${var.environment}' | ${local.ai_cost_events} | stats sum(input_tokens) as input_tokens, sum(output_tokens) as output_tokens, sum(total_tokens) as total_tokens by event_kind | sort total_tokens desc"
-        }
-      },
-      {
-        type = "log", x = 0, y = 6, width = 24, height = 8
-        properties = {
-          title = "Unknown or High-Cost Events", region = var.region
-          query = "SOURCE 'platform-logs-${var.environment}' | ${local.ai_cost_events} | fields @timestamp, service, event, event_kind, model, total_tokens, total_cost_usd, pricing_known | filter pricing_known = false or not ispresent(total_cost_usd) or total_cost_usd > 0 | sort total_cost_usd desc, total_tokens desc | limit 50"
-        }
-      },
-    ]
-  })
+output "ai_costs_dashboard_url" {
+  description = "URL to the AI Costs CloudWatch dashboard"
+  value       = module.ai_costs_dashboard.dashboard_url
 }
 
 module "label_generator_dashboard" {

--- a/terraform/modules/ai_costs_dashboard/README.md
+++ b/terraform/modules/ai_costs_dashboard/README.md
@@ -1,0 +1,43 @@
+# ai_costs_dashboard
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.12.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.100.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [aws_cloudwatch_dashboard.ai_costs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_dashboard) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_dashboard_name"></a> [dashboard\_name](#input\_dashboard\_name) | Name of the CloudWatch dashboard | `string` | `null` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (e.g., development, staging, production) | `string` | n/a | yes |
+| <a name="input_log_group_name"></a> [log\_group\_name](#input\_log\_group\_name) | CloudWatch Log Group name where AI usage logs are sent | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | AWS region | `string` | `"eu-west-2"` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_dashboard_arn"></a> [dashboard\_arn](#output\_dashboard\_arn) | ARN of the CloudWatch dashboard |
+| <a name="output_dashboard_name"></a> [dashboard\_name](#output\_dashboard\_name) | Name of the CloudWatch dashboard |
+| <a name="output_dashboard_url"></a> [dashboard\_url](#output\_dashboard\_url) | URL to the CloudWatch dashboard |
+<!-- END_TF_DOCS -->

--- a/terraform/modules/ai_costs_dashboard/main.tf
+++ b/terraform/modules/ai_costs_dashboard/main.tf
@@ -108,7 +108,7 @@ resource "aws_cloudwatch_dashboard" "ai_costs" {
             EOT
           }
         }
-      ],
+      ]
     )
   })
 }

--- a/terraform/modules/ai_costs_dashboard/main.tf
+++ b/terraform/modules/ai_costs_dashboard/main.tf
@@ -1,0 +1,114 @@
+locals {
+  dashboard_name = var.dashboard_name != null ? var.dashboard_name : "AICosts-${var.environment}"
+  source         = "SOURCE '${var.log_group_name}'"
+  ai_cost_events = "filter event in [\"api_call_completed\", \"embedding_api_call_completed\", \"api_call_failed\", \"embedding_api_call_failed\"] and ispresent(event_kind)"
+
+  search_dashboard_url    = "https://${var.region}.console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=Search-${var.environment}"
+  label_dashboard_url     = "https://${var.region}.console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=LabelGenerator-${var.environment}"
+  self_text_dashboard_url = "https://${var.region}.console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=SelfTextGenerator-${var.environment}"
+}
+
+resource "aws_cloudwatch_dashboard" "ai_costs" {
+  dashboard_name = local.dashboard_name
+
+  dashboard_body = jsonencode({
+    widgets = concat(
+      [
+        {
+          type   = "text"
+          x      = 0
+          y      = 0
+          width  = 24
+          height = 2
+          properties = {
+            markdown = join("\n", [
+              "## AI Costs",
+              "CloudWatch Logs Insights dashboard for OpenAI token usage and estimated USD cost.",
+              "**Start here:** use Total Cost by Event Kind for the selected time window, then inspect token volume and unknown pricing rows.",
+              "**Related:** [Search](${local.search_dashboard_url}) | [Label Generator](${local.label_dashboard_url}) | [Self-Text Generator](${local.self_text_dashboard_url})",
+            ])
+          }
+        }
+      ],
+      [
+        {
+          type   = "log"
+          x      = 0
+          y      = 2
+          width  = 12
+          height = 6
+          properties = {
+            title  = "Total Cost by Event Kind"
+            region = var.region
+            view   = "bar"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.ai_cost_events}
+              | filter ispresent(total_cost_usd)
+              | stats sum(total_cost_usd) as total_cost_usd by event_kind
+              | sort total_cost_usd desc
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 12
+          y      = 2
+          width  = 12
+          height = 6
+          properties = {
+            title  = "Token Totals by Event Kind"
+            region = var.region
+            view   = "bar"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.ai_cost_events}
+              | stats sum(input_tokens) as input_tokens, sum(output_tokens) as output_tokens, sum(total_tokens) as total_tokens by event_kind
+              | sort total_tokens desc
+            EOT
+          }
+        }
+      ],
+      [
+        {
+          type   = "log"
+          x      = 0
+          y      = 8
+          width  = 12
+          height = 7
+          properties = {
+            title  = "Unknown Pricing Events"
+            region = var.region
+            query  = <<-EOT
+              ${local.source}
+              | ${local.ai_cost_events}
+              | filter pricing_known = false or not ispresent(total_cost_usd)
+              | stats count(*) as events, sum(total_tokens) as total_tokens, sum(total_cost_usd) as partial_cost_usd by event_kind, model
+              | sort events desc, partial_cost_usd desc, total_tokens desc
+              | limit 50
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 12
+          y      = 8
+          width  = 12
+          height = 7
+          properties = {
+            title  = "Recent Costed AI Events"
+            region = var.region
+            query  = <<-EOT
+              ${local.source}
+              | ${local.ai_cost_events}
+              | filter ispresent(total_cost_usd)
+              | fields @timestamp, service, event, event_kind, model, input_tokens, output_tokens, total_tokens, total_cost_usd, pricing_known
+              | sort @timestamp desc
+              | limit 50
+            EOT
+          }
+        }
+      ],
+    )
+  })
+}

--- a/terraform/modules/ai_costs_dashboard/main.tf
+++ b/terraform/modules/ai_costs_dashboard/main.tf
@@ -44,7 +44,7 @@ resource "aws_cloudwatch_dashboard" "ai_costs" {
             query  = <<-EOT
               ${local.source}
               | ${local.ai_cost_events}
-              | filter ispresent(total_cost_usd)
+              | filter pricing_known = true and ispresent(total_cost_usd)
               | stats sum(total_cost_usd) as total_cost_usd by event_kind
               | sort total_cost_usd desc
             EOT

--- a/terraform/modules/ai_costs_dashboard/outputs.tf
+++ b/terraform/modules/ai_costs_dashboard/outputs.tf
@@ -1,0 +1,14 @@
+output "dashboard_arn" {
+  description = "ARN of the CloudWatch dashboard"
+  value       = aws_cloudwatch_dashboard.ai_costs.dashboard_arn
+}
+
+output "dashboard_name" {
+  description = "Name of the CloudWatch dashboard"
+  value       = aws_cloudwatch_dashboard.ai_costs.dashboard_name
+}
+
+output "dashboard_url" {
+  description = "URL to the CloudWatch dashboard"
+  value       = "https://${var.region}.console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=${local.dashboard_name}"
+}

--- a/terraform/modules/ai_costs_dashboard/variables.tf
+++ b/terraform/modules/ai_costs_dashboard/variables.tf
@@ -1,0 +1,21 @@
+variable "environment" {
+  description = "Environment name (e.g., development, staging, production)"
+  type        = string
+}
+
+variable "log_group_name" {
+  description = "CloudWatch Log Group name where AI usage logs are sent"
+  type        = string
+}
+
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "eu-west-2"
+}
+
+variable "dashboard_name" {
+  description = "Name of the CloudWatch dashboard"
+  type        = string
+  default     = null
+}

--- a/terraform/modules/ai_costs_dashboard/versions.tf
+++ b/terraform/modules/ai_costs_dashboard/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">=1.12.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5"
+    }
+  }
+}


### PR DESCRIPTION
## What:
Adds a dedicated AI Costs CloudWatch dashboard module and wires it into the Terraform dashboard stack. The main widget aggregates estimated OpenAI cost by `event_kind` for the selected dashboard time window using a single Logs Insights aggregate query.

## Why:
The token-cost telemetry PR added cost fields, but the dashboard was still a compact inline resource. This gives operators a first-class dashboard and URL output for reading total AI cost by event kind, token volume, recent costed events, and unknown pricing rows.

## Ticket:
AI-994

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Read-only CloudWatch dashboard Terraform. No application runtime behaviour, data processing, IAM, networking, or destructive infrastructure changes.



