### PR TITLE
fix(rubocop): split utility task namespaces

### DIFF
--- a/lib/tasks/data_migrations.rake
+++ b/lib/tasks/data_migrations.rake
@@ -1,72 +1,66 @@
-namespace :data do
-  namespace :migrate do
-    task load: :environment do # rubocop:disable Rake/Desc
-      require 'data_migrator'
-      db_for_current_env
-    end
+task 'data:migrate:load' => :environment do # rubocop:disable Rake/Desc
+  require 'data_migrator'
+  db_for_current_env
+end
 
-    desc 'Rollbacks the database one data migration and re migrate up. If you want to rollback more than one step, define STEP=x. Target specific version with VERSION=x.'
-    task redo: :load do
-      if ENV['VERSION']
-        Rake::Task['data:migrate:down'].invoke
-        Rake::Task['data:migrate:up'].invoke
-      else
-        Rake::Task['data:rollback'].invoke
-        Rake::Task['data:migrate'].invoke
-      end
-    end
-
-    desc 'Runs the "up" for a given data migration VERSION.'
-    task up: :load do
-      version = ENV['VERSION'] ? ENV['VERSION'].to_i : nil
-      raise 'VERSION is required' unless version
-
-      ::DataMigrator.migrate_up!(version)
-
-      MaterializeViewHelper.refresh_materialized_view
-    end
-
-    desc 'Runs the "down" for a given data migration VERSION.'
-    task down: :load do
-      version = ENV['VERSION'] ? ENV['VERSION'].to_i : nil
-      raise 'VERSION is required' unless version
-
-      ::DataMigrator.migrate_down!(version)
-
-      MaterializeViewHelper.refresh_materialized_view
-    end
+desc 'Rollbacks the database one data migration and re migrate up. If you want to rollback more than one step, define STEP=x. Target specific version with VERSION=x.'
+task 'data:migrate:redo' => 'data:migrate:load' do
+  if ENV['VERSION']
+    Rake::Task['data:migrate:down'].invoke
+    Rake::Task['data:migrate:up'].invoke
+  else
+    Rake::Task['data:rollback'].invoke
+    Rake::Task['data:migrate'].invoke
   end
+end
 
-  desc 'Migrate data to the latest version - IMPORTANT ensure migrations are idempotent'
-  task migrate: 'migrate:load' do
-    refresh_view = ::DataMigrator.pending_migrations? || ENV['VERSION'].present?
+desc 'Runs the "up" for a given data migration VERSION.'
+task 'data:migrate:up' => 'data:migrate:load' do
+  version = ENV['VERSION'] ? ENV['VERSION'].to_i : nil
+  raise 'VERSION is required' unless version
 
-    ::DataMigrator.migrate_up!(ENV['VERSION'] ? ENV['VERSION'].to_i : nil)
+  ::DataMigrator.migrate_up!(version)
 
-    MaterializeViewHelper.refresh_materialized_view if refresh_view
-  end
+  MaterializeViewHelper.refresh_materialized_view
+end
 
-  desc 'Rollback the latest data migration file or down to specified VERSION=x'
-  task rollback: 'migrate:load' do
-    version = if ENV['VERSION']
-                ENV['VERSION'].to_i
-              else
-                ::DataMigrator.previous_migration
-              end
-    ::DataMigrator.migrate_down! version
+desc 'Runs the "down" for a given data migration VERSION.'
+task 'data:migrate:down' => 'data:migrate:load' do
+  version = ENV['VERSION'] ? ENV['VERSION'].to_i : nil
+  raise 'VERSION is required' unless version
 
-    MaterializeViewHelper.refresh_materialized_view
-  end
+  ::DataMigrator.migrate_down!(version)
 
-  namespace :views do
-    desc 'Refresh materialized views within the site'
-    task refresh: :environment do
-      MaterializeViewHelper.refresh_materialized_view(concurrently: true)
-    end
+  MaterializeViewHelper.refresh_materialized_view
+end
 
-    desc 'Refresh materialized views within the site when unpopulated (does not use CONCURRENTLY)'
-    task populate: :environment do
-      MaterializeViewHelper.refresh_materialized_view(concurrently: false)
-    end
-  end
+desc 'Migrate data to the latest version - IMPORTANT ensure migrations are idempotent'
+task 'data:migrate' => 'data:migrate:load' do
+  refresh_view = ::DataMigrator.pending_migrations? || ENV['VERSION'].present?
+
+  ::DataMigrator.migrate_up!(ENV['VERSION'] ? ENV['VERSION'].to_i : nil)
+
+  MaterializeViewHelper.refresh_materialized_view if refresh_view
+end
+
+desc 'Rollback the latest data migration file or down to specified VERSION=x'
+task 'data:rollback' => 'data:migrate:load' do
+  version = if ENV['VERSION']
+              ENV['VERSION'].to_i
+            else
+              ::DataMigrator.previous_migration
+            end
+  ::DataMigrator.migrate_down! version
+
+  MaterializeViewHelper.refresh_materialized_view
+end
+
+desc 'Refresh materialized views within the site'
+task 'data:views:refresh' => :environment do
+  MaterializeViewHelper.refresh_materialized_view(concurrently: true)
+end
+
+desc 'Refresh materialized views within the site when unpopulated (does not use CONCURRENTLY)'
+task 'data:views:populate' => :environment do
+  MaterializeViewHelper.refresh_materialized_view(concurrently: false)
 end

--- a/lib/tasks/sidekiq.rake
+++ b/lib/tasks/sidekiq.rake
@@ -1,66 +1,64 @@
 # rubocop:disable Style/StringConcatenation
-namespace :sidekiq do
-  require 'sidekiq/api'
+require 'sidekiq/api'
 
-  desc "Get status of batch. You must supply a :bid (batch id), e.g. `rake sidekiq:status['BYUxWr4GbojwaQ']`. Batch ID may be found in the Sidekiq::Worker, e.g., `rake sidekiq:workers`"
-  task :status, [:bid] => :environment do |_task, args|
-    exit unless args[:bid]
-    status = Sidekiq::Batch::Status.new(args[:bid])
-    puts 'batch:        ' + args[:bid]
-    puts 'total:        ' + status.total.to_s # jobs in the batch => 97
-    puts 'failures:     ' + status.failures.to_s # failed jobs so far => 5
-    puts 'pending:      ' + status.pending.to_s # jobs which have not succeeded yet => 17
-    puts 'created_at:   ' + status.created_at.to_s # => 2012-09-04 21:15:05 -0700
-    puts 'complete?:    ' + status.complete?.to_s # if all jobs have executed at least once => false
-    puts 'failure_info: ' + status.failure_info.inspect # an array of failed jobs
-    puts 'data:         ' + status.data.inspect # a hash of data about the batch which can easily be converted to JSON for javascript usage
-  end
+desc "Get status of batch. You must supply a :bid (batch id), e.g. `rake sidekiq:status['BYUxWr4GbojwaQ']`. Batch ID may be found in the Sidekiq::Worker, e.g., `rake sidekiq:workers`"
+task 'sidekiq:status', [:bid] => :environment do |_task, args|
+  exit unless args[:bid]
+  status = Sidekiq::Batch::Status.new(args[:bid])
+  puts 'batch:        ' + args[:bid]
+  puts 'total:        ' + status.total.to_s # jobs in the batch => 97
+  puts 'failures:     ' + status.failures.to_s # failed jobs so far => 5
+  puts 'pending:      ' + status.pending.to_s # jobs which have not succeeded yet => 17
+  puts 'created_at:   ' + status.created_at.to_s # => 2012-09-04 21:15:05 -0700
+  puts 'complete?:    ' + status.complete?.to_s # if all jobs have executed at least once => false
+  puts 'failure_info: ' + status.failure_info.inspect # an array of failed jobs
+  puts 'data:         ' + status.data.inspect # a hash of data about the batch which can easily be converted to JSON for javascript usage
+end
 
-  desc "Print a list of current active worker set for all Sidekiq processes. A 'worker' is defined as a thread currently processing a job"
-  task workers: :environment do
-    Sidekiq::Workers.new.each do |_process_id, _thread_id, work|
-      puts work
-    end
+desc "Print a list of current active worker set for all Sidekiq processes. A 'worker' is defined as a thread currently processing a job"
+task 'sidekiq:workers' => :environment do
+  Sidekiq::Workers.new.each do |_process_id, _thread_id, work|
+    puts work
   end
+end
 
-  desc "List jobs on a queue. You may provide a queue name, e.g., `rake sidekiq:queue['sync']`, or leave blank for the 'default' queue."
-  task :queue, [:queue] => :environment do |_task, args|
-    q = args[:queue] || 'default'
-    queue = Sidekiq::Queue.new(q)
-    puts "queue: #{queue.name}"
-    puts 'jobs:'
-    queue.each do |job|
-      puts job.item.inspect
-    end
+desc "List jobs on a queue. You may provide a queue name, e.g., `rake sidekiq:queue['sync']`, or leave blank for the 'default' queue."
+task 'sidekiq:queue', [:queue] => :environment do |_task, args|
+  q = args[:queue] || 'default'
+  queue = Sidekiq::Queue.new(q)
+  puts "queue: #{queue.name}"
+  puts 'jobs:'
+  queue.each do |job|
+    puts job.item.inspect
   end
+end
 
-  desc 'Info about the current set of Sidekiq processes running'
-  task processes: :environment do
-    Sidekiq::ProcessSet.new.each do |process|
-      puts process.inspect
-    end
+desc 'Info about the current set of Sidekiq processes running'
+task 'sidekiq:processes' => :environment do
+  Sidekiq::ProcessSet.new.each do |process|
+    puts process.inspect
   end
+end
 
-  desc 'Various stats about the Sidekiq installation'
-  task stats: :environment do
-    puts Sidekiq::Stats.new.inspect
-  end
+desc 'Various stats about the Sidekiq installation'
+task 'sidekiq:stats' => :environment do
+  puts Sidekiq::Stats.new.inspect
+end
 
-  desc 'Show all scheduled jobs in chronologically-sorted order'
-  task scheduled: :environment do
-    Sidekiq::ScheduledSet.new.each do |job|
-      puts job.inspect
-    end
+desc 'Show all scheduled jobs in chronologically-sorted order'
+task 'sidekiq:scheduled' => :environment do
+  Sidekiq::ScheduledSet.new.each do |job|
+    puts job.inspect
   end
+end
 
-  desc 'Gets the current schedule'
-  task get_schedule: :environment do
-    puts Sidekiq.get_schedule
-  end
+desc 'Gets the current schedule'
+task 'sidekiq:get_schedule' => :environment do
+  puts Sidekiq.get_schedule
+end
 
-  desc "CAUTION! Clear all of this app's Sidekiq queues from Redis (destructive)."
-  task clear_queue: :environment do
-    Sidekiq.redis(&:flushdb)
-  end
+desc "CAUTION! Clear all of this app's Sidekiq queues from Redis (destructive)."
+task 'sidekiq:clear_queue' => :environment do
+  Sidekiq.redis(&:flushdb)
 end
 # rubocop:enable Style/StringConcatenation

--- a/lib/tasks/test_database.rake
+++ b/lib/tasks/test_database.rake
@@ -1,56 +1,52 @@
 require 'open3'
 
-namespace :db do
-  namespace :test do
-    desc 'Populate empty materialized views after loading the test structure'
-    task populate_empty_materialized_views: :environment do
-      db = begin
-        Sequel::Model.db
-      rescue Sequel::Error
-        Sequel.connect(Rails.application.config.database_configuration.fetch(Rails.env).symbolize_keys)
-      end
+desc 'Populate empty materialized views after loading the test structure'
+task 'db:test:populate_empty_materialized_views' => :environment do
+  db = begin
+    Sequel::Model.db
+  rescue Sequel::Error
+    Sequel.connect(Rails.application.config.database_configuration.fetch(Rails.env).symbolize_keys)
+  end
 
-      db.fetch(<<~SQL).each do |row|
-        SELECT quote_ident(schemaname) || '.' || quote_ident(matviewname) AS view_name
-        FROM pg_matviews
-      SQL
-        db.run("REFRESH MATERIALIZED VIEW #{row[:view_name]}")
-      end
+  db.fetch(<<~SQL).each do |row|
+    SELECT quote_ident(schemaname) || '.' || quote_ident(matviewname) AS view_name
+    FROM pg_matviews
+  SQL
+    db.run("REFRESH MATERIALIZED VIEW #{row[:view_name]}")
+  end
+end
+
+desc 'Prepare parallel test databases'
+task 'db:test:prepare_parallel' => :environment do
+  workers = Integer(ENV.fetch('PARALLEL_TEST_PROCESSORS', 5))
+
+  raise 'PARALLEL_TEST_PROCESSORS must be at least 1' if workers < 1
+
+  puts 'Preparing test databases...'
+
+  1.upto(workers) do |worker|
+    test_env_number = worker == 1 ? '' : worker.to_s
+    database_name = "tariff_test#{test_env_number}"
+    env = {
+      'RAILS_ENV' => 'test',
+      'TEST_ENV_NUMBER' => test_env_number,
+    }
+    command = %w[bundle exec rails db:drop db:create db:structure:load]
+
+    stdout, stderr, status = Open3.capture3(env, *command)
+
+    if ENV['PARALLEL_TEST_PREPARE_VERBOSE'] == 'true'
+      puts stdout
+      warn stderr
     end
 
-    desc 'Prepare parallel test databases'
-    task prepare_parallel: :environment do
-      workers = Integer(ENV.fetch('PARALLEL_TEST_PROCESSORS', 5))
-
-      raise 'PARALLEL_TEST_PROCESSORS must be at least 1' if workers < 1
-
-      puts 'Preparing test databases...'
-
-      1.upto(workers) do |worker|
-        test_env_number = worker == 1 ? '' : worker.to_s
-        database_name = "tariff_test#{test_env_number}"
-        env = {
-          'RAILS_ENV' => 'test',
-          'TEST_ENV_NUMBER' => test_env_number,
-        }
-        command = %w[bundle exec rails db:drop db:create db:structure:load]
-
-        stdout, stderr, status = Open3.capture3(env, *command)
-
-        if ENV['PARALLEL_TEST_PREPARE_VERBOSE'] == 'true'
-          puts stdout
-          warn stderr
-        end
-
-        unless status.success?
-          puts stdout
-          warn stderr
-          abort "Failed to prepare #{database_name}"
-        end
-
-        puts "Prepared #{database_name}"
-      end
+    unless status.success?
+      puts stdout
+      warn stderr
+      abort "Failed to prepare #{database_name}"
     end
+
+    puts "Prepared #{database_name}"
   end
 end
 


### PR DESCRIPTION
## What:
- [x] Extract or shorten long modules/blocks for RuboCop Metrics honesty
- [x] Keep runtime behaviour unchanged (structure only)

## Why:
Long modules and blocks made Metrics cops unenforceable. Domain-scoped extractions keep each change reviewable.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Behaviour-preserving structural extraction/shortening with no intentional API or data behaviour change.