### PR TITLE
fix(rubocop): extract synchronizer update workflow

### DIFF
--- a/app/lib/tariff_synchronizer.rb
+++ b/app/lib/tariff_synchronizer.rb
@@ -1,4 +1,8 @@
 module TariffSynchronizer
+  include UpdateApplication
+  include UpdateRollback
+  include UpdateValidation
+
   class FailedUpdatesError < StandardError; end
 
   delegate :instrument, :subscribe, to: ActiveSupport::Notifications
@@ -17,136 +21,6 @@ module TariffSynchronizer
   # Times to retry downloading update in case of serious problems (host resolution, ssl handshake, partial file) before giving up
   cattr_accessor :exception_retry_count
   self.exception_retry_count = TradeTariffBackend.exception_retry_count
-
-  def apply_updates(update_type)
-    applied_updates = []
-    import_warnings = []
-
-    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-
-    TradeTariffBackend.with_redis_lock do
-      TariffSynchronizer::Instrumentation.lock_acquired(phase: 'apply')
-
-      check_tariff_updates_failures
-      check_sequence
-
-      sequel_models.each(&:unrestrict_primary_key)
-
-      subscribe 'apply.import_warnings' do |*args|
-        event = ActiveSupport::Notifications::Event.new(*args)
-        import_warnings << event.payload
-      end
-
-      date_range = date_range_since_oldest_pending_update
-      date_range.each do |day|
-        applied_updates << perform_update(update_type, day)
-      end
-
-      applied_updates.flatten!
-
-      if applied_updates.any? && BaseUpdate.pending_or_failed.none?
-        duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000).round(2)
-        TariffSynchronizer::Instrumentation.apply_completed(
-          duration_ms:,
-          files_applied: applied_updates.size,
-        )
-        TariffLogger.apply(applied_updates.map(&:filename), import_warnings)
-        true
-      end
-    end
-  rescue Redlock::LockError
-    TariffSynchronizer::Instrumentation.lock_failed(phase: 'apply')
-  end
-
-  def rollback_updates(update_type, rollback_date, keep: false)
-    Rails.autoloaders.main.eager_load
-
-    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-
-    TradeTariffBackend.with_redis_lock do
-      TariffSynchronizer::Instrumentation.lock_acquired(phase: 'rollback')
-
-      date = Date.parse(rollback_date.to_s)
-      updates = update_type.where { issue_date > date }
-      update_filenames = updates.pluck(:filename)
-
-      Sequel::Model.db.transaction do
-        oplog_based_models.each do |model|
-          model.operation_klass
-               .where(filename: update_filenames)
-               .delete
-        end
-
-        TariffChangesJobStatus.find(operation_date: date)&.mark_changes_pending!
-
-        updates.each do |update|
-          update.mark_as_pending
-          update.clear_applied_at
-          update.clear_errors
-          update.delete unless keep
-        end
-
-        DataMigration.since(date.end_of_day).delete
-      end
-
-      duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000).round(2)
-      TariffSynchronizer::Instrumentation.rollback_completed(
-        rollback_date: date.iso8601,
-        duration_ms:,
-        files_count: update_filenames.size,
-      )
-    end
-  rescue Redlock::LockError
-    TariffSynchronizer::Instrumentation.lock_failed(phase: 'rollback')
-  end
-
-  def date_range_since_oldest_pending_update
-    oldest_pending_update = BaseUpdate.oldest_pending
-    return [] if oldest_pending_update.blank?
-
-    (oldest_pending_update.issue_date..update_to)
-  end
-
-  def perform_update(update_type, day)
-    updates = update_type.pending_at(day).to_a
-    updates.map do |update|
-      Instrumentation.file_import_started(filename: update.filename)
-
-      BaseUpdateImporter.perform(update)
-    end
-    updates
-  end
-
-  def check_tariff_updates_failures
-    failed = update_type.failed
-    if failed.any?
-      Instrumentation.failed_updates_detected(filenames: failed.map(&:filename))
-      raise FailedUpdatesError
-    end
-  rescue FailedUpdatesError => e
-    notify_slack_app(e)
-
-    raise
-  end
-
-  def notify_slack_app(exception)
-    SlackNotifierService.call("Error #{exception.class}: #{exception.message}")
-  end
-
-  def check_sequence
-    if update_type.correct_filename_sequence?
-      Instrumentation.sequence_check_passed
-    else
-      Instrumentation.sequence_check_failed(
-        details: 'Wrong sequence between the pending and applied files. Check the admin updates UI.',
-      )
-      raise FailedUpdatesError, 'Wrong sequence between the pending and applied files. Check the admin updates UI.'
-    end
-  rescue FailedUpdatesError => e
-    notify_slack_app(e)
-
-    raise
-  end
 
   def update_type
     TradeTariffBackend.uk? ? CdsUpdate : TaricUpdate

--- a/app/lib/tariff_synchronizer/update_application.rb
+++ b/app/lib/tariff_synchronizer/update_application.rb
@@ -1,0 +1,60 @@
+module TariffSynchronizer
+  module UpdateApplication
+    def apply_updates(update_type)
+      applied_updates = []
+      import_warnings = []
+
+      start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+      TradeTariffBackend.with_redis_lock do
+        TariffSynchronizer::Instrumentation.lock_acquired(phase: 'apply')
+
+        check_tariff_updates_failures
+        check_sequence
+
+        sequel_models.each(&:unrestrict_primary_key)
+
+        subscribe 'apply.import_warnings' do |*args|
+          event = ActiveSupport::Notifications::Event.new(*args)
+          import_warnings << event.payload
+        end
+
+        date_range = date_range_since_oldest_pending_update
+        date_range.each do |day|
+          applied_updates << perform_update(update_type, day)
+        end
+
+        applied_updates.flatten!
+
+        if applied_updates.any? && BaseUpdate.pending_or_failed.none?
+          duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000).round(2)
+          TariffSynchronizer::Instrumentation.apply_completed(
+            duration_ms:,
+            files_applied: applied_updates.size,
+          )
+          TariffLogger.apply(applied_updates.map(&:filename), import_warnings)
+          true
+        end
+      end
+    rescue Redlock::LockError
+      TariffSynchronizer::Instrumentation.lock_failed(phase: 'apply')
+    end
+
+    def date_range_since_oldest_pending_update
+      oldest_pending_update = BaseUpdate.oldest_pending
+      return [] if oldest_pending_update.blank?
+
+      (oldest_pending_update.issue_date..update_to)
+    end
+
+    def perform_update(update_type, day)
+      updates = update_type.pending_at(day).to_a
+      updates.map do |update|
+        Instrumentation.file_import_started(filename: update.filename)
+
+        BaseUpdateImporter.perform(update)
+      end
+      updates
+    end
+  end
+end

--- a/app/lib/tariff_synchronizer/update_rollback.rb
+++ b/app/lib/tariff_synchronizer/update_rollback.rb
@@ -1,0 +1,45 @@
+module TariffSynchronizer
+  module UpdateRollback
+    def rollback_updates(update_type, rollback_date, keep: false)
+      Rails.autoloaders.main.eager_load
+
+      start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+      TradeTariffBackend.with_redis_lock do
+        TariffSynchronizer::Instrumentation.lock_acquired(phase: 'rollback')
+
+        date = Date.parse(rollback_date.to_s)
+        updates = update_type.where { issue_date > date }
+        update_filenames = updates.pluck(:filename)
+
+        Sequel::Model.db.transaction do
+          oplog_based_models.each do |model|
+            model.operation_klass
+                 .where(filename: update_filenames)
+                 .delete
+          end
+
+          TariffChangesJobStatus.find(operation_date: date)&.mark_changes_pending!
+
+          updates.each do |update|
+            update.mark_as_pending
+            update.clear_applied_at
+            update.clear_errors
+            update.delete unless keep
+          end
+
+          DataMigration.since(date.end_of_day).delete
+        end
+
+        duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000).round(2)
+        TariffSynchronizer::Instrumentation.rollback_completed(
+          rollback_date: date.iso8601,
+          duration_ms:,
+          files_count: update_filenames.size,
+        )
+      end
+    rescue Redlock::LockError
+      TariffSynchronizer::Instrumentation.lock_failed(phase: 'rollback')
+    end
+  end
+end

--- a/app/lib/tariff_synchronizer/update_validation.rb
+++ b/app/lib/tariff_synchronizer/update_validation.rb
@@ -1,0 +1,34 @@
+module TariffSynchronizer
+  module UpdateValidation
+    def check_tariff_updates_failures
+      failed = update_type.failed
+      if failed.any?
+        Instrumentation.failed_updates_detected(filenames: failed.map(&:filename))
+        raise FailedUpdatesError
+      end
+    rescue FailedUpdatesError => e
+      notify_slack_app(e)
+
+      raise
+    end
+
+    def notify_slack_app(exception)
+      SlackNotifierService.call("Error #{exception.class}: #{exception.message}")
+    end
+
+    def check_sequence
+      if update_type.correct_filename_sequence?
+        Instrumentation.sequence_check_passed
+      else
+        Instrumentation.sequence_check_failed(
+          details: 'Wrong sequence between the pending and applied files. Check the admin updates UI.',
+        )
+        raise FailedUpdatesError, 'Wrong sequence between the pending and applied files. Check the admin updates UI.'
+      end
+    rescue FailedUpdatesError => e
+      notify_slack_app(e)
+
+      raise
+    end
+  end
+end


### PR DESCRIPTION
## What:
- [x] Extract apply workflow into `TariffSynchronizer::UpdateApplication`
- [x] Extract rollback workflow into `TariffSynchronizer::UpdateRollback`
- [x] Extract failure/sequence checks into `TariffSynchronizer::UpdateValidation`
- [x] Keep `TariffSynchronizer` as a thin module that includes those helpers
- [ ] **DRAFT for human review — do not auto-merge**

## Why:
Warehouse Metrics split of the long `TariffSynchronizer` module. This is structure-only extraction of existing apply/rollback/validation methods, but it sits on the CDS/TARIC sync path.

## Ticket:
N/A

## Risk:
**Risk level:** 🔴

**Reason for rating:**
Touches tariff synchronizer apply/rollback/validation — high-risk sync surface even when the change is intended as a behaviour-preserving extraction. Needs explicit review of autoload includes, method visibility, and sync/regression coverage before merge.

## Checklist:
- [x] Opened as **draft** — leave for user review
- [x] Based on tip of `main` after report helpers (#3420)
- [ ] Confirm Zeitwerk loads nested modules under `app/lib/tariff_synchronizer/`
- [ ] Run relevant sync/rollback specs before ready-for-review

**Do not apply low-risk auto-merge to this PR.**
