### PR TITLE
fix(rubocop): shorten tariff updates report generation

### DIFF
--- a/app/lib/reporting/tariff_updates.rb
+++ b/app/lib/reporting/tariff_updates.rb
@@ -14,80 +14,103 @@ module Reporting
     class << self
       def generate
         with_report_logging do
-          workbook = instrument_report_step('open_workbook') do
-            if Rails.env.development?
-              FileUtils.rm(filename) if File.exist?(filename)
-
-              FastExcel.open(
-                filename,
-                constant_memory: true,
-              )
-            else
-              FastExcel.open(
-                constant_memory: true,
-              )
-            end
-          end
-
-          bold_format = instrument_report_step('add_format') do
-            workbook.add_format(bold: true)
-          end
-
-          worksheet = instrument_report_step('setup_worksheet') do
-            sheet = workbook.add_worksheet(Time.zone.today.iso8601)
-
-            COLUMN_WIDTHS.each_with_index do |width, index|
-              sheet.set_column_width(index, width)
-            end
-
-            sheet.append_row(HEADER_ROW, bold_format)
-            sheet.freeze_panes(1, 0)
-            sheet
-          end
-
+          workbook = open_workbook
+          bold_format = instrument_report_step('add_format') { workbook.add_format(bold: true) }
+          worksheet = setup_worksheet(workbook, bold_format)
           rows = instrument_report_step('load_rows') do
             tariff_updates
           end
 
-          rows_written = instrument_report_step('append_rows') do
-            count = 0
-
-            rows.each do |update|
-              build_rows_for(update).each do |row|
-                worksheet.append_row(row)
-                count += 1
-              end
-            end
-
-            count
-          end
+          rows_written = append_rows(worksheet, rows)
 
           log_report_metric('rows_written', rows_written)
 
-          workbook_data = instrument_report_step('close_workbook', rows_written:) do
-            workbook.close
-            workbook.read_string
-          end
-
-          if workbook_data
-            if Rails.env.development?
-              FileUtils.mkdir_p(file_path) unless File.exist?(file_path)
-              File.open(object_key, 'wb') { |f| f.write(workbook_data) }
-            elsif Rails.env.production?
-              log_report_metric('output_bytes', workbook_data.bytesize)
-
-              instrument_report_step('upload', rows_written:, output_bytes: workbook_data.bytesize) do
-                object.put(
-                  body: workbook_data,
-                  content_type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-                )
-              end
-            end
-          end
+          workbook_data = close_workbook(workbook, rows_written)
+          publish_workbook(workbook_data, rows_written) if workbook_data
         end
       end
 
       private
+
+      def open_workbook
+        instrument_report_step('open_workbook') do
+          if Rails.env.development?
+            FileUtils.rm(filename) if File.exist?(filename)
+            FastExcel.open(filename, constant_memory: true)
+          else
+            FastExcel.open(constant_memory: true)
+          end
+        end
+      end
+
+      def setup_worksheet(workbook, bold_format)
+        instrument_report_step('setup_worksheet') do
+          sheet = workbook.add_worksheet(Time.zone.today.iso8601)
+          configure_worksheet(sheet, bold_format)
+          sheet
+        end
+      end
+
+      def configure_worksheet(sheet, bold_format)
+        COLUMN_WIDTHS.each_with_index do |width, index|
+          sheet.set_column_width(index, width)
+        end
+
+        sheet.append_row(HEADER_ROW, bold_format)
+        sheet.freeze_panes(1, 0)
+      end
+
+      def append_rows(worksheet, rows)
+        instrument_report_step('append_rows') do
+          count = 0
+
+          rows.each do |update|
+            count += append_update_rows(worksheet, update)
+          end
+
+          count
+        end
+      end
+
+      def append_update_rows(worksheet, update)
+        update_rows = build_rows_for(update)
+        update_rows.each do |row|
+          worksheet.append_row(row)
+        end
+
+        update_rows.size
+      end
+
+      def close_workbook(workbook, rows_written)
+        instrument_report_step('close_workbook', rows_written:) do
+          workbook.close
+          workbook.read_string
+        end
+      end
+
+      def publish_workbook(workbook_data, rows_written)
+        if Rails.env.development?
+          write_local_file(workbook_data)
+        elsif Rails.env.production?
+          upload(workbook_data, rows_written)
+        end
+      end
+
+      def write_local_file(workbook_data)
+        FileUtils.mkdir_p(file_path) unless File.exist?(file_path)
+        File.open(object_key, 'wb') { |file| file.write(workbook_data) }
+      end
+
+      def upload(workbook_data, rows_written)
+        log_report_metric('output_bytes', workbook_data.bytesize)
+
+        instrument_report_step('upload', rows_written:, output_bytes: workbook_data.bytesize) do
+          object.put(
+            body: workbook_data,
+            content_type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+          )
+        end
+      end
 
       def tariff_updates
         previous_month = Time.zone.today.last_month


### PR DESCRIPTION
## What:
- [x] Extract or shorten long modules/blocks for RuboCop Metrics honesty
- [x] Keep runtime behaviour unchanged (structure only)

## Why:
Long modules and blocks made Metrics cops unenforceable. Domain-scoped extractions keep each change reviewable.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Behaviour-preserving structural extraction/shortening with no intentional API or data behaviour change.