### PR TITLE
fix(rubocop): shorten tariff update dataset filters

### DIFF
--- a/app/lib/tariff_synchronizer/base_update.rb
+++ b/app/lib/tariff_synchronizer/base_update.rb
@@ -25,7 +25,7 @@ module TariffSynchronizer
       presence_of :filename, :issue_date
     end
 
-    dataset_module do
+    module DatasetFilters
       def by_filename(filename_without_suffix)
         filename = if TradeTariffBackend.uk?
                      "#{filename_without_suffix}.gzip"
@@ -97,6 +97,10 @@ module TariffSynchronizer
           .select(Sequel.expr(:tariff_updates).*)
           .descending.applied.order_prepend(:update_type)
       end
+    end
+
+    dataset_module do
+      include DatasetFilters
     end
 
     def applied?


### PR DESCRIPTION
## What:
- [x] Extract or shorten long modules/blocks for RuboCop Metrics honesty
- [x] Keep runtime behaviour unchanged (structure only)

## Why:
Long modules and blocks made Metrics cops unenforceable. Domain-scoped extractions keep each change reviewable.

## Ticket:
N/A

## Risk:
**Risk level:** 🟠

**Reason for rating:**
Touches a medium-sensitivity domain surface; socialise before merge.