### PR TITLE
fix(rubocop): shorten elasticsearch helper module

### DIFF
--- a/spec/support/elasticsearch_helpers.rb
+++ b/spec/support/elasticsearch_helpers.rb
@@ -18,9 +18,7 @@ module ElasticsearchHelpers
   def index_model(model)
     index_class = INDEX_CLASS_MAP[model.class.name]
 
-    if index_class
-      TradeTariffBackend.search_client.index(index_class, model)
-    end
+    TradeTariffBackend.search_client.index(index_class, model) if index_class
 
     index_search_suggestion(model)
   rescue OpenSearch::Transport::Transport::Errors::NotFound
@@ -31,9 +29,7 @@ module ElasticsearchHelpers
   def delete_model_from_index(model)
     index_class = INDEX_CLASS_MAP[model.class.name]
 
-    if index_class
-      TradeTariffBackend.search_client.delete(index_class, model)
-    end
+    TradeTariffBackend.search_client.delete(index_class, model) if index_class
 
     delete_search_suggestion(model)
   rescue OpenSearch::Transport::Transport::Errors::NotFound


### PR DESCRIPTION
## What:
- [x] Extract or shorten long modules/blocks for RuboCop Metrics honesty (rubocop-split-elasticsearch-helpers)
- [x] Keep behaviour unchanged; structure only

## Why:
Long modules and blocks kept `Metrics/ModuleLength` and `Metrics/BlockLength` unenforceable. Splitting by domain keeps each change reviewable and behaviour-preserving.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Behaviour-preserving structural extraction/shortening with no intentional API or data behaviour change.