### PR TITLE
chore(rubocop): document disabled cops and drop zero-offense disables

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,10 @@ inherit_gem:
     - config/default.yml
     - config/rails.yml
 
+inherit_mode:
+  merge:
+    - Exclude
+
 plugins:
   - rubocop-rspec
   - rubocop-performance
@@ -12,6 +16,8 @@ require:
 
 AllCops:
   Exclude:
+    - ".bundle/**/*"
+    - ".direnv/**/*"
     - "db/schema.rb"
     - "vendor/**/*"
     - "bin/**"
@@ -50,9 +56,13 @@ Layout/AccessModifierIndentation:
 Metrics/AbcSize:
   Max: 20
 
+# Legacy codebase-wide policy cop with many existing offenses; left disabled
+# until it can be split into focused refactors.
 Metrics/BlockLength:
   Enabled: false
 
+# Legacy codebase-wide policy cop with many existing offenses; left disabled
+# until it can be split into focused refactors.
 Metrics/ModuleLength:
   Enabled: false
 
@@ -74,9 +84,13 @@ RSpec/ContextWording:
 RSpec/MultipleMemoizedHelpers:
   Max: 10
 
+# Legacy spec-shape policy cop with many existing offenses; left disabled until
+# specs can be refactored in targeted behaviour-preserving changes.
 RSpec/ExampleLength:
   Enabled: false
 
+# Legacy spec-shape policy cop with many existing offenses; left disabled until
+# specs can be refactored in targeted behaviour-preserving changes.
 RSpec/NestedGroups:
   Enabled: false
 
@@ -89,24 +103,21 @@ Rails/RakeEnvironment:
   Exclude:
     - 'lib/tasks/swagger.rake'
 
+# This application uses Sequel datasets rather than ActiveRecord relations.
 Rails/FindEach:
   Enabled: false
 
-Rails/ActiveRecordAliases:
+# This application uses Sequel rather than ActiveRecord.
+Rails/FindBy:
   Enabled: false
 
-Rails/CreateTableWithTimestamps:
-  Enabled: false # doesn't recognise
-
-Rails/FindBy:
-  Enabled: false # We use sequel not active record
-
+# Sequel persistence methods do not have the same semantics as ActiveRecord's
+# bang/non-bang persistence methods.
 Rails/SaveBang:
   Enabled: false
 
-Rails/UniqueValidationWithoutIndex:
-  Enabled: false
-
+# Legacy codebase-wide documentation policy cop with many existing offenses;
+# left disabled until documentation standards can be introduced deliberately.
 Style/Documentation:
   Enabled: false
 
@@ -126,6 +137,8 @@ RSpec/MessageChain:
 RSpec/IndexedLet:
   Enabled: false
 
+# Legacy spec-shape policy cop with many existing offenses; left disabled until
+# specs can be refactored in targeted behaviour-preserving changes.
 RSpec/MultipleExpectations:
   Enabled: false
 


### PR DESCRIPTION
## What:
- [x] Add `inherit_mode` so `Exclude` lists merge with inherited config
- [x] Exclude local `.bundle/**/*` and `.direnv/**/*` trees from AllCops
- [x] Drop disabled entries for Rails cops with no remaining offenses (`ActiveRecordAliases`, `CreateTableWithTimestamps`, `UniqueValidationWithoutIndex`)
- [x] Document why remaining disabled cops stay off (Sequel vs ActiveRecord assumptions, and large legacy policy cops)

## Why:
Disabled RuboCop rules without explanation hide whether a disable is still needed. This makes the config honest about intentional disables and removes ones that no longer protect against real offenses.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Config and documentation only. No application code changes; remaining disabled cops stay disabled by design.