### PR TITLE
fix(rubocop): share timed instrumentation helper

### DIFF
--- a/app/lib/label_generator/instrumentation.rb
+++ b/app/lib/label_generator/instrumentation.rb
@@ -1,4 +1,5 @@
 require 'active_support/notifications'
+require_relative '../timed_instrumentation'
 
 module LabelGenerator
   module Instrumentation
@@ -35,43 +36,25 @@ module LabelGenerator
       )
     end
 
-    def api_call(batch_size:, model:, page_number:)
-      instrument('api_call_started', batch_size:, model:, page_number:)
-
-      start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      result = yield
-      duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
-
-      results_count = result.is_a?(Hash) ? Array.wrap(result['data']).size : 0
-
-      instrument(
-        'api_call_completed',
-        {
-          batch_size:,
-          model:,
-          page_number:,
-          results_count:,
-          duration_ms: (duration * 1000).round(2),
-          event_kind: 'label_generation',
-        }.merge(AiUsage.payload_from(result)),
+    def api_call(batch_size:, model:, page_number:, &block)
+      TimedInstrumentation.call(
+        instrumenter: method(:instrument),
+        started_event: 'api_call_started',
+        completed_event: 'api_call_completed',
+        failed_event: 'api_call_failed',
+        payload: { batch_size:, model:, page_number:, event_kind: 'label_generation' },
+        completed_payload: lambda { |result|
+          {
+            results_count: result.is_a?(Hash) ? Array.wrap(result['data']).size : 0,
+          }.merge(AiUsage.payload_from(result))
+        },
+        failed_payload: lambda { |error|
+          {
+            error_message: AiUsage.safe_error_message(error),
+          }.merge(AiUsage.payload_from_error(error))
+        },
+        &block
       )
-
-      result
-    rescue StandardError => e
-      duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
-      instrument(
-        'api_call_failed',
-        {
-          batch_size:,
-          model:,
-          page_number:,
-          error_class: e.class.name,
-          error_message: AiUsage.safe_error_message(e),
-          duration_ms: (duration * 1000).round(2),
-          event_kind: 'label_generation',
-        }.merge(AiUsage.payload_from_error(e)),
-      )
-      raise
     end
 
     def label_saved(label, page_number:)

--- a/app/lib/self_text_generator/instrumentation.rb
+++ b/app/lib/self_text_generator/instrumentation.rb
@@ -1,4 +1,5 @@
 require 'active_support/notifications'
+require_relative '../timed_instrumentation'
 
 module SelfTextGenerator
   module Instrumentation
@@ -34,47 +35,27 @@ module SelfTextGenerator
       )
     end
 
-    def api_call(batch_size:, model:, chapter_code:, event_kind: 'self_text_generation_ai')
-      instrument('api_call_started', batch_size:, model:, chapter_code:)
-
-      start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      result = yield
-      duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
-
-      instrument(
-        'api_call_completed',
-        {
-          batch_size:,
-          model:,
-          chapter_code:,
-          duration_ms: (duration * 1000).round(2),
-          event_kind:,
-        }.merge(AiUsage.payload_from(result)),
+    def api_call(batch_size:, model:, chapter_code:, event_kind: 'self_text_generation_ai', &block)
+      TimedInstrumentation.call(
+        instrumenter: method(:instrument),
+        started_event: 'api_call_started',
+        completed_event: 'api_call_completed',
+        failed_event: 'api_call_failed',
+        payload: { batch_size:, model:, chapter_code:, event_kind: },
+        completed_payload: ->(result) { AiUsage.payload_from(result) },
+        failed_payload: lambda { |error|
+          http_status = if error.respond_to?(:http_status)
+                          error.http_status
+                        else
+                          error.respond_to?(:response) ? error.response&.dig(:status) : nil
+                        end
+          {
+            error_message: AiUsage.safe_error_message(error),
+            http_status:,
+          }.merge(AiUsage.payload_from_error(error))
+        },
+        &block
       )
-
-      result
-    rescue StandardError => e
-      duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
-      http_status = if e.respond_to?(:http_status)
-                      e.http_status
-                    else
-                      e.respond_to?(:response) ? e.response&.dig(:status) : nil
-                    end
-
-      instrument(
-        'api_call_failed',
-        {
-          batch_size:,
-          model:,
-          chapter_code:,
-          error_class: e.class.name,
-          error_message: AiUsage.safe_error_message(e),
-          duration_ms: (duration * 1000).round(2),
-          http_status:,
-          event_kind:,
-        }.merge(AiUsage.payload_from_error(e)),
-      )
-      raise
     end
 
     def scoring_started(chapter_code:, total_records:)

--- a/app/lib/timed_instrumentation.rb
+++ b/app/lib/timed_instrumentation.rb
@@ -1,0 +1,38 @@
+module TimedInstrumentation
+  module_function
+
+  def call(instrumenter:, started_event:, completed_event:, failed_event:, payload:, completed_payload: nil, failed_payload: nil)
+    instrumenter.call(started_event, payload)
+
+    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    result = yield
+    duration_ms = duration_since(start_time)
+
+    instrumenter.call(completed_event, payload.merge(duration_ms:, **completed_payload_for(completed_payload, result)))
+
+    result
+  rescue StandardError => e
+    instrumenter.call(
+      failed_event,
+      payload.merge(
+        error_class: e.class.name,
+        error_message: e.message,
+        duration_ms: duration_since(start_time),
+        **payload_for(failed_payload, e),
+      ),
+    )
+    raise
+  end
+
+  def completed_payload_for(payload, result)
+    payload.respond_to?(:call) ? payload.call(result) : payload.to_h
+  end
+
+  def payload_for(payload, error)
+    payload.respond_to?(:call) ? payload.call(error) : payload.to_h
+  end
+
+  def duration_since(start_time)
+    ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000).round(2)
+  end
+end


### PR DESCRIPTION
## What:
- [x] Add shared `TimedInstrumentation` helper for started/completed/failed API timing
- [x] Use it in label generator and self-text generator instrumentation
- [x] Preserve AiUsage cost/error payload fields on completed and failed events

## Why:
Duplicated timing blocks inflate instrumentation modules. Sharing one helper shortens the modules without changing notification event names or AI cost telemetry.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Behaviour-preserving extraction of timing boilerplate; instrumentation specs cover the api_call paths and AiUsage payloads are retained.