### PR TITLE
fix(rubocop): re-enable Layout/AccessModifierIndentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: trade-tariff/trade-tariff-tools/.github/actions/check-pr-lines@main
         with:
-          threshold: 600
+          threshold: 800
           exclude-paths: |
             db/
             data/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,9 +44,6 @@ RSpec/VariableName:
 Layout/LineLength:
   Max: 120
 
-Layout/AccessModifierIndentation:
-  Enabled: false
-
 Metrics/AbcSize:
   Max: 20
 

--- a/app/controllers/api/admin/admin_configurations_controller.rb
+++ b/app/controllers/api/admin/admin_configurations_controller.rb
@@ -21,7 +21,7 @@ module Api
         end
       end
 
-      private
+    private
 
       def configurations
         @configurations ||= AdminConfiguration.all

--- a/app/controllers/api/admin/admin_controller.rb
+++ b/app/controllers/api/admin/admin_controller.rb
@@ -8,7 +8,7 @@ module Api
 
       no_caching
 
-      private
+    private
 
       def set_paper_trail_whodunnit
         TradeTariffRequest.whodunnit = request.headers['X-Whodunnit']

--- a/app/controllers/api/admin/cds_update_notifications_controller.rb
+++ b/app/controllers/api/admin/cds_update_notifications_controller.rb
@@ -12,7 +12,7 @@ module Api
         end
       end
 
-      private
+    private
 
       def cds_update_notification_params
         params.require(:data).permit(:type, attributes: %i[filename])

--- a/app/controllers/api/admin/chapters/chapter_notes_controller.rb
+++ b/app/controllers/api/admin/chapters/chapter_notes_controller.rb
@@ -42,7 +42,7 @@ module Api
           head :no_content
         end
 
-        private
+      private
 
         def chapter_note_params
           params.require(:data).permit(:type, attributes: [:content])

--- a/app/controllers/api/admin/chapters/search_references_controller.rb
+++ b/app/controllers/api/admin/chapters/search_references_controller.rb
@@ -2,7 +2,7 @@ module Api
   module Admin
     module Chapters
       class SearchReferencesController < Api::Admin::SearchReferencesBaseController
-        private
+      private
 
         def search_reference_collection
           chapter.search_references_dataset

--- a/app/controllers/api/admin/chapters_controller.rb
+++ b/app/controllers/api/admin/chapters_controller.rb
@@ -14,7 +14,7 @@ module Api
         render json: Api::Admin::Chapters::ChapterSerializer.new(chapter, options).serializable_hash
       end
 
-      private
+    private
 
       def chapter
         @chapter = Chapter

--- a/app/controllers/api/admin/commodities/search_references_controller.rb
+++ b/app/controllers/api/admin/commodities/search_references_controller.rb
@@ -2,7 +2,7 @@ module Api
   module Admin
     module Commodities
       class SearchReferencesController < Api::Admin::SearchReferencesBaseController
-        private
+      private
 
         def search_reference_collection
           commodity_or_subheading.search_references_dataset

--- a/app/controllers/api/admin/commodities_controller.rb
+++ b/app/controllers/api/admin/commodities_controller.rb
@@ -7,7 +7,7 @@ module Api
         render json: Api::Admin::Commodities::CommoditySerializer.new(@commodity).serializable_hash
       end
 
-      private
+    private
 
       def find_commodity
         @commodity = GoodsNomenclature

--- a/app/controllers/api/admin/customs_tariff_updates/base_controller.rb
+++ b/app/controllers/api/admin/customs_tariff_updates/base_controller.rb
@@ -2,7 +2,7 @@ module Api
   module Admin
     module CustomsTariffUpdates
       class BaseController < AdminController
-        private
+      private
 
         def customs_tariff_update
           @customs_tariff_update ||= CustomsTariffUpdate

--- a/app/controllers/api/admin/customs_tariff_updates/section_notes_controller.rb
+++ b/app/controllers/api/admin/customs_tariff_updates/section_notes_controller.rb
@@ -95,7 +95,7 @@ module Api
                  status: :unprocessable_content
         end
 
-        private
+      private
 
         def compare_notes_index
           if params[:compare_version].present?

--- a/app/controllers/api/admin/customs_tariff_updates_controller.rb
+++ b/app/controllers/api/admin/customs_tariff_updates_controller.rb
@@ -13,7 +13,7 @@ module Api
         render json: Api::Admin::CustomsTariffUpdateSerializer.new(customs_tariff_update, is_collection: false).serializable_hash
       end
 
-      private
+    private
 
       def updates
         @updates ||= CustomsTariffUpdate

--- a/app/controllers/api/admin/description_intercepts_controller.rb
+++ b/app/controllers/api/admin/description_intercepts_controller.rb
@@ -53,7 +53,7 @@ module Api
         render json: Api::Admin::VersionSerializer.new(versions).serializable_hash
       end
 
-      private
+    private
 
       def serializer_class
         Api::Admin::DescriptionInterceptSerializer

--- a/app/controllers/api/admin/footnotes_controller.rb
+++ b/app/controllers/api/admin/footnotes_controller.rb
@@ -26,7 +26,7 @@ module Api
         end
       end
 
-      private
+    private
 
       def footnote_params
         params.require(:data).permit(:type, attributes: [:description])

--- a/app/controllers/api/admin/goods_nomenclature_autocomplete_controller.rb
+++ b/app/controllers/api/admin/goods_nomenclature_autocomplete_controller.rb
@@ -5,7 +5,7 @@ module Api
         render json: Api::Admin::GoodsNomenclatureAutocompleteSerializer.new(results).serializable_hash
       end
 
-      private
+    private
 
       def results
         @results ||= SearchSuggestion

--- a/app/controllers/api/admin/goods_nomenclature_labels_controller.rb
+++ b/app/controllers/api/admin/goods_nomenclature_labels_controller.rb
@@ -5,7 +5,7 @@ module Api
         render json: serialized_collection
       end
 
-      private
+    private
 
       def serialized_collection
         GoodsNomenclatures::GoodsNomenclatureLabelSerializer.new(

--- a/app/controllers/api/admin/goods_nomenclature_self_texts_controller.rb
+++ b/app/controllers/api/admin/goods_nomenclature_self_texts_controller.rb
@@ -3,7 +3,7 @@ module Api
     class GoodsNomenclatureSelfTextsController < AdminController
       include GeneratedContentListing
 
-      private
+    private
 
       def model_class
         GoodsNomenclatureSelfText

--- a/app/controllers/api/admin/goods_nomenclatures/goods_nomenclature_labels_controller.rb
+++ b/app/controllers/api/admin/goods_nomenclatures/goods_nomenclature_labels_controller.rb
@@ -57,7 +57,7 @@ module Api
           render json: serialize(goods_nomenclature_label.reload), status: :ok
         end
 
-        private
+      private
 
         def serialize(label, options = {})
           Api::Admin::GoodsNomenclatures::GoodsNomenclatureLabelSerializer

--- a/app/controllers/api/admin/goods_nomenclatures/goods_nomenclature_self_texts_controller.rb
+++ b/app/controllers/api/admin/goods_nomenclatures/goods_nomenclature_self_texts_controller.rb
@@ -62,7 +62,7 @@ module Api
           render json: serialize(self_text_record.reload), status: :ok
         end
 
-        private
+      private
 
         def serialize(record, options = {})
           GoodsNomenclatureSelfTextSerializer.new(record, options).serializable_hash

--- a/app/controllers/api/admin/green_lanes/category_assessments_controller.rb
+++ b/app/controllers/api/admin/green_lanes/category_assessments_controller.rb
@@ -83,7 +83,7 @@ module Api
           end
         end
 
-        private
+      private
 
         def ca_params
           params.require(:data).require(:attributes).permit(

--- a/app/controllers/api/admin/green_lanes/exempting_additional_code_overrides_controller.rb
+++ b/app/controllers/api/admin/green_lanes/exempting_additional_code_overrides_controller.rb
@@ -10,7 +10,7 @@ module Api
           render json: serialize(collection.to_a, pagination_meta)
         end
 
-        private
+      private
 
         def serializer_class = Api::Admin::GreenLanes::ExemptingAdditionalCodeOverrideSerializer
         def resource_class = ::GreenLanes::ExemptingAdditionalCodeOverride

--- a/app/controllers/api/admin/green_lanes/exempting_certificate_overrides_controller.rb
+++ b/app/controllers/api/admin/green_lanes/exempting_certificate_overrides_controller.rb
@@ -10,7 +10,7 @@ module Api
           render json: serialize(collection.to_a, pagination_meta)
         end
 
-        private
+      private
 
         def serializer_class = Api::Admin::GreenLanes::ExemptingCertificateOverrideSerializer
         def resource_class = ::GreenLanes::ExemptingCertificateOverride

--- a/app/controllers/api/admin/green_lanes/exemptions_controller.rb
+++ b/app/controllers/api/admin/green_lanes/exemptions_controller.rb
@@ -10,7 +10,7 @@ module Api
           render json: serialize(exemptions.to_a, pagination_meta)
         end
 
-        private
+      private
 
         def serializer_class = Api::Admin::GreenLanes::ExemptionSerializer
         def resource_class = ::GreenLanes::Exemption

--- a/app/controllers/api/admin/green_lanes/measure_type_mappings_controller.rb
+++ b/app/controllers/api/admin/green_lanes/measure_type_mappings_controller.rb
@@ -11,7 +11,7 @@ module Api
           render json: serialize(collection.to_a, options)
         end
 
-        private
+      private
 
         def serializer_class = Api::Admin::GreenLanes::MeasureTypeMappingSerializer
         def resource_class = ::GreenLanes::IdentifiedMeasureTypeCategoryAssessment

--- a/app/controllers/api/admin/green_lanes/measures_controller.rb
+++ b/app/controllers/api/admin/green_lanes/measures_controller.rb
@@ -61,7 +61,7 @@ module Api
           head :no_content
         end
 
-        private
+      private
 
         def measures
           @measures ||= ::GreenLanes::Measure.eager(MEASURE_EAGER_GRAPH).order.paginate(current_page, per_page)

--- a/app/controllers/api/admin/green_lanes/themes_controller.rb
+++ b/app/controllers/api/admin/green_lanes/themes_controller.rb
@@ -8,7 +8,7 @@ module Api
           render json: serialize(themes.to_a)
         end
 
-        private
+      private
 
         def themes
           @themes ||= ::GreenLanes::Theme.order(Sequel.asc(:section), Sequel.asc(:subsection))

--- a/app/controllers/api/admin/green_lanes/update_notifications_controller.rb
+++ b/app/controllers/api/admin/green_lanes/update_notifications_controller.rb
@@ -27,7 +27,7 @@ module Api
           end
         end
 
-        private
+      private
 
         def record_count
           update_notifications.pagination_record_count

--- a/app/controllers/api/admin/headings/search_references_controller.rb
+++ b/app/controllers/api/admin/headings/search_references_controller.rb
@@ -2,7 +2,7 @@ module Api
   module Admin
     module Headings
       class SearchReferencesController < Api::Admin::SearchReferencesBaseController
-        private
+      private
 
         def search_reference_collection
           heading.search_references_dataset

--- a/app/controllers/api/admin/headings_controller.rb
+++ b/app/controllers/api/admin/headings_controller.rb
@@ -8,7 +8,7 @@ module Api
         render json: Api::Admin::Headings::HeadingSerializer.new(presented_heading, options).serializable_hash
       end
 
-      private
+    private
 
       def presented_heading
         Api::Admin::Headings::HeadingPresenter.new(heading, search_reference_counts)

--- a/app/controllers/api/admin/live_issues_controller.rb
+++ b/app/controllers/api/admin/live_issues_controller.rb
@@ -35,7 +35,7 @@ module Api
         head :no_content
       end
 
-      private
+    private
 
       def serializer_class = Api::Admin::LiveIssueSerializer
 

--- a/app/controllers/api/admin/news/collections_controller.rb
+++ b/app/controllers/api/admin/news/collections_controller.rb
@@ -8,7 +8,7 @@ module Api
           render json: serialize(::News::Collection.all)
         end
 
-        private
+      private
 
         def serializer_class = Api::Admin::News::CollectionSerializer
         def resource_class = ::News::Collection

--- a/app/controllers/api/admin/news/items_controller.rb
+++ b/app/controllers/api/admin/news/items_controller.rb
@@ -8,7 +8,7 @@ module Api
           render json: serialize(news_items.to_a, pagination_meta)
         end
 
-        private
+      private
 
         def serializer_class = Api::Admin::News::ItemSerializer
         def resource_class = ::News::Item

--- a/app/controllers/api/admin/quota_order_numbers/quota_definitions_controller.rb
+++ b/app/controllers/api/admin/quota_order_numbers/quota_definitions_controller.rb
@@ -32,7 +32,7 @@ module Api
           render json: serialized_quota_definition
         end
 
-        private
+      private
 
         def serialized_quota_definitions
           Api::Admin::QuotaOrderNumbers::QuotaDefinitionSerializer.new(quota_definitions, serializer_options)

--- a/app/controllers/api/admin/reports_controller.rb
+++ b/app/controllers/api/admin/reports_controller.rb
@@ -34,7 +34,7 @@ module Api
         head :accepted
       end
 
-      private
+    private
 
       def report
         @report ||= Reporting::AdminReportRegistry.fetch!(params[:id])

--- a/app/controllers/api/admin/rollbacks_controller.rb
+++ b/app/controllers/api/admin/rollbacks_controller.rb
@@ -18,7 +18,7 @@ module Api
         end
       end
 
-      private
+    private
 
       def rollback_params
         params.require(:data).permit(:type, attributes: %i[date keep reason])

--- a/app/controllers/api/admin/search_analytics_controller.rb
+++ b/app/controllers/api/admin/search_analytics_controller.rb
@@ -16,7 +16,7 @@ module Api
         end
       end
 
-      private
+    private
 
       def error_response(period)
         {

--- a/app/controllers/api/admin/search_diagnostics_controller.rb
+++ b/app/controllers/api/admin/search_diagnostics_controller.rb
@@ -15,7 +15,7 @@ module Api
         render json: error_response(e.message, status: :unprocessable_content), status: :unprocessable_content
       end
 
-      private
+    private
 
       def error_response(message, status:)
         {

--- a/app/controllers/api/admin/search_references_base_controller.rb
+++ b/app/controllers/api/admin/search_references_base_controller.rb
@@ -58,7 +58,7 @@ module Api
         respond_with @search_reference
       end
 
-      private
+    private
 
       def search_references
         @search_references ||= search_reference_collection.by_title.all

--- a/app/controllers/api/admin/search_references_controller.rb
+++ b/app/controllers/api/admin/search_references_controller.rb
@@ -7,7 +7,7 @@ module Api
         render json: Api::Admin::SearchReferences::SearchReferenceListSerializer.new(search_references).serializable_hash
       end
 
-      private
+    private
 
       def letter
         params.dig(:query, :letter) || ''

--- a/app/controllers/api/admin/sections/section_notes_controller.rb
+++ b/app/controllers/api/admin/sections/section_notes_controller.rb
@@ -42,7 +42,7 @@ module Api
           head :no_content
         end
 
-        private
+      private
 
         def section_note_params
           params.require(:data).permit(:type, attributes: [:content])

--- a/app/controllers/api/admin/updates_controller.rb
+++ b/app/controllers/api/admin/updates_controller.rb
@@ -13,7 +13,7 @@ module Api
         render json: Api::Admin::TariffUpdateSerializer.new(update).serializable_hash
       end
 
-      private
+    private
 
       def collection
         @collection ||= TariffSynchronizer::BaseUpdate.eager(:presence_errors)

--- a/app/controllers/api/admin/versions_controller.rb
+++ b/app/controllers/api/admin/versions_controller.rb
@@ -41,7 +41,7 @@ module Api
         ).serializable_hash, status: :ok
       end
 
-      private
+    private
 
       def non_restorable_keys(klass)
         pk_cols = Array(klass.primary_key).map(&:to_s)

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -24,7 +24,7 @@ module Api
       render json: serializer.serialized_errors({ error: exception.message, url: request.url }), status: :bad_request
     end
 
-    protected
+  protected
 
     def current_page
       Integer(params[:page] || 1)

--- a/app/controllers/api/internal/search_controller.rb
+++ b/app/controllers/api/internal/search_controller.rb
@@ -15,7 +15,7 @@ module Api
         render json: Api::Internal::SuggestionsService.new(params).call
       end
 
-      private
+    private
 
       def search_params
         params.permit(:q, :as_of, :request_id, :expanded_query, answers: %i[question answer options])

--- a/app/controllers/api/user/grouped_measure_changes_controller.rb
+++ b/app/controllers/api/user/grouped_measure_changes_controller.rb
@@ -11,7 +11,7 @@ module Api
         render json: serialize
       end
 
-      private
+    private
 
       def tariff_changes
         @tariff_changes ||= Api::User::GroupedMeasureChangesService.new(current_user, id, actual_date).call(page: current_page, per_page:)

--- a/app/controllers/api/user/grouped_measure_commodity_changes_controller.rb
+++ b/app/controllers/api/user/grouped_measure_commodity_changes_controller.rb
@@ -9,7 +9,7 @@ module Api
         render json: Api::User::GroupedMeasureCommodityChangeSerializer.new(grouped_measure_commodity_change, serializer_options).serializable_hash
       end
 
-      private
+    private
 
       def grouped_measure_commodity_change
         TariffChanges::GroupedMeasureCommodityChange.from_id(id)

--- a/app/controllers/api/user/subscription_targets_controller.rb
+++ b/app/controllers/api/user/subscription_targets_controller.rb
@@ -23,7 +23,7 @@ module Api
                   disposition: "attachment; filename=commodity_watch_list-your_codes_#{filename_date}.xlsx"
       end
 
-      private
+    private
 
       def filter_params
         params.fetch(:filter, {}).permit(:active_commodities_type)

--- a/app/controllers/api/user/user_controller.rb
+++ b/app/controllers/api/user/user_controller.rb
@@ -7,7 +7,7 @@ module Api
 
       no_caching
 
-      private
+    private
 
       def actual_date
         super(Time.zone.yesterday)

--- a/app/controllers/api/v1/chapters/chapter_notes_controller.rb
+++ b/app/controllers/api/v1/chapters/chapter_notes_controller.rb
@@ -15,7 +15,7 @@ module Api
           respond_with @chapter_note
         end
 
-        private
+      private
 
         def chapter_note_params
           params.require(:chapter_note).permit(:content)

--- a/app/controllers/api/v1/chapters_controller.rb
+++ b/app/controllers/api/v1/chapters_controller.rb
@@ -46,7 +46,7 @@ module Api
         render json: serialized_result
       end
 
-      private
+    private
 
       def chapter
         @chapter ||= Chapter.actual

--- a/app/controllers/api/v1/commodities_controller.rb
+++ b/app/controllers/api/v1/commodities_controller.rb
@@ -49,7 +49,7 @@ module Api
         render 'api/v1/changes/changes'
       end
 
-      private
+    private
 
       def find_commodity
         @commodity = Commodity.actual

--- a/app/controllers/api/v1/headings_controller.rb
+++ b/app/controllers/api/v1/headings_controller.rb
@@ -96,7 +96,7 @@ module Api
         @heading = non_declarable_heading
       end
 
-      private
+    private
 
       def heading
         @heading ||= if base_heading.declarable?

--- a/app/controllers/api/v1/sections/section_notes_controller.rb
+++ b/app/controllers/api/v1/sections/section_notes_controller.rb
@@ -15,7 +15,7 @@ module Api
           respond_with @section_note
         end
 
-        private
+      private
 
         def section_note_params
           params.require(:section_note).permit(:content)

--- a/app/controllers/api/v2/additional_code_types_controller.rb
+++ b/app/controllers/api/v2/additional_code_types_controller.rb
@@ -5,7 +5,7 @@ module Api
         render json: Api::V2::AdditionalCodes::AdditionalCodeTypeSerializer.new(additional_code_types, {}).serializable_hash
       end
 
-      private
+    private
 
       def additional_code_types
         AdditionalCodeType.all

--- a/app/controllers/api/v2/additional_codes_controller.rb
+++ b/app/controllers/api/v2/additional_codes_controller.rb
@@ -9,7 +9,7 @@ module Api
         end
       end
 
-      private
+    private
 
       def serialized_additional_codes
         Api::V2::AdditionalCodes::AdditionalCodeSerializer.new(

--- a/app/controllers/api/v2/certificate_types_controller.rb
+++ b/app/controllers/api/v2/certificate_types_controller.rb
@@ -5,7 +5,7 @@ module Api
         render json: Api::V2::Certificates::CertificateTypeSerializer.new(certificate_types, {}).serializable_hash
       end
 
-      private
+    private
 
       def certificate_types
         CertificateType.eager(:certificate_type_description).all

--- a/app/controllers/api/v2/certificates_controller.rb
+++ b/app/controllers/api/v2/certificates_controller.rb
@@ -13,7 +13,7 @@ module Api
         render json: serialized_list_of_certificates
       end
 
-      private
+    private
 
       def serialized_list_of_certificates
         Api::V2::Certificates::CertificateListSerializer.new(

--- a/app/controllers/api/v2/changes_controller.rb
+++ b/app/controllers/api/v2/changes_controller.rb
@@ -5,7 +5,7 @@ module Api
         render json: Api::V2::ChangesSerializer.new(changes).serializable_hash
       end
 
-      private
+    private
 
       def changes
         Change.where(change_date: Change.point_in_time).all

--- a/app/controllers/api/v2/chapters_controller.rb
+++ b/app/controllers/api/v2/chapters_controller.rb
@@ -78,7 +78,7 @@ module Api
         end
       end
 
-      private
+    private
 
       def chapter
         scope = Chapter

--- a/app/controllers/api/v2/chemical_substances_controller.rb
+++ b/app/controllers/api/v2/chemical_substances_controller.rb
@@ -5,7 +5,7 @@ module Api
         render json: serialized_chemicals
       end
 
-      private
+    private
 
       def serialized_chemicals
         Api::V2::FullChemicalSerializer.new(full_chemicals).serializable_hash

--- a/app/controllers/api/v2/chemicals_controller.rb
+++ b/app/controllers/api/v2/chemicals_controller.rb
@@ -27,7 +27,7 @@ module Api
         end
       end
 
-      private
+    private
 
       def search_service
         @search_service ||= ChemicalSearchService.new(params, current_page, per_page)

--- a/app/controllers/api/v2/commodities_controller.rb
+++ b/app/controllers/api/v2/commodities_controller.rb
@@ -21,7 +21,7 @@ module Api
         render json: Api::V2::Changes::ChangeSerializer.new(@changes.changes, options).serializable_hash
       end
 
-      private
+    private
 
       def find_commodity
         @commodity = Commodity.actual

--- a/app/controllers/api/v2/description_intercepts_controller.rb
+++ b/app/controllers/api/v2/description_intercepts_controller.rb
@@ -5,7 +5,7 @@ module Api
         render json: Api::V2::DescriptionInterceptSerializer.new(description_intercepts).serializable_hash
       end
 
-      private
+    private
 
       def description_intercepts
         DescriptionIntercept

--- a/app/controllers/api/v2/enquiry_form/submissions_controller.rb
+++ b/app/controllers/api/v2/enquiry_form/submissions_controller.rb
@@ -16,7 +16,7 @@ module Api
         end
       end
 
-      private
+    private
 
       def store_enquiry_form_data
         Sidekiq.redis do |conn|

--- a/app/controllers/api/v2/exchange_rates/base_controller.rb
+++ b/app/controllers/api/v2/exchange_rates/base_controller.rb
@@ -6,7 +6,7 @@ module Api
 
         before_action :validate_exchange_rate_type
 
-        private
+      private
 
         def validate_exchange_rate_type
           raise NotImplementedError, type unless valid_exchange_rate_type?

--- a/app/controllers/api/v2/exchange_rates/files_controller.rb
+++ b/app/controllers/api/v2/exchange_rates/files_controller.rb
@@ -14,7 +14,7 @@ module Api
           )
         end
 
-        private
+      private
 
         def validate_id
           raise Sequel::RecordNotFound unless id.match?(/\A(monthly_csv_hmrc|monthly_csv|monthly_xml|average_csv|spot_csv)_\d{4}-\d{1,2}\z/)

--- a/app/controllers/api/v2/exchange_rates/period_lists_controller.rb
+++ b/app/controllers/api/v2/exchange_rates/period_lists_controller.rb
@@ -8,7 +8,7 @@ module Api
           render json: serialized_period_list
         end
 
-        private
+      private
 
         def serialized_period_list
           ExchangeRates::ExchangeRatePeriodListSerializer.new(

--- a/app/controllers/api/v2/exchange_rates_controller.rb
+++ b/app/controllers/api/v2/exchange_rates_controller.rb
@@ -7,7 +7,7 @@ module Api
         render json: serialized_exchange_rate_collection
       end
 
-      private
+    private
 
       def serialized_exchange_rate_collection
         ExchangeRates::ExchangeRateCollectionSerializer.new(

--- a/app/controllers/api/v2/footnote_types_controller.rb
+++ b/app/controllers/api/v2/footnote_types_controller.rb
@@ -5,7 +5,7 @@ module Api
         render json: Api::V2::Footnotes::FootnoteTypeSerializer.new(footnote_types, {}).serializable_hash
       end
 
-      private
+    private
 
       def footnote_types
         FootnoteType.eager(:footnote_type_description).all

--- a/app/controllers/api/v2/footnotes_controller.rb
+++ b/app/controllers/api/v2/footnotes_controller.rb
@@ -9,7 +9,7 @@ module Api
         end
       end
 
-      private
+    private
 
       def serialized_footnotes
         Api::V2::Footnotes::FootnoteSerializer.new(

--- a/app/controllers/api/v2/geographical_areas_controller.rb
+++ b/app/controllers/api/v2/geographical_areas_controller.rb
@@ -13,7 +13,7 @@ module Api
         render json: CachedGeographicalAreaService.new(actual_date, exclude_none:, countries: true).call
       end
 
-      private
+    private
 
       def serialized_geographical_area
         Api::V2::GeographicalAreaTreeSerializer.new(

--- a/app/controllers/api/v2/goods_nomenclatures_controller.rb
+++ b/app/controllers/api/v2/goods_nomenclatures_controller.rb
@@ -95,7 +95,7 @@ module Api
       end
       helper_method :api_path_builder
 
-      private
+    private
 
       def respond_with(commodities)
         @commodities = commodities

--- a/app/controllers/api/v2/green_lanes/base_controller.rb
+++ b/app/controllers/api/v2/green_lanes/base_controller.rb
@@ -9,7 +9,7 @@ module Api
 
         before_action :check_service, :authenticate, :set_request_scope
 
-        protected
+      protected
 
         def append_info_to_payload(payload)
           super
@@ -17,7 +17,7 @@ module Api
           payload[:auth_type] = @auth_type
         end
 
-        private
+      private
 
         def check_service
           if TradeTariffBackend.uk?

--- a/app/controllers/api/v2/green_lanes/faq_feedback_controller.rb
+++ b/app/controllers/api/v2/green_lanes/faq_feedback_controller.rb
@@ -19,7 +19,7 @@ module Api
           render json: serialize(faq_feedback)
         end
 
-        private
+      private
 
         def faq_feedback_params
           params.require(:data).require(:attributes).permit(

--- a/app/controllers/api/v2/green_lanes/themes_controller.rb
+++ b/app/controllers/api/v2/green_lanes/themes_controller.rb
@@ -6,7 +6,7 @@ module Api
           render json: serialize(themes.to_a)
         end
 
-        private
+      private
 
         def themes
           @themes ||= ::GreenLanes::Theme.order(Sequel.asc(:section), Sequel.asc(:subsection))

--- a/app/controllers/api/v2/knowledge_graph/queries_controller.rb
+++ b/app/controllers/api/v2/knowledge_graph/queries_controller.rb
@@ -14,7 +14,7 @@ module Api
           end
         end
 
-        private
+      private
 
         def attributes
           params.fetch(:data, {}).fetch(:attributes, {}).to_unsafe_h

--- a/app/controllers/api/v2/live_issues_controller.rb
+++ b/app/controllers/api/v2/live_issues_controller.rb
@@ -9,7 +9,7 @@ module Api
         render json: serialize_errors(e)
       end
 
-      private
+    private
 
       def live_issues
         @live_issues ||= LiveIssue.dataset

--- a/app/controllers/api/v2/measure_actions_controller.rb
+++ b/app/controllers/api/v2/measure_actions_controller.rb
@@ -5,7 +5,7 @@ module Api
         render json: Api::V2::MeasureActionSerializer.new(measure_actions).serializable_hash
       end
 
-      private
+    private
 
       def measure_actions
         MeasureAction

--- a/app/controllers/api/v2/measure_condition_codes_controller.rb
+++ b/app/controllers/api/v2/measure_condition_codes_controller.rb
@@ -5,7 +5,7 @@ module Api
         render json: Api::V2::MeasureConditionCodeSerializer.new(measure_condition_codes).serializable_hash
       end
 
-      private
+    private
 
       def measure_condition_codes
         MeasureConditionCode

--- a/app/controllers/api/v2/measures_controller.rb
+++ b/app/controllers/api/v2/measures_controller.rb
@@ -5,7 +5,7 @@ module Api
         render json: Api::V2::MeasureSerializer.new(presented_measure, serializer_options)
       end
 
-      private
+    private
 
       def presented_measure
         measure = Measure.actual

--- a/app/controllers/api/v2/monetary_exchange_rates_controller.rb
+++ b/app/controllers/api/v2/monetary_exchange_rates_controller.rb
@@ -5,7 +5,7 @@ module Api
         render json: Api::V2::MonetaryExchangeRateSerializer.new(rates_last_five_years).serializable_hash
       end
 
-      private
+    private
 
       def rates_last_five_years
         jan_five_years_ago = Time.zone.now.beginning_of_year - 5.years

--- a/app/controllers/api/v2/notifications_controller.rb
+++ b/app/controllers/api/v2/notifications_controller.rb
@@ -19,7 +19,7 @@ module Api
         end
       end
 
-      private
+    private
 
       def notification
         @notification ||= Notification.new(notification_params)

--- a/app/controllers/api/v2/preference_codes_controller.rb
+++ b/app/controllers/api/v2/preference_codes_controller.rb
@@ -9,7 +9,7 @@ module Api
         render json: preference_code
       end
 
-      private
+    private
 
       def preference_codes
         PreferenceCodeSerializer.new(PreferenceCode.all).serializable_hash

--- a/app/controllers/api/v2/quotas_controller.rb
+++ b/app/controllers/api/v2/quotas_controller.rb
@@ -22,7 +22,7 @@ module Api
         render json: serialized_quota_definitions
       end
 
-      private
+    private
 
       def validate_order_number
         return if params[:order_number].blank?

--- a/app/controllers/api/v2/search_controller.rb
+++ b/app/controllers/api/v2/search_controller.rb
@@ -22,7 +22,7 @@ module Api
         render json: results
       end
 
-      private
+    private
 
       def classic_result_metrics(results)
         return { result_count: 0 } unless results.is_a?(Hash) && results[:data].is_a?(Hash)

--- a/app/controllers/api/v2/search_references_controller.rb
+++ b/app/controllers/api/v2/search_references_controller.rb
@@ -7,7 +7,7 @@ module Api
         render json: serialized_search_references
       end
 
-      private
+    private
 
       def serialized_search_references
         Api::V2::SearchReferenceSerializer.new(search_references).serializable_hash

--- a/app/controllers/api/v2/sections_controller.rb
+++ b/app/controllers/api/v2/sections_controller.rb
@@ -49,7 +49,7 @@ module Api
         end
       end
 
-      private
+    private
 
       def chapter_note_eager_load
         TradeTariffBackend.promote_customs_tariff_notes? ? :customs_tariff_chapter_note : :chapter_note

--- a/app/controllers/api/v2/simplified_procedural_code_measures_controller.rb
+++ b/app/controllers/api/v2/simplified_procedural_code_measures_controller.rb
@@ -5,7 +5,7 @@ module Api
         render json: serialized_simplified_procedural_code_measures
       end
 
-      private
+    private
 
       def serialized_simplified_procedural_code_measures
         Api::V2::SimplifiedProceduralCodeMeasureSerializer.new(all_simplified_procedural_code_measures)

--- a/app/controllers/api/v2/subheadings_controller.rb
+++ b/app/controllers/api/v2/subheadings_controller.rb
@@ -9,7 +9,7 @@ module Api
         render json: cached_subheading
       end
 
-      private
+    private
 
       def cached_subheading
         CachedSubheadingService.new(

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,7 +22,7 @@ class ApplicationController < ActionController::API
     head :ok
   end
 
-  protected
+protected
 
   def jsonapi_serializer_options(default_include: nil, **options)
     options = options.dup
@@ -54,7 +54,7 @@ class ApplicationController < ActionController::API
     payload[:client_id] = request.headers['HTTP_X_CLIENT_ID']
   end
 
-  private
+private
 
   def actual_date(default = Time.zone.today)
     as_of_param = params[:as_of].to_s

--- a/app/controllers/concerns/api/admin/generated_content_listing.rb
+++ b/app/controllers/concerns/api/admin/generated_content_listing.rb
@@ -7,7 +7,7 @@ module Api
         render json: serialized_collection
       end
 
-      private
+    private
 
       def serialized_collection
         serializer_class.new(

--- a/app/controllers/concerns/api/admin/resource_actions.rb
+++ b/app/controllers/concerns/api/admin/resource_actions.rb
@@ -40,7 +40,7 @@ module Api
         head :no_content
       end
 
-      private
+    private
 
       def find_record
         resource_class.with_pk!(params[:id])

--- a/app/controllers/concerns/api/admin/serializable.rb
+++ b/app/controllers/concerns/api/admin/serializable.rb
@@ -3,7 +3,7 @@ module Api
     module Serializable
       extend ActiveSupport::Concern
 
-      private
+    private
 
       def serialize(*args)
         serializer_class.new(*args).serializable_hash

--- a/app/controllers/concerns/api/admin/version_browsing.rb
+++ b/app/controllers/concerns/api/admin/version_browsing.rb
@@ -3,7 +3,7 @@ module Api
     module VersionBrowsing
       extend ActiveSupport::Concern
 
-      private
+    private
 
       def serializer_options
         { meta: version_meta }

--- a/app/controllers/concerns/api_key_authenticatable.rb
+++ b/app/controllers/concerns/api_key_authenticatable.rb
@@ -2,7 +2,7 @@ module ApiKeyAuthenticatable
   extend ActiveSupport::Concern
 
   included do
-    private
+  private
 
     def authenticate_with_api_keys
       provided_key = request.headers['X-Api-Key']

--- a/app/controllers/concerns/api_token_authenticatable.rb
+++ b/app/controllers/concerns/api_token_authenticatable.rb
@@ -26,7 +26,7 @@ module ApiTokenAuthenticatable
       true
     end
 
-    private
+  private
 
     def api_tokens
       @api_tokens ||= read_tokens

--- a/app/controllers/concerns/etag_caching.rb
+++ b/app/controllers/concerns/etag_caching.rb
@@ -12,7 +12,7 @@ module EtagCaching
     before_action :set_cache_headers, if: :http_caching_enabled?
   end
 
-  protected
+protected
 
   def set_cache_headers
     if request.get? || request.head?

--- a/app/controllers/concerns/public_user_authenticatable.rb
+++ b/app/controllers/concerns/public_user_authenticatable.rb
@@ -10,7 +10,7 @@ module PublicUserAuthenticatable
   }.freeze
 
   included do
-    private
+  private
 
     attr_reader :current_user
 

--- a/app/controllers/concerns/search_result_tracking.rb
+++ b/app/controllers/concerns/search_result_tracking.rb
@@ -3,7 +3,7 @@ module SearchResultTracking
 
   SEARCH_REQUEST_ID_HEADER = 'X-Search-Request-Id'.freeze
 
-  private
+private
 
   def track_result_selected
     rid = search_request_id

--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -14,7 +14,7 @@ class HealthcheckController < ApplicationController
     render json: resultz
   end
 
-  private
+private
 
   def result
     @result ||= Healthcheck.check

--- a/app/formatters/duty_expression_formatter/context.rb
+++ b/app/formatters/duty_expression_formatter/context.rb
@@ -49,7 +49,7 @@ DutyExpressionFormatter::Context = Data.define(
       )
     end
 
-    private
+  private
 
     def verbose_context_values(verbose, measurement_unit, measurement_unit_qualifier, monetary_unit, duty_amount)
       return [nil, nil] unless verbose

--- a/app/formatters/duty_expression_formatter/output_builder.rb
+++ b/app/formatters/duty_expression_formatter/output_builder.rb
@@ -16,7 +16,7 @@ class DutyExpressionFormatter::OutputBuilder
     strategy_for(context).call
   end
 
-  private
+private
 
   attr_reader :context
 

--- a/app/formatters/duty_expression_formatter/strategies/base.rb
+++ b/app/formatters/duty_expression_formatter/strategies/base.rb
@@ -5,7 +5,7 @@ class DutyExpressionFormatter::Strategies::Base
     @context = context
   end
 
-  private
+private
 
   attr_reader :context
 

--- a/app/formatters/formatter_output_helpers.rb
+++ b/app/formatters/formatter_output_helpers.rb
@@ -1,5 +1,5 @@
 module FormatterOutputHelpers
-  private
+private
 
   def formatted_amount_fragment(formatter_class, amount, formatted:)
     prettified_amount = formatter_class.prettify(amount).to_s

--- a/app/formatters/requirement_duty_expression_formatter/output_builder.rb
+++ b/app/formatters/requirement_duty_expression_formatter/output_builder.rb
@@ -15,7 +15,7 @@ class RequirementDutyExpressionFormatter::OutputBuilder
     [amount_fragment, unit_fragment].compact
   end
 
-  private
+private
 
   attr_reader :context
 

--- a/app/lib/ai_usage.rb
+++ b/app/lib/ai_usage.rb
@@ -2,7 +2,7 @@ module AiUsage
   LOG_FIELDS = %i[provider model event_kind input_tokens output_tokens total_tokens input_cost_usd output_cost_usd total_cost_usd pricing_known].freeze
   Metadata = Data.define(*LOG_FIELDS)
 
-  module_function
+module_function
 
   def metadata_for(model:, event_kind:, usage:)
     usage = normalize_usage(usage)

--- a/app/lib/ai_usage/instrumentation.rb
+++ b/app/lib/ai_usage/instrumentation.rb
@@ -3,7 +3,7 @@ require_relative 'logger'
 
 module AiUsage
   module Instrumentation
-    module_function
+  module_function
 
     def instrument(event_name, payload = {}, &block)
       ActiveSupport::Notifications.instrument("#{event_name}.ai_usage", payload, &block)

--- a/app/lib/cds_importer.rb
+++ b/app/lib/cds_importer.rb
@@ -111,7 +111,7 @@ class CdsImporter
     attr_reader :key, :instance, :mapper, :element_id
   end
 
-  private
+private
 
   attr_reader :oplog_inserts
 

--- a/app/lib/cds_importer/entity_mapper.rb
+++ b/app/lib/cds_importer/entity_mapper.rb
@@ -57,7 +57,7 @@ class CdsImporter
       end
     end
 
-    private
+  private
 
     def implicit_deletes_enabled?
       return file_date < TradeTariffBackend.implicit_deletion_cutoff if file_date

--- a/app/lib/cds_importer/entity_mapper/base_mapper.rb
+++ b/app/lib/cds_importer/entity_mapper/base_mapper.rb
@@ -88,7 +88,7 @@ class CdsImporter
           "#{mapping_path.to_s.length}#{name}"
         end
 
-        protected
+      protected
 
         def before_oplog_inserts(&block)
           before_oplog_inserts_callbacks << block
@@ -144,7 +144,7 @@ class CdsImporter
         @xml_node['filename']
       end
 
-      private
+    private
 
       def build_instance(values)
         unmapped_values = values

--- a/app/lib/cds_importer/excel_writer.rb
+++ b/app/lib/cds_importer/excel_writer.rb
@@ -45,7 +45,7 @@ class CdsImporter
       notify_slack_app(e, @filename)
     end
 
-    private
+  private
 
     attr_reader :workbook, :filename, :package, :bold_style, :regular_style
 

--- a/app/lib/cds_importer/excel_writer/additional_code.rb
+++ b/app/lib/cds_importer/excel_writer/additional_code.rb
@@ -38,7 +38,7 @@ class CdsImporter
          periodic_description(additional_code_description_period, additional_code_description, &method(:period_matches?))]
       end
 
-      private
+    private
 
       def period_matches?(period, description)
         period.additional_code_description_period_sid == description.additional_code_description_period_sid &&

--- a/app/lib/cds_importer/excel_writer/certificate.rb
+++ b/app/lib/cds_importer/excel_writer/certificate.rb
@@ -38,7 +38,7 @@ class CdsImporter
          periodic_description(certificate_description_periods, certificate_descriptions, &method(:period_matches?))]
       end
 
-      private
+    private
 
       def period_matches?(period, description)
         period.certificate_description_period_sid == description.certificate_description_period_sid &&

--- a/app/lib/cds_importer/excel_writer/footnote.rb
+++ b/app/lib/cds_importer/excel_writer/footnote.rb
@@ -40,7 +40,7 @@ class CdsImporter
          periodic_description(footnote_description_periods, footnote_descriptions, &method(:period_matches?))]
       end
 
-      private
+    private
 
       def period_matches?(period, description)
         period.footnote_description_period_sid == description.footnote_description_period_sid &&

--- a/app/lib/cds_importer/excel_writer/geographical_area.rb
+++ b/app/lib/cds_importer/excel_writer/geographical_area.rb
@@ -49,7 +49,7 @@ class CdsImporter
          geo_area.parent_geographical_area_group_sid]
       end
 
-      private
+    private
 
       def geographical_area(geo_area_sid)
         ga = ::GeographicalArea

--- a/app/lib/cds_importer/excel_writer/goods_nomenclature.rb
+++ b/app/lib/cds_importer/excel_writer/goods_nomenclature.rb
@@ -48,7 +48,7 @@ class CdsImporter
         description.present?
       end
 
-      private
+    private
 
       def description
         grouped = models.group_by { |model| model.class.name }

--- a/app/lib/cds_importer/excel_writer/measure.rb
+++ b/app/lib/cds_importer/excel_writer/measure.rb
@@ -58,7 +58,7 @@ class CdsImporter
          measure.measure_sid]
       end
 
-      private
+    private
 
       def measure_type(measure_type_id)
         mt = ::MeasureType.find(measure_type_id: measure_type_id)

--- a/app/lib/cds_importer/excel_writer/quota_definition.rb
+++ b/app/lib/cds_importer/excel_writer/quota_definition.rb
@@ -57,7 +57,7 @@ class CdsImporter
          format_date(quota_definition.validity_end_date)]
       end
 
-      private
+    private
 
       def quota_balance_event_string(quota_balance_events)
         if quota_balance_events.blank?

--- a/app/lib/cds_importer/record_inserter.rb
+++ b/app/lib/cds_importer/record_inserter.rb
@@ -24,7 +24,7 @@ class CdsImporter
       process_batch
     end
 
-    private
+  private
 
     def process_batch
       save_batch

--- a/app/lib/cds_importer/staging_manager.rb
+++ b/app/lib/cds_importer/staging_manager.rb
@@ -85,7 +85,7 @@ class CdsImporter
       @staged_tables.clear
     end
 
-    private
+  private
 
     # Staging table names are short fixed-length identifiers so they are
     # always under PostgreSQL's 63-character limit, regardless of how long the

--- a/app/lib/changes_table_populator/importer.rb
+++ b/app/lib/changes_table_populator/importer.rb
@@ -42,7 +42,7 @@ module ChangesTablePopulator
         .select(&select_condition)
     end
 
-    protected
+  protected
 
     def source_table
       raise NotImplementedError, 'Implement this method in the subclasses'

--- a/app/lib/custom_job_logger.rb
+++ b/app/lib/custom_job_logger.rb
@@ -35,7 +35,7 @@ class CustomJobLogger < ::Sidekiq::JobLogger
     raise e
   end
 
-  private
+private
 
   def query_count
     ::SequelRails::Railties::LogSubscriber.count

--- a/app/lib/customs_tariff_importer/document_fetcher.rb
+++ b/app/lib/customs_tariff_importer/document_fetcher.rb
@@ -42,7 +42,7 @@ module CustomsTariffImporter
       raise
     end
 
-    private
+  private
 
     def all_docx_links(html)
       doc = Nokogiri::HTML(html)

--- a/app/lib/customs_tariff_importer/importer.rb
+++ b/app/lib/customs_tariff_importer/importer.rb
@@ -15,7 +15,7 @@ module CustomsTariffImporter
       documents.map { |doc| import_document(doc) }
     end
 
-    private
+  private
 
     def import_document(fetched)
       if CustomsTariffUpdate.exclude(status: CustomsTariffUpdate::FAILED).where(version: fetched.version).any?

--- a/app/lib/customs_tariff_importer/instrumentation.rb
+++ b/app/lib/customs_tariff_importer/instrumentation.rb
@@ -2,7 +2,7 @@ require 'active_support/notifications'
 
 module CustomsTariffImporter
   module Instrumentation
-    module_function
+  module_function
 
     def instrument(event_name, payload = {}, &block)
       ActiveSupport::Notifications.instrument("#{event_name}.customs_tariff_importer", payload, &block)

--- a/app/lib/customs_tariff_importer/logger.rb
+++ b/app/lib/customs_tariff_importer/logger.rb
@@ -116,7 +116,7 @@ module CustomsTariffImporter
       )
     end
 
-    private
+  private
 
     def log_entry(data)
       data.merge(service: 'customs_tariff_importer', timestamp: Time.current.iso8601).to_json

--- a/app/lib/customs_tariff_importer/notes_extractor.rb
+++ b/app/lib/customs_tariff_importer/notes_extractor.rb
@@ -49,7 +49,7 @@ module CustomsTariffImporter
       raise
     end
 
-    private
+  private
 
     def read_document_xml
       xml_content = nil

--- a/app/lib/customs_tariff_importer/notes_extractor/formatter.rb
+++ b/app/lib/customs_tariff_importer/notes_extractor/formatter.rb
@@ -74,7 +74,7 @@ module CustomsTariffImporter
         @current_chapter = nil
       end
 
-      private
+    private
 
       def paragraph_block(para)
         style = para.at_xpath('./w:pPr/w:pStyle', WORD_NS)&.attr('w:val').to_s

--- a/app/lib/customs_tariff_importer/notes_extractor/formatter/marker_trie.rb
+++ b/app/lib/customs_tariff_importer/notes_extractor/formatter/marker_trie.rb
@@ -123,7 +123,7 @@ module CustomsTariffImporter
 
         private_class_method :parsed_line
 
-        private
+      private
 
         def child_marker_context?(formatted, paragraph_indent_level, paragraph_first_line_indent_level)
           (paragraph_indent_level.positive? && formatted.match?(SOURCE_CHILD_MARKER_LINE_PATTERN)) ||

--- a/app/lib/customs_tariff_importer/notes_extractor/formatter/paragraph_preprocessor.rb
+++ b/app/lib/customs_tariff_importer/notes_extractor/formatter/paragraph_preprocessor.rb
@@ -18,7 +18,7 @@ module CustomsTariffImporter
           normalize_visual_numbering(text, current_paragraph)
         end
 
-        private
+      private
 
         def normalize_source_bullet_marker(text)
           return text unless text.match?(SOURCE_BULLET_MARKER_PATTERN)

--- a/app/lib/customs_tariff_importer/notes_extractor/formatter/table_formatter.rb
+++ b/app/lib/customs_tariff_importer/notes_extractor/formatter/table_formatter.rb
@@ -14,7 +14,7 @@ module CustomsTariffImporter
           ['', markdown_table_row(header), markdown_table_separator(header.length), *body.map { |row| markdown_table_row(row) }, '']
         end
 
-        private
+      private
 
         def table_row_cells(row)
           row.xpath('./w:tc', WORD_NS).flat_map do |cell|

--- a/app/lib/customs_tariff_importer/reimporter.rb
+++ b/app/lib/customs_tariff_importer/reimporter.rb
@@ -12,7 +12,7 @@ module CustomsTariffImporter
       end
     end
 
-    private
+  private
 
     def reimport(update)
       content = TariffSynchronizer::FileService.get(update.s3_path).read

--- a/app/lib/embedding_service.rb
+++ b/app/lib/embedding_service.rb
@@ -80,7 +80,7 @@ class EmbeddingService
     AiUsage.attach_metadata(embeddings, usage)
   end
 
-  private
+private
 
   def usage_metadata(body, event_kind:)
     usage = body.to_h['usage']

--- a/app/lib/green_lanes_updates_publisher/data_updates_finder.rb
+++ b/app/lib/green_lanes_updates_publisher/data_updates_finder.rb
@@ -110,7 +110,7 @@ module GreenLanesUpdatesPublisher
       queries.flat_map { |query| fetch_updates(query) }
     end
 
-    private
+  private
 
     def fetch_updates(query)
       dataset = DB.fetch(

--- a/app/lib/jsonapi_cache_key.rb
+++ b/app/lib/jsonapi_cache_key.rb
@@ -1,7 +1,7 @@
 module JsonapiCacheKey
   include JsonapiQueryOptions
 
-  private
+private
 
   def jsonapi_cache_key_suffix
     return if jsonapi_query_options.blank?

--- a/app/lib/jsonapi_query_options.rb
+++ b/app/lib/jsonapi_query_options.rb
@@ -1,5 +1,5 @@
 module JsonapiQueryOptions
-  private
+private
 
   def jsonapi_query_options
     Thread.current[:jsonapi_query_options] || {}

--- a/app/lib/label_generator/instrumentation.rb
+++ b/app/lib/label_generator/instrumentation.rb
@@ -2,7 +2,7 @@ require 'active_support/notifications'
 
 module LabelGenerator
   module Instrumentation
-    module_function
+  module_function
 
     def instrument(event_name, payload = {}, &block)
       ActiveSupport::Notifications.instrument("#{event_name}.label_generator", payload, &block)

--- a/app/lib/label_generator/logger.rb
+++ b/app/lib/label_generator/logger.rb
@@ -171,7 +171,7 @@ module LabelGenerator
       error log_entry(data)
     end
 
-    private
+  private
 
     def log_entry(data)
       data.merge(

--- a/app/lib/openai_client.rb
+++ b/app/lib/openai_client.rb
@@ -66,7 +66,7 @@ class OpenaiClient
     end
   end
 
-  private
+private
 
   def raise_on_error!(response, model: nil, event_kind: nil)
     ai_usage = usage_metadata(response.body, model:, event_kind:)

--- a/app/lib/reporting.rb
+++ b/app/lib/reporting.rb
@@ -47,7 +47,7 @@ module Reporting
       false
     end
 
-    private
+  private
 
     def reporting_cdn_host?
       TradeTariffBackend.reporting_cdn_host.present?

--- a/app/lib/reporting/admin_report_registry.rb
+++ b/app/lib/reporting/admin_report_registry.rb
@@ -48,7 +48,7 @@ module Reporting
         all.find { |report| report.id == id.to_s } || raise(Sequel::NoMatchingRow)
       end
 
-      private
+    private
 
       def definitions
         [

--- a/app/lib/reporting/basic.rb
+++ b/app/lib/reporting/basic.rb
@@ -91,7 +91,7 @@ module Reporting
         end
       end
 
-      private
+    private
 
       def build_row_for(goods_nomenclature)
         overview_measures = goods_nomenclature.applicable_overview_measures

--- a/app/lib/reporting/category_assessments.rb
+++ b/app/lib/reporting/category_assessments.rb
@@ -52,7 +52,7 @@ module Reporting
         end
       end
 
-      private
+    private
 
       def serialized_assessments
         Api::V2::GreenLanes::CategoryAssessmentSerializer.new(

--- a/app/lib/reporting/commodities.rb
+++ b/app/lib/reporting/commodities.rb
@@ -54,7 +54,7 @@ module Reporting
         Reporting.published_link(xi_object_key)
       end
 
-      private
+    private
 
       def goods_nomenclatures
         Chapter

--- a/app/lib/reporting/declarable_duties.rb
+++ b/app/lib/reporting/declarable_duties.rb
@@ -176,7 +176,7 @@ module Reporting
         end
       end
 
-      private
+    private
 
       def build_row_for(declarable, measure)
         HEADER_ROW.map do |header|

--- a/app/lib/reporting/differences.rb
+++ b/app/lib/reporting/differences.rb
@@ -311,7 +311,7 @@ module Reporting
       Reporting::SupplementaryUnits.get_xi_link_today
     end
 
-    private
+  private
 
     def object_key
       self.class.send(:object_key)
@@ -346,7 +346,7 @@ module Reporting
         end
       end
 
-      private
+    private
 
       def object_key
         "#{service}/reporting/#{year}/#{month}/#{day}/differences_#{now.strftime('%Y-%m-%d')}.xlsx"

--- a/app/lib/reporting/differences/loaders/bad_quota_association.rb
+++ b/app/lib/reporting/differences/loaders/bad_quota_association.rb
@@ -12,7 +12,7 @@ module Reporting
           rows
         end
 
-        private
+      private
 
         def each_row
           ::BadQuotaAssociation.actual.each do |bad_quota_association|

--- a/app/lib/reporting/differences/loaders/candidate_supplementary_unit.rb
+++ b/app/lib/reporting/differences/loaders/candidate_supplementary_unit.rb
@@ -17,7 +17,7 @@ module Reporting
           rows
         end
 
-        private
+      private
 
         def each_row
           each_declarable do |declarable|

--- a/app/lib/reporting/differences/loaders/goods_nomenclature.rb
+++ b/app/lib/reporting/differences/loaders/goods_nomenclature.rb
@@ -16,7 +16,7 @@ module Reporting
           [self.class.name, source, target].join('_')
         end
 
-        private
+      private
 
         def data
           all_missing = source_goods_nomenclatures.keys - target_goods_nomenclatures.keys
@@ -73,7 +73,7 @@ module Reporting
           ]
         end
 
-        private
+      private
 
         attr_reader :goods_nomenclature
 

--- a/app/lib/reporting/differences/loaders/goods_nomenclature_start_date.rb
+++ b/app/lib/reporting/differences/loaders/goods_nomenclature_start_date.rb
@@ -4,7 +4,7 @@ module Reporting
       class GoodsNomenclatureStartDate
         include Reporting::Differences::Loaders::Helpers
 
-        private
+      private
 
         def data
           matching_goods_nomenclature = uk_goods_nomenclature_ids.keys & xi_goods_nomenclature_ids.keys

--- a/app/lib/reporting/differences/loaders/hierarchy.rb
+++ b/app/lib/reporting/differences/loaders/hierarchy.rb
@@ -4,7 +4,7 @@ module Reporting
       class Hierarchy
         include Reporting::Differences::Loaders::Helpers
 
-        private
+      private
 
         def data
           matching_goods_nomenclature = uk_goods_nomenclature_ids.keys & xi_goods_nomenclature_ids.keys

--- a/app/lib/reporting/differences/loaders/incomplete_measure_condition.rb
+++ b/app/lib/reporting/differences/loaders/incomplete_measure_condition.rb
@@ -4,7 +4,7 @@ module Reporting
       class IncompleteMeasureCondition
         include Reporting::Differences::Loaders::Helpers
 
-        private
+      private
 
         def data
           acc = []

--- a/app/lib/reporting/differences/loaders/indentation.rb
+++ b/app/lib/reporting/differences/loaders/indentation.rb
@@ -4,7 +4,7 @@ module Reporting
       class Indentation
         include Reporting::Differences::Loaders::Helpers
 
-        private
+      private
 
         def data
           matching_goods_nomenclature = uk_goods_nomenclature_ids.keys & xi_goods_nomenclature_ids.keys

--- a/app/lib/reporting/differences/loaders/me16.rb
+++ b/app/lib/reporting/differences/loaders/me16.rb
@@ -7,7 +7,7 @@ module Reporting
         delegate :each_chapter,
                  to: :report
 
-        private
+      private
 
         def data
           acc = []

--- a/app/lib/reporting/differences/loaders/me32.rb
+++ b/app/lib/reporting/differences/loaders/me32.rb
@@ -7,7 +7,7 @@ module Reporting
         delegate :each_chapter,
                  to: :report
 
-        private
+      private
 
         def data
           acc = []

--- a/app/lib/reporting/differences/loaders/measure_quota_coverage.rb
+++ b/app/lib/reporting/differences/loaders/measure_quota_coverage.rb
@@ -13,7 +13,7 @@ module Reporting
           @end_of_year = Time.zone.today.end_of_year
         end
 
-        private
+      private
 
         attr_reader :report
 

--- a/app/lib/reporting/differences/loaders/mfn_duplicated.rb
+++ b/app/lib/reporting/differences/loaders/mfn_duplicated.rb
@@ -6,7 +6,7 @@ module Reporting
 
         include Reporting::Differences::Loaders::Helpers
 
-        private
+      private
 
         def data
           acc = []

--- a/app/lib/reporting/differences/loaders/mfn_missing.rb
+++ b/app/lib/reporting/differences/loaders/mfn_missing.rb
@@ -7,7 +7,7 @@ module Reporting
         delegate :each_chapter,
                  to: :report
 
-        private
+      private
 
         def data
           acc = []

--- a/app/lib/reporting/differences/loaders/misapplied_action_code.rb
+++ b/app/lib/reporting/differences/loaders/misapplied_action_code.rb
@@ -4,7 +4,7 @@ module Reporting
       class MisappliedActionCode
         include Reporting::Differences::Loaders::Helpers
 
-        private
+      private
 
         def data
           acc = []

--- a/app/lib/reporting/differences/loaders/missing_vat_measure.rb
+++ b/app/lib/reporting/differences/loaders/missing_vat_measure.rb
@@ -19,7 +19,7 @@ module Reporting
           rows
         end
 
-        private
+      private
 
         def each_row
           each_declarable do |declarable|

--- a/app/lib/reporting/differences/loaders/omitted_duty_measures.rb
+++ b/app/lib/reporting/differences/loaders/omitted_duty_measures.rb
@@ -38,7 +38,7 @@ module Reporting
           rows
         end
 
-        private
+      private
 
         def each_row
           start_time = Time.zone.now

--- a/app/lib/reporting/differences/loaders/quota_exclusion_misalignment.rb
+++ b/app/lib/reporting/differences/loaders/quota_exclusion_misalignment.rb
@@ -17,7 +17,7 @@ module Reporting
           rows
         end
 
-        private
+      private
 
         def misaligned_rows
           TimeMachine.at(report.as_of) do

--- a/app/lib/reporting/differences/loaders/quota_missing_origin.rb
+++ b/app/lib/reporting/differences/loaders/quota_missing_origin.rb
@@ -15,7 +15,7 @@ module Reporting
           rows
         end
 
-        private
+      private
 
         def each_row
           TimeMachine.at(report.as_of) do

--- a/app/lib/reporting/differences/loaders/seasonal.rb
+++ b/app/lib/reporting/differences/loaders/seasonal.rb
@@ -12,7 +12,7 @@ module Reporting
           no_duty: 'No duty found',
         }.freeze
 
-        private
+      private
 
         def data
           acc = []

--- a/app/lib/reporting/differences/loaders/supplementary_unit.rb
+++ b/app/lib/reporting/differences/loaders/supplementary_unit.rb
@@ -17,7 +17,7 @@ module Reporting
           [self.class.name, source, target].join('_')
         end
 
-        private
+      private
 
         attr_reader :source, :target, :report
 
@@ -61,7 +61,7 @@ module Reporting
 
         delegate :hash, to: :to_row
 
-        private
+      private
 
         attr_reader :measure
 

--- a/app/lib/reporting/differences/renderers/overview.rb
+++ b/app/lib/reporting/differences/renderers/overview.rb
@@ -273,7 +273,7 @@ module Reporting
           end
         end
 
-        private
+      private
 
         attr_reader :report
 

--- a/app/lib/reporting/geographical_area_groups.rb
+++ b/app/lib/reporting/geographical_area_groups.rb
@@ -106,7 +106,7 @@ module Reporting
         end
       end
 
-      private
+    private
 
       def build_row_for(group, child)
         HEADER_ROW.map do |header|

--- a/app/lib/reporting/prohibitions.rb
+++ b/app/lib/reporting/prohibitions.rb
@@ -151,7 +151,7 @@ module Reporting
         end
       end
 
-      private
+    private
 
       def build_row_for(declarable, measure)
         HEADER_ROW.map do |header|

--- a/app/lib/reporting/supplementary_units.rb
+++ b/app/lib/reporting/supplementary_units.rb
@@ -65,7 +65,7 @@ module Reporting
         Reporting.published_link(xi_object_key)
       end
 
-      private
+    private
 
       def rows
         Measure

--- a/app/lib/reporting/tariff_updates.rb
+++ b/app/lib/reporting/tariff_updates.rb
@@ -30,7 +30,7 @@ module Reporting
         end
       end
 
-      private
+    private
 
       def open_workbook
         instrument_report_step('open_workbook') do

--- a/app/lib/search/instrumentation.rb
+++ b/app/lib/search/instrumentation.rb
@@ -2,7 +2,7 @@ require 'active_support/notifications'
 
 module Search
   module Instrumentation
-    module_function
+  module_function
 
     ERROR_MESSAGE_MAX_LENGTH = 500
     MAX_LOGGED_RESULTS = 50

--- a/app/lib/search/logger.rb
+++ b/app/lib/search/logger.rb
@@ -265,7 +265,7 @@ module Search
       error log_entry(data, event)
     end
 
-    private
+  private
 
     def log_entry(data, event)
       entry = data.merge(

--- a/app/lib/self_text_generator/instrumentation.rb
+++ b/app/lib/self_text_generator/instrumentation.rb
@@ -2,7 +2,7 @@ require 'active_support/notifications'
 
 module SelfTextGenerator
   module Instrumentation
-    module_function
+  module_function
 
     def instrument(event_name, payload = {}, &block)
       ActiveSupport::Notifications.instrument("#{event_name}.self_text_generator", payload, &block)

--- a/app/lib/self_text_generator/logger.rb
+++ b/app/lib/self_text_generator/logger.rb
@@ -162,7 +162,7 @@ module SelfTextGenerator
       info log_entry(event: 'reindex_completed')
     end
 
-    private
+  private
 
     def log_entry(data)
       data.merge(

--- a/app/lib/sequel/plugins/has_paper_trail.rb
+++ b/app/lib/sequel/plugins/has_paper_trail.rb
@@ -41,7 +41,7 @@ module Sequel
           true
         end
 
-        private
+      private
 
         def register_model(model)
           @tracked_models |= [model]
@@ -61,7 +61,7 @@ module Sequel
           Thread.current[paper_trail_disabled_key] == true
         end
 
-        private
+      private
 
         def paper_trail_disabled_key
           :"paper_trail_disabled_#{name}"
@@ -89,7 +89,7 @@ module Sequel
           create_version('destroy')
         end
 
-        private
+      private
 
         def create_version(event)
           return if model.paper_trail_disabled?

--- a/app/lib/sequel/plugins/optimized_many_to_many.rb
+++ b/app/lib/sequel/plugins/optimized_many_to_many.rb
@@ -2,7 +2,7 @@
 module Sequel
   module Plugins
     module OptimizedManyToMany
-      module_function
+    module_function
 
       def join_conditions(right_key, right_pk, join_table, target_table, db = Sequel::Model.db)
         join_table_name = extract_table_name(join_table)

--- a/app/lib/taric_importer.rb
+++ b/app/lib/taric_importer.rb
@@ -59,7 +59,7 @@ class TaricImporter
       raise ImportException
     end
 
-    private
+  private
 
     def taric_failed_log(exception, hash)
       "Taric import failed: #{exception}".tap do |message|
@@ -70,7 +70,7 @@ class TaricImporter
     end
   end
 
-  private
+private
 
   attr_reader :oplog_inserts
 

--- a/app/lib/taric_importer/record_processor/create_operation.rb
+++ b/app/lib/taric_importer/record_processor/create_operation.rb
@@ -9,7 +9,7 @@ class TaricImporter
         :create
       end
 
-      private
+    private
 
       def get_model_record
         klass.new

--- a/app/lib/taric_importer/record_processor/operation.rb
+++ b/app/lib/taric_importer/record_processor/operation.rb
@@ -28,7 +28,7 @@ class TaricImporter
         raise NotImplementedError
       end
 
-      private
+    private
 
       def ignore_presence_errors?
         TaricSynchronizer.ignore_presence_errors

--- a/app/lib/taric_importer/record_processor/record.rb
+++ b/app/lib/taric_importer/record_processor/record.rb
@@ -34,7 +34,7 @@ class TaricImporter
         @attributes = default_attributes.merge(attrs)
       end
 
-      private
+    private
 
       def default_attributes
         klass.columns.reduce({}) do |memo, column_name|

--- a/app/lib/taric_synchronizer.rb
+++ b/app/lib/taric_synchronizer.rb
@@ -71,7 +71,7 @@ class TaricSynchronizer
       rollback_updates(TaricUpdate, rollback_date, keep:)
     end
 
-    private
+  private
 
     def sync_variables_set?
       username.present? && password.present? && host.present?

--- a/app/lib/tariff_synchronizer/base_update.rb
+++ b/app/lib/tariff_synchronizer/base_update.rb
@@ -162,7 +162,7 @@ module TariffSynchronizer
       ].map(&:to_s).join('-')
     end
 
-    private
+  private
 
     def record_state_change(to_state:)
       TariffUpdateStateChange.insert(
@@ -188,7 +188,7 @@ module TariffSynchronizer
         download_start_date(initial_date:)..download_end_date
       end
 
-      private
+    private
 
       def download_end_date
         Time.zone.today

--- a/app/lib/tariff_synchronizer/base_update_importer.rb
+++ b/app/lib/tariff_synchronizer/base_update_importer.rb
@@ -26,7 +26,7 @@ module TariffSynchronizer
       ActiveSupport::Notifications.unsubscribe(@presence_errors_subscriber)
     end
 
-    private
+  private
 
     # Tracks the last 10 SQL queries executed during the import.
     # These are logged if there is an exception.

--- a/app/lib/tariff_synchronizer/cds_update.rb
+++ b/app/lib/tariff_synchronizer/cds_update.rb
@@ -68,7 +68,7 @@ module TariffSynchronizer
       filename.sub('.gzip', '')
     end
 
-    private
+  private
 
     def check_oplog_inserts
       return if filesize <= TradeTariffBackend.empty_file_size_threshold

--- a/app/lib/tariff_synchronizer/cds_update_downloader.rb
+++ b/app/lib/tariff_synchronizer/cds_update_downloader.rb
@@ -28,7 +28,7 @@ module TariffSynchronizer
       end
     end
 
-    private
+  private
 
     # Example:
     # { "filename"=>"tariff_dailyExtract_v1_20191009T235959.gzip",

--- a/app/lib/tariff_synchronizer/file_service.rb
+++ b/app/lib/tariff_synchronizer/file_service.rb
@@ -109,7 +109,7 @@ module TariffSynchronizer
         end
       end
 
-      private
+    private
 
       def with_s3_retry(operation:, file_path:)
         attempts = 0

--- a/app/lib/tariff_synchronizer/instrumentation.rb
+++ b/app/lib/tariff_synchronizer/instrumentation.rb
@@ -2,7 +2,7 @@ require 'active_support/notifications'
 
 module TariffSynchronizer
   module Instrumentation
-    module_function
+  module_function
 
     def instrument(event_name, payload = {}, &block)
       payload[:service] ||= TradeTariffBackend.service

--- a/app/lib/tariff_synchronizer/sync_logger.rb
+++ b/app/lib/tariff_synchronizer/sync_logger.rb
@@ -228,7 +228,7 @@ module TariffSynchronizer
       )
     end
 
-    private
+  private
 
     def log_entry(data)
       data.merge(

--- a/app/lib/tariff_synchronizer/taric_update.rb
+++ b/app/lib/tariff_synchronizer/taric_update.rb
@@ -59,7 +59,7 @@ module TariffSynchronizer
         current_update.next_update
       end
 
-      private
+    private
 
       def sequence_applicable_updates
         descending.where(state: SEQUENCE_APPLICABLE_STATES).limit(SEQUENCE_APPLICABLE_UPDATE_LIMIT)

--- a/app/lib/tariff_synchronizer/taric_update_downloader.rb
+++ b/app/lib/tariff_synchronizer/taric_update_downloader.rb
@@ -17,7 +17,7 @@ module TariffSynchronizer
       send("create_record_for_#{response.state}_response")
     end
 
-    private
+  private
 
     def response
       @response ||= TariffUpdatesRequester.perform(date_api_url)

--- a/app/lib/tariff_synchronizer/taric_update_downloader_patched.rb
+++ b/app/lib/tariff_synchronizer/taric_update_downloader_patched.rb
@@ -26,7 +26,7 @@ module TariffSynchronizer
       download(@update.next_rollover_update)
     end
 
-    private
+  private
 
     def download(update)
       TariffDownloader.new(

--- a/app/lib/tariff_synchronizer/tariff_downloader.rb
+++ b/app/lib/tariff_synchronizer/tariff_downloader.rb
@@ -31,7 +31,7 @@ module TariffSynchronizer
       persist_exception_for_review(e)
     end
 
-    private
+  private
 
     def create_entry
       return if tariff_update.present?

--- a/app/lib/tariff_synchronizer/tariff_updates_requester.rb
+++ b/app/lib/tariff_synchronizer/tariff_updates_requester.rb
@@ -52,7 +52,7 @@ module TariffSynchronizer
       raise RetriableDownloadError, @url
     end
 
-    private
+  private
 
     def send_request
       uri = URI(@url)

--- a/app/lib/trade_tariff_backend/config.rb
+++ b/app/lib/trade_tariff_backend/config.rb
@@ -285,7 +285,7 @@ module TradeTariffBackend
       ENV.fetch('GOODS_NOMENCLATURE_LABEL_PAGE_SIZE', '10').to_i
     end
 
-    private
+  private
 
     # Parse a comma-separated email list, or a JSON hash whose values are
     # email addresses (the format used when the secret is injected directly

--- a/app/lib/trade_tariff_backend/search_client.rb
+++ b/app/lib/trade_tariff_backend/search_client.rb
@@ -98,7 +98,7 @@ module TradeTariffBackend
       }.merge(search_operation_options))
     end
 
-    private
+  private
 
     def index_instance(index)
       index.is_a?(Class) ? index.new : index

--- a/app/lib/versioned_forwarder.rb
+++ b/app/lib/versioned_forwarder.rb
@@ -10,7 +10,7 @@ class VersionedForwarder
     Rails.application.call(env)
   end
 
-  private
+private
 
   def transform_env(env, service, version, path)
     format = format_from(env)

--- a/app/middleware/clear_cache_control.rb
+++ b/app/middleware/clear_cache_control.rb
@@ -14,7 +14,7 @@ class ClearCacheControl
     [status, headers, body]
   end
 
-  private
+private
 
   def frontend_request?(env)
     env[HTTP_USER_AGENT].to_s.start_with?(FRONTEND_USER_AGENT)

--- a/app/middleware/handle_api_gateway_params.rb
+++ b/app/middleware/handle_api_gateway_params.rb
@@ -33,7 +33,7 @@ class HandleApiGatewayParams
     [status, headers, body]
   end
 
-  private
+private
 
   def build_nested(key, value)
     keys = key.split(SEPARATOR)

--- a/app/middleware/handle_goods_nomenclature.rb
+++ b/app/middleware/handle_goods_nomenclature.rb
@@ -28,7 +28,7 @@ class HandleGoodsNomenclature
     [status, headers, response]
   end
 
-  private
+private
 
   def path_incorrectly_matches_commodity?(path)
     return false unless path.include?('commodities')

--- a/app/models/additional_code.rb
+++ b/app/models/additional_code.rb
@@ -81,7 +81,7 @@ class AdditionalCode < Sequel::Model
       overrides_for(code).dup
     end
 
-    private
+  private
 
     def overrides_for(code)
       additional_codes.dig('code_overrides', code) || {}

--- a/app/models/admin_configuration.rb
+++ b/app/models/admin_configuration.rb
@@ -337,7 +337,7 @@ class AdminConfiguration < Sequel::Model(Sequel[:admin_configurations].qualify(:
     val == true
   end
 
-  private
+private
 
   def validate_unique_name
     if self.class.where(name: name).any?

--- a/app/models/admin_configuration/value_normalizer.rb
+++ b/app/models/admin_configuration/value_normalizer.rb
@@ -5,7 +5,7 @@ class AdminConfiguration
   # appropriate for each config_type. Included as a private mixin on
   # AdminConfiguration; not intended for use outside that class.
   module ValueNormalizer
-    private
+  private
 
     def normalize_value!
       val = self[:value]

--- a/app/models/admin_configuration/value_validator.rb
+++ b/app/models/admin_configuration/value_validator.rb
@@ -5,7 +5,7 @@ class AdminConfiguration
   # config_type. Included as a private mixin on AdminConfiguration; not
   # intended for use outside that class.
   module ValueValidator
-    private
+  private
 
     def validate_value_for_type
       return if config_type.blank?

--- a/app/models/apply.rb
+++ b/app/models/apply.rb
@@ -1,5 +1,5 @@
 class Apply < Sequel::Model
-  private
+private
 
   def validate
     self.whodunnit ||= TradeTariffRequest.whodunnit

--- a/app/models/cds_update_notification.rb
+++ b/app/models/cds_update_notification.rb
@@ -18,7 +18,7 @@ class CdsUpdateNotification < Sequel::Model
     errors.add(:filename, 'must refer to an existing CDS update') unless TariffSynchronizer::CdsUpdate.where(filename: filename).count.positive?
   end
 
-  private
+private
 
   def must_have(attribute)
     errors.add(attribute, "Can't be blank") if send(attribute).blank?

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -118,7 +118,7 @@ class Chapter < GoodsNomenclature
      .order(Sequel.desc(:operation_date, nulls: :last), Sequel.desc(:depth))
   end
 
-  private
+private
 
   def relevant_headings
     "#{short_code}__#{HEADING_SUFFIX}"

--- a/app/models/concerns/admin_listing_dataset.rb
+++ b/app/models/concerns/admin_listing_dataset.rb
@@ -38,7 +38,7 @@ module AdminListingDataset
     end
   end
 
-  private
+private
 
   def generated_content_table
     raise NotImplementedError, "#{self.class} must define #generated_content_table"

--- a/app/models/concerns/classification_description.rb
+++ b/app/models/concerns/classification_description.rb
@@ -18,7 +18,7 @@ module ClassificationDescription
     description&.match(/^other$/i)
   end
 
-  private
+private
 
   def collect_other_chain(description)
     all_other = true

--- a/app/models/concerns/content_addressable_id.rb
+++ b/app/models/concerns/content_addressable_id.rb
@@ -17,7 +17,7 @@ module ContentAddressableId
     @id ||= Digest::MD5.hexdigest(addressable_content)
   end
 
-  private
+private
 
   def addressable_content
     addressable_fields = self.class.content_addressable_fields

--- a/app/models/concerns/formatter.rb
+++ b/app/models/concerns/formatter.rb
@@ -31,7 +31,7 @@ module Formatter
     end
   end
 
-  private
+private
 
   def result_of_attribute_or_method_call(field_name)
     self[field_name.to_s].presence ||

--- a/app/models/concerns/generated_content_lifecycle.rb
+++ b/app/models/concerns/generated_content_lifecycle.rb
@@ -45,7 +45,7 @@ module GeneratedContentLifecycle
     update(expired: true)
   end
 
-  private
+private
 
   def manual_edit_attributes(attributes)
     attributes.merge(

--- a/app/models/concerns/ten_digit_goods_nomenclature.rb
+++ b/app/models/concerns/ten_digit_goods_nomenclature.rb
@@ -104,7 +104,7 @@ module TenDigitGoodsNomenclature
       goods_nomenclature_item_id
     end
 
-    private
+  private
 
     def harmonised_system_code
       goods_nomenclature_item_id.first(6)

--- a/app/models/description_intercept.rb
+++ b/app/models/description_intercept.rb
@@ -123,7 +123,7 @@ class DescriptionIntercept < Sequel::Model
     super
   end
 
-  private
+private
 
   def validate_filter_prefixes
     prefixes = Array(filter_prefixes)

--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -1,5 +1,5 @@
 class Download < Sequel::Model
-  private
+private
 
   def validate
     self.whodunnit ||= TradeTariffRequest.whodunnit

--- a/app/models/exchange_rates/period_list.rb
+++ b/app/models/exchange_rates/period_list.rb
@@ -27,7 +27,7 @@ module ExchangeRates
         period_list
       end
 
-      private
+    private
 
       def periods_for(type, year)
         year = default_year(year, type)

--- a/app/models/exchange_rates/xe_api.rb
+++ b/app/models/exchange_rates/xe_api.rb
@@ -24,7 +24,7 @@ module ExchangeRates
       end
     end
 
-    private
+  private
 
     def send_request(path)
       response = client.get(path)

--- a/app/models/geographical_area.rb
+++ b/app/models/geographical_area.rb
@@ -146,7 +146,7 @@ class GeographicalArea < Sequel::Model
     actual_eu.contained_geographical_areas.map(&:geographical_area_id)
   end
 
-  private
+private
 
   def referenced_id
     REFERENCED_GEOGRAPHICAL_AREAS[geographical_area_id]

--- a/app/models/goods_nomenclature_label.rb
+++ b/app/models/goods_nomenclature_label.rb
@@ -66,7 +66,7 @@ class GoodsNomenclatureLabel < Sequel::Model
       end
     end
 
-    private
+  private
 
     def generated_content_table
       Sequel[:goods_nomenclature_labels]

--- a/app/models/goods_nomenclature_self_text.rb
+++ b/app/models/goods_nomenclature_self_text.rb
@@ -71,7 +71,7 @@ class GoodsNomenclatureSelfText < Sequel::Model
         .limit(limit)
     end
 
-    private
+  private
 
     def generated_content_table
       Sequel[:goods_nomenclature_self_texts]
@@ -117,7 +117,7 @@ class GoodsNomenclatureSelfText < Sequel::Model
       stale_records.size
     end
 
-    private
+  private
 
     def with_self_text(sids)
       where(goods_nomenclature_sid: sids)

--- a/app/models/heading.rb
+++ b/app/models/heading.rb
@@ -79,7 +79,7 @@ class Heading < GoodsNomenclature
      .order(Sequel.desc(:operation_date, nulls: :last))
   end
 
-  private
+private
 
   def relevant_goods_nomenclature
     "#{short_code}______"

--- a/app/models/import_trade_summary.rb
+++ b/app/models/import_trade_summary.rb
@@ -33,7 +33,7 @@ class ImportTradeSummary
     end
   end
 
-  private
+private
 
   def third_country_measures
     @third_country_measures ||= import_measures

--- a/app/models/live_issue.rb
+++ b/app/models/live_issue.rb
@@ -11,7 +11,7 @@ class LiveIssue < Sequel::Model(Sequel[:live_issues].qualify(:public))
     errors.add(:commodities, 'must contain 10 digit commodity codes') if invalid_commodity_codes?
   end
 
-  private
+private
 
   def invalid_commodity_codes?
     return false if commodities.blank?

--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -427,7 +427,7 @@ class Measure < Sequel::Model
       exclude(exclusion_criteria)
     end
 
-    private
+  private
 
     # Builds an OR-combined Sequel condition from a collection of [col_a, col_b]
     # value pairs and applies it as a WHERE clause. Returns the dataset unchanged

--- a/app/models/measure/component_resolver.rb
+++ b/app/models/measure/component_resolver.rb
@@ -68,7 +68,7 @@ class Measure
       @meursing_measures ||= MeursingMeasureFinderService.new(measure, meursing_additional_code_id).call
     end
 
-    private
+  private
 
     attr_reader :measure
 

--- a/app/models/measure/duty_expression_presenter.rb
+++ b/app/models/measure/duty_expression_presenter.rb
@@ -40,7 +40,7 @@ class Measure
       "#{measurement_unit.description} (#{measurement_unit.abbreviation})"
     end
 
-    private
+  private
 
     attr_reader :measure
 

--- a/app/models/measure/geographical_relevance.rb
+++ b/app/models/measure/geographical_relevance.rb
@@ -16,7 +16,7 @@ class Measure
       contained_area_ids.include?(country_id)
     end
 
-    private
+  private
 
     attr_reader :measure
 

--- a/app/models/measure/validity_period.rb
+++ b/app/models/measure/validity_period.rb
@@ -17,7 +17,7 @@ class Measure
       generating_regulation.presence&.effective_end_date
     end
 
-    private
+  private
 
     attr_reader :measure
 

--- a/app/models/measure_collection.rb
+++ b/app/models/measure_collection.rb
@@ -37,7 +37,7 @@ class MeasureCollection < SimpleDelegator
     @filters[:geographical_area_id].present?
   end
 
-  private
+private
 
   def filtering_country
     @filtering_country ||= GeographicalArea.where(geographical_area_id: @filters[:geographical_area_id]).take

--- a/app/models/measure_condition.rb
+++ b/app/models/measure_condition.rb
@@ -192,7 +192,7 @@ class MeasureCondition < Sequel::Model
     (exemption_class? && !is_exempting_certificate_overridden?) || (!exemption_class? && is_exempting_certificate_overridden?)
   end
 
-  private
+private
 
   def is_threshold?
     condition_duty_amount.present?

--- a/app/models/measure_condition_permutations/calculator.rb
+++ b/app/models/measure_condition_permutations/calculator.rb
@@ -24,7 +24,7 @@ module MeasureConditionPermutations
       end
     end
 
-    private
+  private
 
     def measure_conditions
       @measure_conditions ||= @measure.measure_conditions.reject(&:is_excluded_condition?)

--- a/app/models/measure_type_exclusion.rb
+++ b/app/models/measure_type_exclusion.rb
@@ -35,7 +35,7 @@ class MeasureTypeExclusion
       exclusions_by_service[service] ||= parse_file(SOURCES.fetch(service))
     end
 
-    private
+  private
 
     def parse_file(file)
       data = {}

--- a/app/models/measurement_unit.rb
+++ b/app/models/measurement_unit.rb
@@ -71,7 +71,7 @@ class MeasurementUnit < Sequel::Model
       @measurement_units ||= JSON.parse(File.read(Rails.root.join(MEASUREMENT_UNIT_OVERLAY_FILE)))
     end
 
-    private
+  private
 
     def compound_units_for(unit)
       unit['compound_units'].flat_map do |unit_key|

--- a/app/models/news/item.rb
+++ b/app/models/news/item.rb
@@ -141,7 +141,7 @@ module News
       end
     end
 
-    private
+  private
 
     def normalise_ids(ids)
       Array.wrap(ids).map(&:presence).compact.map(&:to_i).uniq

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -40,7 +40,7 @@ class Notification
     super(except:).with_indifferent_access
   end
 
-  private
+private
 
   def personalisation_structure
     return unless personalisation.is_a?(Hash)

--- a/app/models/quota_definition.rb
+++ b/app/models/quota_definition.rb
@@ -199,7 +199,7 @@ class QuotaDefinition < Sequel::Model
     quota_critical_events&.map(&:quota_definition_sid)
   end
 
-  private
+private
 
   def suspension_period_active?
     if last_suspension_period.present?

--- a/app/models/rollback.rb
+++ b/app/models/rollback.rb
@@ -5,7 +5,7 @@ class Rollback < Sequel::Model
     end
   end
 
-  private
+private
 
   def validate
     self.whodunnit ||= TradeTariffRequest.whodunnit

--- a/app/models/rules_of_origin/article.rb
+++ b/app/models/rules_of_origin/article.rb
@@ -16,7 +16,7 @@ module RulesOfOrigin
                              .map { |f| new scheme:, article: f.chomp('.md') }
       end
 
-      private
+    private
 
       def articles_path(scheme)
         scheme.scheme_set.base_path.join('articles', scheme.scheme_code)

--- a/app/models/rules_of_origin/query.rb
+++ b/app/models/rules_of_origin/query.rb
@@ -65,7 +65,7 @@ module RulesOfOrigin
     class InvalidParams < ArgumentError; end
     class InvalidFilter < ArgumentError; end
 
-    private
+  private
 
     def filter=(filter)
       raise InvalidFilter unless filter.is_a?(Hash)

--- a/app/models/rules_of_origin/scheme.rb
+++ b/app/models/rules_of_origin/scheme.rb
@@ -116,7 +116,7 @@ module RulesOfOrigin
       !(validity_start_date&.>(Time.zone.now) || validity_end_date&.<(Time.zone.now))
     end
 
-    private
+  private
 
     def new_proof(proof_attrs)
       Proof.new proof_attrs.merge(scheme: self)

--- a/app/models/simplified_procedural_code.rb
+++ b/app/models/simplified_procedural_code.rb
@@ -38,7 +38,7 @@ class SimplifiedProceduralCode < Sequel::Model
       end
     end
 
-    private
+  private
 
     def to_null_measure(record)
       SimplifiedProceduralCodeMeasure.unrestrict_primary_key

--- a/app/presenters/api/v2/green_lanes/category_assessment_presenter.rb
+++ b/app/presenters/api/v2/green_lanes/category_assessment_presenter.rb
@@ -34,7 +34,7 @@ module Api
             end
           end
 
-          private
+        private
 
           def permutations(assessment)
             ::GreenLanes::PermutationCalculatorService

--- a/app/presenters/api/v2/measures/measure_condition_component_presenter.rb
+++ b/app/presenters/api/v2/measures/measure_condition_component_presenter.rb
@@ -40,7 +40,7 @@ module Api
           end
         end
 
-        private
+      private
 
         attr_reader :measure
 

--- a/app/presenters/api/v2/measures/measure_condition_presenter.rb
+++ b/app/presenters/api/v2/measures/measure_condition_presenter.rb
@@ -60,7 +60,7 @@ module Api
           end
         end
 
-        private
+      private
 
         attr_reader :measure, :measure_condition
 

--- a/app/presenters/api/v2/measures/meursing_measure_component_presenter.rb
+++ b/app/presenters/api/v2/measures/meursing_measure_component_presenter.rb
@@ -6,7 +6,7 @@ module Api
           DutyExpressionFormatter.format(duty_expression_formatter_options)
         end
 
-        private
+      private
 
         def duty_expression_formatter_options
           # There is no possibility of a meursing measure component being at the front of the sequence of components

--- a/app/presenters/label_batch_presenter.rb
+++ b/app/presenters/label_batch_presenter.rb
@@ -26,7 +26,7 @@ class LabelBatchPresenter < SimpleDelegator
       DescriptionHtmlFormatter.call(goods_nomenclature.ancestor_chain_description)
   end
 
-  private
+private
 
   def load_self_texts(batch)
     sids = batch.map(&:goods_nomenclature_sid)

--- a/app/presenters/search/general_rules_presenter.rb
+++ b/app/presenters/search/general_rules_presenter.rb
@@ -8,7 +8,7 @@ module Search
       rendered_rules
     end
 
-    private
+  private
 
     def rules
       @rules ||= CustomsTariffGeneralRule.latest_rules

--- a/app/queries/search/goods_nomenclature_query.rb
+++ b/app/queries/search/goods_nomenclature_query.rb
@@ -43,7 +43,7 @@ module Search
       }
     end
 
-    private
+  private
 
     def index
       @index ||= GoodsNomenclatureIndex.new

--- a/app/queries/search/search_suggestion_query.rb
+++ b/app/queries/search/search_suggestion_query.rb
@@ -35,7 +35,7 @@ module Search
       }
     end
 
-    private
+  private
 
     # Boosts documents whose value exactly matches the query string (case-insensitive).
     # This ensures 100% character matches always rank first.

--- a/app/serializers/concerns/api/shared/csv_serializer.rb
+++ b/app/serializers/concerns/api/shared/csv_serializer.rb
@@ -32,7 +32,7 @@ module Api
 
       delegate :column_options, to: :class
 
-      private
+    private
 
       def header_row
         column_options.pluck(:column_name)

--- a/app/serializers/search/goods_nomenclature_serializer.rb
+++ b/app/serializers/search/goods_nomenclature_serializer.rb
@@ -28,7 +28,7 @@ module Search
       }.compact
     end
 
-    private
+  private
 
     def description
       SearchNegationService.new(full_description).call

--- a/app/serializers/search/search_reference_serializer.rb
+++ b/app/serializers/search/search_reference_serializer.rb
@@ -15,7 +15,7 @@ module Search
       end
     end
 
-    private
+  private
 
     def title_indexed
       SearchNegationService.new(title).call

--- a/app/services/additional_code_finder_service.rb
+++ b/app/services/additional_code_finder_service.rb
@@ -14,7 +14,7 @@ class AdditionalCodeFinderService
     )
   end
 
-  private
+private
 
   attr_reader :code, :type, :description
 

--- a/app/services/ai_response_sanitizer.rb
+++ b/app/services/ai_response_sanitizer.rb
@@ -24,7 +24,7 @@ class AiResponseSanitizer
     end
   end
 
-  private
+private
 
   def sanitize(value)
     case value

--- a/app/services/api/admin/goods_nomenclature_labels/stats_service.rb
+++ b/app/services/api/admin/goods_nomenclature_labels/stats_service.rb
@@ -26,7 +26,7 @@ module Api
           )
         end
 
-        private
+      private
 
         def total_goods_nomenclatures
           base_dataset.count

--- a/app/services/api/internal/input_sanitiser.rb
+++ b/app/services/api/internal/input_sanitiser.rb
@@ -28,7 +28,7 @@ module Api
         { query: sanitised }
       end
 
-      private
+    private
 
       def enabled?
         AdminConfiguration.enabled?('input_sanitiser_enabled')

--- a/app/services/api/internal/query_processing.rb
+++ b/app/services/api/internal/query_processing.rb
@@ -3,7 +3,7 @@ module Api
     module QueryProcessing
       include CustomRegex
 
-      private
+    private
 
       def process_query(term)
         return '' if term.blank?

--- a/app/services/api/internal/search_service.rb
+++ b/app/services/api/internal/search_service.rb
@@ -93,7 +93,7 @@ module Api
         end
       end
 
-      private
+    private
 
       def completion_payload(**payload)
         return payload unless description_intercept

--- a/app/services/api/internal/suggestions_service.rb
+++ b/app/services/api/internal/suggestions_service.rb
@@ -23,7 +23,7 @@ module Api
         SearchSuggestionSerializer.new(suggestions).serializable_hash
       end
 
-      private
+    private
 
       def suggest_results_limit
         AdminConfiguration.integer_value('suggest_results_limit')

--- a/app/services/api/search/error_serialization_service.rb
+++ b/app/services/api/search/error_serialization_service.rb
@@ -11,7 +11,7 @@ module Api
         { errors: }
       end
 
-      private
+    private
 
       def errors
         @records.each_with_object([]) do |record, acc|

--- a/app/services/api/user/active_commodities_report_service.rb
+++ b/app/services/api/user/active_commodities_report_service.rb
@@ -27,7 +27,7 @@ module Api
         workbook
       end
 
-      private
+    private
 
       attr_reader :active_codes, :expired_codes, :invalid_codes
 

--- a/app/services/api/user/active_commodities_report_worksheet_builder.rb
+++ b/app/services/api/user/active_commodities_report_worksheet_builder.rb
@@ -46,7 +46,7 @@ module Api
         set_column_widths(sheet)
       end
 
-      private
+    private
 
       attr_reader :report_rows, :workbook
 

--- a/app/services/api/user/active_commodities_service.rb
+++ b/app/services/api/user/active_commodities_service.rb
@@ -207,7 +207,7 @@ module Api
         [materialize_with_nulls(paginated_codes), total]
       end
 
-      private
+    private
 
       # --- Core data loaders ---
 

--- a/app/services/api/user/commodity_changes_service.rb
+++ b/app/services/api/user/commodity_changes_service.rb
@@ -20,7 +20,7 @@ module Api
         end
       end
 
-      private
+    private
 
       def all_changes
         [

--- a/app/services/api/user/grouped_measure_changes_service.rb
+++ b/app/services/api/user/grouped_measure_changes_service.rb
@@ -17,7 +17,7 @@ module Api
         end
       end
 
-      private
+    private
 
       def measures(page, per_page)
         grouped_measure_change = TariffChanges::GroupedMeasureChange.from_id(id)

--- a/app/services/api/user/my_commodities_meta_service.rb
+++ b/app/services/api/user/my_commodities_meta_service.rb
@@ -12,7 +12,7 @@ module Api
         }
       end
 
-      private
+    private
 
       attr_reader :subscription
 

--- a/app/services/api/user/stop_press_meta_service.rb
+++ b/app/services/api/user/stop_press_meta_service.rb
@@ -14,7 +14,7 @@ module Api
         }
       end
 
-      private
+    private
 
       attr_reader :subscription
 

--- a/app/services/api/v2/classification_search_service.rb
+++ b/app/services/api/v2/classification_search_service.rb
@@ -36,7 +36,7 @@ module Api
         )
       end
 
-      private
+    private
 
       def empty_response
         {

--- a/app/services/appendix_5a_populator_service.rb
+++ b/app/services/appendix_5a_populator_service.rb
@@ -15,7 +15,7 @@ class Appendix5aPopulatorService
     Rails.logger.info 'Finished populating Appendix 5a'
   end
 
-  private
+private
 
   def removed_guidance
     @removed_guidance ||= begin

--- a/app/services/applicable_additional_code_service.rb
+++ b/app/services/applicable_additional_code_service.rb
@@ -15,7 +15,7 @@ class ApplicableAdditionalCodeService
     end
   end
 
-  private
+private
 
   def applicable_additional_codes
     unique_applicable_measures.each_with_object({}) do |measure, acc|

--- a/app/services/applicable_vat_options_service.rb
+++ b/app/services/applicable_vat_options_service.rb
@@ -14,7 +14,7 @@ class ApplicableVatOptionsService
     end
   end
 
-  private
+private
 
   def measures
     @measures.select(&:vat?)

--- a/app/services/cached_commodity_description_service.rb
+++ b/app/services/cached_commodity_description_service.rb
@@ -67,7 +67,7 @@ class CachedCommodityDescriptionService
   end
   private_class_method :cache_key
 
-  private
+private
 
   attr_reader :code
 

--- a/app/services/cached_commodity_service.rb
+++ b/app/services/cached_commodity_service.rb
@@ -133,7 +133,7 @@ class CachedCommodityService
     ResponseFilter.new(cached_data, geographical_area_id).call
   end
 
-  private
+private
 
   attr_reader :actual_date, :filters
 

--- a/app/services/cached_commodity_service/measure_metadata_builder.rb
+++ b/app/services/cached_commodity_service/measure_metadata_builder.rb
@@ -10,7 +10,7 @@ class CachedCommodityService
       end
     end
 
-    private
+  private
 
     attr_reader :presented_commodity
 

--- a/app/services/cached_commodity_service/response_filter.rb
+++ b/app/services/cached_commodity_service/response_filter.rb
@@ -22,7 +22,7 @@ class CachedCommodityService
       @hash
     end
 
-    private
+  private
 
     attr_reader :measure_meta, :geographical_area_id
 

--- a/app/services/cached_geographical_area_service.rb
+++ b/app/services/cached_geographical_area_service.rb
@@ -39,7 +39,7 @@ class CachedGeographicalAreaService
     end
   end
 
-  private
+private
 
   attr_reader :actual_date, :countries, :exclude_none
 

--- a/app/services/cached_quota_order_number_service.rb
+++ b/app/services/cached_quota_order_number_service.rb
@@ -21,7 +21,7 @@ class CachedQuotaOrderNumberService
     end
   end
 
-  private
+private
 
   def quota_order_numbers
     QuotaOrderNumber.with_quota_definitions.eager(EAGER_LOAD).all

--- a/app/services/cached_subheading_service.rb
+++ b/app/services/cached_subheading_service.rb
@@ -50,7 +50,7 @@ class CachedSubheadingService
     )
   end
 
-  private
+private
 
   def presented_subheading
     Api::V2::Subheadings::SubheadingPresenter.new(ns_eager_loaded_subheading)

--- a/app/services/certificate_finder_service.rb
+++ b/app/services/certificate_finder_service.rb
@@ -14,7 +14,7 @@ class CertificateFinderService
     )
   end
 
-  private
+private
 
   attr_reader :type, :code, :description
 

--- a/app/services/chemical_search_service.rb
+++ b/app/services/chemical_search_service.rb
@@ -15,7 +15,7 @@ class ChemicalSearchService
     fetch_by_cas || fetch_by_name
   end
 
-  private
+private
 
   def fetch_by_cas
     cas = cas_cleaned

--- a/app/services/composite_search_text_builder.rb
+++ b/app/services/composite_search_text_builder.rb
@@ -58,7 +58,7 @@ class CompositeSearchTextBuilder
     end
   end
 
-  private
+private
 
   attr_reader :self_text_record, :labels, :search_references, :atar_keywords
 

--- a/app/services/description_intercepts/template_importer.rb
+++ b/app/services/description_intercepts/template_importer.rb
@@ -47,7 +47,7 @@ module DescriptionIntercepts
       failure_result
     end
 
-    private
+  private
 
     def parse_rows
       csv = CSV.parse(@csv_content, headers: true, skip_blanks: true)

--- a/app/services/enquiry_form/csv_generator_service.rb
+++ b/app/services/enquiry_form/csv_generator_service.rb
@@ -10,7 +10,7 @@ class EnquiryForm::CsvGeneratorService
     end
   end
 
-  private
+private
 
   def formatter
     @formatter ||= EnquiryForm::SubmissionFormatter.new(@enquiry_form_data)

--- a/app/services/enquiry_form/submission_formatter.rb
+++ b/app/services/enquiry_form/submission_formatter.rb
@@ -116,7 +116,7 @@ class EnquiryForm::SubmissionFormatter
     values.map { |value| csv_value(value) }
   end
 
-  private
+private
 
   attr_reader :enquiry_form_data
 

--- a/app/services/exchange_rate_service.rb
+++ b/app/services/exchange_rate_service.rb
@@ -9,7 +9,7 @@ class ExchangeRateService
     cached_exchange_rates || fetched_exchange_rates
   end
 
-  private
+private
 
   def cached_exchange_rates(ignore_expiry: false)
     response = TradeTariffBackend.redis.get(REDIS_KEY)

--- a/app/services/exchange_rates/create_average_exchange_rates_service.rb
+++ b/app/services/exchange_rates/create_average_exchange_rates_service.rb
@@ -23,7 +23,7 @@ module ExchangeRates
       upload_average_rate_file(countries_and_rate)
     end
 
-    private
+  private
 
     attr_reader :force_run, :selected_date
 

--- a/app/services/exchange_rates/create_csv_average_rates_service.rb
+++ b/app/services/exchange_rates/create_csv_average_rates_service.rb
@@ -30,7 +30,7 @@ module ExchangeRates
       end
     end
 
-    private
+  private
 
     attr_reader :data
 

--- a/app/services/exchange_rates/create_csv_hmrc_service.rb
+++ b/app/services/exchange_rates/create_csv_hmrc_service.rb
@@ -27,7 +27,7 @@ module ExchangeRates
       end
     end
 
-    private
+  private
 
     def build_row(rate)
       [

--- a/app/services/exchange_rates/create_csv_service.rb
+++ b/app/services/exchange_rates/create_csv_service.rb
@@ -27,7 +27,7 @@ module ExchangeRates
       end
     end
 
-    private
+  private
 
     def build_row(rate)
       [

--- a/app/services/exchange_rates/create_csv_spot_service.rb
+++ b/app/services/exchange_rates/create_csv_spot_service.rb
@@ -26,7 +26,7 @@ module ExchangeRates
       end
     end
 
-    private
+  private
 
     def build_row(rate)
       [

--- a/app/services/exchange_rates/monthly_exchange_rates_service.rb
+++ b/app/services/exchange_rates/monthly_exchange_rates_service.rb
@@ -37,8 +37,8 @@ module ExchangeRates
       ).call
     end
 
-      # Moved this as couldnt find where rates is called outside and as a service should probably have only 1 call action
-    private
+    # Moved this as couldnt find where rates is called outside and as a service should probably have only 1 call action
+  private
 
     def rates
       @rates ||= ::ExchangeRateCurrencyRate

--- a/app/services/exchange_rates/spot_exchange_rates_service.rb
+++ b/app/services/exchange_rates/spot_exchange_rates_service.rb
@@ -28,7 +28,7 @@ module ExchangeRates
         .sort_by { |rate| [rate.country_description, rate.currency_description] }
     end
 
-    private
+  private
 
     attr_reader :sample_date, :download
   end

--- a/app/services/exchange_rates/update_currency_rates_service.rb
+++ b/app/services/exchange_rates/update_currency_rates_service.rb
@@ -18,7 +18,7 @@ module ExchangeRates
       end
     end
 
-    private
+  private
 
     def monthly_rate_type?
       @type == ExchangeRateCurrencyRate::MONTHLY_RATE_TYPE

--- a/app/services/exchange_rates/upload_file_service.rb
+++ b/app/services/exchange_rates/upload_file_service.rb
@@ -22,7 +22,7 @@ module ExchangeRates
       end
     end
 
-    private
+  private
 
     attr_reader :rates, :date, :type, :sample_date
 

--- a/app/services/expand_search_query_service.rb
+++ b/app/services/expand_search_query_service.rb
@@ -25,7 +25,7 @@ class ExpandSearchQueryService
     end
   end
 
-  private
+private
 
   attr_reader :query
 

--- a/app/services/find_ancestors_service.rb
+++ b/app/services/find_ancestors_service.rb
@@ -9,7 +9,7 @@ class FindAncestorsService
     goods_nomenclature.ancestors.dup.push(goods_nomenclature).map(&:goods_nomenclature_item_id)
   end
 
-  private
+private
 
   def goods_nomenclature
     goods_nomenclature_class.by_code(goods_nomenclature_item_id).take

--- a/app/services/footnote_finder_service.rb
+++ b/app/services/footnote_finder_service.rb
@@ -28,7 +28,7 @@ class FootnoteFinderService
     )
   end
 
-  private
+private
 
   attr_reader :type, :id, :description
 

--- a/app/services/full_chemical_populator_service.rb
+++ b/app/services/full_chemical_populator_service.rb
@@ -10,7 +10,7 @@ class FullChemicalPopulatorService
     FullChemical.restrict_primary_key
   end
 
-  private
+private
 
   def process_full_chemicals_in_chunks
     chunk = []

--- a/app/services/generate_self_text/base_self_text_builder.rb
+++ b/app/services/generate_self_text/base_self_text_builder.rb
@@ -60,7 +60,7 @@ module GenerateSelfText
       stats
     end
 
-    private
+  private
 
     attr_reader :chapter, :generated_texts
 

--- a/app/services/generate_self_text/non_other_self_text_builder.rb
+++ b/app/services/generate_self_text/non_other_self_text_builder.rb
@@ -1,6 +1,6 @@
 module GenerateSelfText
   class NonOtherSelfTextBuilder < BaseSelfTextBuilder
-    private
+  private
 
     def select_segments(segments)
       segments.reject { |s| s[:node][:is_other] || s[:node][:goods_nomenclature_class] == 'Chapter' }

--- a/app/services/generate_self_text/other_self_text_builder.rb
+++ b/app/services/generate_self_text/other_self_text_builder.rb
@@ -2,7 +2,7 @@ module GenerateSelfText
   class OtherSelfTextBuilder < BaseSelfTextBuilder
     OTHER_PATTERN = SegmentExtractor::OTHER_PATTERN
 
-    private
+  private
 
     def select_segments(segments)
       segments.select { |s| s[:node][:is_other] }

--- a/app/services/generate_self_text/segment_extractor.rb
+++ b/app/services/generate_self_text/segment_extractor.rb
@@ -38,7 +38,7 @@ module GenerateSelfText
       end
     end
 
-    private
+  private
 
     attr_reader :chapter, :self_texts
 

--- a/app/services/govuk_notifier.rb
+++ b/app/services/govuk_notifier.rb
@@ -42,7 +42,7 @@ class GovukNotifier
     )
   end
 
-  private
+private
 
   def api_key
     @api_key ||= ENV['GOVUK_NOTIFY_API_KEY']

--- a/app/services/green_lanes/fetch_goods_nomenclature_service.rb
+++ b/app/services/green_lanes/fetch_goods_nomenclature_service.rb
@@ -58,7 +58,7 @@ module GreenLanes
       end
     end
 
-    private
+  private
 
     def declarable?
       gn = GoodsNomenclature

--- a/app/services/heading_service/heading_serialization_service.rb
+++ b/app/services/heading_service/heading_serialization_service.rb
@@ -42,7 +42,7 @@ module HeadingService
       end
     end
 
-    private
+  private
 
     attr_reader :heading, :actual_date, :filters
 

--- a/app/services/heading_service/precache_service.rb
+++ b/app/services/heading_service/precache_service.rb
@@ -22,7 +22,7 @@ module HeadingService
       end
     end
 
-    private
+  private
 
     def each_heading
       Chapter.actual.non_hidden.all do |chapter|

--- a/app/services/hybrid_retrieval_service.rb
+++ b/app/services/hybrid_retrieval_service.rb
@@ -43,7 +43,7 @@ class HybridRetrievalService
     Result.new(results: merged, expanded_query: @expanded_query, source_results: opensearch_items + vector_items)
   end
 
-  private
+private
 
   def run_concurrent_retrievals
     opensearch_thread = Thread.new { run_leg(:opensearch) }

--- a/app/services/interactive_search/duplicate_question_guard.rb
+++ b/app/services/interactive_search/duplicate_question_guard.rb
@@ -47,7 +47,7 @@ module InteractiveSearch
       allowed_result(suspicious: true, signals: signals, reason: validation['reason'])
     end
 
-    private
+  private
 
     attr_reader :query, :effective_query, :answers, :candidate_question, :request_id, :attempt_number
 

--- a/app/services/interactive_search_service.rb
+++ b/app/services/interactive_search_service.rb
@@ -52,7 +52,7 @@ class InteractiveSearchService
     end
   end
 
-  private
+private
 
   attr_reader :query, :expanded_query, :opensearch_results, :answers, :request_id, :attempt
 

--- a/app/services/internal_search_query_normaliser_service.rb
+++ b/app/services/internal_search_query_normaliser_service.rb
@@ -14,7 +14,7 @@ class InternalSearchQueryNormaliserService
     Result.new(query: query, expanded_query: expanded_query)
   end
 
-  private
+private
 
   attr_reader :query, :request_id
 

--- a/app/services/label_confidence_scorer.rb
+++ b/app/services/label_confidence_scorer.rb
@@ -31,7 +31,7 @@ class LabelConfidenceScorer
     raise
   end
 
-  private
+private
 
   attr_reader :embedding_service
 

--- a/app/services/label_service.rb
+++ b/app/services/label_service.rb
@@ -55,7 +55,7 @@ class LabelService
 
   attr_reader :last_ai_response
 
-  private
+private
 
   attr_reader :batch, :page_number
 

--- a/app/services/label_suggestions_updater_service.rb
+++ b/app/services/label_suggestions_updater_service.rb
@@ -24,7 +24,7 @@ class LabelSuggestionsUpdaterService
     SearchSuggestion.restrict_primary_key
   end
 
-  private
+private
 
   def delete_existing_label_suggestions
     SearchSuggestion

--- a/app/services/measure_unit_service.rb
+++ b/app/services/measure_unit_service.rb
@@ -18,7 +18,7 @@ class MeasureUnitService
     end
   end
 
-  private
+private
 
   attr_reader :measures
 

--- a/app/services/meursing_measure_component_resolver_service.rb
+++ b/app/services/meursing_measure_component_resolver_service.rb
@@ -15,7 +15,7 @@ class MeursingMeasureComponentResolverService
     end
   end
 
-  private
+private
 
   attr_reader :root_measure, :meursing_measures
 

--- a/app/services/meursing_measure_finder_service.rb
+++ b/app/services/meursing_measure_finder_service.rb
@@ -23,7 +23,7 @@ class MeursingMeasureFinderService
       .select(&method(:relevant_for_country?))
   end
 
-  private
+private
 
   attr_reader :root_measure, :additional_code_id
 

--- a/app/services/opensearch_retrieval_service.rb
+++ b/app/services/opensearch_retrieval_service.rb
@@ -19,7 +19,7 @@ class OpensearchRetrievalService
     Result.new(results: hits.map { |h| build_result_from_hit(h) }, expanded_query: @expanded_query)
   end
 
-  private
+private
 
   def run_search(expanded_query)
     results = search_with_configured_labels do

--- a/app/services/paper_trail/reset_initial_versions.rb
+++ b/app/services/paper_trail/reset_initial_versions.rb
@@ -7,7 +7,7 @@ module PaperTrail
       end
     end
 
-    private
+  private
 
     def tracked_models
       Sequel::Plugins::HasPaperTrail.tracked_models

--- a/app/services/quota_search_service.rb
+++ b/app/services/quota_search_service.rb
@@ -68,7 +68,7 @@ class QuotaSearchService
     @pagination_record_count ||= count_total_records
   end
 
-  private
+private
 
   attr_reader :attributes
 

--- a/app/services/reporting/backfill_differences_reports.rb
+++ b/app/services/reporting/backfill_differences_reports.rb
@@ -49,7 +49,7 @@ module Reporting
       summary
     end
 
-    private
+  private
 
     ReportSource = Data.define(:date, :key)
     Worksheet = Data.define(:worksheet, :worksheet_name, :subtext)

--- a/app/services/search_analytics/cloudwatch_snapshot_query.rb
+++ b/app/services/search_analytics/cloudwatch_snapshot_query.rb
@@ -46,7 +46,7 @@ module SearchAnalytics
       raise QueryError, e.message
     end
 
-    private
+  private
 
     attr_reader :period, :client, :now
 
@@ -233,7 +233,7 @@ module SearchAnalytics
         }
       end
 
-      private
+    private
 
       attr_reader :period, :volume_rows, :zero_result_rows, :summary_all_latency_rows, :summary_view_latency_rows, :source_all_latency_rows, :source_view_latency_rows, :selection_rows, :selection_trend_rows, :improvement_term_rows
 

--- a/app/services/search_analytics/snapshot_refresh.rb
+++ b/app/services/search_analytics/snapshot_refresh.rb
@@ -23,7 +23,7 @@ module SearchAnalytics
       end
     end
 
-    private
+  private
 
     attr_reader :query_class, :now, :periods
 

--- a/app/services/search_diagnostics/request_log_lookup.rb
+++ b/app/services/search_diagnostics/request_log_lookup.rb
@@ -54,7 +54,7 @@ module SearchDiagnostics
       raise QueryError, e.message
     end
 
-    private
+  private
 
     attr_reader :request_id, :lookback_hours, :limit, :client, :now
 

--- a/app/services/search_expansion_decision_service.rb
+++ b/app/services/search_expansion_decision_service.rb
@@ -33,7 +33,7 @@ class SearchExpansionDecisionService
     decision
   end
 
-  private
+private
 
   attr_reader :query, :results, :request_id
 

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -65,7 +65,7 @@ class SearchService
     false
   end
 
-  private
+private
 
   def perform
     @result = if SearchService::RogueSearchService.call(q)

--- a/app/services/search_service/exact_search.rb
+++ b/app/services/search_service/exact_search.rb
@@ -32,7 +32,7 @@ class SearchService
       }
     end
 
-    private
+  private
 
     def find_search_suggestion(query)
       filter = { value: singular_and_plural(query) }

--- a/app/services/search_service/fuzzy_search.rb
+++ b/app/services/search_service/fuzzy_search.rb
@@ -26,7 +26,7 @@ class SearchService
       }.merge(results)
     end
 
-    private
+  private
 
     def query_options
       {}

--- a/app/services/search_suggestion_populator_service.rb
+++ b/app/services/search_suggestion_populator_service.rb
@@ -24,7 +24,7 @@ class SearchSuggestionPopulatorService
     SearchSuggestion.restrict_primary_key
   end
 
-  private
+private
 
   def clear_old_suggestions
     handle_expired_goods_nomenclature

--- a/app/services/self_text_confidence_scorer.rb
+++ b/app/services/self_text_confidence_scorer.rb
@@ -37,7 +37,7 @@ class SelfTextConfidenceScorer
     raise
   end
 
-  private
+private
 
   attr_reader :embedding_service
 

--- a/app/services/self_text_lookup_service.rb
+++ b/app/services/self_text_lookup_service.rb
@@ -34,7 +34,7 @@ class SelfTextLookupService
       self_texts.size
     end
 
-    private
+  private
 
     def load_self_texts
       path = csv_path

--- a/app/services/slack_notifier_service.rb
+++ b/app/services/slack_notifier_service.rb
@@ -4,7 +4,7 @@ class SlackNotifierService
       notifier.presence&.ping(message)
     end
 
-    private
+  private
 
     def notifier
       Rails.application.config.slack_notifier

--- a/app/services/suggestions_service.rb
+++ b/app/services/suggestions_service.rb
@@ -18,7 +18,7 @@ class SuggestionsService
     suggestions
   end
 
-  private
+private
 
   def build_goods_nomenclatures_search_suggestions
     GoodsNomenclature

--- a/app/services/tariff_changes_service/excel_generator.rb
+++ b/app/services/tariff_changes_service/excel_generator.rb
@@ -26,7 +26,7 @@ class TariffChangesService
       workbook
     end
 
-    private
+  private
 
     def setup_sheet_formatting(sheet)
       sheet.set_default_row(40, 0)

--- a/app/services/tariff_changes_service/measure_metadata_generator.rb
+++ b/app/services/tariff_changes_service/measure_metadata_generator.rb
@@ -23,7 +23,7 @@ class TariffChangesService
       }
     end
 
-    private
+  private
 
     def measure
       @measure ||= begin

--- a/app/services/tariff_changes_service/presenter.rb
+++ b/app/services/tariff_changes_service/presenter.rb
@@ -91,7 +91,7 @@ class TariffChangesService
       "#{commodity_api_base_url}?#{query}"
     end
 
-    private
+  private
 
     def commodity_base_url
       "https://www.trade-tariff.service.gov.uk/commodities/#{goods_nomenclature_item_id}"

--- a/app/services/tariff_changes_service/transform_records.rb
+++ b/app/services/tariff_changes_service/transform_records.rb
@@ -18,7 +18,7 @@ class TariffChangesService
       transform_records(tariff_changes)
     end
 
-    private
+  private
 
     attr_accessor :geo_area_cache, :gn_descriptions_cache
 

--- a/app/services/tariff_knowledge/graph_query.rb
+++ b/app/services/tariff_knowledge/graph_query.rb
@@ -66,7 +66,7 @@ module TariffKnowledge
       }
     end
 
-    private
+  private
 
     attr_reader :attributes, :errors, :truncated, :truncation_reason
 

--- a/app/services/tree_integrity_checking_service.rb
+++ b/app/services/tree_integrity_checking_service.rb
@@ -16,7 +16,7 @@ class TreeIntegrityCheckingService
     @failures.empty?
   end
 
-  private
+private
 
   def check_for_tree_break!(chapter)
     chapter.descendants.each do |descendant|

--- a/app/services/validity_period_serializer_service.rb
+++ b/app/services/validity_period_serializer_service.rb
@@ -12,7 +12,7 @@ class ValidityPeriodSerializerService
     ).serializable_hash
   end
 
-  private
+private
 
   attr_reader :params
 

--- a/app/services/vector_retrieval_service.rb
+++ b/app/services/vector_retrieval_service.rb
@@ -35,7 +35,7 @@ class VectorRetrievalService
     end
   end
 
-  private
+private
 
   def apply_score_threshold(rows)
     threshold = AdminConfiguration.integer_value('vector_score_threshold') / 100.0

--- a/app/services/version_diff_service.rb
+++ b/app/services/version_diff_service.rb
@@ -93,7 +93,7 @@ class VersionDiffService
     }
   end
 
-  private
+private
 
   def extract_virtual_fields(obj)
     return {} unless @item_type == 'AdminConfiguration'

--- a/app/workers/action_log_report_worker.rb
+++ b/app/workers/action_log_report_worker.rb
@@ -21,7 +21,7 @@ class ActionLogReportWorker
     ActionLogMailer.daily_report(csv_data, yesterday.strftime('%Y-%m-%d')).deliver_now
   end
 
-  private
+private
 
   def generate_csv(action_logs)
     CSV.generate do |csv|

--- a/app/workers/build_index_page_worker.rb
+++ b/app/workers/build_index_page_worker.rb
@@ -24,7 +24,7 @@ class BuildIndexPageWorker
     raise IndexingError, "Failed building index: #{index_namespace}/#{index_name} - page #{page_number}"
   end
 
-  private
+private
 
   def serialize_for(operation, index, entries)
     entries.each_with_object([]) do |model, memo|

--- a/app/workers/clear_cache_worker.rb
+++ b/app/workers/clear_cache_worker.rb
@@ -23,7 +23,7 @@ class ClearCacheWorker
     Sidekiq::Client.enqueue_in(1.minute, InvalidateCacheWorker)
   end
 
-  private
+private
 
   def clear_frontend_cache
     Rails.logger.info 'Clearing frontend cache'

--- a/app/workers/differences_report_check_worker.rb
+++ b/app/workers/differences_report_check_worker.rb
@@ -15,7 +15,7 @@ class DifferencesReportCheckWorker
     notify if last_log.before?(Date.current.beginning_of_week)
   end
 
-  private
+private
 
   def notify
     SlackNotifierService.call(

--- a/app/workers/differences_report_worker.rb
+++ b/app/workers/differences_report_worker.rb
@@ -11,7 +11,7 @@ class DifferencesReportWorker
     end
   end
 
-  private
+private
 
   def generate_differences
     Reporting::Differences.generate

--- a/app/workers/enquiry_form/send_submission_email_worker.rb
+++ b/app/workers/enquiry_form/send_submission_email_worker.rb
@@ -40,7 +40,7 @@ class EnquiryForm::SendSubmissionEmailWorker
     client.send_email(ENV['ENQUIRY_FORM_EMAIL'], TEMPLATE_ID, personalisation, nil, reference)
   end
 
-  private
+private
 
   def enquiry_form_data(reference)
     data = Sidekiq.redis { |conn| conn.get(self.class.cache_key(reference)) }

--- a/app/workers/faq_feedback_report_worker.rb
+++ b/app/workers/faq_feedback_report_worker.rb
@@ -11,7 +11,7 @@ class FaqFeedbackReportWorker
     end
   end
 
-  private
+private
 
   def send_faq_feedback_report_email
     FaqFeedbackMailer.faq_feedback_message.deliver_now

--- a/app/workers/generate_self_text_worker.rb
+++ b/app/workers/generate_self_text_worker.rb
@@ -22,7 +22,7 @@ class GenerateSelfTextWorker
     end
   end
 
-  private
+private
 
   def chapters_needing_work
     gn = Sequel[:goods_nomenclatures]

--- a/app/workers/goods_nomenclature_reconciliation_worker.rb
+++ b/app/workers/goods_nomenclature_reconciliation_worker.rb
@@ -32,7 +32,7 @@ class GoodsNomenclatureReconciliationWorker
     mark_labels_stale(all_sids)
   end
 
-  private
+private
 
   def detect_changes
     (detect_going_live + detect_inserted_today).uniq { |sid, type, _| [sid, type] }

--- a/app/workers/green_lanes_updates_worker.rb
+++ b/app/workers/green_lanes_updates_worker.rb
@@ -27,7 +27,7 @@ class GreenLanesUpdatesWorker
     end
   end
 
-  private
+private
 
   def create_automated_ca(updates)
     created_updates = updates.select do |update|

--- a/app/workers/import_customs_tariff_document_worker.rb
+++ b/app/workers/import_customs_tariff_document_worker.rb
@@ -36,7 +36,7 @@ class ImportCustomsTariffDocumentWorker
     raise
   end
 
-  private
+private
 
   def notify_completed(imported_count:, skipped_count:, failed_count:, review_backlog:)
     return unless imported_count.positive? || failed_count.positive?

--- a/app/workers/notifications_worker.rb
+++ b/app/workers/notifications_worker.rb
@@ -26,7 +26,7 @@ class NotificationsWorker
     raise
   end
 
-  private
+private
 
   def notification_data(notification_id)
     data = TradeTariffBackend.redis.get("notification_#{notification_id}")

--- a/app/workers/prewarm_commodities_worker.rb
+++ b/app/workers/prewarm_commodities_worker.rb
@@ -61,7 +61,7 @@ class PrewarmCommoditiesWorker
     @client ||= Aws::CloudWatchLogs::Client.new
   end
 
-  private
+private
 
   def preconfigured_goods_nomenclature_item_ids
     ENV.fetch('PREWARM_COMMODITY_IDS', '')

--- a/app/workers/relabel_goods_nomenclature_page_worker.rb
+++ b/app/workers/relabel_goods_nomenclature_page_worker.rb
@@ -57,7 +57,7 @@ class RelabelGoodsNomenclaturePageWorker
     raise
   end
 
-  private
+private
 
   def save_label(label, page_number:)
     unless label.valid?

--- a/app/workers/relabel_goods_nomenclature_worker.rb
+++ b/app/workers/relabel_goods_nomenclature_worker.rb
@@ -30,7 +30,7 @@ class RelabelGoodsNomenclatureWorker
     end
   end
 
-  private
+private
 
   def configured_page_size
     config = AdminConfiguration.classification.by_name('label_page_size')

--- a/app/workers/report_worker.rb
+++ b/app/workers/report_worker.rb
@@ -33,7 +33,7 @@ class ReportWorker
     raise failures.first[:error] if failures.any?
   end
 
-  private
+private
 
   def generate_report?(report)
     return true unless report == Reporting::TariffUpdates

--- a/app/workers/tree_integrity_check_worker.rb
+++ b/app/workers/tree_integrity_check_worker.rb
@@ -10,7 +10,7 @@ class TreeIntegrityCheckWorker
     check(28)
   end
 
-  private
+private
 
   def check(days_from_now = 0)
     date = (Time.zone.today + days_from_now.days).to_date

--- a/config/initializers/jsonapi_serializer_query_options.rb
+++ b/config/initializers/jsonapi_serializer_query_options.rb
@@ -14,7 +14,7 @@ module JsonapiSerializerQueryOptions
     super(resource, options)
   end
 
-  private
+private
 
   def validate_requested_includes!(includes)
     relationships = self.class.relationships_to_serialize || {}

--- a/config/initializers/ses_v2_to_addresses_coercion.rb
+++ b/config/initializers/ses_v2_to_addresses_coercion.rb
@@ -14,7 +14,7 @@
 #   Array(nil)                # => []
 Aws::ActionMailer::SESV2::Mailer.prepend(
   Module.new do
-    private
+  private
 
     def to_addresses(message)
       Array(super)

--- a/lib/data_migrator.rb
+++ b/lib/data_migrator.rb
@@ -31,7 +31,7 @@ class DataMigrator < SequelRails::Migrations
       migrator_class.new(::Sequel::Model.db, migrations_dir, default_opts)
     end
 
-    private
+  private
 
     def default_opts
       ::Sequel::OPTS.merge(

--- a/lib/rubocop/cop/custom/sidekiq_complex_arguments.rb
+++ b/lib/rubocop/cop/custom/sidekiq_complex_arguments.rb
@@ -30,7 +30,7 @@ module RuboCop
           end
         end
 
-        private
+      private
 
         def check_argument(arg)
           # We strictly forbid Hash literals and Array literals

--- a/lib/tasks/admin_configurations.rake
+++ b/lib/tasks/admin_configurations.rake
@@ -1,5 +1,5 @@
 module AdminConfigurationSeeder
-  module_function
+module_function
 
   def model_label(key)
     labels = {

--- a/spec/lib/reporting/reportable_spec.rb
+++ b/spec/lib/reporting/reportable_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Reporting::Reportable do
         end
 
         class << self
-          private
+        private
 
           def object_key
             'uk/reporting/2026/03/23/dummy.csv'

--- a/spec/services/vector_retrieval_service_spec.rb
+++ b/spec/services/vector_retrieval_service_spec.rb
@@ -245,7 +245,7 @@ RSpec.describe VectorRetrievalService do
     end
   end
 
-  private
+private
 
   def populate_search_embedding(sid, embedding)
     vector_literal = "'[#{embedding.join(',')}]'::vector"

--- a/spec/support/elasticsearch_helpers.rb
+++ b/spec/support/elasticsearch_helpers.rb
@@ -40,7 +40,7 @@ module ElasticsearchHelpers
     TradeTariffBackend.search_client.reindex_all
   end
 
-  private
+private
 
   def index_search_suggestion(model)
     index = Search::SearchSuggestionsIndex.new

--- a/spec/support/looping_sequence.rb
+++ b/spec/support/looping_sequence.rb
@@ -15,7 +15,7 @@ class LoopingSequence
     self
   end
 
-  private
+private
 
   attr_accessor :enumerator
   attr_writer :value

--- a/spec/support/matchers/eq_pk.rb
+++ b/spec/support/matchers/eq_pk.rb
@@ -16,7 +16,7 @@ RSpec::Matchers.define :eq_pk do
     end
   end
 
-  private
+private
 
   def model_id(model)
     "#{model.class}:#{model.pk}"


### PR DESCRIPTION
## What:
- [x] Outdent `private`/`protected`/`public`/`module_function` access modifiers across app, lib, config, and specs to match the default style
- [x] Re-enable `Layout/AccessModifierIndentation` in `.rubocop.yml` (removed the previous `Enabled: false` override)
- [x] Raise `check-pr-lines` threshold from 600 to 800 so multi-file mechanical layout autofixes (many 1–2 line deltas) can land as a single PR

## Why:
This cop was disabled while the codebase used indented access modifiers. The offenses are mechanical style fixes with no behaviour change, so the cop can be enforced again and stop accumulating new indented modifiers.

The line-count check counted ~750 non-excluded lines for this autofix (mostly two-line indent changes per file), which exceeded the previous 600 threshold. Raising to 800 keeps the single-kind PR intact without artificial splits.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Pure layout refactor (access modifier indentation) plus a RuboCop config re-enable and a small CI threshold bump for PR size checks. No application logic, API, or data changes.