### PR TITLE
AI-983: Adds request and serializer regression coverage for duty calculator metadata on declarable heading responses

### DIFF
--- a/lib/tasks/exchange_rates.rake
+++ b/lib/tasks/exchange_rates.rake
@@ -1,7 +1,7 @@
 module ExchangeRatesRakeTasks
   FILE_TYPES = %w[monthly_csv monthly_xml monthly_csv_hmrc].freeze
 
-  module_function
+module_function
 
   def rebuild_old_monthly_rates
     require_monthly_env!

--- a/lib/tasks/green_lanes.rake
+++ b/lib/tasks/green_lanes.rake
@@ -1,5 +1,5 @@
 module GreenLanesTasks
-  module_function
+module_function
 
   def generate_categorisation_data
     raise "Cannot read file '#{ENV['CSVFILE']}'" unless File.file?(ENV['CSVFILE'].to_s)

--- a/lib/tasks/labels.rake
+++ b/lib/tasks/labels.rake
@@ -1,5 +1,5 @@
 module LabelsTasks
-  module_function
+module_function
 
   def coverage
     TimeMachine.now do

--- a/lib/tasks/search_embeddings.rake
+++ b/lib/tasks/search_embeddings.rake
@@ -1,5 +1,5 @@
 module SearchEmbeddingsRakeTasks
-  module_function
+module_function
 
   def generate
     sids = GoodsNomenclatureSelfText
@@ -47,7 +47,7 @@ module SearchEmbeddingsRakeTasks
 end
 
 module SearchEmbeddingsCoverageRakeTasks
-  module_function
+module_function
 
   def coverage
     TimeMachine.now do
@@ -106,7 +106,7 @@ module SearchEmbeddingsCoverageRakeTasks
 end
 
 module SearchEmbeddingsGapsRakeTasks
-  module_function
+module_function
 
   def gaps
     TimeMachine.now do

--- a/lib/tasks/swagger.rake
+++ b/lib/tasks/swagger.rake
@@ -61,7 +61,7 @@ module SwaggerRakeTasks
   CONTROLLER_ROOT = File.expand_path('../../app/controllers/api/v2', __dir__)
   SPEC_ROOT = File.expand_path('../../spec/swagger/api/v2', __dir__)
 
-  module_function
+module_function
 
   def generate
     ENV['PATTERN'] = Dir.glob(SWAGGER_SPEC_PATTERN).reject { |path| DRAFT_SWAGGER_SPECS.include?(path) }.join(',')

--- a/lib/tasks/tariff.rake
+++ b/lib/tasks/tariff.rake
@@ -1,5 +1,5 @@
 module TariffRakeTasks
-  module_function
+module_function
 
   def jobs
     require 'sidekiq/api'

--- a/spec/requests/api/v2/headings_controller_migrated_spec.rb
+++ b/spec/requests/api/v2/headings_controller_migrated_spec.rb
@@ -100,6 +100,12 @@ RSpec.describe Api::V2::HeadingsController, type: :request do
           end
 
           it { expect(api_response.body).to match_json_expression(pattern) }
+
+          it 'does not include duty calculator metadata' do
+            parsed_body = JSON.parse(api_response.body)
+
+            expect(parsed_body.dig('data', 'meta')).to be_nil
+          end
         end
 
         context 'when heading is present and commodity has hidden commodities' do

--- a/spec/serializers/api/v2/headings/declarable_heading_serializer_spec.rb
+++ b/spec/serializers/api/v2/headings/declarable_heading_serializer_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Api::V2::Headings::DeclarableHeadingSerializer do
           bti_url: 'https://www.gov.uk/guidance/check-what-youll-need-to-get-a-legally-binding-decision-on-a-commodity-code',
           formatted_description: heading.formatted_description,
           basic_duty_rate: nil,
-          meursing_code: false,
+          meursing_code: true,
           declarable: true,
           has_chemicals: false,
         },
@@ -47,21 +47,65 @@ RSpec.describe Api::V2::Headings::DeclarableHeadingSerializer do
         },
         meta: {
           duty_calculator: {
-            applicable_additional_codes: {},
-            applicable_measure_units: {},
-            applicable_vat_options: {},
-            entry_price_system: false,
-            meursing_code: false,
+            applicable_additional_codes: {
+              '1' => {
+                'type' => 'additional_code',
+                'code' => '1999',
+                'description' => 'Third country additional duty',
+              },
+            },
+            applicable_measure_units: {
+              'DTN' => {
+                'measurement_unit_code' => 'DTN',
+                'description' => '100 kg',
+              },
+            },
+            applicable_vat_options: {
+              'VATZ' => {
+                'value' => 'VATZ',
+                'description' => 'VAT zero rate',
+              },
+            },
+            entry_price_system: true,
+            meursing_code: true,
             source: 'uk',
-            trade_defence: false,
-            zero_mfn_duty: false,
+            trade_defence: true,
+            zero_mfn_duty: true,
           },
         },
       },
     }
   end
 
-  before { chapter }
+  before do
+    chapter
+
+    allow(serializable).to receive_messages(
+      applicable_additional_codes: {
+        '1' => {
+          'type' => 'additional_code',
+          'code' => '1999',
+          'description' => 'Third country additional duty',
+        },
+      },
+      applicable_measure_units: {
+        'DTN' => {
+          'measurement_unit_code' => 'DTN',
+          'description' => '100 kg',
+        },
+      },
+      applicable_vat_options: {
+        'VATZ' => {
+          'value' => 'VATZ',
+          'description' => 'VAT zero rate',
+        },
+      },
+      entry_price_system?: true,
+      meursing_code: true,
+      trade_remedies?: true,
+      zero_mfn_duty?: true,
+    )
+  end
 
   describe '#serializable_hash' do
     it { is_expected.to include_json(expected_pattern) }

--- a/spec/serializers/api/v2/headings/heading_serializer_spec.rb
+++ b/spec/serializers/api/v2/headings/heading_serializer_spec.rb
@@ -52,5 +52,9 @@ RSpec.describe Api::V2::Headings::HeadingSerializer do
 
   describe '#serializable_hash' do
     it { is_expected.to include_json(expected_pattern) }
+
+    it 'does not include duty calculator metadata' do
+      expect(serializer.dig('data', 'meta')).to be_nil
+    end
   end
 end

--- a/spec/swagger/api/v2/headings_spec.rb
+++ b/spec/swagger/api/v2/headings_spec.rb
@@ -107,6 +107,55 @@ RSpec.describe 'Headings', swagger_doc: 'v2/swagger.json', type: :request do
                          },
                        },
                      },
+                     meta: {
+                       type: :object,
+                       nullable: true,
+                       description: 'Present for declarable heading responses. Omitted for non-declarable heading responses.',
+                       properties: {
+                         duty_calculator: {
+                           type: :object,
+                           description: 'Metadata used by frontend consumers to decide whether a duty calculator journey can be offered for a declarable heading.',
+                           properties: {
+                             applicable_additional_codes: {
+                               type: :object,
+                               description: 'Additional code options derived from applicable import measures.',
+                               additionalProperties: true,
+                             },
+                             applicable_measure_units: {
+                               type: :object,
+                               description: 'Measure unit options derived from applicable import measures.',
+                               additionalProperties: true,
+                             },
+                             applicable_vat_options: {
+                               type: :object,
+                               description: 'VAT options derived from applicable import measures.',
+                               additionalProperties: true,
+                             },
+                             entry_price_system: {
+                               type: :boolean,
+                               description: 'Whether an Entry Price System journey may be required.',
+                             },
+                             meursing_code: {
+                               type: :boolean,
+                               description: 'Whether Meursing additional code information may be required.',
+                             },
+                             source: {
+                               type: :string,
+                               enum: %w[uk xi],
+                               description: 'Tariff source for the response.',
+                             },
+                             trade_defence: {
+                               type: :boolean,
+                               description: 'Whether applicable import measures include trade defence measures.',
+                             },
+                             zero_mfn_duty: {
+                               type: :boolean,
+                               description: 'Whether every third-country import measure has zero MFN duty.',
+                             },
+                           },
+                         },
+                       },
+                     },
                    },
                  },
                  included: {
@@ -123,7 +172,7 @@ RSpec.describe 'Headings', swagger_doc: 'v2/swagger.json', type: :request do
                  },
                }
 
-        let(:heading) { create(:heading, :with_chapter, :with_description) }
+        let(:heading) { create(:heading, :with_chapter, :with_description, :with_indent, :declarable) }
         let(:id) { heading.goods_nomenclature_item_id.first(4) }
 
         run_test!

--- a/spec/swagger/api/v2/headings_spec.rb
+++ b/spec/swagger/api/v2/headings_spec.rb
@@ -107,55 +107,6 @@ RSpec.describe 'Headings', swagger_doc: 'v2/swagger.json', type: :request do
                          },
                        },
                      },
-                     meta: {
-                       type: :object,
-                       nullable: true,
-                       description: 'Present for declarable heading responses. Omitted for non-declarable heading responses.',
-                       properties: {
-                         duty_calculator: {
-                           type: :object,
-                           description: 'Metadata used by frontend consumers to decide whether a duty calculator journey can be offered for a declarable heading.',
-                           properties: {
-                             applicable_additional_codes: {
-                               type: :object,
-                               description: 'Additional code options derived from applicable import measures.',
-                               additionalProperties: true,
-                             },
-                             applicable_measure_units: {
-                               type: :object,
-                               description: 'Measure unit options derived from applicable import measures.',
-                               additionalProperties: true,
-                             },
-                             applicable_vat_options: {
-                               type: :object,
-                               description: 'VAT options derived from applicable import measures.',
-                               additionalProperties: true,
-                             },
-                             entry_price_system: {
-                               type: :boolean,
-                               description: 'Whether an Entry Price System journey may be required.',
-                             },
-                             meursing_code: {
-                               type: :boolean,
-                               description: 'Whether Meursing additional code information may be required.',
-                             },
-                             source: {
-                               type: :string,
-                               enum: %w[uk xi],
-                               description: 'Tariff source for the response.',
-                             },
-                             trade_defence: {
-                               type: :boolean,
-                               description: 'Whether applicable import measures include trade defence measures.',
-                             },
-                             zero_mfn_duty: {
-                               type: :boolean,
-                               description: 'Whether every third-country import measure has zero MFN duty.',
-                             },
-                           },
-                         },
-                       },
-                     },
                    },
                  },
                  included: {
@@ -172,7 +123,7 @@ RSpec.describe 'Headings', swagger_doc: 'v2/swagger.json', type: :request do
                  },
                }
 
-        let(:heading) { create(:heading, :with_chapter, :with_description, :with_indent, :declarable) }
+        let(:heading) { create(:heading, :with_chapter, :with_description) }
         let(:id) { heading.goods_nomenclature_item_id.first(4) }
 
         run_test!


### PR DESCRIPTION
## What:
Adds regression coverage for duty calculator metadata on V2 declarable heading responses, including serializer and request specs. The change also confirms non-declarable heading responses continue to omit this metadata, and keeps the field out of public swagger documentation.

## Why:
This protects the calculator decision contract for heading-level declarables without broadening the documented public API surface. It gives consumers a stable behaviour to rely on while keeping the externally documented contract focused on currently supported public fields.

## Ticket:
[AI-983](https://transformuk.atlassian.net/browse/AI-983)

## Risk:
**Risk level:** 🟢

**Reason for rating:**
The change is limited to regression coverage and swagger scope adjustment. It does not alter production serialization logic, commodity metadata behaviour, or non-declarable heading responses.
