### PR TITLE
fix(rubocop): split short task namespaces

### DIFF
--- a/lib/tasks/opensearch.rake
+++ b/lib/tasks/opensearch.rake
@@ -1,35 +1,33 @@
-namespace :opensearch do
-  namespace :search do
-    desc 'Recreate a Search index then reindex the data - INDEX=model_name'
-    task recreate: :environment do
-      raise 'Supply an INDEX env var' if ENV['INDEX'].blank?
+namespace 'opensearch:search' do
+  desc 'Recreate a Search index then reindex the data - INDEX=model_name'
+  task recreate: :environment do
+    raise 'Supply an INDEX env var' if ENV['INDEX'].blank?
 
-      TimeMachine.with_relevant_validity_periods do
-        index_model = ENV['INDEX'].camelize.constantize
-        TradeTariffBackend.search_client.reindex(index_model)
-      end
-    end
-
-    desc 'Recreate then reindex all Search indexes'
-    task recreate_all: :environment do
-      TimeMachine.with_relevant_validity_periods do
-        TradeTariffBackend.search_client.reindex_all
-      end
+    TimeMachine.with_relevant_validity_periods do
+      index_model = ENV['INDEX'].camelize.constantize
+      TradeTariffBackend.search_client.reindex(index_model)
     end
   end
 
-  namespace :cache do
-    desc 'Recreate a Cache index then reindex the data - INDEX=model_name'
-    task recreate: :environment do
-      raise 'Supply an INDEX env var' if ENV['INDEX'].blank?
-
-      index_model = ENV['INDEX'].camelize.constantize
-      TradeTariffBackend.cache_client.reindex(index_model)
+  desc 'Recreate then reindex all Search indexes'
+  task recreate_all: :environment do
+    TimeMachine.with_relevant_validity_periods do
+      TradeTariffBackend.search_client.reindex_all
     end
+  end
+end
 
-    desc 'Recreate then reindex all Cache indexes'
-    task recreate_all: :environment do
-      TradeTariffBackend.cache_client.reindex_all
-    end
+namespace 'opensearch:cache' do
+  desc 'Recreate a Cache index then reindex the data - INDEX=model_name'
+  task recreate: :environment do
+    raise 'Supply an INDEX env var' if ENV['INDEX'].blank?
+
+    index_model = ENV['INDEX'].camelize.constantize
+    TradeTariffBackend.cache_client.reindex(index_model)
+  end
+
+  desc 'Recreate then reindex all Cache indexes'
+  task recreate_all: :environment do
+    TradeTariffBackend.cache_client.reindex_all
   end
 end

--- a/lib/tasks/rules_of_origin.rake
+++ b/lib/tasks/rules_of_origin.rake
@@ -1,42 +1,40 @@
-namespace :rules_of_origin do
-  desc 'validate a CSV rules of origin file - CSVFILE=path/to/file.csv'
-  task validate_rules: :environment do
-    if ENV['CSVFILE'].blank?
-      raise ArgumentError, 'Missing CSVFILE environment variable'
-    end
-
-    invalid_rules = RulesOfOrigin::RuleSet.new(ENV['CSVFILE']).tap(&:import).invalid_rules
-
-    if invalid_rules.empty?
-      puts " ✅  Success: #{ENV['CSVFILE']} is valid"
-    else
-      puts " ❌  FAILURE: #{ENV['CSVFILE']} is invalid"
-      puts '=' * 60
-
-      invalid_rules.each do |invalid_rule|
-        id_rule = sprintf('%12d', invalid_rule.id_rule)
-        puts "#{id_rule}: #{invalid_rule.errors.full_messages.to_sentence}"
-      end
-    end
+desc 'validate a CSV rules of origin file - CSVFILE=path/to/file.csv'
+task 'rules_of_origin:validate_rules' => :environment do
+  if ENV['CSVFILE'].blank?
+    raise ArgumentError, 'Missing CSVFILE environment variable'
   end
 
-  desc 'validate a CSV mappings file - CSVFILE=path/to/file.csv'
-  task validate_mappings: :environment do
-    if ENV['CSVFILE'].blank?
-      raise ArgumentError, 'Missing CSVFILE environment variable'
+  invalid_rules = RulesOfOrigin::RuleSet.new(ENV['CSVFILE']).tap(&:import).invalid_rules
+
+  if invalid_rules.empty?
+    puts " ✅  Success: #{ENV['CSVFILE']} is valid"
+  else
+    puts " ❌  FAILURE: #{ENV['CSVFILE']} is invalid"
+    puts '=' * 60
+
+    invalid_rules.each do |invalid_rule|
+      id_rule = sprintf('%12d', invalid_rule.id_rule)
+      puts "#{id_rule}: #{invalid_rule.errors.full_messages.to_sentence}"
     end
+  end
+end
 
-    invalid_mappings = RulesOfOrigin::HeadingMappings.new(ENV['CSVFILE']).invalid_mappings
+desc 'validate a CSV mappings file - CSVFILE=path/to/file.csv'
+task 'rules_of_origin:validate_mappings' => :environment do
+  if ENV['CSVFILE'].blank?
+    raise ArgumentError, 'Missing CSVFILE environment variable'
+  end
 
-    if invalid_mappings.empty?
-      puts " ✅  Success: #{ENV['CSVFILE']} is valid"
-    else
-      puts " ❌  FAILURE: #{ENV['CSVFILE']} is invalid"
-      puts '=' * 60
+  invalid_mappings = RulesOfOrigin::HeadingMappings.new(ENV['CSVFILE']).invalid_mappings
 
-      invalid_mappings.each do |row_number, errors|
-        puts sprintf('ROW %8d: %s', row_number, errors.join(', '))
-      end
+  if invalid_mappings.empty?
+    puts " ✅  Success: #{ENV['CSVFILE']} is valid"
+  else
+    puts " ❌  FAILURE: #{ENV['CSVFILE']} is invalid"
+    puts '=' * 60
+
+    invalid_mappings.each do |row_number, errors|
+      puts sprintf('ROW %8d: %s', row_number, errors.join(', '))
     end
   end
 end

--- a/lib/tasks/tariff_importer.rake
+++ b/lib/tasks/tariff_importer.rake
@@ -1,41 +1,39 @@
 # Import TARIC or CDS file manually. Usually for initial seed files.
 DummyUpdate = Data.define(:file_path, :issue_date)
 
-namespace :importer do
-  namespace :taric do
-    desc 'Import TARIC file'
-    task import: %i[environment class_eager_load] do
-      if ENV['TARGET'] && TariffSynchronizer::FileService.file_exists?(ENV['TARGET'])
-        Sequel::Model.subclasses.each(&:unrestrict_primary_key)
-        Sequel::Model.plugin :skip_create_refresh
-        dummy_update = DummyUpdate.new(file_path: ENV['TARGET'], issue_date: nil)
-        TaricImporter.new(dummy_update).import(validate: false)
-      else
-        puts 'Please provide TARGET environment variable pointing to Tariff file to import'
-      end
+namespace 'importer:taric' do
+  desc 'Import TARIC file'
+  task import: %i[environment class_eager_load] do
+    if ENV['TARGET'] && TariffSynchronizer::FileService.file_exists?(ENV['TARGET'])
+      Sequel::Model.subclasses.each(&:unrestrict_primary_key)
+      Sequel::Model.plugin :skip_create_refresh
+      dummy_update = DummyUpdate.new(file_path: ENV['TARGET'], issue_date: nil)
+      TaricImporter.new(dummy_update).import(validate: false)
+    else
+      puts 'Please provide TARGET environment variable pointing to Tariff file to import'
     end
   end
+end
 
-  namespace :cds do
-    desc 'Import CDS file'
-    task import: %i[environment class_eager_load] do
-      if ENV['TARGET'] && TariffSynchronizer::FileService.file_exists?(ENV['TARGET'])
-        Sequel::Model.subclasses.each(&:unrestrict_primary_key)
-        Sequel::Model.plugin :skip_create_refresh
-        dummy_update = DummyUpdate.new(file_path: ENV['TARGET'], issue_date: nil)
+namespace 'importer:cds' do
+  desc 'Import CDS file'
+  task import: %i[environment class_eager_load] do
+    if ENV['TARGET'] && TariffSynchronizer::FileService.file_exists?(ENV['TARGET'])
+      Sequel::Model.subclasses.each(&:unrestrict_primary_key)
+      Sequel::Model.plugin :skip_create_refresh
+      dummy_update = DummyUpdate.new(file_path: ENV['TARGET'], issue_date: nil)
 
-        CdsImporter.new(dummy_update).import
-      else
-        puts 'Please provide TARGET environment variable pointing to Tariff file to import'
-      end
+      CdsImporter.new(dummy_update).import
+    else
+      puts 'Please provide TARGET environment variable pointing to Tariff file to import'
     end
   end
+end
 
-  namespace :customs_tariff do
-    desc 'Wipe and re-populate customs tariff notes from stored S3 documents'
-    task reimport: %i[environment] do
-      CustomsTariffImporter::Reimporter.new.call
-      puts 'Customs tariff notes re-imported successfully.'
-    end
+namespace 'importer:customs_tariff' do
+  desc 'Wipe and re-populate customs tariff notes from stored S3 documents'
+  task reimport: %i[environment] do
+    CustomsTariffImporter::Reimporter.new.call
+    puts 'Customs tariff notes re-imported successfully.'
   end
 end


### PR DESCRIPTION
## What:
- [x] Flatten nested Rake namespaces in `lib/tasks/opensearch.rake` into colon-joined namespaces (`opensearch:search`, `opensearch:cache`)
- [x] Flatten nested namespaces in `lib/tasks/rules_of_origin.rake` into full task names (`rules_of_origin:validate_rules`, `rules_of_origin:validate_mappings`)
- [x] Flatten nested namespaces in `lib/tasks/tariff_importer.rake` into colon-joined namespaces (`importer:taric`, `importer:cds`, `importer:customs_tariff`)
- [x] Preserve task invocation names and task body behaviour

## Why:
Nested Rake namespaces inflate block nesting depth and keep Metrics cops unenforceable. Flattening short task files is a low-risk structural step that leaves `rake` task names unchanged.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Structure-only Rake namespace syntax change. Task names and bodies are unchanged. No intentional API or data behaviour change.

## Checklist:
- [x] Structure-only namespace flatten for three short task files
- [x] Based on tip of `main` after admin validator merge
