### PR TITLE
fix(rspec): replace indexed let names

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -118,8 +118,6 @@ Style/StringLiterals:
 RSpec/MessageChain:
   Enabled: false
 
-RSpec/IndexedLet:
-  Enabled: false
 
 RSpec/MultipleExpectations:
   Enabled: false

--- a/spec/integration/cds_importer/record_inserter_spec.rb
+++ b/spec/integration/cds_importer/record_inserter_spec.rb
@@ -58,22 +58,22 @@ RSpec.describe CdsImporter::RecordInserter do
     let(:expected_instrument_operation) { :create }
 
     describe '#save_batch' do
-      let(:measure2) { create(:measure, filename: 'initial_filename.gzip', operation: 'C') }
+      let(:second_measure) { create(:measure, filename: 'initial_filename.gzip', operation: 'C') }
       let(:batch) do
         [CdsImporter::CdsEntity.new(1, 'Measure', measure, measure_mapper),
          CdsImporter::CdsEntity.new(2, 'Certificate', certificate, certificate_mapper),
-         CdsImporter::CdsEntity.new(3, 'Measure', measure2, measure_mapper)]
+         CdsImporter::CdsEntity.new(3, 'Measure', second_measure, measure_mapper)]
       end
 
       it_behaves_like 'a batch insert operation', 2, 1
     end
 
     describe '#save_batch with skip record' do
-      let(:measure2) { create(:measure, :with_skip_import, filename: 'initial_filename.gzip', operation: 'C') }
+      let(:second_measure) { create(:measure, :with_skip_import, filename: 'initial_filename.gzip', operation: 'C') }
       let(:batch) do
         [CdsImporter::CdsEntity.new(1, 'Measure', measure, measure_mapper),
          CdsImporter::CdsEntity.new(2, 'Certificate', certificate, certificate_mapper),
-         CdsImporter::CdsEntity.new(3, 'Measure', measure2, measure_mapper)]
+         CdsImporter::CdsEntity.new(3, 'Measure', second_measure, measure_mapper)]
       end
 
       it_behaves_like 'a batch insert operation', 1, 1
@@ -82,13 +82,13 @@ RSpec.describe CdsImporter::RecordInserter do
     describe '#save_batch error scenario' do
       subject(:inserter) { described_class.new('new_filename.gzip') }
 
-      let(:measure2) { create(:measure, filename: 'initial_filename.gzip', operation: 'C') }
-      let(:certificate2) { create(:certificate, filename: 'initial_filename.gzip', operation: 'C') }
+      let(:second_measure) { create(:measure, filename: 'initial_filename.gzip', operation: 'C') }
+      let(:second_certificate) { create(:certificate, filename: 'initial_filename.gzip', operation: 'C') }
       let(:batch) do
         [CdsImporter::CdsEntity.new(1, 'Measure', measure, measure_mapper),
          CdsImporter::CdsEntity.new(2, 'Certificate', certificate, certificate_mapper),
-         CdsImporter::CdsEntity.new(3, 'Certificate', certificate2, certificate_mapper),
-         CdsImporter::CdsEntity.new(4, 'Measure', measure2, measure_mapper)]
+         CdsImporter::CdsEntity.new(3, 'Certificate', second_certificate, certificate_mapper),
+         CdsImporter::CdsEntity.new(4, 'Measure', second_measure, measure_mapper)]
       end
 
       before do

--- a/spec/lib/cds_importer/excel_writer/additional_code_spec.rb
+++ b/spec/lib/cds_importer/excel_writer/additional_code_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CdsImporter::ExcelWriter::AdditionalCode do
     )
   end
 
-  let(:additional_code_type2) do
+  let(:second_additional_code_type) do
     instance_double(
       AdditionalCode,
       class: instance_double(Class, name: 'AdditionalCode'),
@@ -50,7 +50,7 @@ RSpec.describe CdsImporter::ExcelWriter::AdditionalCode do
     )
   end
 
-  let(:description_period2) do
+  let(:second_description_period) do
     instance_double(
       AdditionalCodeDescriptionPeriod,
       class: instance_double(Class, name: 'AdditionalCodeDescriptionPeriod'),
@@ -63,7 +63,7 @@ RSpec.describe CdsImporter::ExcelWriter::AdditionalCode do
     )
   end
 
-  let(:description2) do
+  let(:second_description) do
     instance_double(
       AdditionalCodeDescription,
       class: instance_double(Class, name: 'AdditionalCodeDescription'),
@@ -77,7 +77,7 @@ RSpec.describe CdsImporter::ExcelWriter::AdditionalCode do
 
   describe '#data_row' do
     context 'when all fields are valid' do
-      let(:models) { [additional_code_type, description, description_period, description2, description_period2] }
+      let(:models) { [additional_code_type, description, description_period, second_description, second_description_period] }
 
       it 'returns a correctly formatted data row' do
         row = mapper.data_row
@@ -107,7 +107,7 @@ RSpec.describe CdsImporter::ExcelWriter::AdditionalCode do
     end
 
     context 'when there are empty fields' do
-      let(:models) { [additional_code_type2, description_period] }
+      let(:models) { [second_additional_code_type, description_period] }
 
       it 'returns a correctly formatted data row' do
         row = mapper.data_row

--- a/spec/lib/cds_importer/excel_writer/base_regulation_spec.rb
+++ b/spec/lib/cds_importer/excel_writer/base_regulation_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe CdsImporter::ExcelWriter::BaseRegulation do
     )
   end
 
-  let(:base_regulation2) do
+  let(:second_base_regulation) do
     instance_double(
       BaseRegulation,
       class: instance_double(Class, name: 'BaseRegulation'),
@@ -46,7 +46,7 @@ RSpec.describe CdsImporter::ExcelWriter::BaseRegulation do
     end
 
     context 'when there are empty fields in base regulation' do
-      let(:models) { [base_regulation2] }
+      let(:models) { [second_base_regulation] }
 
       it 'returns a correctly formatted data row' do
         row = mapper.data_row

--- a/spec/lib/cds_importer/excel_writer/certificate_spec.rb
+++ b/spec/lib/cds_importer/excel_writer/certificate_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CdsImporter::ExcelWriter::Certificate do
     )
   end
 
-  let(:certificate_type2) do
+  let(:second_certificate_type) do
     instance_double(
       Certificate,
       class: instance_double(Class, name: 'Certificate'),
@@ -37,7 +37,7 @@ RSpec.describe CdsImporter::ExcelWriter::Certificate do
     )
   end
 
-  let(:description_period2) do
+  let(:second_description_period) do
     instance_double(
       CertificateDescriptionPeriod,
       class: instance_double(Class, name: 'CertificateDescriptionPeriod'),
@@ -60,7 +60,7 @@ RSpec.describe CdsImporter::ExcelWriter::Certificate do
     )
   end
 
-  let(:description2) do
+  let(:second_description) do
     instance_double(
       CertificateDescription,
       class: instance_double(Class, name: 'CertificateDescription'),
@@ -73,7 +73,7 @@ RSpec.describe CdsImporter::ExcelWriter::Certificate do
 
   describe '#data_row' do
     context 'when all fields are valid' do
-      let(:models) { [certificate_type, description, description_period, description2, description_period2] }
+      let(:models) { [certificate_type, description, description_period, second_description, second_description_period] }
 
       it 'returns a correctly formatted data row' do
         row = mapper.data_row
@@ -103,7 +103,7 @@ RSpec.describe CdsImporter::ExcelWriter::Certificate do
     end
 
     context 'when there are empty fields' do
-      let(:models) { [certificate_type2] }
+      let(:models) { [second_certificate_type] }
 
       it 'returns a correctly formatted data row' do
         row = mapper.data_row

--- a/spec/lib/cds_importer/excel_writer/footnote_spec.rb
+++ b/spec/lib/cds_importer/excel_writer/footnote_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CdsImporter::ExcelWriter::Footnote do
     )
   end
 
-  let(:footnote_type2) do
+  let(:second_footnote_type) do
     instance_double(
       Footnote,
       class: instance_double(Class, name: 'Footnote'),
@@ -37,7 +37,7 @@ RSpec.describe CdsImporter::ExcelWriter::Footnote do
     )
   end
 
-  let(:description_period2) do
+  let(:second_description_period) do
     instance_double(
       FootnoteDescriptionPeriod,
       class: instance_double(Class, name: 'FootnoteDescriptionPeriod'),
@@ -60,7 +60,7 @@ RSpec.describe CdsImporter::ExcelWriter::Footnote do
     )
   end
 
-  let(:description2) do
+  let(:second_description) do
     instance_double(
       FootnoteDescription,
       class: instance_double(Class, name: 'FootnoteDescription'),
@@ -73,7 +73,7 @@ RSpec.describe CdsImporter::ExcelWriter::Footnote do
 
   describe '#data_row' do
     context 'when all fields are valid' do
-      let(:models) { [footnote_type, description, description_period, description2, description_period2] }
+      let(:models) { [footnote_type, description, description_period, second_description, second_description_period] }
 
       it 'returns a correctly formatted data row' do
         row = mapper.data_row
@@ -105,7 +105,7 @@ RSpec.describe CdsImporter::ExcelWriter::Footnote do
     end
 
     context 'when there are empty fields' do
-      let(:models) { [footnote_type2] }
+      let(:models) { [second_footnote_type] }
 
       it 'returns a correctly formatted data row' do
         row = mapper.data_row

--- a/spec/lib/cds_importer/excel_writer/footnote_type_spec.rb
+++ b/spec/lib/cds_importer/excel_writer/footnote_type_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe CdsImporter::ExcelWriter::FootnoteType do
     )
   end
 
-  let(:footnote_type2) do
+  let(:second_footnote_type) do
     instance_double(
       FootnoteType,
       class: instance_double(Class, name: 'FootnoteType'),
@@ -33,7 +33,7 @@ RSpec.describe CdsImporter::ExcelWriter::FootnoteType do
     )
   end
 
-  let(:description2) do
+  let(:second_description) do
     instance_double(
       FootnoteTypeDescription,
       class: instance_double(Class, name: 'FootnoteTypeDescription'),
@@ -58,7 +58,7 @@ RSpec.describe CdsImporter::ExcelWriter::FootnoteType do
     end
 
     context 'when there are empty fields in footnote type' do
-      let(:models) { [footnote_type2] }
+      let(:models) { [second_footnote_type] }
 
       it 'returns a correctly formatted data row' do
         row = mapper.data_row
@@ -73,7 +73,7 @@ RSpec.describe CdsImporter::ExcelWriter::FootnoteType do
     end
 
     context 'when the description is empty' do
-      let(:models) { [footnote_type2, description2] }
+      let(:models) { [second_footnote_type, second_description] }
 
       it 'returns a correctly formatted data row' do
         row = mapper.data_row

--- a/spec/lib/cds_importer/excel_writer/geographical_area_spec.rb
+++ b/spec/lib/cds_importer/excel_writer/geographical_area_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe CdsImporter::ExcelWriter::GeographicalArea do
     )
   end
 
-  let(:description_period2) do
+  let(:second_description_period) do
     instance_double(
       GeographicalAreaDescriptionPeriod,
       class: instance_double(Class, name: 'GeographicalAreaDescriptionPeriod'),
@@ -49,7 +49,7 @@ RSpec.describe CdsImporter::ExcelWriter::GeographicalArea do
     )
   end
 
-  let(:description2) do
+  let(:second_description) do
     instance_double(
       GeographicalAreaDescription,
       class: instance_double(Class, name: 'GeographicalAreaDescription'),
@@ -72,7 +72,7 @@ RSpec.describe CdsImporter::ExcelWriter::GeographicalArea do
     )
   end
 
-  let(:geo_area_membership2) do
+  let(:second_geo_area_membership) do
     instance_double(
       GeographicalAreaMembership,
       class: instance_double(Class, name: 'GeographicalAreaMembership'),
@@ -86,9 +86,9 @@ RSpec.describe CdsImporter::ExcelWriter::GeographicalArea do
 
   describe '#data_row' do
     context 'when all fields are valid' do
-      let(:models) { [geo_area, description, description_period, description2, description_period2, geo_area_membership, geo_area_membership2] }
+      let(:models) { [geo_area, description, description_period, second_description, second_description_period, geo_area_membership, second_geo_area_membership] }
       let!(:membership) { create(:geographical_area, :with_description, geographical_area_sid: 4) }
-      let!(:membership2) { create(:geographical_area, :with_description, geographical_area_sid: 5) }
+      let!(:second_membership) { create(:geographical_area, :with_description, geographical_area_sid: 5) }
 
       it 'returns a correctly formatted data row' do
         row = mapper.data_row
@@ -99,8 +99,8 @@ RSpec.describe CdsImporter::ExcelWriter::GeographicalArea do
         expect(row[3]).to eq('01/01/2025')
         expect(row[4]).to eq('31/12/2025')
         expect(row[5]).to eq("01/01/2025\nCountries - export restriction protective equipment R2020/204\n02/02/2023\nCountries - export restriction protective equipment R 2020/568\n")
-        expect(row[6]).to eq("01/07/2025 : #{membership2.description}\n")
-        expect(row[7]).to eq("01/01/2025 to 30/06/2025 : #{membership.description}\n01/07/2025 : #{membership2.description}\n")
+        expect(row[6]).to eq("01/07/2025 : #{second_membership.description}\n")
+        expect(row[7]).to eq("01/01/2025 to 30/06/2025 : #{membership.description}\n01/07/2025 : #{second_membership.description}\n")
         expect(row[8]).to eq(3)
       end
     end

--- a/spec/lib/cds_importer/excel_writer/goods_nomenclature_spec.rb
+++ b/spec/lib/cds_importer/excel_writer/goods_nomenclature_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe CdsImporter::ExcelWriter::GoodsNomenclature do
     )
   end
 
-  let(:goods_nomenclature2) do
+  let(:second_goods_nomenclature) do
     instance_double(
       GoodsNomenclature,
       class: instance_double(Class, name: 'GoodsNomenclature'),
@@ -42,7 +42,7 @@ RSpec.describe CdsImporter::ExcelWriter::GoodsNomenclature do
     )
   end
 
-  let(:description_period2) do
+  let(:second_description_period) do
     instance_double(
       GoodsNomenclatureDescriptionPeriod,
       class: instance_double(Class, name: 'GoodsNomenclatureDescriptionPeriod'),
@@ -67,7 +67,7 @@ RSpec.describe CdsImporter::ExcelWriter::GoodsNomenclature do
     )
   end
 
-  let(:description2) do
+  let(:second_description) do
     instance_double(
       GoodsNomenclatureDescription,
       class: instance_double(Class, name: 'GoodsNomenclatureDescription'),
@@ -81,7 +81,7 @@ RSpec.describe CdsImporter::ExcelWriter::GoodsNomenclature do
 
   describe '#data_row' do
     context 'when all fields are valid' do
-      let(:models) { [goods_nomenclature, description, description_period, description2, description_period2] }
+      let(:models) { [goods_nomenclature, description, description_period, second_description, second_description_period] }
 
       it 'returns a correctly formatted data row' do
         row = mapper.data_row
@@ -115,7 +115,7 @@ RSpec.describe CdsImporter::ExcelWriter::GoodsNomenclature do
     end
 
     context 'when there are empty fields' do
-      let(:models) { [goods_nomenclature2] }
+      let(:models) { [second_goods_nomenclature] }
 
       it 'returns a correctly formatted data row' do
         row = mapper.data_row

--- a/spec/lib/cds_importer/excel_writer/measure_spec.rb
+++ b/spec/lib/cds_importer/excel_writer/measure_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe CdsImporter::ExcelWriter::Measure do
     )
   end
 
-  let(:measure2) do
+  let(:second_measure) do
     instance_double(
       Measure,
       class: instance_double(Class, name: 'Measure'),
@@ -79,7 +79,7 @@ RSpec.describe CdsImporter::ExcelWriter::Measure do
     )
   end
 
-  let(:condition2) do
+  let(:second_condition) do
     instance_double(
       MeasureCondition,
       class: instance_double(Class, name: 'MeasureCondition'),
@@ -125,7 +125,7 @@ RSpec.describe CdsImporter::ExcelWriter::Measure do
 
     context 'when descriptions not found' do
       let(:models) do
-        [measure2, measure_component, excluded_geo_area, footnote, condition2]
+        [second_measure, measure_component, excluded_geo_area, footnote, second_condition]
       end
 
       it 'returns just the id' do

--- a/spec/lib/cds_importer/excel_writer/measure_type_spec.rb
+++ b/spec/lib/cds_importer/excel_writer/measure_type_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe CdsImporter::ExcelWriter::MeasureType do
     )
   end
 
-  let(:measure_type2) do
+  let(:second_measure_type) do
     instance_double(
       MeasureType,
       class: instance_double(Class, name: 'MeasureType'),
@@ -45,7 +45,7 @@ RSpec.describe CdsImporter::ExcelWriter::MeasureType do
     )
   end
 
-  let(:description2) do
+  let(:second_description) do
     instance_double(
       MeasureTypeDescription,
       class: instance_double(Class, name: 'MeasureTypeDescription'),
@@ -75,7 +75,7 @@ RSpec.describe CdsImporter::ExcelWriter::MeasureType do
     end
 
     context 'when there are empty fields in measure type' do
-      let(:models) { [measure_type2] }
+      let(:models) { [second_measure_type] }
 
       it 'returns a correctly formatted data row' do
         row = mapper.data_row
@@ -95,7 +95,7 @@ RSpec.describe CdsImporter::ExcelWriter::MeasureType do
     end
 
     context 'when the description is empty' do
-      let(:models) { [measure_type2, description2] }
+      let(:models) { [second_measure_type, second_description] }
 
       it 'returns a correctly formatted data row' do
         row = mapper.data_row

--- a/spec/lib/cds_importer/excel_writer/measurement_unit_spec.rb
+++ b/spec/lib/cds_importer/excel_writer/measurement_unit_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe CdsImporter::ExcelWriter::MeasurementUnit do
     )
   end
 
-  let(:measurement_unit2) do
+  let(:second_measurement_unit) do
     instance_double(
       MeasurementUnit,
       class: instance_double(Class, name: 'MeasurementUnit'),
@@ -31,7 +31,7 @@ RSpec.describe CdsImporter::ExcelWriter::MeasurementUnit do
     )
   end
 
-  let(:description2) do
+  let(:second_description) do
     instance_double(
       MeasurementUnitDescription,
       class: instance_double(Class, name: 'MeasurementUnitDescription'),
@@ -55,7 +55,7 @@ RSpec.describe CdsImporter::ExcelWriter::MeasurementUnit do
     end
 
     context 'when there are empty fields in measurement unit' do
-      let(:models) { [measurement_unit2] }
+      let(:models) { [second_measurement_unit] }
 
       it 'returns a correctly formatted data row' do
         row = mapper.data_row
@@ -69,7 +69,7 @@ RSpec.describe CdsImporter::ExcelWriter::MeasurementUnit do
     end
 
     context 'when the description is empty' do
-      let(:models) { [measurement_unit2, description2] }
+      let(:models) { [second_measurement_unit, second_description] }
 
       it 'returns a correctly formatted data row' do
         row = mapper.data_row

--- a/spec/lib/cds_importer/excel_writer/quota_definition_spec.rb
+++ b/spec/lib/cds_importer/excel_writer/quota_definition_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe CdsImporter::ExcelWriter::QuotaDefinition do
     )
   end
 
-  let(:balance_event1) do
+  let(:first_balance_event) do
     instance_double(
       QuotaBalanceEvent,
       class: instance_double(Class, name: 'QuotaBalanceEvent'),
@@ -28,7 +28,7 @@ RSpec.describe CdsImporter::ExcelWriter::QuotaDefinition do
     )
   end
 
-  let(:balance_event2) do
+  let(:second_balance_event) do
     instance_double(
       QuotaBalanceEvent,
       class: instance_double(Class, name: 'QuotaBalanceEvent'),
@@ -38,7 +38,7 @@ RSpec.describe CdsImporter::ExcelWriter::QuotaDefinition do
     )
   end
 
-  let(:models) { [quota_definition, balance_event1, balance_event2] }
+  let(:models) { [quota_definition, first_balance_event, second_balance_event] }
 
   describe '#data_row' do
     let!(:measures) do

--- a/spec/lib/cds_importer/excel_writer/quota_order_number_spec.rb
+++ b/spec/lib/cds_importer/excel_writer/quota_order_number_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CdsImporter::ExcelWriter::QuotaOrderNumber do
     )
   end
 
-  let(:quota_order_number2) do
+  let(:second_quota_order_number) do
     instance_double(
       QuotaOrderNumber,
       class: instance_double(Class, name: 'QuotaOrderNumber'),
@@ -41,7 +41,7 @@ RSpec.describe CdsImporter::ExcelWriter::QuotaOrderNumber do
     end
 
     context 'when there are empty fields in quota order number' do
-      let(:models) { [quota_order_number2] }
+      let(:models) { [second_quota_order_number] }
 
       it 'returns a correctly formatted data row' do
         row = mapper.data_row

--- a/spec/lib/cds_importer/excel_writer_spec.rb
+++ b/spec/lib/cds_importer/excel_writer_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe CdsImporter::ExcelWriter do
   subject(:writer) { described_class.new(filename) }
 
   let(:filename) { 'test.xlsx' }
-  let(:entity1) do
+  let(:first_entity) do
     instance_double(
       CdsImporter::CdsEntity,
       key: 'K',
@@ -10,7 +10,7 @@ RSpec.describe CdsImporter::ExcelWriter do
       instance: 'I1',
     )
   end
-  let(:entity2) do
+  let(:second_entity) do
     instance_double(
       CdsImporter::CdsEntity,
       key: 'K',
@@ -18,7 +18,7 @@ RSpec.describe CdsImporter::ExcelWriter do
       instance: 'I2',
     )
   end
-  let(:entity3) do
+  let(:third_entity) do
     instance_double(
       CdsImporter::CdsEntity,
       key: 'NotExist',
@@ -64,7 +64,7 @@ RSpec.describe CdsImporter::ExcelWriter do
   describe 'process_record' do
     context 'when xml_element_id is nil' do
       it 'sets key, xml_element_id, and adds the instance' do
-        writer.process_record(entity1)
+        writer.process_record(first_entity)
 
         expect(excel_class).not_to have_received(:sheet_name)
         expect(writer.instance_variable_get(:@key)).to eq('K')
@@ -75,8 +75,8 @@ RSpec.describe CdsImporter::ExcelWriter do
 
     context 'when xml_element_id changes' do
       it 'writes existing instances and resets before adding new one' do
-        writer.process_record(entity1)
-        writer.process_record(entity2)
+        writer.process_record(first_entity)
+        writer.process_record(second_entity)
 
         expect(excel).to have_received(:data_row)
         expect(writer.instance_variable_get(:@key)).to eq('K')
@@ -87,8 +87,8 @@ RSpec.describe CdsImporter::ExcelWriter do
 
     context 'when xml_element_id stays the same' do
       it 'does not call write and accumulates instances' do
-        writer.process_record(entity1)
-        writer.process_record(entity1)
+        writer.process_record(first_entity)
+        writer.process_record(first_entity)
 
         expect(excel_class).not_to have_received(:sheet_name)
         expect(writer.instance_variable_get(:@instances)).to eq(%w[I1 I1])
@@ -98,8 +98,8 @@ RSpec.describe CdsImporter::ExcelWriter do
 
   describe 'handle invalid cds entity' do
     it 'handles key that not mapped' do
-      writer.process_record(entity3)
-      writer.process_record(entity1)
+      writer.process_record(third_entity)
+      writer.process_record(first_entity)
 
       expect(excel_class).not_to have_received(:sheet_name)
       expect(writer.instance_variable_get(:@key)).to eq('K')

--- a/spec/lib/customs_tariff_importer/importer_spec.rb
+++ b/spec/lib/customs_tariff_importer/importer_spec.rb
@@ -124,13 +124,13 @@ RSpec.describe CustomsTariffImporter::Importer do
     end
 
     context 'when two documents are returned' do
-      let(:docx_content_2) { 'fake docx binary content v2' }
-      let(:fetched_result_2) do
+      let(:second_docx_content) { 'fake docx binary content v2' }
+      let(:second_fetched_result) do
         CustomsTariffImporter::DocumentFetcher::Result.new(
-          content: docx_content_2,
+          content: second_docx_content,
           url: 'https://assets.publishing.service.gov.uk/media/def456/UKGT_1.31.docx',
           version: '1.31',
-          checksum: Digest::SHA256.hexdigest(docx_content_2),
+          checksum: Digest::SHA256.hexdigest(second_docx_content),
           published_on: Date.new(2026, 3, 3),
           entry_into_force_on: Date.new(2026, 4, 1),
         )
@@ -138,7 +138,7 @@ RSpec.describe CustomsTariffImporter::Importer do
 
       before do
         allow(CustomsTariffImporter::DocumentFetcher).to receive(:new).and_return(
-          instance_double(CustomsTariffImporter::DocumentFetcher, call: [fetched_result, fetched_result_2]),
+          instance_double(CustomsTariffImporter::DocumentFetcher, call: [fetched_result, second_fetched_result]),
         )
       end
 

--- a/spec/lib/customs_tariff_importer/reimporter_spec.rb
+++ b/spec/lib/customs_tariff_importer/reimporter_spec.rb
@@ -94,20 +94,20 @@ RSpec.describe CustomsTariffImporter::Reimporter do
     end
 
     context 'when there are multiple updates' do
-      let(:update2) do
+      let(:second_update) do
         create(:customs_tariff_update,
                version: '1.30',
                status: CustomsTariffUpdate::PENDING,
                validity_start_date: Date.new(2026, 3, 1),
                s3_path: 'data/customs_tariff_documents/UKGT_1.30.docx')
       end
-      let(:docx_io2) { build_docx('SECTION II', 'Section Notes', 'Vegetable products are classified here.', 'CHAPTER 6') }
+      let(:second_docx_io) { build_docx('SECTION II', 'Section Notes', 'Vegetable products are classified here.', 'CHAPTER 6') }
 
       before do
-        update2
+        second_update
         allow(TariffSynchronizer::FileService).to receive(:get)
-          .with(update2.s3_path)
-          .and_return(docx_io2)
+          .with(second_update.s3_path)
+          .and_return(second_docx_io)
       end
 
       it 'reimports notes for every non-failed update' do

--- a/spec/models/chapter_spec.rb
+++ b/spec/models/chapter_spec.rb
@@ -1,24 +1,24 @@
 RSpec.describe Chapter do
   describe 'Associations' do
     context 'with headings' do
-      let!(:chapter)  { create :chapter }
+      let!(:chapter) { create :chapter }
 
-      let!(:heading1) do
+      let!(:first_heading) do
         create :heading, goods_nomenclature_item_id: "#{chapter.goods_nomenclature_item_id.first(2)}10000000",
                          validity_start_date: 10.years.ago,
                          validity_end_date: nil
       end
-      let!(:heading2) do
+      let!(:second_heading) do
         create :heading, goods_nomenclature_item_id: "#{chapter.goods_nomenclature_item_id.first(2)}20000000",
                          validity_start_date: 2.years.ago,
                          validity_end_date: nil
       end
-      let!(:heading3) do
+      let!(:third_heading) do
         create :heading, goods_nomenclature_item_id: "#{chapter.goods_nomenclature_item_id.first(2)}30000000",
                          validity_start_date: 10.years.ago,
                          validity_end_date: 8.years.ago
       end
-      let!(:heading4) do
+      let!(:fourth_heading) do
         create :heading, goods_nomenclature_item_id: "#{chapter.goods_nomenclature_item_id.first(2)}40000000",
                          validity_start_date: 10.years.ago,
                          validity_end_date: nil
@@ -26,7 +26,7 @@ RSpec.describe Chapter do
 
       before do
         # Hidden goods nomenclature
-        create :hidden_goods_nomenclature, goods_nomenclature_item_id: heading4.goods_nomenclature_item_id
+        create :hidden_goods_nomenclature, goods_nomenclature_item_id: fourth_heading.goods_nomenclature_item_id
       end
 
       around do |example|
@@ -36,19 +36,19 @@ RSpec.describe Chapter do
       end
 
       it 'returns headings matched by part of own goods nomenclature item id' do
-        expect(chapter.headings).to include heading1
+        expect(chapter.headings).to include first_heading
       end
 
       it 'returns relevant by actual time headings' do
-        expect(chapter.headings).to include heading2
+        expect(chapter.headings).to include second_heading
       end
 
       it 'does not return heading that is irrelevant to given time' do
-        expect(chapter.headings).not_to include heading3
+        expect(chapter.headings).not_to include third_heading
       end
 
       it 'does not include hidden commodity' do
-        expect(chapter.headings).not_to include heading4
+        expect(chapter.headings).not_to include fourth_heading
       end
     end
   end
@@ -204,23 +204,23 @@ RSpec.describe Chapter do
   end
 
   describe '.by_code' do
-    let!(:chapter1) { create(:chapter, goods_nomenclature_item_id: '1200000000') }
-    let!(:chapter2) { create(:chapter, goods_nomenclature_item_id: '2100000000') }
+    let!(:first_chapter) { create(:chapter, goods_nomenclature_item_id: '1200000000') }
+    let!(:second_chapter) { create(:chapter, goods_nomenclature_item_id: '2100000000') }
 
     it 'returns chapters filtered by goods_nomenclature_item_id', :aggregate_failures do
       chapters = described_class.by_code('12')
-      expect(chapters).to include(chapter1)
-      expect(chapters).not_to include(chapter2)
+      expect(chapters).to include(first_chapter)
+      expect(chapters).not_to include(second_chapter)
     end
   end
 
   describe 'first & last heading' do
     let(:chapter) { create :chapter, goods_nomenclature_item_id: '1200000000' }
-    let!(:heading1) do
+    let!(:first_heading) do
       create :heading, goods_nomenclature_item_id: "#{chapter.goods_nomenclature_item_id.first(2)}10000000",
                        validity_end_date: nil
     end
-    let!(:heading2) do
+    let!(:second_heading) do
       create :heading, goods_nomenclature_item_id: "#{chapter.goods_nomenclature_item_id.first(2)}30000000",
                        validity_end_date: nil
     end
@@ -231,25 +231,25 @@ RSpec.describe Chapter do
 
     describe '#first_heading' do
       it 'returns first heading ordered by goods_nomenclature_item_id' do
-        expect(chapter.first_heading).to eq(heading1)
+        expect(chapter.first_heading).to eq(first_heading)
       end
     end
 
     describe '#last_heading' do
       it 'returns last heading ordered by goods_nomenclature_item_id' do
-        expect(chapter.last_heading).to eq(heading2)
+        expect(chapter.last_heading).to eq(second_heading)
       end
     end
 
     describe '#headings_from' do
       it 'returns first heading short_code' do
-        expect(chapter.headings_from).to eq(heading1.short_code)
+        expect(chapter.headings_from).to eq(first_heading.short_code)
       end
     end
 
     describe '#headings_to' do
       it 'returns last heading short_code' do
-        expect(chapter.headings_to).to eq(heading2.short_code)
+        expect(chapter.headings_to).to eq(second_heading.short_code)
       end
     end
   end

--- a/spec/models/commodity_spec.rb
+++ b/spec/models/commodity_spec.rb
@@ -159,11 +159,11 @@ RSpec.describe Commodity do
   end
 
   describe '.by_code' do
-    let(:commodity1) { create(:commodity, goods_nomenclature_item_id: '123') }
-    let(:commodity2) { create(:commodity, goods_nomenclature_item_id: '456') }
+    let(:first_commodity) { create(:commodity, goods_nomenclature_item_id: '123') }
+    let(:second_commodity) { create(:commodity, goods_nomenclature_item_id: '456') }
 
-    it { expect(described_class.by_code('123')).to include(commodity1) }
-    it { expect(described_class.by_code('123')).not_to include(commodity2) }
+    it { expect(described_class.by_code('123')).to include(first_commodity) }
+    it { expect(described_class.by_code('123')).not_to include(second_commodity) }
   end
 
   describe '.by_productline_suffix' do

--- a/spec/models/commodity_spec.rb
+++ b/spec/models/commodity_spec.rb
@@ -7,22 +7,22 @@ RSpec.describe Commodity do
 
   describe 'associations' do
     describe '#heading' do
-      let!(:gono1) do
+      let!(:matching_goods_nomenclature) do
         create :commodity, validity_start_date: Date.new(1999, 1, 1),
                            validity_end_date: Date.new(2013, 1, 1)
       end
-      let!(:heading1) do
-        create :heading, goods_nomenclature_item_id: "#{gono1.goods_nomenclature_item_id.first(4)}000000",
+      let!(:matching_heading) do
+        create :heading, goods_nomenclature_item_id: "#{matching_goods_nomenclature.goods_nomenclature_item_id.first(4)}000000",
                          validity_start_date: Date.new(1991, 1, 1),
                          validity_end_date: Date.new(2002, 1, 1),
                          producline_suffix: GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX
       end
 
       before do
-        create :commodity, goods_nomenclature_item_id: gono1.goods_nomenclature_item_id,
+        create :commodity, goods_nomenclature_item_id: matching_goods_nomenclature.goods_nomenclature_item_id,
                            validity_start_date: Date.new(2005, 1, 1),
                            validity_end_date: Date.new(2013, 1, 1)
-        create :heading, goods_nomenclature_item_id: "#{gono1.goods_nomenclature_item_id.first(4)}000000",
+        create :heading, goods_nomenclature_item_id: "#{matching_goods_nomenclature.goods_nomenclature_item_id.first(4)}000000",
                          validity_start_date: Date.new(2002, 1, 1),
                          validity_end_date: Date.new(2014, 1, 1),
                          producline_suffix: GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX
@@ -31,7 +31,7 @@ RSpec.describe Commodity do
       context 'when fetching a chapter on a given day' do
         it 'fetches correct chapter' do
           TimeMachine.at('2000-1-1') do
-            expect(gono1.reload.heading.pk).to eq heading1.pk
+            expect(matching_goods_nomenclature.reload.heading.pk).to eq matching_heading.pk
           end
         end
       end
@@ -66,17 +66,17 @@ RSpec.describe Commodity do
 
     describe '#chapter' do
       before do
-        create :heading, goods_nomenclature_item_id: gono1.goods_nomenclature_item_id,
+        create :heading, goods_nomenclature_item_id: matching_goods_nomenclature.goods_nomenclature_item_id,
                          validity_start_date: Date.new(2005, 1, 1),
                          validity_end_date: Date.new(2013, 1, 1)
       end
 
-      let!(:gono1) do
+      let!(:matching_goods_nomenclature) do
         create :heading, validity_start_date: Date.new(1999, 1, 1),
                          validity_end_date: Date.new(2013, 1, 1)
       end
-      let!(:chapter1) do
-        create :chapter, goods_nomenclature_item_id: "#{gono1.goods_nomenclature_item_id.first(2)}00000000",
+      let!(:matching_chapter) do
+        create :chapter, goods_nomenclature_item_id: "#{matching_goods_nomenclature.goods_nomenclature_item_id.first(2)}00000000",
                          validity_start_date: Date.new(1991, 1, 1),
                          validity_end_date: Date.new(2002, 1, 1)
       end
@@ -84,7 +84,7 @@ RSpec.describe Commodity do
       context 'when fetching actual' do
         it 'fetches correct chapter' do
           TimeMachine.at('2000-1-1') do
-            expect(gono1.reload.chapter.pk).to eq chapter1.pk
+            expect(matching_goods_nomenclature.reload.chapter.pk).to eq matching_chapter.pk
           end
         end
       end

--- a/spec/models/concerns/classification_description_spec.rb
+++ b/spec/models/concerns/classification_description_spec.rb
@@ -33,10 +33,10 @@ RSpec.describe ClassificationDescription do
     context 'when the description is "other" and there are ancestors' do
       let(:description) { 'Other' }
 
-      let(:ancestor1) { instance_double(GoodsNomenclature, formatted_description: 'Foo') }
-      let(:ancestor2) { instance_double(GoodsNomenclature, formatted_description: 'Bar') }
+      let(:first_ancestor) { instance_double(GoodsNomenclature, formatted_description: 'Foo') }
+      let(:second_ancestor) { instance_double(GoodsNomenclature, formatted_description: 'Bar') }
 
-      let(:ancestors) { [ancestor1, ancestor2] }
+      let(:ancestors) { [first_ancestor, second_ancestor] }
 
       it 'returns the chain until the first non-other ancestor' do
         expect(descriptions).to eq(%w[Bar Other])
@@ -46,10 +46,10 @@ RSpec.describe ClassificationDescription do
     context 'when ALL ancestors are "other"' do
       let(:description) { 'Other' }
 
-      let(:ancestor1) { instance_double(GoodsNomenclature, formatted_description: 'Other') }
-      let(:ancestor2) { instance_double(GoodsNomenclature, formatted_description: 'Other') }
+      let(:first_ancestor) { instance_double(GoodsNomenclature, formatted_description: 'Other') }
+      let(:second_ancestor) { instance_double(GoodsNomenclature, formatted_description: 'Other') }
 
-      let(:ancestors) { [ancestor1, ancestor2] }
+      let(:ancestors) { [first_ancestor, second_ancestor] }
 
       it 'prepends heading as fallback' do
         expect(descriptions).to eq(%w[Heading Other Other Other])
@@ -59,10 +59,10 @@ RSpec.describe ClassificationDescription do
     context 'when ALL ancestors are "other" and heading is nil' do
       let(:description) { 'Other' }
 
-      let(:ancestor1) { instance_double(GoodsNomenclature, formatted_description: 'Other') }
-      let(:ancestor2) { instance_double(GoodsNomenclature, formatted_description: 'Other') }
+      let(:first_ancestor) { instance_double(GoodsNomenclature, formatted_description: 'Other') }
+      let(:second_ancestor) { instance_double(GoodsNomenclature, formatted_description: 'Other') }
 
-      let(:ancestors) { [ancestor1, ancestor2] }
+      let(:ancestors) { [first_ancestor, second_ancestor] }
       let(:heading) { nil }
 
       before do
@@ -101,8 +101,8 @@ RSpec.describe ClassificationDescription do
 
     context 'when description is "other" with a non-other ancestor' do
       let(:description) { 'Other' }
-      let(:ancestor1) { instance_double(GoodsNomenclature, description: 'Live horses') }
-      let(:ancestors) { [ancestor1] }
+      let(:first_ancestor) { instance_double(GoodsNomenclature, description: 'Live horses') }
+      let(:ancestors) { [first_ancestor] }
 
       it 'chains ancestor > Other' do
         expect(raw_desc).to eq('Live horses > Other')
@@ -111,8 +111,8 @@ RSpec.describe ClassificationDescription do
 
     context 'when all ancestors are "other"' do
       let(:description) { 'Other' }
-      let(:ancestor1) { instance_double(GoodsNomenclature, description: 'Other') }
-      let(:ancestors) { [ancestor1] }
+      let(:first_ancestor) { instance_double(GoodsNomenclature, description: 'Other') }
+      let(:ancestors) { [first_ancestor] }
 
       it 'prepends heading as fallback' do
         expect(raw_desc).to eq('Heading > Other > Other')

--- a/spec/models/goods_nomenclature_spec.rb
+++ b/spec/models/goods_nomenclature_spec.rb
@@ -543,11 +543,11 @@ RSpec.describe GoodsNomenclature do
 
     context 'when the description is not "other"' do
       let(:goods_nomenclature) { create(:goods_nomenclature, :with_description, description: 'bar') }
-      let(:ancestor1) {  create(:goods_nomenclature, :with_description, description: 'foo') }
-      let(:ancestor2) {  create(:goods_nomenclature, :with_description, description: 'bar') }
+      let(:first_ancestor) { create(:goods_nomenclature, :with_description, description: 'foo') }
+      let(:second_ancestor) { create(:goods_nomenclature, :with_description, description: 'bar') }
 
       before do
-        allow(goods_nomenclature).to receive(:ancestors).and_return([ancestor1, ancestor2])
+        allow(goods_nomenclature).to receive(:ancestors).and_return([first_ancestor, second_ancestor])
       end
 
       it { is_expected.to eq('Bar') }
@@ -555,11 +555,11 @@ RSpec.describe GoodsNomenclature do
 
     context 'when the description is "other"' do
       let(:goods_nomenclature) { create(:goods_nomenclature, :with_description, description: 'other') }
-      let(:ancestor1) {  create(:goods_nomenclature, :with_description, description: 'foo') }
-      let(:ancestor2) {  create(:goods_nomenclature, :with_description, description: 'bar') }
+      let(:first_ancestor) { create(:goods_nomenclature, :with_description, description: 'foo') }
+      let(:second_ancestor) { create(:goods_nomenclature, :with_description, description: 'bar') }
 
       before do
-        allow(goods_nomenclature).to receive(:ancestors).and_return([ancestor1, ancestor2])
+        allow(goods_nomenclature).to receive(:ancestors).and_return([first_ancestor, second_ancestor])
       end
 
       it { is_expected.to eq('Bar > Other') }

--- a/spec/models/goods_nomenclatures/nested_set_spec.rb
+++ b/spec/models/goods_nomenclatures/nested_set_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe GoodsNomenclatures::NestedSet do
         subheading = create(:subheading, parent: heading)
         subsubheading = create(:subheading, parent: subheading)
         commodity1 = create(:commodity, parent: subsubheading)
-        commodity2 = create(:commodity, parent: subsubheading)
+        second_commodity = create(:commodity, parent: subsubheading)
         commodity3 = create(:commodity, parent: subheading)
         second_tree = create(:subheading, :with_chapter_and_heading, :with_children)
 
@@ -66,7 +66,7 @@ RSpec.describe GoodsNomenclatures::NestedSet do
           subheading:,
           subsubheading:,
           commodity1:,
-          commodity2:,
+          second_commodity:,
           commodity3:,
           second_tree:,
         }
@@ -204,10 +204,10 @@ RSpec.describe GoodsNomenclatures::NestedSet do
       end
 
       describe '#descendants' do
-        it_behaves_like 'it has descendants', 'chapter', :chapter, %i[heading subheading subsubheading commodity1 commodity2 commodity3]
-        it_behaves_like 'it has descendants', 'heading', :heading, %i[subheading subsubheading commodity1 commodity2 commodity3]
-        it_behaves_like 'it has descendants', 'subheading', :subheading, %i[subsubheading commodity1 commodity2 commodity3]
-        it_behaves_like 'it has descendants', 'nested subheading', :subsubheading, %i[commodity1 commodity2]
+        it_behaves_like 'it has descendants', 'chapter', :chapter, %i[heading subheading subsubheading commodity1 second_commodity commodity3]
+        it_behaves_like 'it has descendants', 'heading', :heading, %i[subheading subsubheading commodity1 second_commodity commodity3]
+        it_behaves_like 'it has descendants', 'subheading', :subheading, %i[subsubheading commodity1 second_commodity commodity3]
+        it_behaves_like 'it has descendants', 'nested subheading', :subsubheading, %i[commodity1 second_commodity]
         it_behaves_like 'it has descendants', 'leaf commodity', :commodity1, %i[]
         it_behaves_like 'it has descendants', 'second leaf commodity', :commodity3, %i[]
 
@@ -222,7 +222,7 @@ RSpec.describe GoodsNomenclatures::NestedSet do
         context 'with hidden_goods_nomenclatures' do
           before do
             create :hidden_goods_nomenclature,
-                   goods_nomenclature_item_id: tree[:commodity2].goods_nomenclature_item_id
+                   goods_nomenclature_item_id: tree[:second_commodity].goods_nomenclature_item_id
           end
 
           it_behaves_like 'it has descendants', 'nested subheading', :subsubheading, %i[commodity1]
@@ -244,13 +244,13 @@ RSpec.describe GoodsNomenclatures::NestedSet do
           context 'for eager loaded goods_nomenclatures childs descendants' do
             subject { eager_loaded.associations[:children].first.associations[:descendants] }
 
-            it { is_expected.to eq_pk tree.values_at(:commodity1, :commodity2) }
+            it { is_expected.to eq_pk tree.values_at(:commodity1, :second_commodity) }
           end
 
           context 'for eager loaded goods nomenclatures childs children' do
             subject { eager_loaded.associations[:children].first.associations[:children] }
 
-            it { is_expected.to eq_pk [tree[:commodity1], tree[:commodity2]] }
+            it { is_expected.to eq_pk [tree[:commodity1], tree[:second_commodity]] }
           end
 
           context 'for eager loaded goods nomenclatures childs parent' do
@@ -306,7 +306,7 @@ RSpec.describe GoodsNomenclatures::NestedSet do
         it_behaves_like 'it has children', 'chapter', :chapter, %i[heading]
         it_behaves_like 'it has children', 'heading', :heading, %i[subheading]
         it_behaves_like 'it has children', 'subheading', :subheading, %i[subsubheading commodity3]
-        it_behaves_like 'it has children', 'nested subheading', :subsubheading, %i[commodity1 commodity2]
+        it_behaves_like 'it has children', 'nested subheading', :subsubheading, %i[commodity1 second_commodity]
         it_behaves_like 'it has children', 'leaf commodity', :commodity1, %i[]
         it_behaves_like 'it has children', 'second leaf commodity', :commodity3, %i[]
 
@@ -347,7 +347,7 @@ RSpec.describe GoodsNomenclatures::NestedSet do
                  number_indents: 2
 
           create :goods_nomenclature_indent,
-                 goods_nomenclature: tree[:commodity2],
+                 goods_nomenclature: tree[:second_commodity],
                  validity_start_date: 1.week.ago.at_beginning_of_day,
                  number_indents: 2
         end
@@ -365,15 +365,15 @@ RSpec.describe GoodsNomenclatures::NestedSet do
         end
 
         describe '#descendants' do
-          it_behaves_like 'it has descendants', 'heading', :heading, %i[subheading subsubheading commodity1 commodity2 commodity3]
+          it_behaves_like 'it has descendants', 'heading', :heading, %i[subheading subsubheading commodity1 second_commodity commodity3]
           it_behaves_like 'it has descendants', 'subheading', :subheading, %i[]
-          it_behaves_like 'it has descendants', 'nested subheading', :subsubheading, %i[commodity1 commodity2 commodity3]
+          it_behaves_like 'it has descendants', 'nested subheading', :subsubheading, %i[commodity1 second_commodity commodity3]
         end
 
         describe '#children' do
           it_behaves_like 'it has children', 'heading', :heading, %i[subheading subsubheading]
           it_behaves_like 'it has children', 'subheading', :subheading, %i[]
-          it_behaves_like 'it has children', 'nested subheading', :subsubheading, %i[commodity1 commodity2 commodity3]
+          it_behaves_like 'it has children', 'nested subheading', :subsubheading, %i[commodity1 second_commodity commodity3]
         end
 
         context 'when accessing historical data via TimeMachine' do
@@ -396,15 +396,15 @@ RSpec.describe GoodsNomenclatures::NestedSet do
           end
 
           describe '#descendants' do
-            it_behaves_like 'it has descendants', 'heading', :heading, %i[subheading subsubheading commodity1 commodity2 commodity3]
-            it_behaves_like 'it has descendants', 'subheading', :subheading, %i[subsubheading commodity1 commodity2 commodity3]
-            it_behaves_like 'it has descendants', 'nested subheading', :subsubheading, %i[commodity1 commodity2]
+            it_behaves_like 'it has descendants', 'heading', :heading, %i[subheading subsubheading commodity1 second_commodity commodity3]
+            it_behaves_like 'it has descendants', 'subheading', :subheading, %i[subsubheading commodity1 second_commodity commodity3]
+            it_behaves_like 'it has descendants', 'nested subheading', :subsubheading, %i[commodity1 second_commodity]
           end
 
           describe '#children' do
             it_behaves_like 'it has children', 'heading', :heading, %i[subheading]
             it_behaves_like 'it has children', 'subheading', :subheading, %i[subsubheading commodity3]
-            it_behaves_like 'it has children', 'nested subheading', :subsubheading, %i[commodity1 commodity2]
+            it_behaves_like 'it has children', 'nested subheading', :subsubheading, %i[commodity1 second_commodity]
           end
         end
 

--- a/spec/models/goods_nomenclatures/tree_node_spec.rb
+++ b/spec/models/goods_nomenclatures/tree_node_spec.rb
@@ -139,19 +139,19 @@ RSpec.describe GoodsNomenclatures::TreeNode do
   end
 
   describe '.ancestor_node_constraints' do
-    subject { described_class.ancestor_node_constraints(table1, table2) }
+    subject { described_class.ancestor_node_constraints(first_table, second_table) }
 
-    let(:table1) { GoodsNomenclatures::TreeNodeAlias.new(:table1) }
-    let(:table2) { GoodsNomenclatures::TreeNodeAlias.new(:table2) }
+    let(:first_table) { GoodsNomenclatures::TreeNodeAlias.new(:first_table) }
+    let(:second_table) { GoodsNomenclatures::TreeNodeAlias.new(:second_table) }
 
     it { is_expected.to be_instance_of Sequel::SQL::BooleanExpression }
   end
 
   describe '.descendant_node_constraints' do
-    subject { described_class.descendant_node_constraints(table1, table2) }
+    subject { described_class.descendant_node_constraints(first_table, second_table) }
 
-    let(:table1) { GoodsNomenclatures::TreeNodeAlias.new(:table1) }
-    let(:table2) { GoodsNomenclatures::TreeNodeAlias.new(:table2) }
+    let(:first_table) { GoodsNomenclatures::TreeNodeAlias.new(:first_table) }
+    let(:second_table) { GoodsNomenclatures::TreeNodeAlias.new(:second_table) }
 
     it { is_expected.to be_instance_of Sequel::SQL::BooleanExpression }
   end

--- a/spec/models/heading_spec.rb
+++ b/spec/models/heading_spec.rb
@@ -87,11 +87,11 @@ RSpec.describe Heading do
   end
 
   describe '.by_code' do
-    let!(:heading1) { create(:heading, goods_nomenclature_item_id: '1234000000') }
-    let!(:heading2) { create(:heading, goods_nomenclature_item_id: '4321000000') }
+    let!(:first_heading) { create(:heading, goods_nomenclature_item_id: '1234000000') }
+    let!(:second_heading) { create(:heading, goods_nomenclature_item_id: '4321000000') }
 
     it { expect(described_class.by_code('1234')).to be_a(Sequel::Dataset) }
-    it { expect(described_class.by_code('1234')).to include(heading1) }
-    it { expect(described_class.by_code('1234')).not_to include(heading2) }
+    it { expect(described_class.by_code('1234')).to include(first_heading) }
+    it { expect(described_class.by_code('1234')).not_to include(second_heading) }
   end
 end

--- a/spec/models/news/item_spec.rb
+++ b/spec/models/news/item_spec.rb
@@ -310,16 +310,16 @@ RSpec.describe News::Item do
 
       let(:first_item_with_chapters) { create(:news_item, chapters: '01') }
       let(:second_item_with_chapters) { create(:news_item, chapters: '02') }
-      let(:first_and_second_item_with_chapters) { create(:news_item, chapters: '01,02') }
-      let(:third_and_fourth_item_with_chapters) { create(:news_item, chapters: '03,04') }
+      let(:item_with_chapters_one_and_two) { create(:news_item, chapters: '01,02') }
+      let(:item_with_chapters_three_and_four) { create(:news_item, chapters: '03,04') }
       let(:item_with_nil_chapters) { create(:news_item, chapters: nil) }
       let(:item_with_empty_chapters) { create(:news_item, chapters: '') }
 
       before do
         first_item_with_chapters
         second_item_with_chapters
-        first_and_second_item_with_chapters
-        third_and_fourth_item_with_chapters
+        item_with_chapters_one_and_two
+        item_with_chapters_three_and_four
         item_with_nil_chapters
         item_with_empty_chapters
       end
@@ -329,8 +329,8 @@ RSpec.describe News::Item do
 
         it 'returns all items' do
           expect(result.count).to eq(6)
-          expect(result).to include(first_item_with_chapters, second_item_with_chapters, first_and_second_item_with_chapters,
-                                    third_and_fourth_item_with_chapters, item_with_nil_chapters, item_with_empty_chapters)
+          expect(result).to include(first_item_with_chapters, second_item_with_chapters, item_with_chapters_one_and_two,
+                                    item_with_chapters_three_and_four, item_with_nil_chapters, item_with_empty_chapters)
         end
       end
 
@@ -339,8 +339,8 @@ RSpec.describe News::Item do
 
         it 'returns all items' do
           expect(result.count).to eq(6)
-          expect(result).to include(first_item_with_chapters, second_item_with_chapters, first_and_second_item_with_chapters,
-                                    third_and_fourth_item_with_chapters, item_with_nil_chapters, item_with_empty_chapters)
+          expect(result).to include(first_item_with_chapters, second_item_with_chapters, item_with_chapters_one_and_two,
+                                    item_with_chapters_three_and_four, item_with_nil_chapters, item_with_empty_chapters)
         end
       end
 
@@ -348,8 +348,8 @@ RSpec.describe News::Item do
         let(:chapters) { '01' }
 
         it 'returns items that include that chapter' do
-          expect(result).to include(first_item_with_chapters, first_and_second_item_with_chapters)
-          expect(result).not_to include(second_item_with_chapters, third_and_fourth_item_with_chapters)
+          expect(result).to include(first_item_with_chapters, item_with_chapters_one_and_two)
+          expect(result).not_to include(second_item_with_chapters, item_with_chapters_three_and_four)
         end
 
         it 'includes items with nil chapters' do
@@ -365,8 +365,8 @@ RSpec.describe News::Item do
         let(:chapters) { '01,02' }
 
         it 'returns items that include any of those chapters' do
-          expect(result).to include(first_item_with_chapters, second_item_with_chapters, first_and_second_item_with_chapters)
-          expect(result).not_to include(third_and_fourth_item_with_chapters)
+          expect(result).to include(first_item_with_chapters, second_item_with_chapters, item_with_chapters_one_and_two)
+          expect(result).not_to include(item_with_chapters_three_and_four)
         end
 
         it 'includes items with nil chapters' do
@@ -384,7 +384,7 @@ RSpec.describe News::Item do
         it 'returns only items with nil or empty chapters' do
           expect(result).to include(item_with_nil_chapters, item_with_empty_chapters)
           expect(result).not_to include(first_item_with_chapters, second_item_with_chapters,
-                                        first_and_second_item_with_chapters, third_and_fourth_item_with_chapters)
+                                        item_with_chapters_one_and_two, item_with_chapters_three_and_four)
         end
       end
 
@@ -392,8 +392,8 @@ RSpec.describe News::Item do
         let(:chapters) { ' 01 , 02 ' }
 
         it 'trims spaces and returns items that include any of those chapters' do
-          expect(result).to include(first_item_with_chapters, second_item_with_chapters, first_and_second_item_with_chapters)
-          expect(result).not_to include(third_and_fourth_item_with_chapters)
+          expect(result).to include(first_item_with_chapters, second_item_with_chapters, item_with_chapters_one_and_two)
+          expect(result).not_to include(item_with_chapters_three_and_four)
         end
       end
     end

--- a/spec/models/news/item_spec.rb
+++ b/spec/models/news/item_spec.rb
@@ -308,18 +308,18 @@ RSpec.describe News::Item do
     describe '.for_chapters' do
       subject(:result) { described_class.for_chapters(chapters) }
 
-      let(:item_with_chapters_01) { create(:news_item, chapters: '01') }
-      let(:item_with_chapters_02) { create(:news_item, chapters: '02') }
-      let(:item_with_chapters_01_02) { create(:news_item, chapters: '01,02') }
-      let(:item_with_chapters_03_04) { create(:news_item, chapters: '03,04') }
+      let(:first_item_with_chapters) { create(:news_item, chapters: '01') }
+      let(:second_item_with_chapters) { create(:news_item, chapters: '02') }
+      let(:first_and_second_item_with_chapters) { create(:news_item, chapters: '01,02') }
+      let(:third_and_fourth_item_with_chapters) { create(:news_item, chapters: '03,04') }
       let(:item_with_nil_chapters) { create(:news_item, chapters: nil) }
       let(:item_with_empty_chapters) { create(:news_item, chapters: '') }
 
       before do
-        item_with_chapters_01
-        item_with_chapters_02
-        item_with_chapters_01_02
-        item_with_chapters_03_04
+        first_item_with_chapters
+        second_item_with_chapters
+        first_and_second_item_with_chapters
+        third_and_fourth_item_with_chapters
         item_with_nil_chapters
         item_with_empty_chapters
       end
@@ -329,8 +329,8 @@ RSpec.describe News::Item do
 
         it 'returns all items' do
           expect(result.count).to eq(6)
-          expect(result).to include(item_with_chapters_01, item_with_chapters_02, item_with_chapters_01_02,
-                                    item_with_chapters_03_04, item_with_nil_chapters, item_with_empty_chapters)
+          expect(result).to include(first_item_with_chapters, second_item_with_chapters, first_and_second_item_with_chapters,
+                                    third_and_fourth_item_with_chapters, item_with_nil_chapters, item_with_empty_chapters)
         end
       end
 
@@ -339,8 +339,8 @@ RSpec.describe News::Item do
 
         it 'returns all items' do
           expect(result.count).to eq(6)
-          expect(result).to include(item_with_chapters_01, item_with_chapters_02, item_with_chapters_01_02,
-                                    item_with_chapters_03_04, item_with_nil_chapters, item_with_empty_chapters)
+          expect(result).to include(first_item_with_chapters, second_item_with_chapters, first_and_second_item_with_chapters,
+                                    third_and_fourth_item_with_chapters, item_with_nil_chapters, item_with_empty_chapters)
         end
       end
 
@@ -348,8 +348,8 @@ RSpec.describe News::Item do
         let(:chapters) { '01' }
 
         it 'returns items that include that chapter' do
-          expect(result).to include(item_with_chapters_01, item_with_chapters_01_02)
-          expect(result).not_to include(item_with_chapters_02, item_with_chapters_03_04)
+          expect(result).to include(first_item_with_chapters, first_and_second_item_with_chapters)
+          expect(result).not_to include(second_item_with_chapters, third_and_fourth_item_with_chapters)
         end
 
         it 'includes items with nil chapters' do
@@ -365,8 +365,8 @@ RSpec.describe News::Item do
         let(:chapters) { '01,02' }
 
         it 'returns items that include any of those chapters' do
-          expect(result).to include(item_with_chapters_01, item_with_chapters_02, item_with_chapters_01_02)
-          expect(result).not_to include(item_with_chapters_03_04)
+          expect(result).to include(first_item_with_chapters, second_item_with_chapters, first_and_second_item_with_chapters)
+          expect(result).not_to include(third_and_fourth_item_with_chapters)
         end
 
         it 'includes items with nil chapters' do
@@ -383,8 +383,8 @@ RSpec.describe News::Item do
 
         it 'returns only items with nil or empty chapters' do
           expect(result).to include(item_with_nil_chapters, item_with_empty_chapters)
-          expect(result).not_to include(item_with_chapters_01, item_with_chapters_02,
-                                        item_with_chapters_01_02, item_with_chapters_03_04)
+          expect(result).not_to include(first_item_with_chapters, second_item_with_chapters,
+                                        first_and_second_item_with_chapters, third_and_fourth_item_with_chapters)
         end
       end
 
@@ -392,8 +392,8 @@ RSpec.describe News::Item do
         let(:chapters) { ' 01 , 02 ' }
 
         it 'trims spaces and returns items that include any of those chapters' do
-          expect(result).to include(item_with_chapters_01, item_with_chapters_02, item_with_chapters_01_02)
-          expect(result).not_to include(item_with_chapters_03_04)
+          expect(result).to include(first_item_with_chapters, second_item_with_chapters, first_and_second_item_with_chapters)
+          expect(result).not_to include(third_and_fourth_item_with_chapters)
         end
       end
     end

--- a/spec/models/public_users/user_spec.rb
+++ b/spec/models/public_users/user_spec.rb
@@ -297,7 +297,7 @@ RSpec.describe PublicUsers::User do
       let(:user_with_chapters_two_and_three) { create(:public_user, :with_chapters_preference, chapters: '02,03') }
       let(:user_with_chapters_three_and_four) { create(:public_user, :with_chapters_preference, chapters: '03,04') }
       let(:fourth_user_with_chapter) { create(:public_user, :with_chapters_preference, chapters: '04') }
-      let(:user_with_chapter_1_2_3_4) { create(:public_user, :with_chapters_preference, chapters: '01,02,03,04') }
+      let(:user_with_chapters_one_to_four) { create(:public_user, :with_chapters_preference, chapters: '01,02,03,04') }
       let(:user_with_nil_preference) { create(:public_user, :with_chapters_preference, chapters: nil) }
       let(:user_with_empty_preference) { create(:public_user, :with_chapters_preference, chapters: '') }
 
@@ -306,7 +306,7 @@ RSpec.describe PublicUsers::User do
         user_with_chapters_two_and_three
         user_with_chapters_three_and_four
         fourth_user_with_chapter
-        user_with_chapter_1_2_3_4
+        user_with_chapters_one_to_four
         user_with_nil_preference
         user_with_empty_preference
       end
@@ -320,7 +320,7 @@ RSpec.describe PublicUsers::User do
             user_with_chapters_two_and_three,
             user_with_chapters_three_and_four,
             fourth_user_with_chapter,
-            user_with_chapter_1_2_3_4,
+            user_with_chapters_one_to_four,
             user_with_nil_preference,
             user_with_empty_preference,
           )
@@ -336,7 +336,7 @@ RSpec.describe PublicUsers::User do
             user_with_chapters_two_and_three,
             user_with_chapters_three_and_four,
             fourth_user_with_chapter,
-            user_with_chapter_1_2_3_4,
+            user_with_chapters_one_to_four,
             user_with_nil_preference,
             user_with_empty_preference,
           )
@@ -347,7 +347,7 @@ RSpec.describe PublicUsers::User do
         let(:chapters) { %w[01] }
 
         it 'returns expected users' do
-          expect(dataset).to contain_exactly(first_user_with_chapter, user_with_chapter_1_2_3_4, user_with_nil_preference, user_with_empty_preference)
+          expect(dataset).to contain_exactly(first_user_with_chapter, user_with_chapters_one_to_four, user_with_nil_preference, user_with_empty_preference)
         end
       end
 
@@ -355,7 +355,7 @@ RSpec.describe PublicUsers::User do
         let(:chapters) { '01' }
 
         it 'returns expected users' do
-          expect(dataset).to contain_exactly(first_user_with_chapter, user_with_chapter_1_2_3_4, user_with_nil_preference, user_with_empty_preference)
+          expect(dataset).to contain_exactly(first_user_with_chapter, user_with_chapters_one_to_four, user_with_nil_preference, user_with_empty_preference)
         end
       end
 
@@ -363,7 +363,7 @@ RSpec.describe PublicUsers::User do
         let(:chapters) { %w[01 02] }
 
         it 'returns expected users' do
-          expect(dataset).to contain_exactly(first_user_with_chapter, user_with_chapters_two_and_three, user_with_chapter_1_2_3_4, user_with_nil_preference, user_with_empty_preference)
+          expect(dataset).to contain_exactly(first_user_with_chapter, user_with_chapters_two_and_three, user_with_chapters_one_to_four, user_with_nil_preference, user_with_empty_preference)
         end
       end
     end

--- a/spec/models/public_users/user_spec.rb
+++ b/spec/models/public_users/user_spec.rb
@@ -294,8 +294,8 @@ RSpec.describe PublicUsers::User do
       subject(:dataset) { described_class.matching_chapters(chapters) }
 
       let(:first_user_with_chapter) { create(:public_user, :with_chapters_preference, chapters: '01') }
-      let(:second_and_third_user_with_chapter) { create(:public_user, :with_chapters_preference, chapters: '02,03') }
-      let(:third_and_fourth_user_with_chapter) { create(:public_user, :with_chapters_preference, chapters: '03,04') }
+      let(:user_with_chapters_two_and_three) { create(:public_user, :with_chapters_preference, chapters: '02,03') }
+      let(:user_with_chapters_three_and_four) { create(:public_user, :with_chapters_preference, chapters: '03,04') }
       let(:fourth_user_with_chapter) { create(:public_user, :with_chapters_preference, chapters: '04') }
       let(:user_with_chapter_1_2_3_4) { create(:public_user, :with_chapters_preference, chapters: '01,02,03,04') }
       let(:user_with_nil_preference) { create(:public_user, :with_chapters_preference, chapters: nil) }
@@ -303,8 +303,8 @@ RSpec.describe PublicUsers::User do
 
       before do
         first_user_with_chapter
-        second_and_third_user_with_chapter
-        third_and_fourth_user_with_chapter
+        user_with_chapters_two_and_three
+        user_with_chapters_three_and_four
         fourth_user_with_chapter
         user_with_chapter_1_2_3_4
         user_with_nil_preference
@@ -317,8 +317,8 @@ RSpec.describe PublicUsers::User do
         it 'returns all users' do
           expect(dataset).to contain_exactly(
             first_user_with_chapter,
-            second_and_third_user_with_chapter,
-            third_and_fourth_user_with_chapter,
+            user_with_chapters_two_and_three,
+            user_with_chapters_three_and_four,
             fourth_user_with_chapter,
             user_with_chapter_1_2_3_4,
             user_with_nil_preference,
@@ -333,8 +333,8 @@ RSpec.describe PublicUsers::User do
         it 'returns all users' do
           expect(dataset).to contain_exactly(
             first_user_with_chapter,
-            second_and_third_user_with_chapter,
-            third_and_fourth_user_with_chapter,
+            user_with_chapters_two_and_three,
+            user_with_chapters_three_and_four,
             fourth_user_with_chapter,
             user_with_chapter_1_2_3_4,
             user_with_nil_preference,
@@ -363,7 +363,7 @@ RSpec.describe PublicUsers::User do
         let(:chapters) { %w[01 02] }
 
         it 'returns expected users' do
-          expect(dataset).to contain_exactly(first_user_with_chapter, second_and_third_user_with_chapter, user_with_chapter_1_2_3_4, user_with_nil_preference, user_with_empty_preference)
+          expect(dataset).to contain_exactly(first_user_with_chapter, user_with_chapters_two_and_three, user_with_chapter_1_2_3_4, user_with_nil_preference, user_with_empty_preference)
         end
       end
     end

--- a/spec/models/public_users/user_spec.rb
+++ b/spec/models/public_users/user_spec.rb
@@ -293,19 +293,19 @@ RSpec.describe PublicUsers::User do
     describe '.matching_chapters' do
       subject(:dataset) { described_class.matching_chapters(chapters) }
 
-      let(:user_with_chapter_1) { create(:public_user, :with_chapters_preference, chapters: '01') }
-      let(:user_with_chapter_2_3) { create(:public_user, :with_chapters_preference, chapters: '02,03') }
-      let(:user_with_chapter_3_4) { create(:public_user, :with_chapters_preference, chapters: '03,04') }
-      let(:user_with_chapter_4) { create(:public_user, :with_chapters_preference, chapters: '04') }
+      let(:first_user_with_chapter) { create(:public_user, :with_chapters_preference, chapters: '01') }
+      let(:second_and_third_user_with_chapter) { create(:public_user, :with_chapters_preference, chapters: '02,03') }
+      let(:third_and_fourth_user_with_chapter) { create(:public_user, :with_chapters_preference, chapters: '03,04') }
+      let(:fourth_user_with_chapter) { create(:public_user, :with_chapters_preference, chapters: '04') }
       let(:user_with_chapter_1_2_3_4) { create(:public_user, :with_chapters_preference, chapters: '01,02,03,04') }
       let(:user_with_nil_preference) { create(:public_user, :with_chapters_preference, chapters: nil) }
       let(:user_with_empty_preference) { create(:public_user, :with_chapters_preference, chapters: '') }
 
       before do
-        user_with_chapter_1
-        user_with_chapter_2_3
-        user_with_chapter_3_4
-        user_with_chapter_4
+        first_user_with_chapter
+        second_and_third_user_with_chapter
+        third_and_fourth_user_with_chapter
+        fourth_user_with_chapter
         user_with_chapter_1_2_3_4
         user_with_nil_preference
         user_with_empty_preference
@@ -316,10 +316,10 @@ RSpec.describe PublicUsers::User do
 
         it 'returns all users' do
           expect(dataset).to contain_exactly(
-            user_with_chapter_1,
-            user_with_chapter_2_3,
-            user_with_chapter_3_4,
-            user_with_chapter_4,
+            first_user_with_chapter,
+            second_and_third_user_with_chapter,
+            third_and_fourth_user_with_chapter,
+            fourth_user_with_chapter,
             user_with_chapter_1_2_3_4,
             user_with_nil_preference,
             user_with_empty_preference,
@@ -332,10 +332,10 @@ RSpec.describe PublicUsers::User do
 
         it 'returns all users' do
           expect(dataset).to contain_exactly(
-            user_with_chapter_1,
-            user_with_chapter_2_3,
-            user_with_chapter_3_4,
-            user_with_chapter_4,
+            first_user_with_chapter,
+            second_and_third_user_with_chapter,
+            third_and_fourth_user_with_chapter,
+            fourth_user_with_chapter,
             user_with_chapter_1_2_3_4,
             user_with_nil_preference,
             user_with_empty_preference,
@@ -347,7 +347,7 @@ RSpec.describe PublicUsers::User do
         let(:chapters) { %w[01] }
 
         it 'returns expected users' do
-          expect(dataset).to contain_exactly(user_with_chapter_1, user_with_chapter_1_2_3_4, user_with_nil_preference, user_with_empty_preference)
+          expect(dataset).to contain_exactly(first_user_with_chapter, user_with_chapter_1_2_3_4, user_with_nil_preference, user_with_empty_preference)
         end
       end
 
@@ -355,7 +355,7 @@ RSpec.describe PublicUsers::User do
         let(:chapters) { '01' }
 
         it 'returns expected users' do
-          expect(dataset).to contain_exactly(user_with_chapter_1, user_with_chapter_1_2_3_4, user_with_nil_preference, user_with_empty_preference)
+          expect(dataset).to contain_exactly(first_user_with_chapter, user_with_chapter_1_2_3_4, user_with_nil_preference, user_with_empty_preference)
         end
       end
 
@@ -363,7 +363,7 @@ RSpec.describe PublicUsers::User do
         let(:chapters) { %w[01 02] }
 
         it 'returns expected users' do
-          expect(dataset).to contain_exactly(user_with_chapter_1, user_with_chapter_2_3, user_with_chapter_1_2_3_4, user_with_nil_preference, user_with_empty_preference)
+          expect(dataset).to contain_exactly(first_user_with_chapter, second_and_third_user_with_chapter, user_with_chapter_1_2_3_4, user_with_nil_preference, user_with_empty_preference)
         end
       end
     end

--- a/spec/models/tariff_change_spec.rb
+++ b/spec/models/tariff_change_spec.rb
@@ -91,28 +91,28 @@ RSpec.describe TariffChange do
     let(:operation_date) { Date.new(2025, 1, 15) }
 
     context 'when there are tariff changes for the given operation date' do
-      let(:matching_change1) { create(:tariff_change, operation_date: operation_date) }
-      let(:matching_change2) { create(:tariff_change, operation_date: operation_date) }
+      let(:first_matching_change) { create(:tariff_change, operation_date: operation_date) }
+      let(:second_matching_change) { create(:tariff_change, operation_date: operation_date) }
       let(:non_matching_change) { create(:tariff_change, operation_date: operation_date + 1.day) }
 
       it 'deletes all tariff changes for that date' do
-        matching_change1 # ensure record exists
-        matching_change2 # ensure record exists
+        first_matching_change # ensure record exists
+        second_matching_change # ensure record exists
         expect { described_class.delete_for(operation_date: operation_date) }
           .to change(described_class, :count).by(-2)
       end
 
       it 'does not delete tariff changes for other dates' do
-        matching_change1 # ensure records exist
-        matching_change2 # ensure records exist
+        first_matching_change # ensure records exist
+        second_matching_change # ensure records exist
         described_class.delete_for(operation_date: operation_date)
 
         expect(described_class.where(id: non_matching_change.id).first).not_to be_nil
       end
 
       it 'returns the number of deleted records' do
-        matching_change1 # ensure records exist
-        matching_change2 # ensure records exist
+        first_matching_change # ensure records exist
+        second_matching_change # ensure records exist
         result = described_class.delete_for(operation_date: operation_date)
 
         expect(result).to eq(2)
@@ -170,15 +170,15 @@ RSpec.describe TariffChange do
   end
 
   describe '.measures' do
-    let!(:measure_change1) { create(:tariff_change, type: 'Measure') }
-    let!(:measure_change2) { create(:tariff_change, type: 'Measure') }
+    let!(:first_measure_change) { create(:tariff_change, type: 'Measure') }
+    let!(:second_measure_change) { create(:tariff_change, type: 'Measure') }
     let!(:commodity_change) { create(:tariff_change, type: 'Commodity') }
     let!(:other_change) { create(:tariff_change, type: 'SomeOtherType') }
 
     it 'returns only tariff changes with type Measure' do
       result = described_class.measures.all
 
-      expect(result).to contain_exactly(measure_change1, measure_change2)
+      expect(result).to contain_exactly(first_measure_change, second_measure_change)
       expect(result).not_to include(commodity_change, other_change)
     end
 
@@ -194,13 +194,13 @@ RSpec.describe TariffChange do
       operation_date = Date.current
       different_date = Date.current + 1.day
 
-      measure_change1.update(operation_date: operation_date)
-      measure_change2.update(operation_date: different_date)
+      first_measure_change.update(operation_date: operation_date)
+      second_measure_change.update(operation_date: different_date)
 
       result = described_class.measures.where(operation_date: operation_date).all
 
-      expect(result).to contain_exactly(measure_change1)
-      expect(result).not_to include(measure_change2)
+      expect(result).to contain_exactly(first_measure_change)
+      expect(result).not_to include(second_measure_change)
     end
   end
 

--- a/spec/models/tariff_changes/grouped_measure_change_spec.rb
+++ b/spec/models/tariff_changes/grouped_measure_change_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe TariffChanges::GroupedMeasureChange do
 
   let(:excluded_area_ids) { %w[FR DE] }
   let!(:geographical_area) { create(:geographical_area, :with_description, geographical_area_id: 'GB') }
-  let!(:excluded_area_1) { create(:geographical_area, :with_description, geographical_area_id: 'FR') }
-  let!(:excluded_area_2) { create(:geographical_area, :with_description, geographical_area_id: 'DE') }
+  let!(:first_excluded_area) { create(:geographical_area, :with_description, geographical_area_id: 'FR') }
+  let!(:second_excluded_area) { create(:geographical_area, :with_description, geographical_area_id: 'DE') }
 
   describe '#geographical_area' do
     context 'when geographical_area_id is present' do
@@ -61,7 +61,7 @@ RSpec.describe TariffChanges::GroupedMeasureChange do
     context 'when excluded_geographical_area_ids is an array' do
       it 'returns the corresponding GeographicalAreas' do
         result = grouped_measure_change.excluded_geographical_areas
-        expect(result).to contain_exactly(excluded_area_1, excluded_area_2)
+        expect(result).to contain_exactly(first_excluded_area, second_excluded_area)
       end
 
       it 'returns areas ordered by geographical_area_id' do
@@ -81,7 +81,7 @@ RSpec.describe TariffChanges::GroupedMeasureChange do
 
       it 'converts to array and returns the corresponding GeographicalArea' do
         result = grouped_measure_change.excluded_geographical_areas
-        expect(result).to contain_exactly(excluded_area_1)
+        expect(result).to contain_exactly(first_excluded_area)
       end
     end
 
@@ -90,7 +90,7 @@ RSpec.describe TariffChanges::GroupedMeasureChange do
 
       it 'filters out nil values and returns valid GeographicalAreas' do
         result = grouped_measure_change.excluded_geographical_areas
-        expect(result).to contain_exactly(excluded_area_1, excluded_area_2)
+        expect(result).to contain_exactly(first_excluded_area, second_excluded_area)
       end
     end
 
@@ -123,7 +123,7 @@ RSpec.describe TariffChanges::GroupedMeasureChange do
 
       it 'returns only the existing GeographicalAreas' do
         result = grouped_measure_change.excluded_geographical_areas
-        expect(result).to contain_exactly(excluded_area_1, excluded_area_2)
+        expect(result).to contain_exactly(first_excluded_area, second_excluded_area)
       end
     end
 

--- a/spec/models/tariff_changes/grouped_measure_commodity_change_spec.rb
+++ b/spec/models/tariff_changes/grouped_measure_commodity_change_spec.rb
@@ -524,11 +524,11 @@ RSpec.describe TariffChanges::GroupedMeasureCommodityChange do
         )
       end
 
-      let(:import_measure_type_2) { create(:measure_type, :import, measure_type_id: '999') }
-      let(:measure_4) do
+      let(:secondary_import_measure_type) { create(:measure_type, :import, measure_type_id: '999') }
+      let(:secondary_import_measure) do
         create(:measure,
                measure_sid: 400,
-               measure_type_id: import_measure_type_2.measure_type_id,
+               measure_type_id: secondary_import_measure_type.measure_type_id,
                geographical_area_id: 'GB',
                geographical_area_sid: geographical_area.geographical_area_sid)
       end
@@ -536,18 +536,18 @@ RSpec.describe TariffChanges::GroupedMeasureCommodityChange do
       before do
         geographical_area
         import_measure_type
-        import_measure_type_2
+        secondary_import_measure_type
 
         create(:tariff_change,
                type: 'Measure',
-               object_sid: measure_4.measure_sid,
+               object_sid: secondary_import_measure.measure_sid,
                operation_date: date,
                goods_nomenclature_item_id: '1234567890',
                metadata: {
                  'measure' => {
-                   'measure_type_id' => measure_4.measure_type_id,
-                   'trade_movement_code' => import_measure_type_2.trade_movement_code,
-                   'geographical_area_id' => measure_4.geographical_area_id,
+                   'measure_type_id' => secondary_import_measure.measure_type_id,
+                   'trade_movement_code' => secondary_import_measure_type.trade_movement_code,
+                   'geographical_area_id' => secondary_import_measure.geographical_area_id,
                    'excluded_geographical_area_ids' => [],
                  },
                })
@@ -577,10 +577,10 @@ RSpec.describe TariffChanges::GroupedMeasureCommodityChange do
         result = grouped_commodity_change.measure_changes(date)
 
         expect(result).to be_a(Hash)
-        expect(result.keys).to contain_exactly(import_measure_type.description, import_measure_type_2.description)
+        expect(result.keys).to contain_exactly(import_measure_type.description, secondary_import_measure_type.description)
 
         expect(result[import_measure_type.description]).to all(be_a(Hash))
-        expect(result[import_measure_type_2.description]).to all(be_a(Hash))
+        expect(result[secondary_import_measure_type.description]).to all(be_a(Hash))
 
         expect(result.values.flatten).to all(
           include(:measure_sid, :date_of_effect, :change_type, :additional_code, :quota_order_number),

--- a/spec/models/tariff_changes/grouped_measure_commodity_change_spec.rb
+++ b/spec/models/tariff_changes/grouped_measure_commodity_change_spec.rb
@@ -250,8 +250,8 @@ RSpec.describe TariffChanges::GroupedMeasureCommodityChange do
   describe '#measure_changes' do
     let(:date) { Date.parse('2023-01-15') }
     let(:geographical_area) { create(:geographical_area, geographical_area_id: 'GB') }
-    let(:excluded_area_1) { create(:geographical_area, geographical_area_id: 'FR') }
-    let(:excluded_area_2) { create(:geographical_area, geographical_area_id: 'DE') }
+    let(:first_excluded_area) { create(:geographical_area, geographical_area_id: 'FR') }
+    let(:second_excluded_area) { create(:geographical_area, geographical_area_id: 'DE') }
     let(:import_measure_type) { create(:measure_type, :import) }
     let(:export_measure_type) { create(:measure_type, :export) }
 
@@ -270,7 +270,7 @@ RSpec.describe TariffChanges::GroupedMeasureCommodityChange do
     end
 
     context 'when grouped_measure_change exists' do
-      let(:measure_1) do
+      let(:first_measure) do
         create(:measure,
                measure_sid: 100,
                measure_type_id: import_measure_type.measure_type_id,
@@ -278,7 +278,7 @@ RSpec.describe TariffChanges::GroupedMeasureCommodityChange do
                geographical_area_sid: geographical_area.geographical_area_sid)
       end
 
-      let(:measure_2) do
+      let(:second_measure) do
         create(:measure,
                measure_sid: 200,
                measure_type_id: export_measure_type.measure_type_id,
@@ -286,7 +286,7 @@ RSpec.describe TariffChanges::GroupedMeasureCommodityChange do
                geographical_area_sid: geographical_area.geographical_area_sid)
       end
 
-      let(:measure_3) do
+      let(:third_measure) do
         create(:measure,
                measure_sid: 300,
                measure_type_id: import_measure_type.measure_type_id,
@@ -295,33 +295,33 @@ RSpec.describe TariffChanges::GroupedMeasureCommodityChange do
 
       before do
         geographical_area
-        excluded_area_1
-        excluded_area_2
+        first_excluded_area
+        second_excluded_area
         import_measure_type
         export_measure_type
 
         create(:measure_excluded_geographical_area,
-               measure_sid: measure_1.measure_sid,
+               measure_sid: first_measure.measure_sid,
                excluded_geographical_area: 'FR')
         create(:measure_excluded_geographical_area,
-               measure_sid: measure_1.measure_sid,
+               measure_sid: first_measure.measure_sid,
                excluded_geographical_area: 'DE')
 
         create(:tariff_change,
                type: 'Measure',
-               object_sid: measure_1.measure_sid,
+               object_sid: first_measure.measure_sid,
                operation_date: date,
                goods_nomenclature_item_id: '1234567890')
 
         create(:tariff_change,
                type: 'Measure',
-               object_sid: measure_2.measure_sid,
+               object_sid: second_measure.measure_sid,
                operation_date: date,
                goods_nomenclature_item_id: '1234567890')
 
         create(:tariff_change,
                type: 'Measure',
-               object_sid: measure_3.measure_sid,
+               object_sid: third_measure.measure_sid,
                operation_date: date,
                goods_nomenclature_item_id: '1234567890')
       end
@@ -381,7 +381,7 @@ RSpec.describe TariffChanges::GroupedMeasureCommodityChange do
                  date_of_effect: Date.parse('2023-01-10'),
                  goods_nomenclature_item_id: '1234567890')
 
-          late_change = TariffChange.find(type: 'Measure', object_sid: measure_1.measure_sid, operation_date: date)
+          late_change = TariffChange.find(type: 'Measure', object_sid: first_measure.measure_sid, operation_date: date)
           late_change.update(date_of_effect: Date.parse('2023-01-20'))
 
           result = grouped_commodity_change.measure_changes(date)

--- a/spec/presenters/api/v2/chapters/headings_presenter_spec.rb
+++ b/spec/presenters/api/v2/chapters/headings_presenter_spec.rb
@@ -18,10 +18,10 @@ RSpec.describe Api::V2::Chapters::HeadingPresenter do
     end
 
     context 'when some are nested' do
-      let(:headings) { [nongrouping1, grouping] + nongrouping }
-      let(:nongrouping1) { build :heading, :non_grouping }
+      let(:headings) { [first_nongrouping_heading, grouping] + nongrouping }
+      let(:first_nongrouping_heading) { build :heading, :non_grouping }
 
-      it { is_expected.to eq(nongrouping1 => nil, grouping => nongrouping) }
+      it { is_expected.to eq(first_nongrouping_heading => nil, grouping => nongrouping) }
     end
 
     context 'when pls decreases again' do
@@ -34,10 +34,10 @@ RSpec.describe Api::V2::Chapters::HeadingPresenter do
 
     context 'with multiple trees in set' do
       let(:second_grouping) { build :heading, :grouping }
-      let(:nongrouping2) { build_list :heading, 2, :non_grouping }
-      let(:headings) { [grouping] + nongrouping + [second_grouping] + nongrouping2 }
+      let(:second_nongrouping_headings) { build_list :heading, 2, :non_grouping }
+      let(:headings) { [grouping] + nongrouping + [second_grouping] + second_nongrouping_headings }
 
-      it { is_expected.to eq grouping => nongrouping, second_grouping => nongrouping2 }
+      it { is_expected.to eq grouping => nongrouping, second_grouping => second_nongrouping_headings }
     end
   end
 

--- a/spec/presenters/api/v2/chapters/headings_presenter_spec.rb
+++ b/spec/presenters/api/v2/chapters/headings_presenter_spec.rb
@@ -25,19 +25,19 @@ RSpec.describe Api::V2::Chapters::HeadingPresenter do
     end
 
     context 'when pls decreases again' do
-      let(:grouping2) { build :heading, :grouping }
-      let(:grouping3) { build :heading, :grouping }
-      let(:headings) { [grouping] + nongrouping + [grouping2, grouping3] }
+      let(:second_grouping) { build :heading, :grouping }
+      let(:third_grouping) { build :heading, :grouping }
+      let(:headings) { [grouping] + nongrouping + [second_grouping, third_grouping] }
 
-      it { is_expected.to eq grouping => nongrouping, grouping2 => nil, grouping3 => nil }
+      it { is_expected.to eq grouping => nongrouping, second_grouping => nil, third_grouping => nil }
     end
 
     context 'with multiple trees in set' do
-      let(:grouping2) { build :heading, :grouping }
+      let(:second_grouping) { build :heading, :grouping }
       let(:nongrouping2) { build_list :heading, 2, :non_grouping }
-      let(:headings) { [grouping] + nongrouping + [grouping2] + nongrouping2 }
+      let(:headings) { [grouping] + nongrouping + [second_grouping] + nongrouping2 }
 
-      it { is_expected.to eq grouping => nongrouping, grouping2 => nongrouping2 }
+      it { is_expected.to eq grouping => nongrouping, second_grouping => nongrouping2 }
     end
   end
 

--- a/spec/presenters/api/v2/green_lanes/goods_nomenclature_presenter_spec.rb
+++ b/spec/presenters/api/v2/green_lanes/goods_nomenclature_presenter_spec.rb
@@ -113,14 +113,14 @@ RSpec.describe Api::V2::GreenLanes::GoodsNomenclaturePresenter do
     subject { presenter.descendant_category_assessments }
 
     let(:gn) { create :goods_nomenclature, :with_ancestors, :with_children }
-    let(:measures) { [measure, measure2] }
+    let(:measures) { [measure, second_measure] }
 
     let :measure do
       create :measure, goods_nomenclature: gn.children.first,
                        generating_regulation: create(:base_regulation)
     end
 
-    let :measure2 do
+    let :second_measure do
       create :measure, goods_nomenclature: gn.children.first.children.first,
                        generating_regulation: create(:base_regulation)
     end
@@ -136,7 +136,7 @@ RSpec.describe Api::V2::GreenLanes::GoodsNomenclaturePresenter do
         create_list :category_assessment, 1, measure: measures.first
       end
 
-      let :measure2 do
+      let :second_measure do
         create :measure, goods_nomenclature: gn.children.first.children.first,
                          measure_type_id: measure.measure_type_id,
                          generating_regulation: measure.generating_regulation,
@@ -151,7 +151,7 @@ RSpec.describe Api::V2::GreenLanes::GoodsNomenclaturePresenter do
         create_list :category_assessment, 1, measure: measures.first
       end
 
-      let :measure2 do
+      let :second_measure do
         create :measure, goods_nomenclature: gn.children.first.children.first,
                          measure_type_id: measure.measure_type_id,
                          generating_regulation: measure.generating_regulation

--- a/spec/presenters/label_batch_presenter_spec.rb
+++ b/spec/presenters/label_batch_presenter_spec.rb
@@ -93,8 +93,8 @@ RSpec.describe LabelBatchPresenter do
     end
 
     context 'with multiple commodities in a batch' do
-      let(:commodity2) { create(:commodity, :with_description) }
-      let(:batch) { [commodity, commodity2] }
+      let(:second_commodity) { create(:commodity, :with_description) }
+      let(:batch) { [commodity, second_commodity] }
 
       before do
         create(:goods_nomenclature_self_text,
@@ -102,14 +102,14 @@ RSpec.describe LabelBatchPresenter do
                goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
                self_text: 'First self-text')
         create(:goods_nomenclature_self_text,
-               goods_nomenclature_sid: commodity2.goods_nomenclature_sid,
-               goods_nomenclature_item_id: commodity2.goods_nomenclature_item_id,
+               goods_nomenclature_sid: second_commodity.goods_nomenclature_sid,
+               goods_nomenclature_item_id: second_commodity.goods_nomenclature_item_id,
                self_text: 'Second self-text')
       end
 
       it 'batch-loads all self-texts' do
         expect(presenter.contextual_description_for(commodity)).to eq('First self-text')
-        expect(presenter.contextual_description_for(commodity2)).to eq('Second self-text')
+        expect(presenter.contextual_description_for(second_commodity)).to eq('Second self-text')
       end
     end
   end

--- a/spec/requests/api/user/grouped_measure_changes_controller_spec.rb
+++ b/spec/requests/api/user/grouped_measure_changes_controller_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe Api::User::GroupedMeasureChangesController do
   describe '#index' do
     let(:measure_changes_service) { instance_double(Api::User::GroupedMeasureChangesService) }
     let(:geographical_area) { create(:geographical_area, :with_description, geographical_area_id: 'GB') }
-    let(:excluded_area_1) { create(:geographical_area, :with_description, geographical_area_id: 'FR') }
-    let(:excluded_area_2) { create(:geographical_area, :with_description, geographical_area_id: 'DE') }
+    let(:first_excluded_area) { create(:geographical_area, :with_description, geographical_area_id: 'FR') }
+    let(:second_excluded_area) { create(:geographical_area, :with_description, geographical_area_id: 'DE') }
     let(:grouped_measure_change) do
       TariffChanges::GroupedMeasureChange.new(
         trade_direction: 'import',

--- a/spec/requests/api/v1/sections_controller_spec.rb
+++ b/spec/requests/api/v1/sections_controller_spec.rb
@@ -34,10 +34,10 @@ RSpec.describe Api::V1::SectionsController do
   end
 
   describe 'GET #index' do
-    let!(:chapter1) { create :chapter, :with_section }
-    let!(:chapter2) { create :chapter, :with_section }
-    let(:section1)  { chapter1.section }
-    let(:section2)  { chapter2.section }
+    let!(:first_chapter) { create :chapter, :with_section }
+    let!(:second_chapter) { create :chapter, :with_section }
+    let(:first_section) { first_chapter.section }
+    let(:second_section) { second_chapter.section }
 
     let(:pattern) do
       [

--- a/spec/requests/api/v2/chapters_controller_migrated_spec.rb
+++ b/spec/requests/api/v2/chapters_controller_migrated_spec.rb
@@ -134,28 +134,28 @@ RSpec.describe Api::V2::ChaptersController do
   end
 
   describe 'GET #index' do
-    let!(:chapter1) { create :chapter, :with_section, :with_note }
-    let!(:chapter2) { create :chapter, :with_section, :with_note }
+    let!(:first_chapter) { create :chapter, :with_section, :with_note }
+    let!(:second_chapter) { create :chapter, :with_section, :with_note }
 
     let(:pattern) do
       {
         data: [
           {
-            id: chapter1.goods_nomenclature_sid.to_s,
+            id: first_chapter.goods_nomenclature_sid.to_s,
             type: 'chapter',
             attributes: {
-              goods_nomenclature_sid: chapter1.goods_nomenclature_sid,
-              goods_nomenclature_item_id: chapter1.goods_nomenclature_item_id,
-              formatted_description: chapter1.formatted_description,
+              goods_nomenclature_sid: first_chapter.goods_nomenclature_sid,
+              goods_nomenclature_item_id: first_chapter.goods_nomenclature_item_id,
+              formatted_description: first_chapter.formatted_description,
             },
           },
           {
-            id: chapter2.goods_nomenclature_sid.to_s,
+            id: second_chapter.goods_nomenclature_sid.to_s,
             type: 'chapter',
             attributes: {
-              goods_nomenclature_sid: chapter2.goods_nomenclature_sid,
-              goods_nomenclature_item_id: chapter2.goods_nomenclature_item_id,
-              formatted_description: chapter2.formatted_description,
+              goods_nomenclature_sid: second_chapter.goods_nomenclature_sid,
+              goods_nomenclature_item_id: second_chapter.goods_nomenclature_item_id,
+              formatted_description: second_chapter.formatted_description,
             },
           },
         ],
@@ -176,7 +176,7 @@ RSpec.describe Api::V2::ChaptersController do
       attributes = JSON.parse(response.body).fetch('data').first.fetch('attributes')
 
       expect(attributes).to eq(
-        'formatted_description' => chapter1.formatted_description,
+        'formatted_description' => first_chapter.formatted_description,
       )
     end
   end

--- a/spec/requests/api/v2/chemicals_controller_spec.rb
+++ b/spec/requests/api/v2/chemicals_controller_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Api::V2::ChemicalsController, type: :request do
-  let(:chemical1) { create :chemical, :with_name }
+  let(:named_chemical) { create :chemical, :with_name }
   let(:goods_nomenclature) { create :goods_nomenclature }
-  let(:chemical_gn_association) { create :chemicals_goods_nomenclatures, chemical_id: chemical1.id, goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid }
+  let(:chemical_gn_association) { create :chemicals_goods_nomenclatures, chemical_id: named_chemical.id, goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid }
 
   let(:api_short_object_pattern) do
     {
@@ -151,7 +151,7 @@ RSpec.describe Api::V2::ChemicalsController, type: :request do
 
   context 'with the `:id` (i.e., CAS number) parameter, GET #show' do
     it 'returns one record' do
-      get "/uk/api/chemicals/#{chemical1.cas}.json", headers: request_headers(format: :json)
+      get "/uk/api/chemicals/#{named_chemical.cas}.json", headers: request_headers(format: :json)
 
       expect(response.body).to match_json_expression api_long_object_pattern
     end
@@ -159,7 +159,7 @@ RSpec.describe Api::V2::ChemicalsController, type: :request do
 
   context 'with the `:cas` (i.e., CAS number) parameter, GET #search' do
     it 'returns all matching records (which should normally be one record), as a collection' do
-      get '/uk/api/chemicals/search.json', params: { cas: chemical1.cas }, headers: request_headers(format: :json)
+      get '/uk/api/chemicals/search.json', params: { cas: named_chemical.cas }, headers: request_headers(format: :json)
 
       expect(response.body).to match_json_expression search_long_collection_pattern
     end
@@ -167,7 +167,7 @@ RSpec.describe Api::V2::ChemicalsController, type: :request do
 
   context 'with the `:name` (i.e., partial chemical name) parameter, GET #search' do
     it 'returns all matching records as a collection' do
-      get '/uk/api/chemicals/search.json', params: { name: chemical1.name[1..5] }, headers: request_headers(format: :json)
+      get '/uk/api/chemicals/search.json', params: { name: named_chemical.name[1..5] }, headers: request_headers(format: :json)
 
       expect(response.body).to match_json_expression search_long_collection_pattern
     end

--- a/spec/requests/api/v2/footnote_types_controller_spec.rb
+++ b/spec/requests/api/v2/footnote_types_controller_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Api::V2::FootnoteTypesController, type: :request do
   describe '#index' do
-    let(:footnote_type_1) { create :footnote_type }
+    let(:first_footnote_type) { create :footnote_type }
     let(:pattern) do
       {
         "data": [{
@@ -29,13 +29,13 @@ RSpec.describe Api::V2::FootnoteTypesController, type: :request do
                  }],
       }
     end
-    let(:footnote_type_2) { create :footnote_type }
-    let(:footnote_type_3) { create :footnote_type }
+    let(:second_footnote_type) { create :footnote_type }
+    let(:third_footnote_type) { create :footnote_type }
 
     before do
-      create :footnote_type_description, footnote_type_id: footnote_type_1.footnote_type_id
-      create :footnote_type_description, footnote_type_id: footnote_type_2.footnote_type_id
-      create :footnote_type_description, footnote_type_id: footnote_type_3.footnote_type_id
+      create :footnote_type_description, footnote_type_id: first_footnote_type.footnote_type_id
+      create :footnote_type_description, footnote_type_id: second_footnote_type.footnote_type_id
+      create :footnote_type_description, footnote_type_id: third_footnote_type.footnote_type_id
     end
 
     it 'returns all footnote types' do

--- a/spec/requests/api/v2/sections_controller_migrated_spec.rb
+++ b/spec/requests/api/v2/sections_controller_migrated_spec.rb
@@ -100,36 +100,36 @@ RSpec.describe Api::V2::SectionsController do
   end
 
   describe '#index' do
-    before { create :section_note, section_id: section1.id }
+    before { create :section_note, section_id: first_section.id }
 
-    let!(:section1)  { create(:chapter, :with_section).section }
-    let!(:section2)  { create(:chapter, :with_section).section }
+    let!(:first_section) { create(:chapter, :with_section).section }
+    let!(:second_section) { create(:chapter, :with_section).section }
 
     let(:pattern) do
       {
         data: [
           {
-            id: section1.id.to_s,
+            id: first_section.id.to_s,
             type: 'section',
             attributes: {
-              id: section1.id,
-              position: section1.position,
-              title: section1.title,
-              numeral: section1.numeral,
-              chapter_from: section1.chapter_from,
-              chapter_to: section1.chapter_to,
+              id: first_section.id,
+              position: first_section.position,
+              title: first_section.title,
+              numeral: first_section.numeral,
+              chapter_from: first_section.chapter_from,
+              chapter_to: first_section.chapter_to,
             },
           },
           {
-            id: section2.id.to_s,
+            id: second_section.id.to_s,
             type: 'section',
             attributes: {
-              id: section2.id,
-              position: section2.position,
-              title: section2.title,
-              numeral: section2.numeral,
-              chapter_from: section2.chapter_from,
-              chapter_to: section2.chapter_to,
+              id: second_section.id,
+              position: second_section.position,
+              title: second_section.title,
+              numeral: second_section.numeral,
+              chapter_from: second_section.chapter_from,
+              chapter_to: second_section.chapter_to,
             },
           },
         ],

--- a/spec/serializers/api/user/commodity_changes_serializer_spec.rb
+++ b/spec/serializers/api/user/commodity_changes_serializer_spec.rb
@@ -1,12 +1,12 @@
 RSpec.describe Api::User::CommodityChangesSerializer do
-  let(:tariff_change1) { build(:tariff_change, id: 1) }
-  let(:tariff_change2) { build(:tariff_change, id: 2) }
+  let(:first_tariff_change) { build(:tariff_change, id: 1) }
+  let(:second_tariff_change) { build(:tariff_change, id: 2) }
   let(:object) do
     TariffChanges::GroupedCommodityChange.new(
       id: 'ending',
       description: 'desc',
       count: 2,
-      tariff_changes: [tariff_change1, tariff_change2],
+      tariff_changes: [first_tariff_change, second_tariff_change],
     )
   end
   let(:serializer) { described_class.new([object]) }

--- a/spec/serializers/api/user/grouped_measure_change_serializer_spec.rb
+++ b/spec/serializers/api/user/grouped_measure_change_serializer_spec.rb
@@ -124,13 +124,13 @@ RSpec.describe Api::User::GroupedMeasureChangeSerializer do
 
       it 'includes the commodity data' do
         commodity1 = create(:goods_nomenclature, goods_nomenclature_item_id: '1234567890')
-        commodity2 = create(:goods_nomenclature, goods_nomenclature_item_id: '9876543210')
+        second_commodity = create(:goods_nomenclature, goods_nomenclature_item_id: '9876543210')
 
         serializable.grouped_measure_commodity_changes.each do |change|
           if change.goods_nomenclature_item_id == '1234567890'
             change.commodity = commodity1
           elsif change.goods_nomenclature_item_id == '9876543210'
-            change.commodity = commodity2
+            change.commodity = second_commodity
           end
         end
 

--- a/spec/services/api/admin/goods_nomenclature_labels/stats_service_spec.rb
+++ b/spec/services/api/admin/goods_nomenclature_labels/stats_service_spec.rb
@@ -24,13 +24,13 @@ RSpec.describe Api::Admin::GoodsNomenclatureLabels::StatsService do
     end
 
     context 'when there are labels with various attributes' do
-      let(:commodity1) { create :commodity }
-      let(:commodity2) { create :commodity }
-      let(:commodity3) { create :commodity }
+      let(:first_commodity) { create :commodity }
+      let(:second_commodity) { create :commodity }
+      let(:third_commodity) { create :commodity }
 
       before do
         create :goods_nomenclature_label,
-               goods_nomenclature: commodity1,
+               goods_nomenclature: first_commodity,
                labels: {
                  'description' => 'A product description',
                  'known_brands' => [],
@@ -39,7 +39,7 @@ RSpec.describe Api::Admin::GoodsNomenclatureLabels::StatsService do
                }
 
         create :goods_nomenclature_label,
-               goods_nomenclature: commodity2,
+               goods_nomenclature: second_commodity,
                labels: {
                  'description' => '',
                  'known_brands' => %w[BrandA BrandB],
@@ -48,7 +48,7 @@ RSpec.describe Api::Admin::GoodsNomenclatureLabels::StatsService do
                }
 
         create :goods_nomenclature_label,
-               goods_nomenclature: commodity3,
+               goods_nomenclature: third_commodity,
                labels: {
                  'description' => 'Full description',
                  'known_brands' => %w[Brand],
@@ -79,16 +79,16 @@ RSpec.describe Api::Admin::GoodsNomenclatureLabels::StatsService do
     end
 
     context 'when distinguishing AI-created from human-edited' do
-      let(:commodity1) { create :commodity }
-      let(:commodity2) { create :commodity }
+      let(:first_commodity) { create :commodity }
+      let(:second_commodity) { create :commodity }
 
       before do
         create :goods_nomenclature_label,
-               goods_nomenclature: commodity1,
+               goods_nomenclature: first_commodity,
                labels: { 'description' => 'AI description' }
 
         create :goods_nomenclature_label,
-               goods_nomenclature: commodity2,
+               goods_nomenclature: second_commodity,
                labels: { 'description' => 'Human edited' },
                manually_edited: true
       end

--- a/spec/services/api/user/targets_filter_service/my_commodities_targets_filter_service_spec.rb
+++ b/spec/services/api/user/targets_filter_service/my_commodities_targets_filter_service_spec.rb
@@ -2,8 +2,8 @@ RSpec.describe Api::User::TargetsFilterService::MyCommoditiesTargetsFilterServic
   let(:subscription) { create(:user_subscription, subscription_type: Subscriptions::Type.my_commodities) }
   let(:service) { described_class.new(subscription) }
 
-  let(:commodity1) { create(:commodity, goods_nomenclature_sid: 123) }
-  let(:commodity2) { create(:commodity, goods_nomenclature_sid: 456) }
+  let(:first_commodity) { create(:commodity, goods_nomenclature_sid: 123) }
+  let(:second_commodity) { create(:commodity, goods_nomenclature_sid: 456) }
 
   let(:active_commodities_service) { instance_double(Api::User::ActiveCommoditiesService) }
 
@@ -43,7 +43,7 @@ RSpec.describe Api::User::TargetsFilterService::MyCommoditiesTargetsFilterServic
         allow(active_commodities_service)
           .to receive(:active_commodities)
           .with(page: 1, per_page: 20)
-          .and_return([[commodity1, commodity2], 2])
+          .and_return([[first_commodity, second_commodity], 2])
       end
 
       it 'maps commodities into subscription targets' do
@@ -51,7 +51,7 @@ RSpec.describe Api::User::TargetsFilterService::MyCommoditiesTargetsFilterServic
 
         expect(total).to eq(2)
         expect(targets.first.target_type).to eq('commodity')
-        expect(targets.first.commodity).to eq(commodity1)
+        expect(targets.first.commodity).to eq(first_commodity)
       end
     end
 

--- a/spec/services/composite_search_text_builder_spec.rb
+++ b/spec/services/composite_search_text_builder_spec.rb
@@ -157,33 +157,33 @@ RSpec.describe CompositeSearchTextBuilder do
   end
 
   describe '.batch' do
-    let(:self_text_1) do
+    let(:first_self_text) do
       create(:goods_nomenclature_self_text,
-             goods_nomenclature_sid: commodity_1.goods_nomenclature_sid,
-             goods_nomenclature_item_id: commodity_1.goods_nomenclature_item_id,
+             goods_nomenclature_sid: first_commodity.goods_nomenclature_sid,
+             goods_nomenclature_item_id: first_commodity.goods_nomenclature_item_id,
              self_text: 'Description one')
     end
 
-    let(:self_text_2) do
+    let(:second_self_text) do
       create(:goods_nomenclature_self_text,
-             goods_nomenclature_sid: commodity_2.goods_nomenclature_sid,
-             goods_nomenclature_item_id: commodity_2.goods_nomenclature_item_id,
+             goods_nomenclature_sid: second_commodity.goods_nomenclature_sid,
+             goods_nomenclature_item_id: second_commodity.goods_nomenclature_item_id,
              self_text: 'Description two')
     end
 
-    let(:commodity_1) { create(:commodity, :with_description, :declarable) }
-    let(:commodity_2) { create(:commodity, :with_description, :declarable) }
+    let(:first_commodity) { create(:commodity, :with_description, :declarable) }
+    let(:second_commodity) { create(:commodity, :with_description, :declarable) }
 
     it 'returns composite text keyed by SID' do
-      records = [self_text_1, self_text_2]
+      records = [first_self_text, second_self_text]
       result = described_class.batch(records)
 
       expect(result.keys).to contain_exactly(
-        commodity_1.goods_nomenclature_sid,
-        commodity_2.goods_nomenclature_sid,
+        first_commodity.goods_nomenclature_sid,
+        second_commodity.goods_nomenclature_sid,
       )
-      expect(result[commodity_1.goods_nomenclature_sid]).to eq('Description one')
-      expect(result[commodity_2.goods_nomenclature_sid]).to eq('Description two')
+      expect(result[first_commodity.goods_nomenclature_sid]).to eq('Description one')
+      expect(result[second_commodity.goods_nomenclature_sid]).to eq('Description two')
     end
 
     it 'returns empty hash for empty input' do

--- a/spec/services/generate_self_text/other_self_text_builder_spec.rb
+++ b/spec/services/generate_self_text/other_self_text_builder_spec.rb
@@ -184,7 +184,7 @@ RSpec.describe GenerateSelfText::OtherSelfTextBuilder do
     end
 
     context 'when AI returns fewer descriptions than targets' do
-      let(:other_commodity2) do
+      let(:second_other_commodity) do
         create(:commodity, :with_description,
                description: 'Other',
                parent: heading)
@@ -203,7 +203,7 @@ RSpec.describe GenerateSelfText::OtherSelfTextBuilder do
       end
 
       before do
-        other_commodity2
+        second_other_commodity
         allow(ai_client).to receive(:call).and_return(partial_response)
       end
 

--- a/spec/services/green_lanes/permutation_calculator_service_spec.rb
+++ b/spec/services/green_lanes/permutation_calculator_service_spec.rb
@@ -23,13 +23,13 @@ RSpec.describe GreenLanes::PermutationCalculatorService do
     end
 
     context 'with related measures' do
-      let(:measures) { [measure, measure2] }
+      let(:measures) { [measure, second_measure] }
 
       let :measure do
         create :measure, :with_additional_code, :with_measure_type, :with_base_regulation
       end
 
-      let :measure2 do
+      let :second_measure do
         create :measure, measure_type_id: measure.measure_type_id,
                          generating_regulation: measure.generating_regulation,
                          additional_code_sid: measure.additional_code_sid,

--- a/spec/services/quota_search_service_spec.rb
+++ b/spec/services/quota_search_service_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe QuotaSearchService do
   let!(:duplicate_measure) { create :measure, :with_goods_nomenclature, ordernumber: first_quota_order_number.quota_order_number_id, validity_start_date: validity_start_date + 1.hour }
 
   let(:second_quota_order_number) { create :quota_order_number }
-  let(:goods_nomenclature2) { create :goods_nomenclature, parent: create(:heading) }
-  let!(:second_measure) { create :measure, goods_nomenclature: goods_nomenclature2, ordernumber: second_quota_order_number.quota_order_number_id, validity_start_date: }
+  let(:second_measure_goods_nomenclature) { create :goods_nomenclature, parent: create(:heading) }
+  let!(:second_measure) { create :measure, goods_nomenclature: second_measure_goods_nomenclature, ordernumber: second_quota_order_number.quota_order_number_id, validity_start_date: }
   let!(:second_quota_definition) do
     create :quota_definition,
            quota_order_number_sid: second_quota_order_number.quota_order_number_sid,

--- a/spec/services/quota_search_service_spec.rb
+++ b/spec/services/quota_search_service_spec.rb
@@ -7,47 +7,47 @@ RSpec.describe QuotaSearchService do
   end
 
   let(:validity_start_date) { Time.zone.yesterday }
-  let(:quota_order_number1) { create :quota_order_number }
-  let!(:measure1) { create :measure, :with_goods_nomenclature, ordernumber: quota_order_number1.quota_order_number_id, validity_start_date: }
-  let!(:quota_definition1) do
+  let(:first_quota_order_number) { create :quota_order_number }
+  let!(:first_measure) { create :measure, :with_goods_nomenclature, ordernumber: first_quota_order_number.quota_order_number_id, validity_start_date: }
+  let!(:first_quota_definition) do
     create :quota_definition,
-           quota_order_number_sid: quota_order_number1.quota_order_number_sid,
-           quota_order_number_id: quota_order_number1.quota_order_number_id,
+           quota_order_number_sid: first_quota_order_number.quota_order_number_sid,
+           quota_order_number_id: first_quota_order_number.quota_order_number_id,
            critical_state: 'Y',
            validity_start_date:
   end
-  let!(:quota_order_number_origin1) do
+  let!(:first_quota_order_number_origin) do
     create :quota_order_number_origin,
            :with_geographical_area,
-           quota_order_number_sid: quota_order_number1.quota_order_number_sid
+           quota_order_number_sid: first_quota_order_number.quota_order_number_sid
   end
-  let!(:duplicate_measure) { create :measure, :with_goods_nomenclature, ordernumber: quota_order_number1.quota_order_number_id, validity_start_date: validity_start_date + 1.hour }
+  let!(:duplicate_measure) { create :measure, :with_goods_nomenclature, ordernumber: first_quota_order_number.quota_order_number_id, validity_start_date: validity_start_date + 1.hour }
 
-  let(:quota_order_number2) { create :quota_order_number }
+  let(:second_quota_order_number) { create :quota_order_number }
   let(:goods_nomenclature2) { create :goods_nomenclature, parent: create(:heading) }
-  let!(:measure2) { create :measure, goods_nomenclature: goods_nomenclature2, ordernumber: quota_order_number2.quota_order_number_id, validity_start_date: }
-  let!(:quota_definition2) do
+  let!(:second_measure) { create :measure, goods_nomenclature: goods_nomenclature2, ordernumber: second_quota_order_number.quota_order_number_id, validity_start_date: }
+  let!(:second_quota_definition) do
     create :quota_definition,
-           quota_order_number_sid: quota_order_number2.quota_order_number_sid,
-           quota_order_number_id: quota_order_number2.quota_order_number_id,
+           quota_order_number_sid: second_quota_order_number.quota_order_number_sid,
+           quota_order_number_id: second_quota_order_number.quota_order_number_id,
            critical_state: 'N',
            validity_start_date:
   end
   let(:geographical_area_with_members) { create(:geographical_area, :with_members) }
   let(:geographical_area_member) { geographical_area_with_members.contained_geographical_areas.first }
-  let!(:quota_order_number_origin2) do
+  let!(:second_quota_order_number_origin) do
     create(
       :quota_order_number_origin,
       geographical_area: geographical_area_with_members,
-      quota_order_number_sid: quota_order_number2.quota_order_number_sid,
+      quota_order_number_sid: second_quota_order_number.quota_order_number_sid,
     )
   end
   let(:current_page) { 1 }
   let(:per_page) { 20 }
 
   before do
-    measure1.update(geographical_area_id: quota_order_number_origin1.geographical_area_id)
-    measure2.update(geographical_area_id: quota_order_number_origin2.geographical_area_id)
+    first_measure.update(geographical_area_id: first_quota_order_number_origin.geographical_area_id)
+    second_measure.update(geographical_area_id: second_quota_order_number_origin.geographical_area_id)
   end
 
   describe '#status' do
@@ -63,31 +63,31 @@ RSpec.describe QuotaSearchService do
       let(:filter) { { 'order_number' => duplicate_measure.ordernumber } }
 
       it 'returns the correct quota definition' do
-        expect(service.call).to eq([quota_definition1])
+        expect(service.call).to eq([first_quota_definition])
       end
     end
 
     context 'when filtering by a fully-qualified goods_nomenclature_item_id' do
-      let(:filter) { { 'goods_nomenclature_item_id' => measure1.goods_nomenclature_item_id } }
+      let(:filter) { { 'goods_nomenclature_item_id' => first_measure.goods_nomenclature_item_id } }
 
       it 'returns the correct quota definition' do
-        expect(service.call).to eq([quota_definition1])
+        expect(service.call).to eq([first_quota_definition])
       end
     end
 
     context 'when filtering by a NOT fully-qualified goods_nomenclature_item_id' do
-      let(:filter) { { 'goods_nomenclature_item_id' => measure1.goods_nomenclature_item_id[0..6] } }
+      let(:filter) { { 'goods_nomenclature_item_id' => first_measure.goods_nomenclature_item_id[0..6] } }
 
       it 'returns the correct quota definition' do
-        expect(service.call).to eq([quota_definition1])
+        expect(service.call).to eq([first_quota_definition])
       end
     end
 
     context 'when filtering by the geographical_area_id' do
-      let(:filter) { { 'geographical_area_id' => quota_order_number_origin1.geographical_area_id } }
+      let(:filter) { { 'geographical_area_id' => first_quota_order_number_origin.geographical_area_id } }
 
       it_with_refresh_materialized_view 'returns the correct quota definition' do
-        expect(service.call).to eq([quota_definition1])
+        expect(service.call).to eq([first_quota_definition])
       end
     end
 
@@ -95,15 +95,15 @@ RSpec.describe QuotaSearchService do
       let(:filter) { { 'geographical_area_id' => geographical_area_member.geographical_area_id } }
 
       it_with_refresh_materialized_view 'returns the correct quota definition' do
-        expect(service.call).to eq([quota_definition2])
+        expect(service.call).to eq([second_quota_definition])
       end
     end
 
     context 'when filtering by the order number' do
-      let(:filter) { { 'order_number' => quota_order_number1.quota_order_number_id } }
+      let(:filter) { { 'order_number' => first_quota_order_number.quota_order_number_id } }
 
       it 'returns the correct quota definition' do
-        expect(service.call).to eq([quota_definition1])
+        expect(service.call).to eq([first_quota_definition])
       end
     end
 
@@ -111,7 +111,7 @@ RSpec.describe QuotaSearchService do
       let(:filter) { { 'critical' => 'Y' } }
 
       it 'returns the correct quota definition' do
-        expect(service.call).to eq([quota_definition1])
+        expect(service.call).to eq([first_quota_definition])
       end
     end
 
@@ -119,11 +119,11 @@ RSpec.describe QuotaSearchService do
       let(:filter) { { 'status' => 'exhausted' } }
 
       before do
-        create :quota_exhaustion_event, quota_definition: quota_definition1
+        create :quota_exhaustion_event, quota_definition: first_quota_definition
       end
 
       it 'returns the correct quota definition' do
-        expect(service.call).to eq([quota_definition1])
+        expect(service.call).to eq([first_quota_definition])
       end
     end
 
@@ -131,11 +131,11 @@ RSpec.describe QuotaSearchService do
       let(:filter) { { 'status' => 'not_exhausted' } }
 
       before do
-        create :quota_exhaustion_event, quota_definition: quota_definition1
+        create :quota_exhaustion_event, quota_definition: first_quota_definition
       end
 
       it 'returns the correct quota definition' do
-        expect(service.call).to eq([quota_definition2])
+        expect(service.call).to eq([second_quota_definition])
       end
     end
 
@@ -144,13 +144,13 @@ RSpec.describe QuotaSearchService do
 
       before do
         create :quota_blocking_period,
-               quota_definition_sid: quota_definition1.quota_definition_sid,
+               quota_definition_sid: first_quota_definition.quota_definition_sid,
                blocking_start_date: Time.zone.today,
                blocking_end_date: 1.year.from_now
       end
 
       it 'returns the correct quota definition' do
-        expect(service.call).to eq([quota_definition1])
+        expect(service.call).to eq([first_quota_definition])
       end
     end
 
@@ -159,13 +159,13 @@ RSpec.describe QuotaSearchService do
 
       before do
         create :quota_blocking_period,
-               quota_definition_sid: quota_definition1.quota_definition_sid,
+               quota_definition_sid: first_quota_definition.quota_definition_sid,
                blocking_start_date: Time.zone.today,
                blocking_end_date: 1.year.from_now
       end
 
       it 'returns the correct quota definition' do
-        expect(service.call).to eq([quota_definition2])
+        expect(service.call).to eq([second_quota_definition])
       end
     end
 

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -486,21 +486,21 @@ RSpec.describe SearchService do
       before do
         create :search_suggestion,
                :search_reference,
-               goods_nomenclature: heading1,
+               goods_nomenclature: first_heading,
                value: 'acid oil'
 
         create :search_suggestion,
                :search_reference,
-               goods_nomenclature: heading2,
+               goods_nomenclature: second_heading,
                value: 'other kind of oil'
       end
 
-      let!(:heading1) do
+      let!(:first_heading) do
         create :heading, :with_description,
                goods_nomenclature_item_id: '2851000000',
                description: 'Test 1'
       end
-      let!(:heading2) do
+      let!(:second_heading) do
         create :heading, :with_description,
                goods_nomenclature_item_id: '2920000000',
                description: 'Test 2'
@@ -511,7 +511,7 @@ RSpec.describe SearchService do
           type: 'exact_match',
           entry: {
             endpoint: 'headings',
-            id: heading1.goods_nomenclature_item_id.first(4),
+            id: first_heading.goods_nomenclature_item_id.first(4),
           }.ignore_extra_keys!,
         }.ignore_extra_keys!
       end

--- a/spec/services/tariff_changes_service/measure_metadata_generator_spec.rb
+++ b/spec/services/tariff_changes_service/measure_metadata_generator_spec.rb
@@ -30,32 +30,32 @@ RSpec.describe TariffChangesService::MeasureMetadataGenerator do
       end
 
       context 'when measure has excluded geographical areas' do
-        let(:excluded_area1) { create(:geographical_area) }
-        let(:excluded_area2) { create(:geographical_area) }
-        let(:excluded_area3) { create(:geographical_area) }
+        let(:first_excluded_area) { create(:geographical_area) }
+        let(:second_excluded_area) { create(:geographical_area) }
+        let(:third_excluded_area) { create(:geographical_area) }
 
         before do
           create(:measure_excluded_geographical_area,
                  measure_sid: measure.measure_sid,
-                 excluded_geographical_area: excluded_area2.geographical_area_id,
-                 geographical_area_sid: excluded_area2.geographical_area_sid)
+                 excluded_geographical_area: second_excluded_area.geographical_area_id,
+                 geographical_area_sid: second_excluded_area.geographical_area_sid)
           create(:measure_excluded_geographical_area,
                  measure_sid: measure.measure_sid,
-                 excluded_geographical_area: excluded_area1.geographical_area_id,
-                 geographical_area_sid: excluded_area1.geographical_area_sid)
+                 excluded_geographical_area: first_excluded_area.geographical_area_id,
+                 geographical_area_sid: first_excluded_area.geographical_area_sid)
           create(:measure_excluded_geographical_area,
                  measure_sid: measure.measure_sid,
-                 excluded_geographical_area: excluded_area3.geographical_area_id,
-                 geographical_area_sid: excluded_area3.geographical_area_sid)
+                 excluded_geographical_area: third_excluded_area.geographical_area_id,
+                 geographical_area_sid: third_excluded_area.geographical_area_sid)
         end
 
         it 'includes all excluded geographical area ids' do
           metadata = described_class.call(measure.measure_sid)
 
           expect(metadata['measure']['excluded_geographical_area_ids']).to include(
-            excluded_area1.geographical_area_id,
-            excluded_area2.geographical_area_id,
-            excluded_area3.geographical_area_id,
+            first_excluded_area.geographical_area_id,
+            second_excluded_area.geographical_area_id,
+            third_excluded_area.geographical_area_id,
           )
         end
 

--- a/spec/services/tariff_changes_service/presenter_spec.rb
+++ b/spec/services/tariff_changes_service/presenter_spec.rb
@@ -342,8 +342,8 @@ RSpec.describe TariffChangesService::Presenter do
       end
 
       context 'when excluded_geographical_areas are provided' do
-        let(:excluded_area_1) { create(:geographical_area, :with_description, geographical_area_id: 'DE') }
-        let(:excluded_area_2) { create(:geographical_area, :with_description, geographical_area_id: 'IT') }
+        let(:first_excluded_area) { create(:geographical_area, :with_description, geographical_area_id: 'DE') }
+        let(:second_excluded_area) { create(:geographical_area, :with_description, geographical_area_id: 'IT') }
         let(:tariff_change) do
           create(:tariff_change,
                  type: 'Measure',
@@ -352,21 +352,21 @@ RSpec.describe TariffChangesService::Presenter do
                  metadata: {
                    'measure' => {
                      'geographical_area_id' => geo_area.geographical_area_id,
-                     'excluded_geographical_area_ids' => [excluded_area_1.geographical_area_id, excluded_area_2.geographical_area_id],
+                     'excluded_geographical_area_ids' => [first_excluded_area.geographical_area_id, second_excluded_area.geographical_area_id],
                    },
                  })
         end
         let(:geo_area_cache) do
           {
             geo_area.geographical_area_id => geo_area,
-            excluded_area_1.geographical_area_id => excluded_area_1,
-            excluded_area_2.geographical_area_id => excluded_area_2,
+            first_excluded_area.geographical_area_id => first_excluded_area,
+            second_excluded_area.geographical_area_id => second_excluded_area,
           }
         end
 
         before do
-          allow(excluded_area_1.geographical_area_description).to receive(:description).and_return('Germany')
-          allow(excluded_area_2.geographical_area_description).to receive(:description).and_return('Italy')
+          allow(first_excluded_area.geographical_area_description).to receive(:description).and_return('Germany')
+          allow(second_excluded_area.geographical_area_description).to receive(:description).and_return('Italy')
         end
 
         it 'includes excluded areas in the result' do

--- a/spec/services/tariff_changes_service/transform_records_spec.rb
+++ b/spec/services/tariff_changes_service/transform_records_spec.rb
@@ -127,31 +127,31 @@ RSpec.describe TariffChangesService::TransformRecords do
     end
 
     context 'when filtering by goods_nomenclature_sids' do
-      let(:goods_nomenclature_sids) { [goods_nomenclature1.goods_nomenclature_sid] }
-      let(:goods_nomenclature1) do
+      let(:goods_nomenclature_sids) { [first_goods_nomenclature.goods_nomenclature_sid] }
+      let(:first_goods_nomenclature) do
         create(:goods_nomenclature,
                goods_nomenclature_item_id: '0101010100',
                validity_start_date: 1.day.ago)
       end
-      let(:goods_nomenclature2) do
+      let(:second_goods_nomenclature) do
         create(:goods_nomenclature,
                goods_nomenclature_item_id: '0202020200',
                validity_start_date: 1.day.ago)
       end
 
       before do
-        goods_nomenclature1
-        goods_nomenclature2
-        create(:goods_nomenclature_description, goods_nomenclature_sid: goods_nomenclature1.goods_nomenclature_sid)
-        create(:goods_nomenclature_description, goods_nomenclature_sid: goods_nomenclature2.goods_nomenclature_sid)
+        first_goods_nomenclature
+        second_goods_nomenclature
+        create(:goods_nomenclature_description, goods_nomenclature_sid: first_goods_nomenclature.goods_nomenclature_sid)
+        create(:goods_nomenclature_description, goods_nomenclature_sid: second_goods_nomenclature.goods_nomenclature_sid)
         create(:tariff_change,
                operation_date: operation_date,
-               goods_nomenclature_sid: goods_nomenclature1.goods_nomenclature_sid,
-               goods_nomenclature_item_id: goods_nomenclature1.goods_nomenclature_item_id)
+               goods_nomenclature_sid: first_goods_nomenclature.goods_nomenclature_sid,
+               goods_nomenclature_item_id: first_goods_nomenclature.goods_nomenclature_item_id)
         create(:tariff_change,
                operation_date: operation_date,
-               goods_nomenclature_sid: goods_nomenclature2.goods_nomenclature_sid,
-               goods_nomenclature_item_id: goods_nomenclature2.goods_nomenclature_item_id)
+               goods_nomenclature_sid: second_goods_nomenclature.goods_nomenclature_sid,
+               goods_nomenclature_item_id: second_goods_nomenclature.goods_nomenclature_item_id)
       end
 
       it 'returns only tariff changes matching the given sids' do

--- a/spec/unit/taric_importer_spec.rb
+++ b/spec/unit/taric_importer_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe TaricImporter do
 
   describe '#import' do
     let(:example_date) { Date.new(2013, 8, 2) }
-    let(:example_date2) { Date.new(2014, 8, 2) }
+    let(:second_example_date) { Date.new(2014, 8, 2) }
     let(:taric_update) { create :taric_update, example_date: }
-    let(:taric_update2) { create :taric_update, example_date: example_date2 }
+    let(:second_taric_update) { create :taric_update, example_date: second_example_date }
 
     before do
       ExplicitAbrogationRegulation.unrestrict_primary_key
@@ -43,7 +43,7 @@ RSpec.describe TaricImporter do
         Measure.unrestrict_primary_key
         allow(taric_update).to receive(:file_path)
           .and_return('spec/fixtures/taric_samples/create_measure.xml')
-        allow(taric_update2).to receive(:file_path)
+        allow(second_taric_update).to receive(:file_path)
           .and_return('spec/fixtures/taric_samples/update_measure.xml')
       end
 
@@ -56,7 +56,7 @@ RSpec.describe TaricImporter do
 
       it 'imports single Measure and updates it' do
         described_class.new(taric_update).import
-        described_class.new(taric_update2).import
+        described_class.new(second_taric_update).import
         expect(Measure.count).to eq 1
       end
 
@@ -75,11 +75,11 @@ RSpec.describe TaricImporter do
 
       it 'creates two Measure::Operation(oplog) entries after update', :aggregate_failures do
         described_class.new(taric_update).import
-        described_class.new(taric_update2).import
+        described_class.new(second_taric_update).import
 
         expect(Measure::Operation.count).to eq 2
 
-        update = Measure::Operation.where(operation: 'U', measure_sid: '3318239', operation_date: example_date2).first
+        update = Measure::Operation.where(operation: 'U', measure_sid: '3318239', operation_date: second_example_date).first
         expect(update).to be_present
         expect(update.validity_end_date).to be_present
       end

--- a/spec/unit/time_machine_spec.rb
+++ b/spec/unit/time_machine_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe TimeMachine do
-  let!(:commodity1) do
+  let!(:first_commodity) do
     create :commodity, validity_start_date: Time.zone.now.ago(1.day),
                        validity_end_date: Time.zone.now.in(1.day)
   end
-  let!(:commodity2) do
+  let!(:second_commodity) do
     create :commodity, validity_start_date: Time.zone.now.ago(20.days),
                        validity_end_date: Time.zone.now.ago(10.days)
   end
@@ -11,22 +11,22 @@ RSpec.describe TimeMachine do
   describe '.at' do
     it 'sets date to current date if argument is blank', :aggregate_failures do
       described_class.at(nil) do
-        expect(Commodity.actual.all).to     include commodity1
-        expect(Commodity.actual.all).not_to include commodity2
+        expect(Commodity.actual.all).to     include first_commodity
+        expect(Commodity.actual.all).not_to include second_commodity
       end
     end
 
     it 'sets date to current date if argument is errorenous', :aggregate_failures do
       described_class.at('#&$*(#)') do
-        expect(Commodity.actual.all).to     include commodity1
-        expect(Commodity.actual.all).not_to include commodity2
+        expect(Commodity.actual.all).to     include first_commodity
+        expect(Commodity.actual.all).not_to include second_commodity
       end
     end
 
     it 'parses and sets valid date from argument', :aggregate_failures do
       described_class.at(Time.zone.now.ago(15.days).to_s) do
-        expect(Commodity.actual.all).not_to include commodity1
-        expect(Commodity.actual.all).to     include commodity2
+        expect(Commodity.actual.all).not_to include first_commodity
+        expect(Commodity.actual.all).to     include second_commodity
       end
     end
   end
@@ -34,8 +34,8 @@ RSpec.describe TimeMachine do
   describe '.now' do
     it 'sets date to current date', :aggregate_failures do
       described_class.now do
-        expect(Commodity.actual.all).to     include commodity1
-        expect(Commodity.actual.all).not_to include commodity2
+        expect(Commodity.actual.all).to     include first_commodity
+        expect(Commodity.actual.all).not_to include second_commodity
       end
     end
   end

--- a/spec/unit/time_machine_spec.rb
+++ b/spec/unit/time_machine_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe TimeMachine do
       end
     end
 
-    it 'sets date to current date if argument is errorenous', :aggregate_failures do
+    it 'sets date to current date if argument is erroneous', :aggregate_failures do
       described_class.at('#&$*(#)') do
         expect(Commodity.actual.all).to     include first_commodity
         expect(Commodity.actual.all).not_to include second_commodity

--- a/spec/workers/my_commodities_subscription_worker_spec.rb
+++ b/spec/workers/my_commodities_subscription_worker_spec.rb
@@ -6,18 +6,18 @@ RSpec.describe MyCommoditiesSubscriptionWorker, type: :worker do
 
   describe '#perform' do
     context 'when users have tariff changes on the date' do
-      let(:user1) { create(:public_user, :with_my_commodities_subscription) }
-      let(:user2) { create(:public_user, :with_my_commodities_subscription) }
+      let(:first_user) { create(:public_user, :with_my_commodities_subscription) }
+      let(:second_user) { create(:public_user, :with_my_commodities_subscription) }
 
       before do
         allow(TariffChangesJobStatus).to receive(:for_date).and_return(status)
-        # Create subscription targets for user1
-        subscription1 = PublicUsers::Subscription.where(user_id: user1.id, subscription_type_id: Subscriptions::Type.my_commodities.id).first
+        # Create subscription targets for first_user
+        subscription1 = PublicUsers::Subscription.where(user_id: first_user.id, subscription_type_id: Subscriptions::Type.my_commodities.id).first
         create(:subscription_target, user_subscriptions_uuid: subscription1.uuid, target_id: '1000')
         create(:subscription_target, user_subscriptions_uuid: subscription1.uuid, target_id: '2000')
 
-        # Create subscription targets for user2
-        subscription2 = PublicUsers::Subscription.where(user_id: user2.id, subscription_type_id: Subscriptions::Type.my_commodities.id).first
+        # Create subscription targets for second_user
+        subscription2 = PublicUsers::Subscription.where(user_id: second_user.id, subscription_type_id: Subscriptions::Type.my_commodities.id).first
         create(:subscription_target, user_subscriptions_uuid: subscription2.uuid, target_id: '3000')
 
         # Create tariff changes for the date
@@ -31,8 +31,8 @@ RSpec.describe MyCommoditiesSubscriptionWorker, type: :worker do
       it 'queues email worker for each user with changes' do
         instance.perform(date)
 
-        expect(MyCommoditiesEmailWorker).to have_received(:perform_async).with(user1.id, '08/12/2025', 2)
-        expect(MyCommoditiesEmailWorker).to have_received(:perform_async).with(user2.id, '08/12/2025', 1)
+        expect(MyCommoditiesEmailWorker).to have_received(:perform_async).with(first_user.id, '08/12/2025', 2)
+        expect(MyCommoditiesEmailWorker).to have_received(:perform_async).with(second_user.id, '08/12/2025', 1)
         expect(status).to have_received(:mark_emails_sent!)
       end
     end

--- a/spec/workers/relabel_goods_nomenclature_page_worker_spec.rb
+++ b/spec/workers/relabel_goods_nomenclature_page_worker_spec.rb
@@ -177,8 +177,8 @@ RSpec.describe RelabelGoodsNomenclaturePageWorker, type: :worker do
     end
 
     context 'with multiple labels (mixed success and failure)' do
-      let(:commodity2) { create(:commodity) }
-      let(:sids) { [commodity.goods_nomenclature_sid, commodity2.goods_nomenclature_sid] }
+      let(:second_commodity) { create(:commodity) }
+      let(:sids) { [commodity.goods_nomenclature_sid, second_commodity.goods_nomenclature_sid] }
 
       let(:valid_label) do
         GoodsNomenclatureLabel.build(commodity, ai_response['data'].first)
@@ -186,7 +186,7 @@ RSpec.describe RelabelGoodsNomenclaturePageWorker, type: :worker do
 
       let(:invalid_label) do
         GoodsNomenclatureLabel.new(
-          goods_nomenclature: commodity2,
+          goods_nomenclature: second_commodity,
           labels: nil,
         )
       end


### PR DESCRIPTION
## What:
- [x] Rename numbered `let` helpers to descriptive names in affected specs
- [x] Re-enable `RSpec/IndexedLet` in `.rubocop.yml`

## Why:
Indexed let names hide intent and were only allowed while the cop was disabled. Renaming the helpers is a behaviour-preserving spec cleanup that lets the cop stay on for new code.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Spec-only renames and a RuboCop re-enable. No production code changes.