### PR TITLE
fix(rubocop): shorten supplementary units report

### DIFF
--- a/app/lib/reporting/supplementary_units.rb
+++ b/app/lib/reporting/supplementary_units.rb
@@ -20,32 +20,11 @@ module Reporting
 
           log_report_metric('rows_written', report_rows.size)
 
-          csv_data = instrument_report_step('serialize_csv', rows_written: report_rows.size) do
-            CSV.generate(write_headers: true, headers: HEADER_ROW) do |csv|
-              report_rows.each do |row|
-                csv << row
-              end
-            end
-          end
-
+          csv_data = serialize_csv(report_rows)
           return if report_rows.empty?
 
           log_report_metric('output_bytes', csv_data.bytesize)
-
-          if Rails.env.development?
-            instrument_report_step('write_local_file', output_bytes: csv_data.bytesize) do
-              File.write(File.basename(object_key), csv_data)
-            end
-          end
-
-          if Rails.env.production?
-            instrument_report_step('upload', output_bytes: csv_data.bytesize) do
-              object.put(
-                body: csv_data,
-                content_type: 'text/csv',
-              )
-            end
-          end
+          publish_csv(csv_data)
         end
       end
 
@@ -92,6 +71,36 @@ module Reporting
               measures__geographical_area_id
             ],
           )
+      end
+
+      def serialize_csv(report_rows)
+        instrument_report_step('serialize_csv', rows_written: report_rows.size) do
+          CSV.generate(write_headers: true, headers: HEADER_ROW) do |csv|
+            report_rows.each do |row|
+              csv << row
+            end
+          end
+        end
+      end
+
+      def publish_csv(csv_data)
+        write_local_file(csv_data) if Rails.env.development?
+        upload(csv_data) if Rails.env.production?
+      end
+
+      def write_local_file(csv_data)
+        instrument_report_step('write_local_file', output_bytes: csv_data.bytesize) do
+          File.write(File.basename(object_key), csv_data)
+        end
+      end
+
+      def upload(csv_data)
+        instrument_report_step('upload', output_bytes: csv_data.bytesize) do
+          object.put(
+            body: csv_data,
+            content_type: 'text/csv',
+          )
+        end
       end
 
       def object_key


### PR DESCRIPTION
## What:
- [x] Extract or shorten long modules/blocks for RuboCop Metrics honesty
- [x] Keep runtime behaviour unchanged (structure only)

## Why:
Long modules and blocks made Metrics cops unenforceable. Domain-scoped extractions keep each change reviewable.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Behaviour-preserving structural extraction/shortening with no intentional API or data behaviour change.