### PR TITLE
fix(rubocop): re-enable Rails/FilePath

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -80,8 +80,6 @@ RSpec/ExampleLength:
 RSpec/NestedGroups:
   Enabled: false
 
-Rails/FilePath:
-  Enabled: false
 
 # swagger:generate intentionally omits :environment — rswag:specs:swaggerize
 # runs rspec in a subprocess and does not need Rails loaded in this process.

--- a/spec/factory_bot_shared_sequences_spec.rb
+++ b/spec/factory_bot_shared_sequences_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe FactoryBot do
         names = shared_sequence_names.select { |name| content.match?(/sequence\(\s*:#{name}\b/) }
         next if names.empty?
 
-        [path.delete_prefix("#{Rails.root}/"), names]
+        [Pathname.new(path).relative_path_from(Rails.root).to_s, names]
       end
 
       expect(offenders).to eq([]), <<~MESSAGE


### PR DESCRIPTION
## What:
- [x] Prefer `Pathname#relative_path_from` when computing paths relative to `Rails.root` in the factory bot shared-sequence spec
- [x] Re-enable `Rails/FilePath` in `.rubocop.yml`
- [x] Confirm no remaining `Rails/FilePath` offenses under `app`, `lib`, and `spec`

## Why:
The cop was disabled despite the rest of the tree already matching the preferred path style. Fixing the last offender lets the config enforce the style going forward.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
One-line path helper change in a spec plus a RuboCop re-enable. No production behaviour change.