### PR TITLE
fix(rubocop): extract tariff task helpers

### DIFF
--- a/lib/tasks/tariff.rake
+++ b/lib/tasks/tariff.rake
@@ -1,11 +1,7 @@
-namespace :tariff do
-  desc 'Reindex relevant entities on ElasticSearch'
-  task reindex: %w[environment] do
-    TradeTariffBackend.reindex
-  end
+module TariffRakeTasks
+module_function
 
-  desc 'List queued jobs'
-  task jobs: %w[environment] do
+  def jobs
     require 'sidekiq/api'
 
     Sidekiq::Queue.all.each do |queue|
@@ -27,53 +23,41 @@ namespace :tariff do
     end
   end
 
-  desc 'Download and apply Taric or CDS data using Sidekiq'
-  task sync: %w[environment sync:download_apply_and_reindex]
-
-  namespace :sync do
-    desc 'Update database by downloading and then applying TARIC or CDS updates via worker'
-    task download_apply_and_reindex: %i[environment class_eager_load] do
-      if TradeTariffBackend.uk?
-        CdsUpdatesSynchronizerWorker.perform_async(true, true)
-      else
-        TaricUpdatesSynchronizerWorker.perform_async(true)
-      end
-    end
-
-    desc 'Download pending Taric or CDS update files, Update tariff_updates table'
-    task download: %i[environment class_eager_load] do
-      if TradeTariffBackend.uk?
-        CdsSynchronizer.download
-      else
-        TaricSynchronizer.download
-      end
-    end
-
-    desc 'Apply pending updates for Taric or CDS'
-    task apply: %i[environment class_eager_load] do
-      if TradeTariffBackend.uk?
-        CdsSynchronizer.apply
-      else
-        TaricSynchronizer.apply
-      end
-    end
-
-    desc 'Rollback to specific date in the past'
-    task rollback: %w[environment class_eager_load] do
-      if ENV['DATE']
-        if TradeTariffBackend.uk?
-          CdsSynchronizer.rollback(ENV['DATE'], keep: ENV['KEEP'])
-        else
-          TaricSynchronizer.rollback(ENV['DATE'], keep: ENV['KEEP'])
-        end
-      else
-        raise ArgumentError, "Please set the date using environment variable 'DATE'"
-      end
+  def download_apply_and_reindex
+    if TradeTariffBackend.uk?
+      CdsUpdatesSynchronizerWorker.perform_async(true, true)
+    else
+      TaricUpdatesSynchronizerWorker.perform_async(true)
     end
   end
 
-  desc 'Check tree integrity - optionally for DATE'
-  task check_integrity: %w[environment] do
+  def download
+    if TradeTariffBackend.uk?
+      CdsSynchronizer.download
+    else
+      TaricSynchronizer.download
+    end
+  end
+
+  def apply
+    if TradeTariffBackend.uk?
+      CdsSynchronizer.apply
+    else
+      TaricSynchronizer.apply
+    end
+  end
+
+  def rollback
+    raise ArgumentError, "Please set the date using environment variable 'DATE'" unless ENV['DATE']
+
+    if TradeTariffBackend.uk?
+      CdsSynchronizer.rollback(ENV['DATE'], keep: ENV['KEEP'])
+    else
+      TaricSynchronizer.rollback(ENV['DATE'], keep: ENV['KEEP'])
+    end
+  end
+
+  def check_integrity
     date = ENV['DATE'].presence ? Time.zone.parse(ENV['DATE']).to_day : Time.zone.today
 
     TimeMachine.at(date) do
@@ -88,21 +72,14 @@ namespace :tariff do
     end
   end
 
-  desc 'Recreate changes'
-  task recreate_changes_data: %w[environment] do
+  def recreate_changes_data
     Change.db.transaction do
       Change.dataset.delete
       ChangesTablePopulator.populate_backlog
     end
   end
 
-  desc 'Populate tariff changes for the past year'
-  task populate_tariff_changes: %w[environment] do
-    TariffChangesService.populate_backlog(from: Time.zone.today - 1.year)
-  end
-
-  desc 'Refresh materialized views'
-  task refresh: :environment do
+  def refresh
     require_relative '../../app/helpers/materialize_view_helper'
 
     concurrently = ENV['CONCURRENTLY'] == 'true'
@@ -110,4 +87,57 @@ namespace :tariff do
     puts "Refreshing materialized views#{' concurrently' if concurrently}..."
     MaterializeViewHelper.refresh_materialized_view(concurrently: concurrently)
   end
+end
+
+desc 'Reindex relevant entities on ElasticSearch'
+task 'tariff:reindex' => :environment do
+  TradeTariffBackend.reindex
+end
+
+desc 'List queued jobs'
+task 'tariff:jobs' => :environment do
+  TariffRakeTasks.jobs
+end
+
+desc 'Download and apply Taric or CDS data using Sidekiq'
+task 'tariff:sync' => %w[environment tariff:sync:download_apply_and_reindex]
+
+desc 'Update database by downloading and then applying TARIC or CDS updates via worker'
+task 'tariff:sync:download_apply_and_reindex' => %i[environment class_eager_load] do
+  TariffRakeTasks.download_apply_and_reindex
+end
+
+desc 'Download pending Taric or CDS update files, Update tariff_updates table'
+task 'tariff:sync:download' => %i[environment class_eager_load] do
+  TariffRakeTasks.download
+end
+
+desc 'Apply pending updates for Taric or CDS'
+task 'tariff:sync:apply' => %i[environment class_eager_load] do
+  TariffRakeTasks.apply
+end
+
+desc 'Rollback to specific date in the past'
+task 'tariff:sync:rollback' => %w[environment class_eager_load] do
+  TariffRakeTasks.rollback
+end
+
+desc 'Check tree integrity - optionally for DATE'
+task 'tariff:check_integrity' => :environment do
+  TariffRakeTasks.check_integrity
+end
+
+desc 'Recreate changes'
+task 'tariff:recreate_changes_data' => :environment do
+  TariffRakeTasks.recreate_changes_data
+end
+
+desc 'Populate tariff changes for the past year'
+task 'tariff:populate_tariff_changes' => :environment do
+  TariffChangesService.populate_backlog(from: Time.zone.today - 1.year)
+end
+
+desc 'Refresh materialized views'
+task 'tariff:refresh' => :environment do
+  TariffRakeTasks.refresh
 end


### PR DESCRIPTION
## What:
- [x] Extract or shorten long modules/blocks for RuboCop Metrics honesty
- [x] Keep runtime behaviour unchanged (structure only)

## Why:
Long modules and blocks made Metrics cops unenforceable. Domain-scoped extractions keep each change reviewable.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Behaviour-preserving structural extraction/shortening with no intentional API or data behaviour change.