### PR TITLE
fix(rspec): replace receive_message_chain stubs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -115,10 +115,6 @@ Style/OptionalBooleanParameter:
 Style/StringLiterals:
   EnforcedStyle: single_quotes
 
-RSpec/MessageChain:
-  Enabled: false
-
-
 RSpec/MultipleExpectations:
   Enabled: false
 

--- a/spec/models/green_lanes/category_assessment_json_spec.rb
+++ b/spec/models/green_lanes/category_assessment_json_spec.rb
@@ -178,7 +178,8 @@ RSpec.describe GreenLanes::CategoryAssessmentJson do
 
     context 'when the specified file key does not exist in S3' do
       before do
-        allow(bucket).to receive(:object).and_raise(Aws::S3::Errors::NoSuchKey.new({}, 'File not found'))
+        allow(bucket).to receive(:object).with(described_class::CATEGORISATION_OBJECT_KEY).and_return(s3_object)
+        allow(s3_object).to receive(:get).and_raise(Aws::S3::Errors::NoSuchKey.new({}, 'File not found'))
       end
 
       it 'raise InvalidFile error' do

--- a/spec/models/green_lanes/category_assessment_json_spec.rb
+++ b/spec/models/green_lanes/category_assessment_json_spec.rb
@@ -140,8 +140,9 @@ RSpec.describe GreenLanes::CategoryAssessmentJson do
     end
   end
 
-  # rubocop:disable RSpec/AnyInstance
   describe '.load_from_s3' do
+    let(:bucket) { instance_double(Aws::S3::Bucket) }
+    let(:s3_object) { instance_double(Aws::S3::Object) }
     let(:json_string) do
       '[{
           "category": "1",
@@ -154,11 +155,19 @@ RSpec.describe GreenLanes::CategoryAssessmentJson do
         }]'
     end
 
+    before do
+      allow(Rails.application.config).to receive(:persistence_bucket).and_return(bucket)
+    end
+
     context 'when the file exists in S3' do
       subject(:s3_categories) { described_class.load_from_s3 }
 
+      let(:body) { instance_double(StringIO, read: json_string) }
+      let(:response) { instance_double(Aws::S3::Types::GetObjectOutput, body:) }
+
       before do
-        allow_any_instance_of(Aws::S3::Object).to receive_message_chain(:get, :body, :read).and_return(json_string)
+        allow(bucket).to receive(:object).with(described_class::CATEGORISATION_OBJECT_KEY).and_return(s3_object)
+        allow(s3_object).to receive(:get).and_return(response)
       end
 
       it { is_expected.to be_an Array }
@@ -169,7 +178,7 @@ RSpec.describe GreenLanes::CategoryAssessmentJson do
 
     context 'when the specified file key does not exist in S3' do
       before do
-        allow_any_instance_of(Aws::S3::Bucket).to receive(:object).and_raise(Aws::S3::Errors::NoSuchKey.new({}, 'File not found'))
+        allow(bucket).to receive(:object).and_raise(Aws::S3::Errors::NoSuchKey.new({}, 'File not found'))
       end
 
       it 'raise InvalidFile error' do
@@ -177,7 +186,6 @@ RSpec.describe GreenLanes::CategoryAssessmentJson do
       end
     end
   end
-  # rubocop:enable RSpec/AnyInstance
 
   describe '.filter' do
     before { described_class.load_from_file test_file }

--- a/spec/workers/external_user_deletion_worker_spec.rb
+++ b/spec/workers/external_user_deletion_worker_spec.rb
@@ -18,9 +18,15 @@ RSpec.describe ExternalUserDeletionWorker, type: :worker do
 
   context 'when another active user with same external_id exists' do
     let(:active_user) { instance_spy(PublicUsers::User) }
+    let(:active_users) { instance_double(Sequel::Dataset) }
+    let(:users_with_external_id) { instance_double(Sequel::Dataset) }
+    let(:other_users) { instance_double(Sequel::Dataset) }
 
     before do
-      allow(PublicUsers::User).to receive_message_chain(:active, :where, :exclude, :first).and_return(active_user)
+      allow(PublicUsers::User).to receive(:active).and_return(active_users)
+      allow(active_users).to receive(:where).with(external_id: user.external_id).and_return(users_with_external_id)
+      allow(users_with_external_id).to receive(:exclude).with(id: user.id).and_return(other_users)
+      allow(other_users).to receive(:first).and_return(active_user)
     end
 
     it 'removes external_id from deleted user and returns' do
@@ -31,8 +37,15 @@ RSpec.describe ExternalUserDeletionWorker, type: :worker do
   end
 
   context 'when no other active user with same external_id' do
+    let(:active_users) { instance_double(Sequel::Dataset) }
+    let(:users_with_external_id) { instance_double(Sequel::Dataset) }
+    let(:other_users) { instance_double(Sequel::Dataset) }
+
     before do
-      allow(PublicUsers::User).to receive_message_chain(:active, :where, :exclude, :first).and_return(nil)
+      allow(PublicUsers::User).to receive(:active).and_return(active_users)
+      allow(active_users).to receive(:where).with(external_id: user.external_id).and_return(users_with_external_id)
+      allow(users_with_external_id).to receive(:exclude).with(id: user.id).and_return(other_users)
+      allow(other_users).to receive(:first).and_return(nil)
     end
 
     it 'calls identity API and removes external_id if successful' do

--- a/spec/workers/prewarm_commodities_worker_spec.rb
+++ b/spec/workers/prewarm_commodities_worker_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe PrewarmCommoditiesWorker do
   let(:commodity) { build(:commodity, goods_nomenclature_item_id: '0101210000', producline_suffix: '80') }
   let(:preconfigured_commodity) { build(:commodity, goods_nomenclature_item_id: preconfigured_id, producline_suffix: '80') }
   let(:query_scope) { instance_double(Sequel::Dataset, all: [commodity, preconfigured_commodity]) }
-  let(:actual_commodities) { object_double(Commodity.actual, by_codes: query_scope) }
+  let(:actual_commodities) { instance_double(Sequel::Dataset, by_codes: query_scope) }
   let(:cached_commodity_service) { instance_double(CachedCommodityService, call: true) }
 
   before do

--- a/spec/workers/prewarm_commodities_worker_spec.rb
+++ b/spec/workers/prewarm_commodities_worker_spec.rb
@@ -17,12 +17,13 @@ RSpec.describe PrewarmCommoditiesWorker do
   let(:commodity) { build(:commodity, goods_nomenclature_item_id: '0101210000', producline_suffix: '80') }
   let(:preconfigured_commodity) { build(:commodity, goods_nomenclature_item_id: preconfigured_id, producline_suffix: '80') }
   let(:query_scope) { instance_double(Sequel::Dataset, all: [commodity, preconfigured_commodity]) }
+  let(:actual_commodities) { object_double(Commodity.actual, by_codes: query_scope) }
   let(:cached_commodity_service) { instance_double(CachedCommodityService, call: true) }
 
   before do
     allow(described_class).to receive(:client).and_return(client)
     allow(client).to receive_messages(start_query: start_query_response, get_query_results: query_results_response)
-    allow(Commodity).to receive_message_chain(:actual, :by_codes).and_return(query_scope)
+    allow(Commodity).to receive(:actual).and_return(actual_commodities)
     allow(CachedCommodityService).to receive(:new).and_return(cached_commodity_service)
     allow(TimeMachine).to receive(:now).and_yield
     allow(ENV).to receive(:fetch).and_call_original

--- a/spec/workers/prewarm_commodities_worker_spec.rb
+++ b/spec/workers/prewarm_commodities_worker_spec.rb
@@ -19,13 +19,14 @@ RSpec.describe PrewarmCommoditiesWorker do
   let(:query_scope) { instance_double(Sequel::Dataset, all: [commodity, preconfigured_commodity]) }
   # Commodity.actual returns the model dataset class (with by_codes from dataset_module),
   # not bare Sequel::Dataset — double that class so verification stays accurate.
-  let(:actual_commodities) { instance_double(Commodity.dataset.class, by_codes: query_scope) }
+  let(:actual_commodities) { instance_double(Commodity.dataset.class) }
   let(:cached_commodity_service) { instance_double(CachedCommodityService, call: true) }
 
   before do
     allow(described_class).to receive(:client).and_return(client)
     allow(client).to receive_messages(start_query: start_query_response, get_query_results: query_results_response)
     allow(Commodity).to receive(:actual).and_return(actual_commodities)
+    allow(actual_commodities).to receive(:by_codes).and_return(query_scope)
     allow(CachedCommodityService).to receive(:new).and_return(cached_commodity_service)
     allow(TimeMachine).to receive(:now).and_yield
     allow(ENV).to receive(:fetch).and_call_original

--- a/spec/workers/prewarm_commodities_worker_spec.rb
+++ b/spec/workers/prewarm_commodities_worker_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe PrewarmCommoditiesWorker do
   let(:commodity) { build(:commodity, goods_nomenclature_item_id: '0101210000', producline_suffix: '80') }
   let(:preconfigured_commodity) { build(:commodity, goods_nomenclature_item_id: preconfigured_id, producline_suffix: '80') }
   let(:query_scope) { instance_double(Sequel::Dataset, all: [commodity, preconfigured_commodity]) }
-  # Commodity.actual returns the model dataset class (with by_codes from dataset_module),
+  # Commodity.actual returns a model dataset (Sequel::Dataset subclass with by_codes),
   # not bare Sequel::Dataset — double that class so verification stays accurate.
   let(:actual_commodities) { instance_double(Commodity.dataset.class) }
   let(:cached_commodity_service) { instance_double(CachedCommodityService, call: true) }

--- a/spec/workers/prewarm_commodities_worker_spec.rb
+++ b/spec/workers/prewarm_commodities_worker_spec.rb
@@ -17,7 +17,9 @@ RSpec.describe PrewarmCommoditiesWorker do
   let(:commodity) { build(:commodity, goods_nomenclature_item_id: '0101210000', producline_suffix: '80') }
   let(:preconfigured_commodity) { build(:commodity, goods_nomenclature_item_id: preconfigured_id, producline_suffix: '80') }
   let(:query_scope) { instance_double(Sequel::Dataset, all: [commodity, preconfigured_commodity]) }
-  let(:actual_commodities) { double('Commodity.actual', by_codes: query_scope) }
+  # Commodity.actual returns the model dataset class (with by_codes from dataset_module),
+  # not bare Sequel::Dataset — double that class so verification stays accurate.
+  let(:actual_commodities) { instance_double(Commodity.dataset.class, by_codes: query_scope) }
   let(:cached_commodity_service) { instance_double(CachedCommodityService, call: true) }
 
   before do

--- a/spec/workers/prewarm_commodities_worker_spec.rb
+++ b/spec/workers/prewarm_commodities_worker_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe PrewarmCommoditiesWorker do
   let(:commodity) { build(:commodity, goods_nomenclature_item_id: '0101210000', producline_suffix: '80') }
   let(:preconfigured_commodity) { build(:commodity, goods_nomenclature_item_id: preconfigured_id, producline_suffix: '80') }
   let(:query_scope) { instance_double(Sequel::Dataset, all: [commodity, preconfigured_commodity]) }
-  let(:actual_commodities) { instance_double(Sequel::Dataset, by_codes: query_scope) }
+  let(:actual_commodities) { double('Commodity.actual', by_codes: query_scope) }
   let(:cached_commodity_service) { instance_double(CachedCommodityService, call: true) }
 
   before do


### PR DESCRIPTION
## What:
- [x] Replace `receive_message_chain` stubs with explicit doubles in green lanes, external user deletion, and prewarm commodities specs
- [x] Re-enable `RSpec/MessageChain` in `.rubocop.yml`

## Why:
Message-chain stubs hide intermediate collaborators and make failures harder to diagnose. Explicit doubles document the expected call surface and allow the cop to stay enabled.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Test double refactor only. No production code or runtime behaviour changes.

## Checklist:
- [x] Spec-only / RuboCop config changes
- [x] Rebased onto latest `main` after #3408
