### PR TITLE
fix(rubocop): shorten remaining report generation helpers

### DIFF
--- a/app/lib/reporting/geographical_area_groups.rb
+++ b/app/lib/reporting/geographical_area_groups.rb
@@ -39,74 +39,80 @@ module Reporting
     class << self
       def generate
         with_report_logging do
-          workbook = instrument_report_step('open_workbook') do
-            if Rails.env.development?
-              FileUtils.rm(filename) if File.exist?(filename)
-
-              FastExcel.open(
-                filename,
-                constant_memory: true,
-              )
-            else
-              FastExcel.open(
-                constant_memory: true,
-              )
-            end
-          end
-
-          bold_format = instrument_report_step('add_format') do
-            workbook.add_format(bold: true)
-          end
-
-          worksheet = instrument_report_step('setup_worksheet') do
-            sheet = workbook.add_worksheet(Time.zone.today.iso8601)
-
-            COLUMN_WIDTHS.each_with_index do |width, index|
-              sheet.set_column_width(index, width)
-            end
-
-            sheet.append_row(HEADER_ROW, bold_format)
-            sheet.freeze_panes(1, 0)
-            sheet.autofilter(0, 1, 1, 4)
-            sheet
-          end
-
+          workbook = open_workbook
+          bold_format = instrument_report_step('add_format') { workbook.add_format(bold: true) }
+          worksheet = setup_worksheet(workbook, bold_format)
           rows = instrument_report_step('load_rows') do
             geographical_area_group_and_children
           end
 
-          rows_written = 0
-          rows_written = instrument_report_step('append_rows') do
-            rows.each_with_index do |(group, child), index|
-              row = build_row_for(group, child)
-              worksheet.append_row(row)
-              rows_written = index + 1
-            end
-
-            rows_written
-          end
+          rows_written = append_rows(worksheet, rows)
 
           log_report_metric('rows_written', rows_written)
 
-          workbook_data = instrument_report_step('close_workbook', rows_written:) do
-            workbook.close
-            Rails.env.production? ? workbook.read_string : nil
-          end
+          workbook_data = close_workbook(workbook, rows_written)
 
           log_report_metric('output_bytes', workbook_data.bytesize) if workbook_data
-
-          if Rails.env.production?
-            instrument_report_step('upload', rows_written:, output_bytes: workbook_data.bytesize) do
-              object.put(
-                body: workbook_data,
-                content_type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-              )
-            end
-          end
+          upload(workbook_data, rows_written) if Rails.env.production?
         end
       end
 
     private
+
+      def open_workbook
+        instrument_report_step('open_workbook') do
+          if Rails.env.development?
+            FileUtils.rm(filename) if File.exist?(filename)
+            FastExcel.open(filename, constant_memory: true)
+          else
+            FastExcel.open(constant_memory: true)
+          end
+        end
+      end
+
+      def setup_worksheet(workbook, bold_format)
+        instrument_report_step('setup_worksheet') do
+          sheet = workbook.add_worksheet(Time.zone.today.iso8601)
+          configure_worksheet(sheet, bold_format)
+          sheet
+        end
+      end
+
+      def configure_worksheet(sheet, bold_format)
+        COLUMN_WIDTHS.each_with_index do |width, index|
+          sheet.set_column_width(index, width)
+        end
+
+        sheet.append_row(HEADER_ROW, bold_format)
+        sheet.freeze_panes(1, 0)
+        sheet.autofilter(0, 1, 1, 4)
+      end
+
+      def append_rows(worksheet, rows)
+        instrument_report_step('append_rows') do
+          rows.each do |group, child|
+            worksheet.append_row(build_row_for(group, child))
+          end
+
+          rows.size
+        end
+      end
+
+      def close_workbook(workbook, rows_written)
+        instrument_report_step('close_workbook', rows_written:) do
+          workbook.close
+          Rails.env.production? ? workbook.read_string : nil
+        end
+      end
+
+      def upload(workbook_data, rows_written)
+        instrument_report_step('upload', rows_written:, output_bytes: workbook_data.bytesize) do
+          object.put(
+            body: workbook_data,
+            content_type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+          )
+        end
+      end
 
       def build_row_for(group, child)
         HEADER_ROW.map do |header|

--- a/app/lib/reporting/prohibitions.rb
+++ b/app/lib/reporting/prohibitions.rb
@@ -95,63 +95,79 @@ module Reporting
     class << self
       def generate
         with_report_logging do
-          workbook = instrument_report_step('open_workbook') do
-            if Rails.env.development?
-              FileUtils.rm(filename) if File.exist?(filename)
-              FastExcel.open(filename, constant_memory: true)
-            else
-              FastExcel.open(constant_memory: true)
-            end
-          end
-
+          workbook = open_workbook
           bold_format = instrument_report_step('add_format') { workbook.add_format(bold: true) }
-
-          worksheet = instrument_report_step('setup_worksheet') do
-            sheet = workbook.add_worksheet(Time.zone.today.iso8601)
-
-            COLUMN_WIDTHS.each_with_index do |width, index|
-              sheet.set_column_width(index, width)
-            end
-
-            sheet.append_row(HEADER_ROW, bold_format)
-            sheet.freeze_panes(1, 0)
-            sheet.autofilter(0, 1, 1, 25)
-            sheet
-          end
-
-          rows_written = instrument_report_step('append_rows') do
-            count = 0
-
-            each_declarable_and_measure do |declarable, measure|
-              row = build_row_for(declarable, measure)
-              worksheet.append_row(row)
-              count += 1
-            end
-
-            count
-          end
+          worksheet = setup_worksheet(workbook, bold_format)
+          rows_written = append_rows(worksheet)
 
           log_report_metric('rows_written', rows_written)
 
-          workbook_data = instrument_report_step('close_workbook', rows_written:) do
-            workbook.close
-            Rails.env.production? ? workbook.read_string : nil
-          end
-
-          if workbook_data
-            log_report_metric('output_bytes', workbook_data.bytesize)
-
-            instrument_report_step('upload', rows_written:, output_bytes: workbook_data.bytesize) do
-              object.put(
-                body: workbook_data,
-                content_type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-              )
-            end
-          end
+          workbook_data = close_workbook(workbook, rows_written)
+          upload(workbook_data, rows_written) if workbook_data
         end
       end
 
     private
+
+      def open_workbook
+        instrument_report_step('open_workbook') do
+          if Rails.env.development?
+            FileUtils.rm(filename) if File.exist?(filename)
+            FastExcel.open(filename, constant_memory: true)
+          else
+            FastExcel.open(constant_memory: true)
+          end
+        end
+      end
+
+      def setup_worksheet(workbook, bold_format)
+        instrument_report_step('setup_worksheet') do
+          sheet = workbook.add_worksheet(Time.zone.today.iso8601)
+          configure_worksheet(sheet, bold_format)
+          sheet
+        end
+      end
+
+      def configure_worksheet(sheet, bold_format)
+        COLUMN_WIDTHS.each_with_index do |width, index|
+          sheet.set_column_width(index, width)
+        end
+
+        sheet.append_row(HEADER_ROW, bold_format)
+        sheet.freeze_panes(1, 0)
+        sheet.autofilter(0, 1, 1, 25)
+      end
+
+      def append_rows(worksheet)
+        instrument_report_step('append_rows') do
+          count = 0
+
+          each_declarable_and_measure do |declarable, measure|
+            worksheet.append_row(build_row_for(declarable, measure))
+            count += 1
+          end
+
+          count
+        end
+      end
+
+      def close_workbook(workbook, rows_written)
+        instrument_report_step('close_workbook', rows_written:) do
+          workbook.close
+          Rails.env.production? ? workbook.read_string : nil
+        end
+      end
+
+      def upload(workbook_data, rows_written)
+        log_report_metric('output_bytes', workbook_data.bytesize)
+
+        instrument_report_step('upload', rows_written:, output_bytes: workbook_data.bytesize) do
+          object.put(
+            body: workbook_data,
+            content_type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+          )
+        end
+      end
 
       def build_row_for(declarable, measure)
         HEADER_ROW.map do |header|

--- a/app/lib/reporting/supplementary_units.rb
+++ b/app/lib/reporting/supplementary_units.rb
@@ -20,32 +20,11 @@ module Reporting
 
           log_report_metric('rows_written', report_rows.size)
 
-          csv_data = instrument_report_step('serialize_csv', rows_written: report_rows.size) do
-            CSV.generate(write_headers: true, headers: HEADER_ROW) do |csv|
-              report_rows.each do |row|
-                csv << row
-              end
-            end
-          end
-
+          csv_data = serialize_csv(report_rows)
           return if report_rows.empty?
 
           log_report_metric('output_bytes', csv_data.bytesize)
-
-          if Rails.env.development?
-            instrument_report_step('write_local_file', output_bytes: csv_data.bytesize) do
-              File.write(File.basename(object_key), csv_data)
-            end
-          end
-
-          if Rails.env.production?
-            instrument_report_step('upload', output_bytes: csv_data.bytesize) do
-              object.put(
-                body: csv_data,
-                content_type: 'text/csv',
-              )
-            end
-          end
+          publish_csv(csv_data)
         end
       end
 
@@ -92,6 +71,36 @@ module Reporting
               measures__geographical_area_id
             ],
           )
+      end
+
+      def serialize_csv(report_rows)
+        instrument_report_step('serialize_csv', rows_written: report_rows.size) do
+          CSV.generate(write_headers: true, headers: HEADER_ROW) do |csv|
+            report_rows.each do |row|
+              csv << row
+            end
+          end
+        end
+      end
+
+      def publish_csv(csv_data)
+        write_local_file(csv_data) if Rails.env.development?
+        upload(csv_data) if Rails.env.production?
+      end
+
+      def write_local_file(csv_data)
+        instrument_report_step('write_local_file', output_bytes: csv_data.bytesize) do
+          File.write(File.basename(object_key), csv_data)
+        end
+      end
+
+      def upload(csv_data)
+        instrument_report_step('upload', output_bytes: csv_data.bytesize) do
+          object.put(
+            body: csv_data,
+            content_type: 'text/csv',
+          )
+        end
       end
 
       def object_key


### PR DESCRIPTION
## What:
- [x] Extract serialize/publish helpers in `Reporting::SupplementaryUnits`
- [x] Extract workbook open/setup/append/close/upload helpers in `Reporting::Prohibitions`
- [x] Extract matching workbook helpers in `Reporting::GeographicalAreaGroups`
- [x] Keep report output, S3 keys, and logging instrumentation behaviour unchanged

## Why:
Long `generate` methods keep Metrics method-length unenforceable. These are mechanical extractions that preserve existing report logging helpers already on main.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Behaviour-preserving structural extraction of report generation helpers only. No intentional API or data behaviour change. Tariff updates report was already merged earlier.

## Checklist:
- [x] Structure-only helper extraction
- [x] Based on tip of `main` after labels tasks (#3419)
