### PR TITLE
fix(rubocop): shorten basic report generation

### DIFF
--- a/app/lib/reporting/basic.rb
+++ b/app/lib/reporting/basic.rb
@@ -62,36 +62,45 @@ module Reporting
 
           log_report_metric('rows_written', rows.size)
 
-          csv_data = instrument_report_step('serialize_csv', rows_written: rows.size) do
-            CSV.generate(write_headers: true, headers: HEADER_ROW) do |csv|
-              rows.each do |row|
-                csv << row
-              end
-            end
-          end
-
+          csv_data = serialize_csv(rows)
           return if rows.empty?
 
           log_report_metric('output_bytes', csv_data.bytesize)
+          publish_csv(csv_data)
+        end
+      end
 
-          if Rails.env.development?
-            instrument_report_step('write_local_file', output_bytes: csv_data.bytesize) do
-              File.write(File.basename(object_key), csv_data)
-            end
-          end
+    private
 
-          if Rails.env.production?
-            instrument_report_step('upload', output_bytes: csv_data.bytesize) do
-              object.put(
-                body: csv_data,
-                content_type: 'text/csv',
-              )
+      def serialize_csv(rows)
+        instrument_report_step('serialize_csv', rows_written: rows.size) do
+          CSV.generate(write_headers: true, headers: HEADER_ROW) do |csv|
+            rows.each do |row|
+              csv << row
             end
           end
         end
       end
 
-    private
+      def publish_csv(csv_data)
+        write_local_file(csv_data) if Rails.env.development?
+        upload(csv_data) if Rails.env.production?
+      end
+
+      def write_local_file(csv_data)
+        instrument_report_step('write_local_file', output_bytes: csv_data.bytesize) do
+          File.write(File.basename(object_key), csv_data)
+        end
+      end
+
+      def upload(csv_data)
+        instrument_report_step('upload', output_bytes: csv_data.bytesize) do
+          object.put(
+            body: csv_data,
+            content_type: 'text/csv',
+          )
+        end
+      end
 
       def build_row_for(goods_nomenclature)
         overview_measures = goods_nomenclature.applicable_overview_measures

--- a/lib/tasks/exchange_rates.rake
+++ b/lib/tasks/exchange_rates.rake
@@ -1,7 +1,7 @@
 module ExchangeRatesRakeTasks
   FILE_TYPES = %w[monthly_csv monthly_xml monthly_csv_hmrc].freeze
 
-  module_function
+module_function
 
   def rebuild_old_monthly_rates
     require_monthly_env!

--- a/lib/tasks/green_lanes.rake
+++ b/lib/tasks/green_lanes.rake
@@ -1,5 +1,5 @@
 module GreenLanesTasks
-  module_function
+module_function
 
   def generate_categorisation_data
     raise "Cannot read file '#{ENV['CSVFILE']}'" unless File.file?(ENV['CSVFILE'].to_s)

--- a/lib/tasks/labels.rake
+++ b/lib/tasks/labels.rake
@@ -1,5 +1,5 @@
 module LabelsTasks
-  module_function
+module_function
 
   def coverage
     TimeMachine.now do

--- a/lib/tasks/search_embeddings.rake
+++ b/lib/tasks/search_embeddings.rake
@@ -1,5 +1,5 @@
 module SearchEmbeddingsRakeTasks
-  module_function
+module_function
 
   def generate
     sids = GoodsNomenclatureSelfText
@@ -47,7 +47,7 @@ module SearchEmbeddingsRakeTasks
 end
 
 module SearchEmbeddingsCoverageRakeTasks
-  module_function
+module_function
 
   def coverage
     TimeMachine.now do
@@ -106,7 +106,7 @@ module SearchEmbeddingsCoverageRakeTasks
 end
 
 module SearchEmbeddingsGapsRakeTasks
-  module_function
+module_function
 
   def gaps
     TimeMachine.now do

--- a/lib/tasks/swagger.rake
+++ b/lib/tasks/swagger.rake
@@ -61,7 +61,7 @@ module SwaggerRakeTasks
   CONTROLLER_ROOT = File.expand_path('../../app/controllers/api/v2', __dir__)
   SPEC_ROOT = File.expand_path('../../spec/swagger/api/v2', __dir__)
 
-  module_function
+module_function
 
   def generate
     ENV['PATTERN'] = Dir.glob(SWAGGER_SPEC_PATTERN).reject { |path| DRAFT_SWAGGER_SPECS.include?(path) }.join(',')

--- a/lib/tasks/tariff.rake
+++ b/lib/tasks/tariff.rake
@@ -1,5 +1,5 @@
 module TariffRakeTasks
-  module_function
+module_function
 
   def jobs
     require 'sidekiq/api'


### PR DESCRIPTION
## What:
- [x] Extract `serialize_csv` and `publish_csv` helpers from `Reporting::Basic.generate`
- [x] Extract `write_local_file` and `upload` steps used by publish
- [x] Keep existing report logging metrics, CSV headers, row building, and object keys unchanged

## Why:
Shorten the basic report `generate` method so Metrics method length can be approached without changing report output or S3 keys.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Behaviour-preserving extraction of serialize/publish steps in an offline reporting rake path. No measure, duty, sync, or API behaviour changes.
