### PR TITLE
chore(rubocop): document disabled cops and drop zero-offense disables

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,10 @@ inherit_gem:
     - config/default.yml
     - config/rails.yml
 
+inherit_mode:
+  merge:
+    - Exclude
+
 plugins:
   - rubocop-rspec
   - rubocop-performance
@@ -12,6 +16,8 @@ require:
 
 AllCops:
   Exclude:
+    - ".bundle/**/*"
+    - ".direnv/**/*"
     - "db/schema.rb"
     - "vendor/**/*"
     - "bin/**"
@@ -47,9 +53,13 @@ Layout/LineLength:
 Metrics/AbcSize:
   Max: 20
 
+# Legacy codebase-wide policy cop with many existing offenses; left disabled
+# until it can be split into focused refactors.
 Metrics/BlockLength:
   Enabled: false
 
+# Legacy codebase-wide policy cop with many existing offenses; left disabled
+# until it can be split into focused refactors.
 Metrics/ModuleLength:
   Enabled: false
 
@@ -71,12 +81,15 @@ RSpec/ContextWording:
 RSpec/MultipleMemoizedHelpers:
   Max: 10
 
+# Legacy spec-shape policy cop with many existing offenses; left disabled until
+# specs can be refactored in targeted behaviour-preserving changes.
 RSpec/ExampleLength:
   Enabled: false
 
+# Legacy spec-shape policy cop with many existing offenses; left disabled until
+# specs can be refactored in targeted behaviour-preserving changes.
 RSpec/NestedGroups:
   Enabled: false
-
 
 # swagger:generate intentionally omits :environment — rswag:specs:swaggerize
 # runs rspec in a subprocess and does not need Rails loaded in this process.
@@ -84,24 +97,21 @@ Rails/RakeEnvironment:
   Exclude:
     - 'lib/tasks/swagger.rake'
 
+# This application uses Sequel datasets rather than ActiveRecord relations.
 Rails/FindEach:
   Enabled: false
 
-Rails/ActiveRecordAliases:
+# This application uses Sequel rather than ActiveRecord.
+Rails/FindBy:
   Enabled: false
 
-Rails/CreateTableWithTimestamps:
-  Enabled: false # doesn't recognise
-
-Rails/FindBy:
-  Enabled: false # We use sequel not active record
-
+# Sequel persistence methods do not have the same semantics as ActiveRecord's
+# bang/non-bang persistence methods.
 Rails/SaveBang:
   Enabled: false
 
-Rails/UniqueValidationWithoutIndex:
-  Enabled: false
-
+# Legacy codebase-wide documentation policy cop with many existing offenses;
+# left disabled until documentation standards can be introduced deliberately.
 Style/Documentation:
   Enabled: false
 
@@ -115,6 +125,8 @@ Style/OptionalBooleanParameter:
 Style/StringLiterals:
   EnforcedStyle: single_quotes
 
+# Legacy spec-shape policy cop with many existing offenses; left disabled until
+# specs can be refactored in targeted behaviour-preserving changes.
 RSpec/MultipleExpectations:
   Enabled: false
 


### PR DESCRIPTION
## What:
- [x] Add `inherit_mode` so `Exclude` lists merge with inherited config
- [x] Exclude local `.bundle/**/*` and `.direnv/**/*` trees from AllCops
- [x] Drop disabled entries for Rails cops with no remaining offenses (`ActiveRecordAliases`, `CreateTableWithTimestamps`, `UniqueValidationWithoutIndex`)
- [x] Document why remaining disabled cops stay off (Sequel vs ActiveRecord assumptions, and large legacy policy cops)
- [x] Keep already-re-enabled cops on (FilePath #3376, AccessModifierIndentation #3407, IndexedLet #3408, MessageChain #3409)

## Why:
Disabled RuboCop rules without explanation hide whether a disable is still needed. This makes the config honest about intentional disables and removes ones that no longer protect against real offenses.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Config and documentation only. No application code changes; remaining disabled cops stay disabled by design. Metrics re-enables stay out of this PR.

## Checklist:
- [x] Config-only change
- [x] Based on latest `main` after #3409
