### PR TITLE
fix(rubocop): extract report logging helpers

### DIFF
--- a/app/lib/reporting/report_logging.rb
+++ b/app/lib/reporting/report_logging.rb
@@ -1,0 +1,89 @@
+module Reporting
+  module ReportLogging
+    REPORT_BACKTRACE_LINES = 20
+
+    def instrument(label = "#{self.class.name}##{__method__}")
+      ::SequelRails::Railties::LogSubscriber.reset_runtime
+      ::SequelRails::Railties::LogSubscriber.reset_count
+      start_time = Time.zone.now
+      yield if block_given?
+    ensure
+      end_time = Time.zone.now
+      duration = end_time - start_time
+      Rails.logger.info("#{label} Total Time: #{duration.round(2)} seconds")
+      Rails.logger.info("#{label} SQL Queries: #{::SequelRails::Railties::LogSubscriber.count}, Total SQL Time: #{::SequelRails::Railties::LogSubscriber.runtime.round(2)} ms")
+    end
+
+    def with_report_logging
+      start_time = Time.zone.now
+      log_report_event(status: 'start')
+      result = yield if block_given?
+      log_report_event(
+        status: 'ok',
+        duration_seconds: (Time.zone.now - start_time).round(2),
+      )
+      result
+    rescue StandardError => e
+      log_report_event(
+        status: 'error',
+        duration_seconds: (Time.zone.now - start_time).round(2),
+        error_class: e.class.name,
+        error_message: e.message,
+      )
+      Rails.logger.error(e.backtrace.take(REPORT_BACKTRACE_LINES).join("\n")) if e.backtrace.present?
+      raise
+    end
+
+    def instrument_report_step(step, **attributes)
+      ::SequelRails::Railties::LogSubscriber.reset_runtime
+      ::SequelRails::Railties::LogSubscriber.reset_count
+      start_time = Time.zone.now
+
+      result = yield if block_given?
+
+      log_report_event(
+        step:,
+        status: 'ok',
+        duration_seconds: (Time.zone.now - start_time).round(2),
+        sql_queries: ::SequelRails::Railties::LogSubscriber.count,
+        sql_time_ms: ::SequelRails::Railties::LogSubscriber.runtime.round(2),
+        **attributes,
+      )
+      result
+    rescue StandardError => e
+      log_report_event(
+        step:,
+        status: 'error',
+        duration_seconds: (Time.zone.now - start_time).round(2),
+        sql_queries: ::SequelRails::Railties::LogSubscriber.count,
+        sql_time_ms: ::SequelRails::Railties::LogSubscriber.runtime.round(2),
+        error_class: e.class.name,
+        error_message: e.message,
+        **attributes,
+      )
+      raise
+    end
+
+    def log_report_metric(metric, value, **attributes)
+      log_report_event(metric:, value:, **attributes)
+    end
+
+    def log_report_event(**attributes)
+      Rails.logger.info(
+        "reporting #{report_log_attributes(attributes).map { |key, value| "#{key}=#{value.inspect}" }.join(' ')}",
+      )
+    end
+
+    def report_log_attributes(attributes = {})
+      {
+        report: report_name,
+        service:,
+        object_key: object_key,
+      }.merge(attributes.compact)
+    end
+
+    def report_name
+      respond_to?(:name) ? name : self.class.name
+    end
+  end
+end

--- a/app/lib/reporting/reportable.rb
+++ b/app/lib/reporting/reportable.rb
@@ -2,9 +2,9 @@ module Reporting
   module Reportable
     extend ActiveSupport::Concern
 
-    REPORT_BACKTRACE_LINES = 20
-
     module SharedMethods
+      include Reporting::ReportLogging
+
       def mem
         @mem ||= GetProcessMem.new
       end
@@ -60,90 +60,6 @@ module Reporting
           filename: filename.gsub(File.extname(filename), '.zip'),
           content_type: 'application/zip',
         }
-      end
-
-      def instrument(label = "#{self.class.name}##{__method__}")
-        ::SequelRails::Railties::LogSubscriber.reset_runtime
-        ::SequelRails::Railties::LogSubscriber.reset_count
-        start_time = Time.zone.now
-        yield if block_given?
-      ensure
-        end_time = Time.zone.now
-        duration = end_time - start_time
-        Rails.logger.info("#{label} Total Time: #{duration.round(2)} seconds")
-        Rails.logger.info("#{label} SQL Queries: #{::SequelRails::Railties::LogSubscriber.count}, Total SQL Time: #{::SequelRails::Railties::LogSubscriber.runtime.round(2)} ms")
-      end
-
-      def with_report_logging
-        start_time = Time.zone.now
-        log_report_event(status: 'start')
-        result = yield if block_given?
-        log_report_event(
-          status: 'ok',
-          duration_seconds: (Time.zone.now - start_time).round(2),
-        )
-        result
-      rescue StandardError => e
-        log_report_event(
-          status: 'error',
-          duration_seconds: (Time.zone.now - start_time).round(2),
-          error_class: e.class.name,
-          error_message: e.message,
-        )
-        Rails.logger.error(e.backtrace.take(REPORT_BACKTRACE_LINES).join("\n")) if e.backtrace.present?
-        raise
-      end
-
-      def instrument_report_step(step, **attributes)
-        ::SequelRails::Railties::LogSubscriber.reset_runtime
-        ::SequelRails::Railties::LogSubscriber.reset_count
-        start_time = Time.zone.now
-
-        result = yield if block_given?
-
-        log_report_event(
-          step:,
-          status: 'ok',
-          duration_seconds: (Time.zone.now - start_time).round(2),
-          sql_queries: ::SequelRails::Railties::LogSubscriber.count,
-          sql_time_ms: ::SequelRails::Railties::LogSubscriber.runtime.round(2),
-          **attributes,
-        )
-        result
-      rescue StandardError => e
-        log_report_event(
-          step:,
-          status: 'error',
-          duration_seconds: (Time.zone.now - start_time).round(2),
-          sql_queries: ::SequelRails::Railties::LogSubscriber.count,
-          sql_time_ms: ::SequelRails::Railties::LogSubscriber.runtime.round(2),
-          error_class: e.class.name,
-          error_message: e.message,
-          **attributes,
-        )
-        raise
-      end
-
-      def log_report_metric(metric, value, **attributes)
-        log_report_event(metric:, value:, **attributes)
-      end
-
-      def log_report_event(**attributes)
-        Rails.logger.info(
-          "reporting #{report_log_attributes(attributes).map { |key, value| "#{key}=#{value.inspect}" }.join(' ')}",
-        )
-      end
-
-      def report_log_attributes(attributes = {})
-        {
-          report: report_name,
-          service:,
-          object_key: object_key,
-        }.merge(attributes.compact)
-      end
-
-      def report_name
-        respond_to?(:name) ? name : self.class.name
       end
     end
 


### PR DESCRIPTION
## What:
- [x] Extract report instrumentation/logging methods into `Reporting::ReportLogging`
- [x] Keep `Reportable` including the shared module so call sites stay the same
- [x] Rebased onto latest `main` after config honesty #3410 (supersedes closed #3380)

## Why:
Long modules and blocks kept Metrics cops unenforceable. Domain-scoped extraction of report logging is a low-risk structural step toward honesty without changing runtime behaviour.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Behaviour-preserving structural extraction only. No intentional API or data behaviour change.

## Checklist:
- [x] Structure-only reporting helper move
- [x] Based on tip of `main` after #3410
