### PR TITLE
fix(rubocop): shorten engine route blocks

### DIFF
--- a/app/engines/admin_api.rb
+++ b/app/engines/admin_api.rb
@@ -1,161 +1,213 @@
 class AdminApi < ::Rails::Engine
 end
 
-AdminApi.routes.draw do
-  namespace :api, defaults: { format: 'json' }, path: '' do
-    scope module: :admin do
-      resources :sections, only: %i[index show] do
-        scope module: 'sections', constraints: { id: /\d+/ } do
-          resource :section_note, only: %i[show create update destroy]
+module AdminApiRoutes
+  def draw_admin_api_routes
+    namespace :api, defaults: { format: 'json' }, path: '' do
+      scope module: :admin do
+        draw_admin_catalogue_routes
+        draw_admin_search_and_report_routes
+        draw_admin_goods_content_routes
+        draw_customs_tariff_update_routes
+        resources :quota_order_numbers, module: 'quota_order_numbers', only: [] do
+          resources :quota_definitions, only: %i[index show]
         end
       end
 
-      resources :updates, only: %i[index show]
-      resources :rollbacks, only: %i[create index]
-      resources :clear_caches, only: %i[create]
-      resources :downloads, only: %i[create]
-      resources :applies, only: %i[create]
-      resources :footnotes, only: %i[index show update]
-      resources :search_references, only: [:index]
-      resources :search_diagnostics, only: [:show], param: :request_id, constraints: { request_id: /[^\/.]+/ }
-      resources :search_analytics, only: [:index]
-      resources :cds_update_notifications, only: [:create]
-      resources :reports, only: %i[index show], constraints: { id: /[a-z_]+/ } do
-        member do
-          post :run
-          post :send_email
-          post :backfill
-        end
-      end
+      draw_admin_named_routes
+    end
+  end
 
-      resources :chapters, only: %i[index show], constraints: { id: /\d{2}/ } do
-        scope module: 'chapters', constraints: { chapter_id: /\d{2}/, id: /\d+/ } do
-          resource :chapter_note, only: %i[show create update destroy]
-          resources :search_references, only: %i[show index destroy create update]
-        end
-      end
-
-      resources :headings, only: [:show], constraints: { id: /\d{4}/ } do
-        scope module: 'headings', constraints: { heading_id: /\d{4}/, id: /\d+/ } do
-          resources :search_references, only: %i[show index destroy create update]
-        end
-      end
-
-      resources :commodities, as: :admin_commodity, only: %i[show] do
-        scope module: 'commodities' do
-          resources :search_references, only: %i[show index destroy create update]
-        end
-      end
-
-      resources :goods_nomenclatures, only: %i[], constraints: { id: /\d+/ } do
-        scope module: 'goods_nomenclatures' do
-          resource :goods_nomenclature_label, only: %i[show update] do
-            post :score
-            post :regenerate
-            post :approve
-            post :reject
-            get :versions
-          end
-          resource :goods_nomenclature_self_text, only: %i[show update] do
-            post :score
-            post :regenerate
-            post :approve
-            post :reject
-            get :versions
-          end
-          resource :tariff_knowledge_compressed_note, only: %i[show update] do
-            post :regenerate
-            post :approve
-            post :reject
-            get :versions
-          end
-        end
-      end
-
-      namespace :goods_nomenclature_labels do
-        resource :stats, only: [:show]
-      end
-
-      resources :goods_nomenclature_labels, only: [:index]
-      resources :goods_nomenclature_self_texts, only: [:index]
-      resources :tariff_knowledge_compressed_notes, only: [:index]
-      resources :versions, only: [:index] do
-        member do
-          post :restore
-        end
-      end
-
-      get  'customs_tariff_updates',          to: 'customs_tariff_updates#index'
-      get  'customs_tariff_updates/:version', to: 'customs_tariff_updates#show', constraints: { version: /\d+\.\d+/ }
-      get  'customs_tariff_updates/:customs_tariff_update_version/section_notes',      to: 'customs_tariff_updates/section_notes#index',  constraints: { customs_tariff_update_version: /[^\/]+/ }
-      get  'customs_tariff_updates/:customs_tariff_update_version/section_notes/:id',  to: 'customs_tariff_updates/section_notes#show',   constraints: { customs_tariff_update_version: /[^\/]+/ }
-      patch 'customs_tariff_updates/:customs_tariff_update_version/section_notes/:id', to: 'customs_tariff_updates/section_notes#update', constraints: { customs_tariff_update_version: /[^\/]+/ }
-      post 'customs_tariff_updates/:customs_tariff_update_version/section_notes',
-           to: 'customs_tariff_updates/section_notes#create',
-           constraints: { customs_tariff_update_version: /[^\/]+/ }
-      delete 'customs_tariff_updates/:customs_tariff_update_version/section_notes/:id',
-             to: 'customs_tariff_updates/section_notes#destroy',
-             constraints: { customs_tariff_update_version: /[^\/]+/ }
-      post  'customs_tariff_updates/:customs_tariff_update_version/reimport',
-            to: 'customs_tariff_updates/reimport#create',
-            constraints: { customs_tariff_update_version: /[^\/]+/ }
-      get   'customs_tariff_updates/:customs_tariff_update_version/chapter_notes',      to: 'customs_tariff_updates/chapter_notes#index',  constraints: { customs_tariff_update_version: /[^\/]+/ }
-      get   'customs_tariff_updates/:customs_tariff_update_version/chapter_notes/:id',  to: 'customs_tariff_updates/chapter_notes#show',   constraints: { customs_tariff_update_version: /[^\/]+/ }
-      patch 'customs_tariff_updates/:customs_tariff_update_version/chapter_notes/:id',  to: 'customs_tariff_updates/chapter_notes#update', constraints: { customs_tariff_update_version: /[^\/]+/ }
-      delete 'customs_tariff_updates/:customs_tariff_update_version/chapter_notes/:id',
-             to: 'customs_tariff_updates/chapter_notes#destroy',
-             constraints: { customs_tariff_update_version: /[^\/]+/ }
-      post 'customs_tariff_updates/:customs_tariff_update_version/chapter_notes',
-           to: 'customs_tariff_updates/chapter_notes#create',
-           constraints: { customs_tariff_update_version: /[^\/]+/ }
-      get 'customs_tariff_updates/:customs_tariff_update_version/sections_summary', to: 'customs_tariff_updates/sections_summary#index', constraints: { customs_tariff_update_version: /[^\/]+/ }
-
-      resources :quota_order_numbers, module: 'quota_order_numbers', only: %i[] do
-        resources :quota_definitions, only: %i[index show]
+  def draw_admin_catalogue_routes
+    resources :sections, only: %i[index show] do
+      scope module: 'sections', constraints: { id: /\d+/ } do
+        resource :section_note, only: %i[show create update destroy]
       end
     end
 
-    # avoid admin named routes clashing with public api named routes
-    namespace :admin, path: '' do
-      if Rails.env.development? || TradeTariffBackend.uk?
-        namespace :news do
-          resources :items, only: %i[index show create update destroy]
-          resources :collections, only: %i[index show create update]
-        end
-
-        resources :news_items, only: %i[index show create update destroy],
-                               controller: 'news/items'
-
-        resources :live_issues, only: %i[index show create update destroy]
-        resources :admin_configurations, only: %i[index show update]
-        resources :description_intercepts, only: %i[index show create update destroy] do
-          collection do
-            post :bulk_import
-          end
-
-          member do
-            get :versions
-          end
-        end
-        resources :goods_nomenclature_autocomplete, only: [:index]
+    resources :chapters, only: %i[index show], constraints: { id: /\d{2}/ } do
+      scope module: 'chapters', constraints: { chapter_id: /\d{2}/, id: /\d+/ } do
+        resource :chapter_note, only: %i[show create update destroy]
+        resources :search_references, only: %i[show index destroy create update]
       end
+    end
 
-      namespace :green_lanes do
-        resources :category_assessments, only: %i[index show create update destroy] do
-          member do
-            post 'exemptions', to: 'category_assessments#add_exemption'
-            delete 'exemptions', to: 'category_assessments#remove_exemption'
-          end
-        end
+    draw_admin_heading_and_commodity_routes
+  end
 
-        resources :themes, only: %i[index]
-        resources :exempting_certificate_overrides, only: %i[index show create destroy]
-        resources :exempting_additional_code_overrides, only: %i[index show create destroy]
-        resources :exemptions, only: %i[index show create update destroy]
-        resources :measures, only: %i[index show create update destroy]
-        resources :update_notifications, only: %i[index show update]
-        resources :measure_type_mappings, only: %i[index show create destroy]
+  def draw_admin_heading_and_commodity_routes
+    resources :headings, only: [:show], constraints: { id: /\d{4}/ } do
+      scope module: 'headings', constraints: { heading_id: /\d{4}/, id: /\d+/ } do
+        resources :search_references, only: %i[show index destroy create update]
+      end
+    end
+
+    resources :commodities, as: :admin_commodity, only: %i[show] do
+      scope module: 'commodities' do
+        resources :search_references, only: %i[show index destroy create update]
       end
     end
   end
+
+  def draw_admin_search_and_report_routes
+    resources :updates, only: %i[index show]
+    resources :rollbacks, only: %i[create index]
+    resources :clear_caches, only: %i[create]
+    resources :downloads, only: %i[create]
+    resources :applies, only: %i[create]
+    resources :footnotes, only: %i[index show update]
+    resources :search_references, only: [:index]
+    resources :search_diagnostics, only: [:show], param: :request_id, constraints: { request_id: /[^\/.]+/ }
+    resources :search_analytics, only: [:index]
+    resources :cds_update_notifications, only: [:create]
+    resources :reports, only: %i[index show], constraints: { id: /[a-z_]+/ } do
+      member do
+        post :run
+        post :send_email
+        post :backfill
+      end
+    end
+  end
+
+  def draw_admin_goods_content_routes
+    resources :goods_nomenclatures, only: [], constraints: { id: /\d+/ } do
+      scope module: 'goods_nomenclatures' do
+        draw_admin_goods_nomenclature_member_routes
+      end
+    end
+
+    namespace(:goods_nomenclature_labels) { resource :stats, only: [:show] }
+    resources :goods_nomenclature_labels, only: [:index]
+    resources :goods_nomenclature_self_texts, only: [:index]
+    resources :tariff_knowledge_compressed_notes, only: [:index]
+    resources(:versions, only: [:index]) { member { post :restore } }
+  end
+
+  def draw_admin_goods_nomenclature_member_routes
+    resource :goods_nomenclature_label, only: %i[show update] do
+      post :score
+      post :regenerate
+      post :approve
+      post :reject
+      get :versions
+    end
+
+    resource :goods_nomenclature_self_text, only: %i[show update] do
+      post :score
+      post :regenerate
+      post :approve
+      post :reject
+      get :versions
+    end
+
+    resource :tariff_knowledge_compressed_note, only: %i[show update] do
+      post :regenerate
+      post :approve
+      post :reject
+      get :versions
+    end
+  end
+
+  def draw_customs_tariff_update_routes
+    get 'customs_tariff_updates', to: 'customs_tariff_updates#index'
+    get 'customs_tariff_updates/:version', to: 'customs_tariff_updates#show', constraints: { version: /\d+\.\d+/ }
+    draw_customs_tariff_update_section_note_routes
+    draw_customs_tariff_update_chapter_note_routes
+    post 'customs_tariff_updates/:customs_tariff_update_version/reimport',
+         to: 'customs_tariff_updates/reimport#create',
+         constraints: customs_tariff_update_constraints
+    get 'customs_tariff_updates/:customs_tariff_update_version/sections_summary',
+        to: 'customs_tariff_updates/sections_summary#index',
+        constraints: customs_tariff_update_constraints
+  end
+
+  def draw_customs_tariff_update_section_note_routes
+    get 'customs_tariff_updates/:customs_tariff_update_version/section_notes',
+        to: 'customs_tariff_updates/section_notes#index',
+        constraints: customs_tariff_update_constraints
+    get 'customs_tariff_updates/:customs_tariff_update_version/section_notes/:id',
+        to: 'customs_tariff_updates/section_notes#show',
+        constraints: customs_tariff_update_constraints
+    patch 'customs_tariff_updates/:customs_tariff_update_version/section_notes/:id',
+          to: 'customs_tariff_updates/section_notes#update',
+          constraints: customs_tariff_update_constraints
+    post 'customs_tariff_updates/:customs_tariff_update_version/section_notes',
+         to: 'customs_tariff_updates/section_notes#create',
+         constraints: customs_tariff_update_constraints
+    delete 'customs_tariff_updates/:customs_tariff_update_version/section_notes/:id',
+           to: 'customs_tariff_updates/section_notes#destroy',
+           constraints: customs_tariff_update_constraints
+  end
+
+  def draw_customs_tariff_update_chapter_note_routes
+    get 'customs_tariff_updates/:customs_tariff_update_version/chapter_notes',
+        to: 'customs_tariff_updates/chapter_notes#index',
+        constraints: customs_tariff_update_constraints
+    get 'customs_tariff_updates/:customs_tariff_update_version/chapter_notes/:id',
+        to: 'customs_tariff_updates/chapter_notes#show',
+        constraints: customs_tariff_update_constraints
+    patch 'customs_tariff_updates/:customs_tariff_update_version/chapter_notes/:id',
+          to: 'customs_tariff_updates/chapter_notes#update',
+          constraints: customs_tariff_update_constraints
+    delete 'customs_tariff_updates/:customs_tariff_update_version/chapter_notes/:id',
+           to: 'customs_tariff_updates/chapter_notes#destroy',
+           constraints: customs_tariff_update_constraints
+    post 'customs_tariff_updates/:customs_tariff_update_version/chapter_notes',
+         to: 'customs_tariff_updates/chapter_notes#create',
+         constraints: customs_tariff_update_constraints
+  end
+
+  def customs_tariff_update_constraints
+    { customs_tariff_update_version: /[^\/]+/ }
+  end
+
+  def draw_admin_named_routes
+    namespace :admin, path: '' do
+      draw_uk_admin_routes
+      draw_green_lanes_admin_routes
+    end
+  end
+
+  def draw_uk_admin_routes
+    return unless Rails.env.development? || TradeTariffBackend.uk?
+
+    namespace :news do
+      resources :items, only: %i[index show create update destroy]
+      resources :collections, only: %i[index show create update]
+    end
+
+    resources :news_items, only: %i[index show create update destroy], controller: 'news/items'
+    resources :live_issues, only: %i[index show create update destroy]
+    resources :admin_configurations, only: %i[index show update]
+    resources :description_intercepts, only: %i[index show create update destroy] do
+      collection { post :bulk_import }
+      member { get :versions }
+    end
+    resources :goods_nomenclature_autocomplete, only: [:index]
+  end
+
+  def draw_green_lanes_admin_routes
+    namespace :green_lanes do
+      resources :category_assessments, only: %i[index show create update destroy] do
+        member do
+          post 'exemptions', to: 'category_assessments#add_exemption'
+          delete 'exemptions', to: 'category_assessments#remove_exemption'
+        end
+      end
+
+      resources :themes, only: %i[index]
+      resources :exempting_certificate_overrides, only: %i[index show create destroy]
+      resources :exempting_additional_code_overrides, only: %i[index show create destroy]
+      resources :exemptions, only: %i[index show create update destroy]
+      resources :measures, only: %i[index show create update destroy]
+      resources :update_notifications, only: %i[index show update]
+      resources :measure_type_mappings, only: %i[index show create destroy]
+    end
+  end
+end
+
+AdminApi.routes.draw do
+  extend AdminApiRoutes
+
+  draw_admin_api_routes
 end

--- a/app/engines/v1_api.rb
+++ b/app/engines/v1_api.rb
@@ -1,50 +1,55 @@
 class V1Api < ::Rails::Engine
 end
 
+module V1ApiRoutes
+  def draw_v1_catalogue_routes
+    resources :sections, only: %i[index show] do
+      collection { get :tree }
+      scope module: 'sections', constraints: { id: /\d+/ } do
+        resource :section_note, only: %i[show]
+      end
+    end
+
+    resources :chapters, only: %i[index show], constraints: { id: /\d{2}/ } do
+      member { get :changes }
+      scope module: 'chapters', constraints: { chapter_id: /\d{2}/, id: /\d+/ } do
+        resource :chapter_note, only: %i[show]
+      end
+    end
+  end
+
+  def draw_v1_goods_routes
+    resources :headings, only: [:show], constraints: { id: /\d{4}/ } do
+      member { get :changes }
+    end
+
+    resources :commodities, only: [:show], constraints: { id: /\d{10}/, as_of: /.*/ } do
+      member { get :changes }
+    end
+
+    get '/headings/:id/tree' => 'headings#tree'
+  end
+
+  def draw_v1_error_routes
+    match '/400', to: 'errors#bad_request', via: :all
+    match '/404', to: 'errors#not_found', via: :all
+    match '/405', to: 'errors#method_not_allowed', via: :all
+    match '/406', to: 'errors#not_acceptable', via: :all
+    match '/422', to: 'errors#unprocessable_content', via: :all
+    match '/500', to: 'errors#internal_server_error', via: :all
+    match '/501', to: 'errors#not_implemented', via: :all
+    match '/503', to: 'errors#maintenance', via: :all
+  end
+end
+
 V1Api.routes.draw do
+  extend V1ApiRoutes
+
   namespace :api, defaults: { format: 'json' }, path: '/' do
     scope module: :v1 do
-      resources :sections, only: %i[index show] do
-        collection do
-          get :tree
-        end
-        scope module: 'sections', constraints: { id: /\d+/ } do
-          resource :section_note, only: %i[show]
-        end
-      end
-
-      resources :chapters, only: %i[index show], constraints: { id: /\d{2}/ } do
-        member do
-          get :changes
-        end
-
-        scope module: 'chapters', constraints: { chapter_id: /\d{2}/, id: /\d+/ } do
-          resource :chapter_note, only: %i[show]
-        end
-      end
-
-      resources :headings, only: [:show], constraints: { id: /\d{4}/ } do
-        member do
-          get :changes
-        end
-      end
-
-      resources :commodities, only: [:show], constraints: { id: /\d{10}/, as_of: /.*/ } do
-        member do
-          get :changes
-        end
-      end
-
-      get '/headings/:id/tree' => 'headings#tree'
-
-      match '/400', to: 'errors#bad_request', via: :all
-      match '/404', to: 'errors#not_found', via: :all
-      match '/405', to: 'errors#method_not_allowed', via: :all
-      match '/406', to: 'errors#not_acceptable', via: :all
-      match '/422', to: 'errors#unprocessable_content', via: :all
-      match '/500', to: 'errors#internal_server_error', via: :all
-      match '/501', to: 'errors#not_implemented', via: :all
-      match '/503', to: 'errors#maintenance', via: :all
+      draw_v1_catalogue_routes
+      draw_v1_goods_routes
+      draw_v1_error_routes
     end
   end
 end

--- a/app/engines/v2_api.rb
+++ b/app/engines/v2_api.rb
@@ -1,175 +1,170 @@
 class V2Api < ::Rails::Engine
 end
 
+module V2ApiRoutes
+  def draw_v2_section_routes
+    resources :sections, only: %i[index show] do
+      collection { get :tree }
+      member { get :chapters }
+    end
+
+    resources :chapters, only: %i[index show], constraints: { id: /\d{1,2}/ } do
+      member do
+        get :changes
+        get :headings
+      end
+    end
+  end
+
+  def draw_v2_goods_routes
+    resources :headings, only: [:show], constraints: { id: /\d{4}/ } do
+      member do
+        get :changes
+        get :commodities
+      end
+      resources :validity_periods, only: [:index]
+    end
+
+    resources :subheadings, only: [:show] do
+      resources :validity_periods, only: [:index]
+    end
+
+    resources :commodities, only: [:show], constraints: { id: /\d{10}/ } do
+      member { get :changes }
+      resources :validity_periods, only: [:index]
+    end
+  end
+
+  def draw_v2_lookup_routes
+    resources :geographical_areas, only: %i[index show] do
+      collection { get :countries }
+    end
+    resources :chemical_substances, only: %i[index]
+    resources :simplified_procedural_code_measures, only: %i[index]
+    resources :description_intercepts, only: %i[index]
+    resources :preference_codes, only: %i[index show]
+    resources :monetary_exchange_rates, only: [:index]
+  end
+
+  def draw_v2_measure_routes
+    resources(:updates, only: []) { collection { get :latest } }
+    resources :search_references, only: [:index]
+    resources(:quotas, only: []) { collection { get :search } }
+    resources(:certificates, only: [:index]) { collection { get :search } }
+    resources :certificate_types, only: [:index]
+    resources :measure_actions, only: %i[index]
+    resources :measure_condition_codes, only: %i[index]
+    resources :quota_order_numbers, only: %i[index]
+    resources :measure_types, only: %i[index show]
+    resources :measures, only: %i[show], constraints: { id: /-?\d+/ }
+    resources(:additional_codes, only: []) { collection { get :search } }
+    resources :additional_code_types, only: [:index]
+    resources(:footnotes, only: []) { collection { get :search } }
+    resources :footnote_types, only: [:index]
+    resources(:chemicals, only: %i[index show]) { collection { get :search } }
+  end
+
+  def draw_v2_exchange_rate_routes
+    return unless TradeTariffBackend.uk?
+
+    namespace :exchange_rates do
+      get 'period_lists(/:year)', to: 'period_lists#show', as: :period_list
+      resources :files, only: [:show]
+    end
+
+    resources :exchange_rates, only: [:show]
+  end
+
+  def draw_v2_rules_of_origin_routes
+    scope module: :rules_of_origin do
+      resources :rules_of_origin_schemes, controller: 'schemes', only: %i[index]
+      get '/rules_of_origin_schemes/:heading_code/:country_code',
+          to: 'schemes#index',
+          as: :rules_of_origin
+      get '/rules_of_origin_schemes/:commodity_code',
+          to: 'product_specific_rules#index',
+          as: :product_specific_rules
+    end
+  end
+
+  def draw_v2_news_routes
+    return unless Rails.env.development? || TradeTariffBackend.uk?
+
+    namespace :news do
+      resources :items, only: %i[index show]
+      resources :years, only: %i[index]
+      resources :collections, only: %i[index] do
+        resources :items, only: %i[index], shallow: true
+      end
+    end
+
+    get '/news_items/:id', to: 'news/items#show', as: nil
+    get '/news_items', to: 'news/items#index', as: nil
+  end
+
+  def draw_v2_search_routes
+    get '/changes(/:as_of)', to: 'changes#index', as: :changes, constraints: { as_of: /\d{4}-\d{1,2}-\d{1,2}/ }
+    post 'search' => 'search#search'
+    get 'search' => 'search#search'
+    get 'search_suggestions' => 'search#suggestions'
+    match 'classification_search' => 'classification_search#search', via: %i[get post]
+
+    namespace :knowledge_graph do
+      resources :queries, only: %i[create]
+    end
+  end
+
+  def draw_v2_goods_nomenclature_routes
+    get '/headings/:id/tree' => 'headings#tree'
+    get 'goods_nomenclatures/section/:position', to: 'goods_nomenclatures#show_by_section', constraints: { position: /\d+/ }
+    get 'goods_nomenclatures/chapter/:chapter_id', to: 'goods_nomenclatures#show_by_chapter', constraints: { chapter_id: /\d{2}/ }
+    get 'goods_nomenclatures/heading/:heading_id', to: 'goods_nomenclatures#show_by_heading', constraints: { heading_id: /\d{4}/ }
+    get 'goods_nomenclatures/:id', to: 'goods_nomenclatures#show', constraints: { id: /\d{4,10}/ }
+  end
+
+  def draw_v2_green_lanes_routes
+    namespace :green_lanes do
+      resources :goods_nomenclatures, only: %i[show], constraints: { id: /\d{4,10}/ }
+      resources :themes, only: %i[index]
+      resources :faq_feedback, only: %i[create index show]
+    end
+  end
+
+  def draw_v2_error_routes
+    match '/400', to: 'errors#bad_request', via: :all
+    match '/404', to: 'errors#not_found', via: :all
+    match '/405', to: 'errors#method_not_allowed', via: :all
+    match '/406', to: 'errors#not_acceptable', via: :all
+    match '/422', to: 'errors#unprocessable_content', via: :all
+    match '/500', to: 'errors#internal_server_error', via: :all
+    match '/501', to: 'errors#not_implemented', via: :all
+    match '/503', to: 'errors#maintenance', via: :all
+  end
+end
+
 V2Api.routes.draw do
+  extend V2ApiRoutes
+
   get 'healthcheck' => 'healthcheck#index'
 
   namespace :api, defaults: { format: 'json' }, path: '/' do
     scope module: :v2 do
       resources :notifications, only: %i[create]
-
-      resources :sections, only: %i[index show] do
-        collection do
-          get :tree
-        end
-
-        member do
-          get :chapters
-        end
-      end
-
-      if TradeTariffBackend.uk?
-        namespace :exchange_rates do
-          get 'period_lists(/:year)', to: 'period_lists#show', as: :period_list
-          resources :files, only: [:show]
-        end
-
-        resources :exchange_rates, only: [:show]
-      end
-
-      resources :chapters, only: %i[index show], constraints: { id: /\d{1,2}/ } do
-        member do
-          get :changes
-          get :headings
-        end
-      end
-
-      resources :headings, only: [:show], constraints: { id: /\d{4}/ } do
-        member do
-          get :changes
-          get :commodities
-        end
-
-        resources :validity_periods, only: [:index]
-      end
-
-      resources :subheadings, only: [:show] do
-        resources :validity_periods, only: [:index]
-      end
-
-      resources :commodities, only: [:show], constraints: { id: /\d{10}/ } do
-        member do
-          get :changes
-        end
-
-        resources :validity_periods, only: [:index]
-      end
-
-      resources :geographical_areas, only: %i[index show] do
-        collection { get :countries }
-      end
-
-      resources :chemical_substances, only: %i[index]
-      resources :simplified_procedural_code_measures, only: %i[index]
-      resources :description_intercepts, only: %i[index]
-
-      resources :preference_codes, only: %i[index show]
-
-      resources :monetary_exchange_rates, only: [:index]
-
-      resources :updates, only: [] do
-        collection { get :latest }
-      end
-
-      resources :search_references, only: [:index]
-
-      resources :quotas, only: [] do
-        collection { get :search }
-      end
-
-      resources :certificates, only: [:index] do
-        collection { get :search }
-      end
-
-      resources :certificate_types, only: [:index]
-
-      resources :measure_actions, only: %i[index]
-      resources :measure_condition_codes, only: %i[index]
-      resources :quota_order_numbers, only: %i[index]
-      resources :measure_types, only: %i[index show]
-      resources :measures, only: %i[show], constraints: { id: /-?\d+/ }
-
-      resources :additional_codes, only: [] do
-        collection { get :search }
-      end
-
-      resources :additional_code_types, only: [:index]
-
-      resources :footnotes, only: [] do
-        collection { get :search }
-      end
-
-      resources :footnote_types, only: [:index]
-
-      resources :chemicals, only: %i[index show] do
-        collection { get :search }
-      end
-
-      scope module: :rules_of_origin do
-        resources :rules_of_origin_schemes,
-                  controller: 'schemes',
-                  only: %i[index]
-        get '/rules_of_origin_schemes/:heading_code/:country_code',
-            to: 'schemes#index',
-            as: :rules_of_origin
-        get '/rules_of_origin_schemes/:commodity_code',
-            to: 'product_specific_rules#index',
-            as: :product_specific_rules
-      end
-
-      if Rails.env.development? || TradeTariffBackend.uk?
-        namespace :news do
-          resources :items, only: %i[index show]
-          resources :years, only: %i[index]
-          resources :collections, only: %i[index] do
-            resources :items, only: %i[index], shallow: true
-          end
-        end
-
-        get '/news_items/:id', to: 'news/items#show', as: nil
-        get '/news_items', to: 'news/items#index', as: nil
-      end
-
+      draw_v2_section_routes
+      draw_v2_exchange_rate_routes
+      draw_v2_goods_routes
+      draw_v2_lookup_routes
+      draw_v2_measure_routes
+      draw_v2_rules_of_origin_routes
+      draw_v2_news_routes
       get 'live_issues', to: 'live_issues#index'
-
       namespace :enquiry_form do
         resources :submissions, only: %i[create]
       end
-
-      get '/changes(/:as_of)', to: 'changes#index', as: :changes, constraints: { as_of: /\d{4}-\d{1,2}-\d{1,2}/ }
-
-      post 'search' => 'search#search'
-      get 'search' => 'search#search'
-      get 'search_suggestions' => 'search#suggestions'
-      match 'classification_search' => 'classification_search#search', via: %i[get post]
-
-      namespace :knowledge_graph do
-        resources :queries, only: %i[create]
-      end
-
-      get '/headings/:id/tree' => 'headings#tree'
-
-      get 'goods_nomenclatures/section/:position', to: 'goods_nomenclatures#show_by_section', constraints: { position: /\d+/ }
-      get 'goods_nomenclatures/chapter/:chapter_id', to: 'goods_nomenclatures#show_by_chapter', constraints: { chapter_id: /\d{2}/ }
-      get 'goods_nomenclatures/heading/:heading_id', to: 'goods_nomenclatures#show_by_heading', constraints: { heading_id: /\d{4}/ }
-      get 'goods_nomenclatures/:id', to: 'goods_nomenclatures#show', constraints: { id: /\d{4,10}/ }
-
-      namespace :green_lanes do
-        resources :goods_nomenclatures, only: %i[show], constraints: { id: /\d{4,10}/ }
-
-        resources :themes, only: %i[index]
-
-        resources :faq_feedback, only: %i[create index show]
-      end
-
-      match '/400', to: 'errors#bad_request', via: :all
-      match '/404', to: 'errors#not_found', via: :all
-      match '/405', to: 'errors#method_not_allowed', via: :all
-      match '/406', to: 'errors#not_acceptable', via: :all
-      match '/422', to: 'errors#unprocessable_content', via: :all
-      match '/500', to: 'errors#internal_server_error', via: :all
-      match '/501', to: 'errors#not_implemented', via: :all
-      match '/503', to: 'errors#maintenance', via: :all
+      draw_v2_search_routes
+      draw_v2_goods_nomenclature_routes
+      draw_v2_green_lanes_routes
+      draw_v2_error_routes
     end
   end
 end


### PR DESCRIPTION
## What:
- [x] Extract or shorten long modules/blocks for RuboCop Metrics honesty
- [x] Keep runtime behaviour unchanged (structure only)

## Why:
Long modules and blocks made Metrics cops unenforceable. Domain-scoped extractions keep each change reviewable.

## Ticket:
N/A

## Risk:
**Risk level:** 🟠

**Reason for rating:**
Touches a medium-sensitivity domain surface; socialise before merge.