### PR TITLE
fix(rubocop): shorten environment config blocks

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -10,78 +10,70 @@ class SchemaQueryFilterLogger < SimpleDelegator
   end
 end
 
+module DevelopmentEnvironmentConfig
+module_function
+
+  def configure(config)
+    configure_reloading(config)
+    configure_error_reporting(config)
+    configure_caching(config)
+    configure_mailer(config)
+    configure_deprecations(config)
+    configure_development_diagnostics(config)
+  end
+
+  def configure_reloading(config)
+    config.enable_reloading = true
+    config.eager_load = false
+  end
+
+  def configure_error_reporting(config)
+    config.action_dispatch.show_exceptions = :all
+    config.consider_all_requests_local = true
+    config.server_timing = true
+  end
+
+  def configure_caching(config)
+    if Rails.root.join('tmp/caching-dev.txt').exist?
+      config.action_controller.perform_caching = true
+      config.action_controller.enable_fragment_cache_logging = true
+      config.cache_store = :memory_store
+      config.public_file_server.headers = { 'Cache-Control' => "public, max-age=#{2.days.to_i}" }
+    else
+      config.action_controller.perform_caching = false
+      config.cache_store = :null_store
+    end
+  end
+
+  def configure_mailer(config)
+    config.action_mailer.raise_delivery_errors = false
+    config.action_mailer.perform_caching = false
+    config.action_mailer.default_url_options = { host: ENV.fetch('DEFAULT_MAIL_HOST', 'host.docker.internal'), port: 3000 }
+    config.action_mailer.delivery_method = :letter_opener
+  end
+
+  def configure_deprecations(config)
+    config.active_support.deprecation = :log
+    config.active_support.disallowed_deprecation = :raise
+    config.active_support.disallowed_deprecation_warnings = []
+  end
+
+  def configure_development_diagnostics(config)
+    # enable sequel transaction logs by setting RAILS_LOG_LEVEL=debug
+    config.log_level = ENV.fetch('RAILS_LOG_LEVEL', 'info').to_sym
+    config.active_job.verbose_enqueue_logs = true
+    config.action_controller.raise_on_missing_callback_actions = true
+
+    config.after_initialize do
+      Rails.logger = SchemaQueryFilterLogger.new(Rails.logger)
+    end
+  end
+end
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  # In the development environment your application's code is reloaded any time
-  # it changes. This slows down response time but is perfect for development
-  # since you don't have to restart the web server when you make code changes.
-  config.enable_reloading = true
-
-  # Do not eager load code on boot.
-  config.eager_load = false
-
-  # Show full error reports.
-
-  # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = :all
-
-  config.consider_all_requests_local = true
-
-  # Enable server timing
-  config.server_timing = true
-
-  # Enable/disable caching. By default caching is disabled.
-  # Run rails dev:cache to toggle caching.
-  if Rails.root.join('tmp/caching-dev.txt').exist?
-    config.action_controller.perform_caching = true
-    config.action_controller.enable_fragment_cache_logging = true
-
-    config.cache_store = :memory_store
-    config.public_file_server.headers = {
-      'Cache-Control' => "public, max-age=#{2.days.to_i}",
-    }
-  else
-    config.action_controller.perform_caching = false
-
-    config.cache_store = :null_store
-  end
-
-  # enable sequel transaction logs by setting RAILS_LOG_LEVEL=debug
-  config.log_level = ENV.fetch('RAILS_LOG_LEVEL', 'info').to_sym
-
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
-
-  config.action_mailer.perform_caching = false
-
-  # Mailcatcher configuration.
-  config.action_mailer.default_url_options = { host: ENV.fetch('DEFAULT_MAIL_HOST', 'host.docker.internal'), port: 3000 }
-  config.action_mailer.delivery_method = :letter_opener
-
-  # Print deprecation notices to the Rails logger.
-  config.active_support.deprecation = :log
-
-  # Raise exceptions for disallowed deprecations.
-  config.active_support.disallowed_deprecation = :raise
-
-  # Tell Active Support which deprecation messages to disallow.
-  config.active_support.disallowed_deprecation_warnings = []
-
-  # Highlight code that enqueued background job in logs.
-  config.active_job.verbose_enqueue_logs = true
-
-  # Raises error for missing translations.
-  # config.i18n.raise_on_missing_translations = true
-
-  # Annotate rendered view with file names.
-  # config.action_view.annotate_rendered_view_with_filenames = true
-
-  # Raise error when a before_action's only/except options reference missing actions
-  config.action_controller.raise_on_missing_callback_actions = true
+  DevelopmentEnvironmentConfig.configure(config)
 
   # NOTE: We must output to STDOUT to give visibility to N+1s. You can configure a higher RAILS_LOG_LEVEL in .env.development or in .env if you want to reduce the verbosity.
-  config.after_initialize do
-    Rails.logger = SchemaQueryFilterLogger.new(Rails.logger)
-  end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -3,129 +3,115 @@ require 'active_support/core_ext/integer/time'
 require_relative '../../app/lib/trade_tariff_backend'
 require_relative '../../app/middleware/sidekiq_basic_auth'
 
-Rails.application.configure do
-  force_ssl_enabled = ENV.fetch('RAILS_FORCE_SSL', 'false') == 'true'
-  assume_ssl_enabled = force_ssl_enabled && ENV.fetch('RAILS_ASSUME_SSL', 'true') == 'true'
+module ProductionEnvironmentConfig
+module_function
 
+  def configure(config)
+    configure_runtime(config)
+    configure_ssl(config)
+    configure_logging(config)
+    configure_cache(config)
+    configure_mailer(config)
+    configure_sidekiq_auth(config)
+  end
+
+  def configure_runtime(config)
+    config.enable_reloading = false
+    config.eager_load = true
+    config.consider_all_requests_local = false
+    config.action_controller.perform_caching = true
+    config.public_file_server.enabled = false
+  end
+
+  def configure_ssl(config)
+    force_ssl_enabled = ENV.fetch('RAILS_FORCE_SSL', 'false') == 'true'
+    assume_ssl_enabled = force_ssl_enabled && ENV.fetch('RAILS_ASSUME_SSL', 'true') == 'true'
+
+    config.force_ssl = force_ssl_enabled
+    config.assume_ssl = assume_ssl_enabled
+  end
+
+  def configure_logging(config)
+    config.logger = ActiveSupport::Logger.new($stdout)
+    config.lograge.enabled = true
+    config.lograge.formatter = Lograge::Formatters::Logstash.new
+    config.lograge.custom_options = lograge_custom_options
+    config.lograge.ignore_actions = %w[
+      HealthcheckController#index
+      HealthcheckController#checkz
+    ]
+    config.silence_healthcheck_path = '/healthcheckz'
+    config.log_tags = [:request_id]
+    config.log_level = ENV.fetch('RAILS_LOG_LEVEL', 'info')
+    config.active_support.deprecation = :notify
+  end
+
+  def lograge_custom_options
+    truncate_message = truncate_lograge_exception_message
+
+    lambda do |event|
+      exception = event.payload[:exception_object]
+      exception_class, exception_message = event.payload[:exception]
+      raw_exception_message = exception&.message || exception_message
+
+      {
+        request_id: event.payload[:request_id],
+        auth_type: event.payload[:auth_type],
+        client_id: event.payload[:client_id],
+        accept: event.payload[:headers]&.[]('HTTP_ACCEPT'),
+        exception_class: exception&.class&.name || exception_class,
+        params: event.payload[:params].except('controller', 'action', 'format', 'utf8'),
+        user_agent: event.payload[:user_agent],
+      }.merge(truncate_message.call(raw_exception_message)).compact
+    end
+  end
+
+  def truncate_lograge_exception_message
+    max_length = 500
+
+    lambda do |exception_message|
+      next {} if exception_message.blank?
+
+      message = exception_message.to_s
+
+      {
+        exception_message: message.first(max_length),
+        exception_message_truncated: message.length > max_length,
+      }
+    end
+  end
+
+  def configure_cache(config)
+    config.cache_store = :redis_cache_store,
+                         TradeTariffBackend.redis_config.merge({
+                           expires_in: 1.day,
+                           namespace: "rails-cache-#{ENV['SERVICE'].presence || 'uk'}",
+                           pool: { size: TradeTariffBackend.max_threads },
+                         })
+  end
+
+  def configure_mailer(config)
+    config.action_mailer.perform_caching = false
+    config.action_mailer.delivery_method = :ses_v2
+    config.i18n.fallbacks = [I18n.default_locale]
+  end
+
+  def configure_sidekiq_auth(config)
+    config.middleware.use(SidekiqBasicAuth) do |username, password|
+      secure_credential_compare(username, :username) & secure_credential_compare(password, :password)
+    end
+  end
+
+  def secure_credential_compare(value, credential_key)
+    ActiveSupport::SecurityUtils.secure_compare(
+      ::Digest::SHA256.hexdigest(value),
+      ::Digest::SHA256.hexdigest(Rails.application.credentials.dig(:sidekiq, credential_key)),
+    )
+  end
+end
+
+Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  # Code is not reloaded between requests.
-  config.enable_reloading = false
-
-  # Eager load code on boot. This eager loads most of Rails and
-  # your application in memory, allowing both threaded web servers
-  # and those relying on copy on write to perform better.
-  # Rake tasks automatically ignore this option for performance.
-  config.eager_load = true
-
-  # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local = false
-  config.action_controller.perform_caching = true
-  # Ensures that a master key has been made available in ENV["RAILS_MASTER_KEY"], config/master.key, or an environment
-  # key such as config/credentials/production.key. This key is used to decrypt credentials (and other encrypted files).
-  # config.require_master_key = true
-
-  # Disable serving static files from `public/`, relying on NGINX/Apache to do so instead.
-  config.public_file_server.enabled = false
-
-  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.asset_host = "http://assets.example.com"
-
-  # Specifies the header that your server uses for sending files.
-  # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for Apache
-  # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
-
-  # Assume all access to the app is happening through a SSL-terminating reverse proxy.
-  # Can be used together with config.force_ssl for Strict-Transport-Security and secure cookies.
-  # config.assume_ssl = true
-
-  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = force_ssl_enabled
-  config.assume_ssl = assume_ssl_enabled
-
-  # Log to STDOUT by default
-  config.logger = ActiveSupport::Logger.new($stdout)
-  config.lograge.enabled = true
-  config.lograge.formatter = Lograge::Formatters::Logstash.new
-  lograge_exception_message_max_length = 500
-  truncate_lograge_exception_message = lambda do |exception_message|
-    next {} if exception_message.blank?
-
-    message = exception_message.to_s
-
-    {
-      exception_message: message.first(lograge_exception_message_max_length),
-      exception_message_truncated: message.length > lograge_exception_message_max_length,
-    }
-  end
-
-  config.lograge.custom_options = lambda do |event|
-    exception = event.payload[:exception_object]
-    exception_class, exception_message = event.payload[:exception]
-    raw_exception_message = exception&.message || exception_message
-
-    {
-      request_id: event.payload[:request_id],
-      auth_type: event.payload[:auth_type],
-      client_id: event.payload[:client_id],
-      accept: event.payload[:headers]&.[]('HTTP_ACCEPT'),
-      exception_class: exception&.class&.name || exception_class,
-      params: event.payload[:params].except('controller', 'action', 'format', 'utf8'),
-      user_agent: event.payload[:user_agent],
-    }.merge(truncate_lograge_exception_message.call(raw_exception_message)).compact
-  end
-
-  config.lograge.ignore_actions = [
-    'HealthcheckController#index',
-    'HealthcheckController#checkz',
-  ]
-
-  config.silence_healthcheck_path = '/healthcheckz'
-
-  # Rails cache store
-  config.cache_store = :redis_cache_store,
-                       TradeTariffBackend.redis_config.merge({
-                         expires_in: 1.day,
-                         namespace: "rails-cache-#{ENV['SERVICE'].presence || 'uk'}",
-                         pool: { size: TradeTariffBackend.max_threads },
-                       })
-
-  # Prepend all log lines with the following tags.
-  config.log_tags = [:request_id]
-
-  # Info include generic and useful information about system operation, but avoids logging too much
-  # information to avoid inadvertent exposure of personally identifiable information (PII). If you
-  # want to log everything, set the level to "debug".
-  config.log_level = ENV.fetch('RAILS_LOG_LEVEL', 'info')
-
-  # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
-
-  # Use a real queuing backend for Active Job (and separate queues per environment).
-  # config.active_job.queue_adapter = :resque
-  # config.active_job.queue_name_prefix = "trade_tariff_backend_production"
-
-  config.action_mailer.perform_caching = false
-
-  # Ignore bad email addresses and do not raise email delivery errors.
-  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
-  config.action_mailer.delivery_method = :ses_v2
-
-  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
-  # the I18n.default_locale when a translation cannot be found).
-  config.i18n.fallbacks = [I18n.default_locale]
-
-  # Send deprecation notices to registered listeners.
-  config.active_support.deprecation = :notify
-  config.middleware.use(SidekiqBasicAuth) do |username, password|
-    ActiveSupport::SecurityUtils.secure_compare(
-      ::Digest::SHA256.hexdigest(username),
-      ::Digest::SHA256.hexdigest(Rails.application.credentials.dig(:sidekiq, :username)),
-    ) &
-      ActiveSupport::SecurityUtils.secure_compare(
-        ::Digest::SHA256.hexdigest(password),
-        ::Digest::SHA256.hexdigest(Rails.application.credentials.dig(:sidekiq, :password)),
-      )
-  end
+  ProductionEnvironmentConfig.configure(config)
 end


### PR DESCRIPTION
## What:
- [x] Extract or shorten long modules/blocks for RuboCop Metrics honesty
- [x] Keep runtime behaviour unchanged (structure only)

## Why:
Long modules and blocks made Metrics cops unenforceable. Domain-scoped extractions keep each change reviewable.

## Ticket:
N/A

## Risk:
**Risk level:** 🟠

**Reason for rating:**
Touches a medium-sensitivity domain surface; socialise before merge.