### PR TITLE
fix(rubocop): shorten geographical area group report

### DIFF
--- a/app/lib/reporting/geographical_area_groups.rb
+++ b/app/lib/reporting/geographical_area_groups.rb
@@ -39,74 +39,80 @@ module Reporting
     class << self
       def generate
         with_report_logging do
-          workbook = instrument_report_step('open_workbook') do
-            if Rails.env.development?
-              FileUtils.rm(filename) if File.exist?(filename)
-
-              FastExcel.open(
-                filename,
-                constant_memory: true,
-              )
-            else
-              FastExcel.open(
-                constant_memory: true,
-              )
-            end
-          end
-
-          bold_format = instrument_report_step('add_format') do
-            workbook.add_format(bold: true)
-          end
-
-          worksheet = instrument_report_step('setup_worksheet') do
-            sheet = workbook.add_worksheet(Time.zone.today.iso8601)
-
-            COLUMN_WIDTHS.each_with_index do |width, index|
-              sheet.set_column_width(index, width)
-            end
-
-            sheet.append_row(HEADER_ROW, bold_format)
-            sheet.freeze_panes(1, 0)
-            sheet.autofilter(0, 1, 1, 4)
-            sheet
-          end
-
+          workbook = open_workbook
+          bold_format = instrument_report_step('add_format') { workbook.add_format(bold: true) }
+          worksheet = setup_worksheet(workbook, bold_format)
           rows = instrument_report_step('load_rows') do
             geographical_area_group_and_children
           end
 
-          rows_written = 0
-          rows_written = instrument_report_step('append_rows') do
-            rows.each_with_index do |(group, child), index|
-              row = build_row_for(group, child)
-              worksheet.append_row(row)
-              rows_written = index + 1
-            end
-
-            rows_written
-          end
+          rows_written = append_rows(worksheet, rows)
 
           log_report_metric('rows_written', rows_written)
 
-          workbook_data = instrument_report_step('close_workbook', rows_written:) do
-            workbook.close
-            Rails.env.production? ? workbook.read_string : nil
-          end
+          workbook_data = close_workbook(workbook, rows_written)
 
           log_report_metric('output_bytes', workbook_data.bytesize) if workbook_data
-
-          if Rails.env.production?
-            instrument_report_step('upload', rows_written:, output_bytes: workbook_data.bytesize) do
-              object.put(
-                body: workbook_data,
-                content_type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-              )
-            end
-          end
+          upload(workbook_data, rows_written) if Rails.env.production?
         end
       end
 
       private
+
+      def open_workbook
+        instrument_report_step('open_workbook') do
+          if Rails.env.development?
+            FileUtils.rm(filename) if File.exist?(filename)
+            FastExcel.open(filename, constant_memory: true)
+          else
+            FastExcel.open(constant_memory: true)
+          end
+        end
+      end
+
+      def setup_worksheet(workbook, bold_format)
+        instrument_report_step('setup_worksheet') do
+          sheet = workbook.add_worksheet(Time.zone.today.iso8601)
+          configure_worksheet(sheet, bold_format)
+          sheet
+        end
+      end
+
+      def configure_worksheet(sheet, bold_format)
+        COLUMN_WIDTHS.each_with_index do |width, index|
+          sheet.set_column_width(index, width)
+        end
+
+        sheet.append_row(HEADER_ROW, bold_format)
+        sheet.freeze_panes(1, 0)
+        sheet.autofilter(0, 1, 1, 4)
+      end
+
+      def append_rows(worksheet, rows)
+        instrument_report_step('append_rows') do
+          rows.each do |group, child|
+            worksheet.append_row(build_row_for(group, child))
+          end
+
+          rows.size
+        end
+      end
+
+      def close_workbook(workbook, rows_written)
+        instrument_report_step('close_workbook', rows_written:) do
+          workbook.close
+          Rails.env.production? ? workbook.read_string : nil
+        end
+      end
+
+      def upload(workbook_data, rows_written)
+        instrument_report_step('upload', rows_written:, output_bytes: workbook_data.bytesize) do
+          object.put(
+            body: workbook_data,
+            content_type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+          )
+        end
+      end
 
       def build_row_for(group, child)
         HEADER_ROW.map do |header|


### PR DESCRIPTION
## What:
- [x] Extract or shorten long modules/blocks for RuboCop Metrics honesty
- [x] Keep runtime behaviour unchanged (structure only)

## Why:
Long modules and blocks made Metrics cops unenforceable. Domain-scoped extractions keep each change reviewable.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Behaviour-preserving structural extraction/shortening with no intentional API or data behaviour change.