### PR TITLE
fix(rubocop): shorten customs tariff note imports

### DIFF
--- a/app/lib/customs_tariff_importer/importer.rb
+++ b/app/lib/customs_tariff_importer/importer.rb
@@ -48,35 +48,7 @@ module CustomsTariffImporter
           document_created_on: fetched.published_on,
         )
 
-        extracted.chapters.each do |chapter_id, content|
-          CustomsTariffChapterNote.create(
-            customs_tariff_update_version: update.version,
-            chapter_id:,
-            content:,
-            validity_start_date: update.validity_start_date,
-            status: CustomsTariffChapterNote::PENDING,
-          )
-        end
-
-        extracted.sections.each do |section_id, content|
-          CustomsTariffSectionNote.create(
-            customs_tariff_update_version: update.version,
-            section_id:,
-            content:,
-            validity_start_date: update.validity_start_date,
-            status: CustomsTariffSectionNote::PENDING,
-          )
-        end
-
-        extracted.general_rules.each do |rule_label, content|
-          CustomsTariffGeneralRule.create(
-            customs_tariff_update_version: update.version,
-            rule_label:,
-            content:,
-            validity_start_date: update.validity_start_date,
-            status: CustomsTariffGeneralRule::PENDING,
-          )
-        end
+        create_notes(update, extracted)
       end
 
       duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000).round(2)
@@ -91,6 +63,48 @@ module CustomsTariffImporter
       )
       record_failure(fetched&.version, e.message)
       Result.new(status: :failed, version: fetched&.version, error: e.message)
+    end
+
+    def create_notes(update, extracted)
+      create_chapter_notes(update, extracted.chapters)
+      create_section_notes(update, extracted.sections)
+      create_general_rules(update, extracted.general_rules)
+    end
+
+    def create_chapter_notes(update, chapters)
+      chapters.each do |chapter_id, content|
+        CustomsTariffChapterNote.create(
+          customs_tariff_update_version: update.version,
+          chapter_id:,
+          content:,
+          validity_start_date: update.validity_start_date,
+          status: CustomsTariffChapterNote::PENDING,
+        )
+      end
+    end
+
+    def create_section_notes(update, sections)
+      sections.each do |section_id, content|
+        CustomsTariffSectionNote.create(
+          customs_tariff_update_version: update.version,
+          section_id:,
+          content:,
+          validity_start_date: update.validity_start_date,
+          status: CustomsTariffSectionNote::PENDING,
+        )
+      end
+    end
+
+    def create_general_rules(update, general_rules)
+      general_rules.each do |rule_label, content|
+        CustomsTariffGeneralRule.create(
+          customs_tariff_update_version: update.version,
+          rule_label:,
+          content:,
+          validity_start_date: update.validity_start_date,
+          status: CustomsTariffGeneralRule::PENDING,
+        )
+      end
     end
 
     def record_failure(version, message)

--- a/app/lib/customs_tariff_importer/reimporter.rb
+++ b/app/lib/customs_tariff_importer/reimporter.rb
@@ -23,35 +23,49 @@ module CustomsTariffImporter
         CustomsTariffChapterNote.where(customs_tariff_update_version: update.version).delete
         CustomsTariffGeneralRule.where(customs_tariff_update_version: update.version).delete
 
-        extracted.sections.each do |section_id, note_content|
-          CustomsTariffSectionNote.create(
-            customs_tariff_update_version: update.version,
-            section_id:,
-            content: note_content,
-            validity_start_date: update.validity_start_date,
-            status: CustomsTariffSectionNote::PENDING,
-          )
-        end
+        create_notes(update, extracted)
+      end
+    end
 
-        extracted.chapters.each do |chapter_id, note_content|
-          CustomsTariffChapterNote.create(
-            customs_tariff_update_version: update.version,
-            chapter_id:,
-            content: note_content,
-            validity_start_date: update.validity_start_date,
-            status: CustomsTariffChapterNote::PENDING,
-          )
-        end
+    def create_notes(update, extracted)
+      create_section_notes(update, extracted.sections)
+      create_chapter_notes(update, extracted.chapters)
+      create_general_rules(update, extracted.general_rules)
+    end
 
-        extracted.general_rules.each do |rule_label, note_content|
-          CustomsTariffGeneralRule.create(
-            customs_tariff_update_version: update.version,
-            rule_label:,
-            content: note_content,
-            validity_start_date: update.validity_start_date,
-            status: CustomsTariffGeneralRule::PENDING,
-          )
-        end
+    def create_section_notes(update, sections)
+      sections.each do |section_id, note_content|
+        CustomsTariffSectionNote.create(
+          customs_tariff_update_version: update.version,
+          section_id:,
+          content: note_content,
+          validity_start_date: update.validity_start_date,
+          status: CustomsTariffSectionNote::PENDING,
+        )
+      end
+    end
+
+    def create_chapter_notes(update, chapters)
+      chapters.each do |chapter_id, note_content|
+        CustomsTariffChapterNote.create(
+          customs_tariff_update_version: update.version,
+          chapter_id:,
+          content: note_content,
+          validity_start_date: update.validity_start_date,
+          status: CustomsTariffChapterNote::PENDING,
+        )
+      end
+    end
+
+    def create_general_rules(update, general_rules)
+      general_rules.each do |rule_label, note_content|
+        CustomsTariffGeneralRule.create(
+          customs_tariff_update_version: update.version,
+          rule_label:,
+          content: note_content,
+          validity_start_date: update.validity_start_date,
+          status: CustomsTariffGeneralRule::PENDING,
+        )
       end
     end
   end


### PR DESCRIPTION
## What:
- [x] Extract or shorten long modules/blocks for RuboCop Metrics honesty
- [x] Keep runtime behaviour unchanged (structure only)

## Why:
Long modules and blocks made Metrics cops unenforceable. Domain-scoped extractions keep each change reviewable.

## Ticket:
N/A

## Risk:
**Risk level:** 🟠

**Reason for rating:**
Touches a medium-sensitivity domain surface; socialise before merge.