### PR TITLE
fix(rubocop): extract exchange rate task helpers

### DIFF
--- a/lib/tasks/exchange_rates.rake
+++ b/lib/tasks/exchange_rates.rake
@@ -1,87 +1,20 @@
-namespace :exchange_rates do
-  desc 'Remove and re-build old monthly rates inclusive of the provided data (does not download from XE)'
-  task rebuild_old_monthly_rates: :environment do
-    raise ArgumentError, 'Supply an MONTH_START_PERIOD env var' if ENV['MONTH_START_PERIOD'].blank?
-    raise ArgumentError, 'Supply an YEAR_START_PERIOD env var' if ENV['YEAR_START_PERIOD'].blank?
-    raise ArgumentError, 'Supply an MONTH_END_PERIOD env var' if ENV['MONTH_END_PERIOD'].blank?
-    raise ArgumentError, 'Supply an YEAR_END_PERIOD env var' if ENV['YEAR_END_PERIOD'].blank?
-    raise ArgumentError, 'Supply an CURRENCY_CODE env var' if ENV['CURRENCY_CODE'].blank?
+module ExchangeRatesRakeTasks
+  FILE_TYPES = %w[monthly_csv monthly_xml monthly_csv_hmrc].freeze
 
-    from_date = Date.new(ENV['YEAR_START_PERIOD'].to_i, ENV['MONTH_START_PERIOD'].to_i).beginning_of_month
-    to_date = Date.new(ENV['YEAR_END_PERIOD'].to_i, ENV['MONTH_END_PERIOD'].to_i).end_of_month
+  module_function
 
-    if ENV['CURRENCY_CODE']
-      ExchangeRateCurrencyRate.where(rate_type: ExchangeRateCurrencyRate::MONTHLY_RATE_TYPE,
-                                     validity_end_date: from_date.beginning_of_day..to_date.end_of_day,
-                                     currency_code: ENV['CURRENCY_CODE']).delete
-    end
+  def rebuild_old_monthly_rates
+    require_monthly_env!
+    from_date, to_date = monthly_date_range
+    months_and_years = months_and_years_between(from_date, to_date)
 
-    months_and_years_between = []
-
-    while from_date <= to_date
-      months_and_years_between << [from_date.month, from_date.year]
-      from_date = from_date.next_month
-    end
-
-    file_types = %w[monthly_csv monthly_xml monthly_csv_hmrc]
-
-    Sequel::Model.db.transaction do
-      file_types.each do |file_type|
-        months_and_years_between.each do |month_and_year|
-          month = month_and_year[0]
-          year = month_and_year[1]
-
-          # Get DB file object
-          file = ExchangeRateFile.where(type: file_type,
-                                        period_month: month,
-                                        period_year: year).first
-          next unless file
-
-          # S3 object location
-          s3_file_path = file.object_key
-
-          # Delete DB object
-          file.delete
-
-          # Delete file in S3
-          TariffSynchronizer::FileService.delete_file(s3_file_path, true)
-        end
-      end
-    end
-
-    months_and_years_between.each do |month_and_year|
-      month = month_and_year[0]
-      year = month_and_year[1]
-      date = Date.new(year, month, 1)
-
-      # This bit of code is to generate the dat on which the rates were sampled from and is our published date
-      # We have the month for where the rates are valid for but this will give us the wednesday before
-      # the penultimute thursday of the previous month.
-      last_day_of_previous_month = date - 1
-      last_thursday_of_month_before = last_day_of_previous_month.downto(1).find { |d| d.wday == 4 }
-      sample_date = last_thursday_of_month_before - 8
-
-      # Note we dont download from XE new rates
-      ExchangeRates::MonthlyExchangeRatesService.new(date, sample_date, download: false).call
-    end
-
-    # We dont want to have the HMRC CSV pre Aug 2023 so this clears out those files
-    date_range = (Date.new(2000, 1, 1)..Date.new(2023, 8, 31)).select { |d| d.day == 1 }
-    date_array = date_range.map { |date| [date.month, date.year] }
-
-    date_array.each do |month_and_year|
-      month = month_and_year[0]
-      year = month_and_year[1]
-
-      ExchangeRateFile.where(type: 'monthly_csv_hmrc',
-                             period_month: month,
-                             period_year: year).delete
-    end
+    delete_monthly_rates(from_date, to_date)
+    delete_monthly_files(months_and_years)
+    rebuild_monthly_files(months_and_years)
+    prune_old_hmrc_monthly_files
   end
 
-  # This only accepts one period to delete the file and all the avg rates in that month
-  desc 'Remove and rebuild average rates'
-  task rebuild_average_rates: :environment do
+  def rebuild_average_rates
     raise 'Supply an AVG_PERIOD_MONTH env var' if ENV['AVG_PERIOD_MONTH'].blank?
     raise 'Supply an AVG_PERIOD_YEAR env var' if ENV['AVG_PERIOD_YEAR'].blank?
     raise 'Invalid' unless ExchangeRates::CreateAverageExchangeRatesService::VALID_MONTHS.include?(ENV['AVG_PERIOD_MONTH'].to_i)
@@ -104,5 +37,88 @@ namespace :exchange_rates do
     date = validity_end_date.iso8601
 
     ExchangeRates::CreateAverageExchangeRatesService.call(force_run: false, selected_date: date)
+  end
+
+  def require_monthly_env!
+    raise ArgumentError, 'Supply an MONTH_START_PERIOD env var' if ENV['MONTH_START_PERIOD'].blank?
+    raise ArgumentError, 'Supply an YEAR_START_PERIOD env var' if ENV['YEAR_START_PERIOD'].blank?
+    raise ArgumentError, 'Supply an MONTH_END_PERIOD env var' if ENV['MONTH_END_PERIOD'].blank?
+    raise ArgumentError, 'Supply an YEAR_END_PERIOD env var' if ENV['YEAR_END_PERIOD'].blank?
+    raise ArgumentError, 'Supply an CURRENCY_CODE env var' if ENV['CURRENCY_CODE'].blank?
+  end
+
+  def monthly_date_range
+    from_date = Date.new(ENV['YEAR_START_PERIOD'].to_i, ENV['MONTH_START_PERIOD'].to_i).beginning_of_month
+    to_date = Date.new(ENV['YEAR_END_PERIOD'].to_i, ENV['MONTH_END_PERIOD'].to_i).end_of_month
+
+    [from_date, to_date]
+  end
+
+  def months_and_years_between(from_date, to_date)
+    [].tap do |months_and_years|
+      while from_date <= to_date
+        months_and_years << [from_date.month, from_date.year]
+        from_date = from_date.next_month
+      end
+    end
+  end
+
+  def delete_monthly_rates(from_date, to_date)
+    ExchangeRateCurrencyRate.where(rate_type: ExchangeRateCurrencyRate::MONTHLY_RATE_TYPE,
+                                   validity_end_date: from_date.beginning_of_day..to_date.end_of_day,
+                                   currency_code: ENV['CURRENCY_CODE']).delete
+  end
+
+  def delete_monthly_files(months_and_years)
+    Sequel::Model.db.transaction do
+      FILE_TYPES.each do |file_type|
+        months_and_years.each do |month, year|
+          delete_exchange_rate_file(file_type, month, year)
+        end
+      end
+    end
+  end
+
+  def delete_exchange_rate_file(file_type, month, year)
+    file = ExchangeRateFile.where(type: file_type, period_month: month, period_year: year).first
+    return unless file
+
+    s3_file_path = file.object_key
+    file.delete
+    TariffSynchronizer::FileService.delete_file(s3_file_path, true)
+  end
+
+  def rebuild_monthly_files(months_and_years)
+    months_and_years.each do |month, year|
+      date = Date.new(year, month, 1)
+
+      ExchangeRates::MonthlyExchangeRatesService.new(date, sample_date_for(date), download: false).call
+    end
+  end
+
+  def sample_date_for(date)
+    last_day_of_previous_month = date - 1
+    last_thursday_of_month_before = last_day_of_previous_month.downto(1).find { |d| d.wday == 4 }
+
+    last_thursday_of_month_before - 8
+  end
+
+  def prune_old_hmrc_monthly_files
+    (Date.new(2000, 1, 1)..Date.new(2023, 8, 31)).select { |date| date.day == 1 }.each do |date|
+      ExchangeRateFile.where(type: 'monthly_csv_hmrc', period_month: date.month, period_year: date.year).delete
+    end
+  end
+end
+
+namespace :exchange_rates do
+  desc 'Remove and re-build old monthly rates inclusive of the provided data (does not download from XE)'
+  task rebuild_old_monthly_rates: :environment do
+    ExchangeRatesRakeTasks.rebuild_old_monthly_rates
+  end
+
+  # This only accepts one period to delete the file and all the avg rates in that month
+  desc 'Remove and rebuild average rates'
+  task rebuild_average_rates: :environment do
+    ExchangeRatesRakeTasks.rebuild_average_rates
   end
 end


### PR DESCRIPTION
## What:
- [x] Extract `rebuild_old_monthly_rates` and `rebuild_average_rates` task bodies into `ExchangeRatesRakeTasks` helpers
- [x] Keep rake task names and external behaviour unchanged
- [x] Structure-only shortening of `lib/tasks/exchange_rates.rake`

## Why:
Long task blocks keep Metrics cops unenforceable. Extracting helper methods is a low-risk structural step that preserves rake entrypoints and exchange-rate rebuild behaviour.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Behaviour-preserving structural extraction of rake task helpers only. No intentional API or data behaviour change.

## Checklist:
- [x] Structure-only helper extraction
- [x] Based on tip of `main` after short task namespaces merge
