### PR TITLE
fix(rubocop): shorten self text tasks

### DIFF
--- a/lib/tasks/self_texts.rake
+++ b/lib/tasks/self_texts.rake
@@ -1,35 +1,42 @@
-namespace :self_texts do
-  desc 'Show self-text coverage statistics'
-  task coverage: :environment do
-    TimeMachine.now do
-      total_gn = GoodsNomenclature.actual.non_hidden.count - Chapter.actual.count
-      total_self_texts = GoodsNomenclatureSelfText.count
-      missing = total_gn - total_self_texts
-      stale = GoodsNomenclatureSelfText.where(stale: true).count
-      needing_work = missing + stale
-      coverage = total_gn.positive? ? (total_self_texts * 100.0 / total_gn).round(2) : 0
+module SelfTextsTasks
+module_function
 
-      by_type = GoodsNomenclatureSelfText
-        .group_and_count(:generation_type)
-        .order(:generation_type)
-        .all
-
-      puts 'Self-Text Coverage Statistics'
-      puts '-' * 30
-      puts "Total GN (excl. chapters): #{total_gn}"
-      puts "With self-text:            #{total_self_texts}"
-      puts "Missing:                   #{missing}"
-      puts "Coverage:                  #{coverage}%"
-      puts "Stale:                     #{stale}"
-      puts "Needing work:              #{needing_work}"
-      puts
-      puts 'By generation type:'
-      by_type.each { |row| puts "  #{row[:generation_type]}: #{row[:count]}" }
-    end
+  def coverage
+    TimeMachine.now { print_coverage_stats(coverage_stats) }
   end
 
-  desc 'Regenerate all self-texts by marking them stale and re-enqueuing'
-  task regenerate: :environment do
+  def coverage_stats
+    total_gn = GoodsNomenclature.actual.non_hidden.count - Chapter.actual.count
+    total_self_texts = GoodsNomenclatureSelfText.count
+    missing = total_gn - total_self_texts
+    stale = GoodsNomenclatureSelfText.where(stale: true).count
+
+    {
+      total_gn:,
+      total_self_texts:,
+      missing:,
+      stale:,
+      needing_work: missing + stale,
+      coverage: total_gn.positive? ? (total_self_texts * 100.0 / total_gn).round(2) : 0,
+      by_type: GoodsNomenclatureSelfText.group_and_count(:generation_type).order(:generation_type).all,
+    }
+  end
+
+  def print_coverage_stats(stats)
+    puts 'Self-Text Coverage Statistics'
+    puts '-' * 30
+    puts "Total GN (excl. chapters): #{stats[:total_gn]}"
+    puts "With self-text:            #{stats[:total_self_texts]}"
+    puts "Missing:                   #{stats[:missing]}"
+    puts "Coverage:                  #{stats[:coverage]}%"
+    puts "Stale:                     #{stats[:stale]}"
+    puts "Needing work:              #{stats[:needing_work]}"
+    puts
+    puts 'By generation type:'
+    stats[:by_type].each { |row| puts "  #{row[:generation_type]}: #{row[:count]}" }
+  end
+
+  def regenerate
     dataset = GoodsNomenclatureSelfText.where(stale: false, manually_edited: false)
     item_ids = dataset.select_map(:goods_nomenclature_sid)
     count = dataset.update(stale: true)
@@ -40,412 +47,482 @@ namespace :self_texts do
     puts 'Enqueued regeneration. Check Sidekiq for progress.'
   end
 
-  desc 'Generate self-texts for all chapters (background) or a single chapter (inline with CHAPTER=XX)'
-  task generate: :environment do
+  def generate
     if ENV['CHAPTER']
-      chapter = TimeMachine.now { Chapter.actual.by_code(ENV['CHAPTER']).take }
-      raise "Chapter #{ENV['CHAPTER']} not found" unless chapter
-
-      puts "Generating self-texts for chapter #{ENV['CHAPTER']}..."
-      ai = GenerateSelfText::OtherSelfTextBuilder.call(chapter)
-      non_other_ai = GenerateSelfText::NonOtherSelfTextBuilder.call(chapter)
-      puts "Other AI: #{ai.inspect}"
-      puts "Non-Other AI: #{non_other_ai.inspect}"
+      generate_chapter
     else
-      puts 'Enqueuing self-text generation for all chapters...'
-      GenerateSelfTextWorker.perform_async
-      puts 'Done. Check Sidekiq for progress.'
+      enqueue_generation
     end
   end
 
-  desc 'Populate EU reference self-texts from CSV into existing generated rows'
-  task populate_eu_references: :environment do
+  def generate_chapter
+    chapter = TimeMachine.now { Chapter.actual.by_code(ENV['CHAPTER']).take }
+    raise "Chapter #{ENV['CHAPTER']} not found" unless chapter
+
+    puts "Generating self-texts for chapter #{ENV['CHAPTER']}..."
+    ai = GenerateSelfText::OtherSelfTextBuilder.call(chapter)
+    non_other_ai = GenerateSelfText::NonOtherSelfTextBuilder.call(chapter)
+    puts "Other AI: #{ai.inspect}"
+    puts "Non-Other AI: #{non_other_ai.inspect}"
+  end
+
+  def enqueue_generation
+    puts 'Enqueuing self-text generation for all chapters...'
+    GenerateSelfTextWorker.perform_async
+    puts 'Done. Check Sidekiq for progress.'
+  end
+
+  def populate_eu_references
     require 'csv'
 
     csv_path = Rails.root.join('data/CN2026_SelfText_EN_DE_FR.csv')
-
-    unless File.exist?(csv_path)
-      puts "CSV not found at #{csv_path}"
-      exit 1
-    end
+    missing_csv!(csv_path) unless File.exist?(csv_path)
 
     stats = { updated: 0, skipped_no_match: 0, skipped_blank: 0 }
-
-    CSV.foreach(csv_path, headers: true) do |row|
-      code = row['CN_CODE']
-      eu_text = row['SelfText_EN']&.strip
-
-      next stats[:skipped_blank] += 1 if code.blank? || eu_text.blank?
-
-      normalized = code.gsub(/\s/, '').ljust(10, '0')
-
-      dataset = GoodsNomenclatureSelfText
-        .where(goods_nomenclature_item_id: normalized)
-        .where(Sequel.|(
-                 { eu_self_text: nil },
-                 Sequel.~(eu_self_text: eu_text),
-               ))
-      item_ids = dataset.select_map(:goods_nomenclature_sid)
-      count = dataset.update(eu_self_text: eu_text, eu_embedding: nil)
-
-      PaperTrail::BulkVersioning.record_current_versions_for_item_ids!(model: GoodsNomenclatureSelfText, item_ids:) if count.positive?
-
-      if count.positive?
-        stats[:updated] += count
-      else
-        existing = GoodsNomenclatureSelfText.where(goods_nomenclature_item_id: normalized).count
-        stats[:skipped_no_match] += 1 if existing.zero?
-      end
-    end
-
+    CSV.foreach(csv_path, headers: true) { |row| populate_eu_reference(row, stats) }
     puts "EU references populated: #{stats[:updated]} updated, #{stats[:skipped_no_match]} no matching generated text, #{stats[:skipped_blank]} blank"
   end
 
-  desc 'Generate embeddings for self-texts and EU references via OpenAI'
-  task generate_embeddings: :environment do
+  def missing_csv!(csv_path)
+    puts "CSV not found at #{csv_path}"
+    exit 1
+  end
+
+  def populate_eu_reference(row, stats)
+    code = row['CN_CODE']
+    eu_text = row['SelfText_EN']&.strip
+
+    return stats[:skipped_blank] += 1 if code.blank? || eu_text.blank?
+
+    normalized = code.gsub(/\s/, '').ljust(10, '0')
+    dataset = eu_reference_update_dataset(normalized, eu_text)
+    item_ids = dataset.select_map(:goods_nomenclature_sid)
+    count = dataset.update(eu_self_text: eu_text, eu_embedding: nil)
+    PaperTrail::BulkVersioning.record_current_versions_for_item_ids!(model: GoodsNomenclatureSelfText, item_ids:) if count.positive?
+    update_eu_reference_stats(stats, normalized, count)
+  end
+
+  def eu_reference_update_dataset(normalized, eu_text)
+    GoodsNomenclatureSelfText
+      .where(goods_nomenclature_item_id: normalized)
+      .where(Sequel.|({ eu_self_text: nil }, Sequel.~(eu_self_text: eu_text)))
+  end
+
+  def update_eu_reference_stats(stats, normalized, count)
+    if count.positive?
+      stats[:updated] += count
+    else
+      existing = GoodsNomenclatureSelfText.where(goods_nomenclature_item_id: normalized).count
+      stats[:skipped_no_match] += 1 if existing.zero?
+    end
+  end
+
+  def generate_embeddings
     service = EmbeddingService.new
+    generated = embedding_records(:embedding, :self_text, :self_text)
+    puts "Pass 1: #{generated.size} generated self-texts need embeddings..."
+    generate_embedding_batches(
+      service,
+      generated,
+      :embedding,
+      :self_text,
+      'Generated',
+      event_kind: 'self_text_embedding_backfill',
+    )
 
-    # Pass 1: generated self-texts missing embeddings
-    generate_texts = GoodsNomenclatureSelfText
-      .where(embedding: nil)
-      .exclude(self_text: nil)
-      .select(:goods_nomenclature_sid, :self_text)
-      .all
-
-    puts "Pass 1: #{generate_texts.size} generated self-texts need embeddings..."
-
-    generate_texts.each_slice(EmbeddingService::BATCH_SIZE).with_index do |batch, i|
-      texts = batch.map(&:self_text)
-      embeddings = AiUsage::Instrumentation.embedding_api_call(
-        event_kind: 'self_text_embedding_backfill',
-        batch_size: texts.size,
-        model: EmbeddingService::MODEL,
-      ) { service.embed_batch(texts, event_kind: 'self_text_embedding_backfill') }
-
-      batch.zip(embeddings).each do |record, embedding|
-        update_dataset = GoodsNomenclatureSelfText.where(goods_nomenclature_sid: record.goods_nomenclature_sid)
-        update_dataset.update(embedding: Sequel.lit("'[#{embedding.join(',')}]'::vector"))
-        PaperTrail::BulkVersioning.record_current_versions_for_dataset!(model: GoodsNomenclatureSelfText, dataset: update_dataset)
-      end
-
-      processed = [(i + 1) * EmbeddingService::BATCH_SIZE, generate_texts.size].min
-      puts "  Generated: #{processed}/#{generate_texts.size} embedded"
-    end
-
-    # Pass 2: EU references missing embeddings
-    eu_texts = GoodsNomenclatureSelfText
-      .where(eu_embedding: nil)
-      .exclude(eu_self_text: nil)
-      .select(:goods_nomenclature_sid, :eu_self_text)
-      .all
-
-    puts "Pass 2: #{eu_texts.size} EU references need embeddings..."
-
-    eu_texts.each_slice(EmbeddingService::BATCH_SIZE).with_index do |batch, i|
-      texts = batch.map(&:eu_self_text)
-      embeddings = AiUsage::Instrumentation.embedding_api_call(
-        event_kind: 'eu_self_text_embedding_backfill',
-        batch_size: texts.size,
-        model: EmbeddingService::MODEL,
-      ) { service.embed_batch(texts, event_kind: 'eu_self_text_embedding_backfill') }
-
-      batch.zip(embeddings).each do |record, embedding|
-        update_dataset = GoodsNomenclatureSelfText.where(goods_nomenclature_sid: record.goods_nomenclature_sid)
-        update_dataset.update(eu_embedding: Sequel.lit("'[#{embedding.join(',')}]'::vector"))
-        PaperTrail::BulkVersioning.record_current_versions_for_dataset!(model: GoodsNomenclatureSelfText, dataset: update_dataset)
-      end
-
-      processed = [(i + 1) * EmbeddingService::BATCH_SIZE, eu_texts.size].min
-      puts "  EU: #{processed}/#{eu_texts.size} embedded"
-    end
-
+    eu_references = embedding_records(:eu_embedding, :eu_self_text, :eu_self_text)
+    puts "Pass 2: #{eu_references.size} EU references need embeddings..."
+    generate_embedding_batches(
+      service,
+      eu_references,
+      :eu_embedding,
+      :eu_self_text,
+      'EU',
+      event_kind: 'eu_self_text_embedding_backfill',
+    )
     puts 'Embedding generation complete.'
   end
 
-  desc 'Fix encoding artefacts (e.g. pure9e -> puree) in existing AI-generated self-texts'
-  task fix_encoding_artefacts: :environment do
+  def embedding_records(embedding_column, text_column, select_text_column)
+    GoodsNomenclatureSelfText
+      .where(embedding_column => nil)
+      .exclude(text_column => nil)
+      .select(:goods_nomenclature_sid, select_text_column)
+      .all
+  end
+
+  def generate_embedding_batches(service, records, embedding_column, text_column, label, event_kind:)
+    records.each_slice(EmbeddingService::BATCH_SIZE).with_index do |batch, index|
+      texts = batch.map { |record| record.public_send(text_column) }
+      embeddings = AiUsage::Instrumentation.embedding_api_call(
+        event_kind:,
+        batch_size: texts.size,
+        model: EmbeddingService::MODEL,
+      ) { service.embed_batch(texts, event_kind:) }
+      update_embeddings(batch, embeddings, embedding_column)
+      processed = [(index + 1) * EmbeddingService::BATCH_SIZE, records.size].min
+      puts "  #{label}: #{processed}/#{records.size} embedded"
+    end
+  end
+
+  def update_embeddings(batch, embeddings, embedding_column)
+    batch.zip(embeddings).each do |record, embedding|
+      update_dataset = GoodsNomenclatureSelfText.where(goods_nomenclature_sid: record.goods_nomenclature_sid)
+      update_dataset.update(embedding_column => Sequel.lit("'[#{embedding.join(',')}]'::vector"))
+      PaperTrail::BulkVersioning.record_current_versions_for_dataset!(model: GoodsNomenclatureSelfText, dataset: update_dataset)
+    end
+  end
+
+  def fix_encoding_artefacts
     sanitiser = GenerateSelfText::EncodingArtefactSanitiser
     fixed = 0
 
     GoodsNomenclatureSelfText.where(generation_type: %w[ai ai_non_other]).each do |record|
-      sanitised = sanitiser.call(record.self_text)
-      next if sanitised == record.self_text
-
-      record.update(
-        self_text: sanitised,
-        embedding: nil,
-        search_embedding: nil,
-        search_embedding_stale: true,
-      )
-      fixed += 1
-      puts "Fixed [#{record.goods_nomenclature_item_id}] sid=#{record.goods_nomenclature_sid}: #{record.self_text.truncate(80)}"
+      fixed += fix_encoding_artefact(record, sanitiser)
     end
 
     puts "Done. Fixed #{fixed} records."
   end
 
-  desc 'Score all self-texts (populate EU refs, generate embeddings, compute confidence)'
-  task score: :environment do
+  def fix_encoding_artefact(record, sanitiser)
+    sanitised = sanitiser.call(record.self_text)
+    return 0 if sanitised == record.self_text
+
+    record.update(self_text: sanitised, embedding: nil, search_embedding: nil, search_embedding_stale: true)
+    puts "Fixed [#{record.goods_nomenclature_item_id}] sid=#{record.goods_nomenclature_sid}: #{record.self_text.truncate(80)}"
+    1
+  end
+
+  def score
     sids = GoodsNomenclatureSelfText.select_map(:goods_nomenclature_sid)
     puts "Scoring #{sids.size} self-texts..."
-
     SelfTextConfidenceScorer.new.score(sids)
-
     puts 'Scoring complete.'
   end
 
-  desc 'Show busy and queued self-text generation workers with chapter details'
-  task status: :environment do
+  def status
     require 'json'
 
     TimeMachine.now do
-      puts 'BUSY:'
-      Sidekiq::Workers.new.each do |_pid, _tid, work|
-        payload = JSON.parse(work.payload)
-        next unless payload['class'].include?('SelfText')
-
-        sid = payload['args']&.first
-        ch = Chapter.where(goods_nomenclature_sid: sid).first
-        label = ch ? "#{ch.goods_nomenclature_item_id.first(2)} - #{ch.description}" : "sid=#{sid}"
-        puts "  #{label} (running since #{Time.zone.at(work.run_at)})"
-      end
-
+      print_busy_self_text_workers
       puts
-      queued = Sidekiq::Queue.all.flat_map do |q|
-        q.select { |j| j.klass.include?('SelfText') }
-      end
-
-      puts "QUEUED (#{queued.size}):"
-      queued.each do |job|
-        sid = job.args&.first
-        ch = Chapter.where(goods_nomenclature_sid: sid).first
-        label = ch ? "#{ch.goods_nomenclature_item_id.first(2)} - #{ch.description}" : "sid=#{sid}"
-        puts "  #{label} (enqueued #{Time.zone.at(job.enqueued_at)}) [#{job.queue}]"
-      end
+      print_queued_self_text_workers
     end
   end
 
-  desc 'Show self-text gaps and stale records grouped by chapter and heading (CHAPTER=XX to filter)'
-  task gaps: :environment do
+  def print_busy_self_text_workers
+    puts 'BUSY:'
+    Sidekiq::Workers.new.each do |_pid, _tid, work|
+      payload = JSON.parse(work.payload)
+      next unless payload['class'].include?('SelfText')
+
+      puts "  #{chapter_label(payload['args']&.first)} (running since #{Time.zone.at(work.run_at)})"
+    end
+  end
+
+  def print_queued_self_text_workers
+    queued = Sidekiq::Queue.all.flat_map { |queue| queue.select { |job| job.klass.include?('SelfText') } }
+    puts "QUEUED (#{queued.size}):"
+    queued.each do |job|
+      puts "  #{chapter_label(job.args&.first)} (enqueued #{Time.zone.at(job.enqueued_at)}) [#{job.queue}]"
+    end
+  end
+
+  def chapter_label(sid)
+    chapter = Chapter.where(goods_nomenclature_sid: sid).first
+    chapter ? "#{chapter.goods_nomenclature_item_id.first(2)} - #{chapter.description}" : "sid=#{sid}"
+  end
+
+  def gaps
     TimeMachine.now do
-      gn = Sequel[:goods_nomenclatures]
-      st = Sequel[:goods_nomenclature_self_texts]
-
-      # All actual non-chapter GN items left-joined to self_texts
-      base = GoodsNomenclature.actual
-        .non_hidden
-        .exclude(gn[:goods_nomenclature_item_id] => Chapter.actual.select(:goods_nomenclature_item_id))
-        .left_join(:goods_nomenclature_self_texts, { st[:goods_nomenclature_sid] => gn[:goods_nomenclature_sid] })
-
-      if ENV['CHAPTER']
-        base = base.where(Sequel.like(gn[:goods_nomenclature_item_id], "#{ENV['CHAPTER'].ljust(2, '0')}%"))
-      end
-
-      needing_work_ds = base.where(Sequel.expr(st[:goods_nomenclature_sid] => nil) | Sequel.expr(st[:stale] => true))
-
-      # --- Chapter summary ---
-      chapter_stats = base
-        .select_group(Sequel.function(:substr, gn[:goods_nomenclature_item_id], 1, 2).as(:ch))
-        .select_append { count(Sequel.lit('*')).as(total) }
-        .select_append { count(Sequel.case([[{ st[:goods_nomenclature_sid] => nil }, 1]], nil)).as(missing) }
-        .select_append { count(Sequel.case([[{ st[:stale] => true }, 1]], nil)).as(stale) }
-        .order(:ch)
-        .all
-
-      # Load chapter descriptions for display
-      chapter_descs = Chapter.actual
-        .eager(:goods_nomenclature_descriptions)
-        .all
-        .to_h { |c| [c.goods_nomenclature_item_id.first(2), c.description&.truncate(50)] }
-
-      puts 'Self-Text Gaps and Stale Records by Chapter'
-      puts '=' * 100
-      printf "%-4s %-50s %6s %6s %6s %6s %7s\n", 'Ch', 'Description', 'Total', 'Miss', 'Stale', 'Work', 'Cov %'
-      puts '-' * 100
-
-      chapter_stats.each do |row|
-        ch = row[:ch]
-        total = row[:total]
-        miss = row[:missing]
-        stale = row[:stale]
-        work = miss + stale
-        cov = total.positive? ? ((total - miss) * 100.0 / total).round(1) : 0
-        printf "%-4s %-50s %6d %6d %6d %6d %6.1f%%\n", ch, chapter_descs[ch] || '?', total, miss, stale, work, cov
-      end
-
-      total_all = chapter_stats.sum { |r| r[:total] }
-      miss_all = chapter_stats.sum { |r| r[:missing] }
-      stale_all = chapter_stats.sum { |r| r[:stale] }
-      work_all = miss_all + stale_all
-      cov_all = total_all.positive? ? ((total_all - miss_all) * 100.0 / total_all).round(1) : 0
-      puts '-' * 100
-      printf "%-55s %6d %6d %6d %6d %6.1f%%\n", 'TOTAL', total_all, miss_all, stale_all, work_all, cov_all
-      puts
-
-      # --- Heading detail (only chapters with work needed) ---
-      gap_chapters = chapter_stats.select { |r| r[:missing].positive? || r[:stale].positive? }.map { |r| r[:ch] }
-
-      if gap_chapters.any?
-        heading_stats = needing_work_ds
-          .select_group(
-            Sequel.function(:substr, gn[:goods_nomenclature_item_id], 1, 2).as(:ch),
-            Sequel.function(:substr, gn[:goods_nomenclature_item_id], 1, 4).as(:hd),
-          )
-          .select_append { count(Sequel.case([[{ st[:goods_nomenclature_sid] => nil }, 1]], nil)).as(missing) }
-          .select_append { count(Sequel.case([[{ st[:stale] => true }, 1]], nil)).as(stale) }
-          .order(:ch, :hd)
-          .all
-
-        heading_descs = Heading.actual
-          .eager(:goods_nomenclature_descriptions)
-          .all
-          .to_h { |h| [h.goods_nomenclature_item_id.first(4), h.description&.truncate(50)] }
-
-        puts 'Self-Texts Needing Work by Heading'
-        puts '=' * 90
-        printf "%-6s %-50s %6s %6s %6s\n", 'Head', 'Description', 'Miss', 'Stale', 'Work'
-        puts '-' * 90
-
-        current_ch = nil
-        heading_stats.each do |row|
-          if row[:ch] != current_ch
-            current_ch = row[:ch]
-            puts "-- Chapter #{current_ch}: #{chapter_descs[current_ch] || '?'} --"
-          end
-          work = row[:missing] + row[:stale]
-          printf "  %-4s %-48s %6d %6d %6d\n", row[:hd], heading_descs[row[:hd]] || '?', row[:missing], row[:stale], work
-        end
-        puts
-
-        # --- Full list of GN items needing work ---
-        puts 'All Goods Nomenclatures Needing Work (ordered by item_id, producline_suffix)'
-        puts '=' * 110
-        printf "%-12s %-4s %-7s %-80s\n", 'Item ID', 'PLS', 'Reason', 'Description'
-        puts '-' * 110
-
-        work_rows = needing_work_ds
-          .select(
-            gn[:goods_nomenclature_sid],
-            gn[:goods_nomenclature_item_id],
-            gn[:producline_suffix],
-            Sequel.case([[{ st[:goods_nomenclature_sid] => nil }, 'missing']], 'stale').as(:reason),
-          )
-          .order(gn[:goods_nomenclature_item_id], gn[:producline_suffix])
-          .all
-
-        if work_rows.any?
-          work_sids = work_rows.map { |r| r[:goods_nomenclature_sid] }
-          descriptions = GoodsNomenclature.actual
-            .where(goods_nomenclature_sid: work_sids)
-            .eager(:goods_nomenclature_descriptions)
-            .all
-            .to_h { |item| [item.goods_nomenclature_sid, item.description&.truncate(80) || '?'] }
-
-          work_rows.each do |row|
-            printf "%-12s %-4s %-7s %-80s\n",
-                   row[:goods_nomenclature_item_id],
-                   row[:producline_suffix],
-                   row[:reason],
-                   descriptions[row[:goods_nomenclature_sid]] || '?'
-          end
-        end
-
-        puts '-' * 110
-        puts "Total needing work: #{work_rows.size}"
-      else
-        puts 'No gaps found - full coverage, nothing stale!'
-      end
+      context = gap_context
+      print_gap_chapter_summary(context)
+      print_gap_heading_details(context)
     end
   end
 
-  desc 'Validate generated self-texts - report similarity and coherence scores'
-  task validate: :environment do
+  def gap_context
+    goods_nomenclatures_table = Sequel[:goods_nomenclatures]
+    self_texts_table = Sequel[:goods_nomenclature_self_texts]
+    base = gap_base_dataset(goods_nomenclatures_table, self_texts_table)
+    needing_work = base.where(Sequel.expr(self_texts_table[:goods_nomenclature_sid] => nil) | Sequel.expr(self_texts_table[:stale] => true))
+    chapter_stats = gap_chapter_stats(base, goods_nomenclatures_table, self_texts_table)
+
+    { goods_nomenclatures_table:, self_texts_table:, needing_work:, chapter_stats:, chapter_descs: gap_chapter_descriptions }
+  end
+
+  def gap_base_dataset(goods_nomenclatures_table, self_texts_table)
+    base = GoodsNomenclature.actual
+      .non_hidden
+      .exclude(goods_nomenclatures_table[:goods_nomenclature_item_id] => Chapter.actual.select(:goods_nomenclature_item_id))
+      .left_join(:goods_nomenclature_self_texts, { self_texts_table[:goods_nomenclature_sid] => goods_nomenclatures_table[:goods_nomenclature_sid] })
+
+    return base unless ENV['CHAPTER']
+
+    base.where(Sequel.like(goods_nomenclatures_table[:goods_nomenclature_item_id], "#{ENV['CHAPTER'].ljust(2, '0')}%"))
+  end
+
+  def gap_chapter_stats(base, goods_nomenclatures_table, self_texts_table)
+    base
+      .select_group(Sequel.function(:substr, goods_nomenclatures_table[:goods_nomenclature_item_id], 1, 2).as(:ch))
+      .select_append { count(Sequel.lit('*')).as(total) }
+      .select_append { count(Sequel.case([[{ self_texts_table[:goods_nomenclature_sid] => nil }, 1]], nil)).as(missing) }
+      .select_append { count(Sequel.case([[{ self_texts_table[:stale] => true }, 1]], nil)).as(stale) }
+      .order(:ch)
+      .all
+  end
+
+  def gap_chapter_descriptions
+    Chapter.actual
+      .eager(:goods_nomenclature_descriptions)
+      .all
+      .to_h { |chapter| [chapter.goods_nomenclature_item_id.first(2), chapter.description&.truncate(50)] }
+  end
+
+  def print_gap_chapter_summary(context)
+    puts 'Self-Text Gaps and Stale Records by Chapter'
+    puts '=' * 100
+    printf "%-4s %-50s %6s %6s %6s %6s %7s\n", 'Ch', 'Description', 'Total', 'Miss', 'Stale', 'Work', 'Cov %'
+    puts '-' * 100
+    context[:chapter_stats].each { |row| print_gap_chapter_row(row, context[:chapter_descs]) }
+    print_gap_chapter_total(context[:chapter_stats])
+  end
+
+  def print_gap_chapter_row(row, chapter_descs)
+    total = row[:total]
+    work = row[:missing] + row[:stale]
+    coverage = total.positive? ? ((total - row[:missing]) * 100.0 / total).round(1) : 0
+    printf "%-4s %-50s %6d %6d %6d %6d %6.1f%%\n",
+           row[:ch], chapter_descs[row[:ch]] || '?', total, row[:missing], row[:stale], work, coverage
+  end
+
+  def print_gap_chapter_total(chapter_stats)
+    totals = gap_chapter_totals(chapter_stats)
+    puts '-' * 100
+    printf "%-55s %6d %6d %6d %6d %6.1f%%\n",
+           'TOTAL', totals[:total], totals[:missing], totals[:stale], totals[:work], totals[:coverage]
+    puts
+  end
+
+  def gap_chapter_totals(chapter_stats)
+    total = chapter_stats.sum { |row| row[:total] }
+    missing = chapter_stats.sum { |row| row[:missing] }
+    stale = chapter_stats.sum { |row| row[:stale] }
+    work = missing + stale
+    coverage = total.positive? ? ((total - missing) * 100.0 / total).round(1) : 0
+
+    { total:, missing:, stale:, work:, coverage: }
+  end
+
+  def print_gap_heading_details(context)
+    if gap_chapters(context[:chapter_stats]).any?
+      print_gap_headings(context)
+    else
+      puts 'No gaps found - full coverage, nothing stale!'
+    end
+  end
+
+  def gap_chapters(chapter_stats)
+    chapter_stats.select { |row| row[:missing].positive? || row[:stale].positive? }.map { |row| row[:ch] }
+  end
+
+  def print_gap_headings(context)
+    heading_stats = gap_heading_stats(context)
+    heading_descs = gap_heading_descriptions
+    puts 'Self-Texts Needing Work by Heading'
+    puts '=' * 90
+    printf "%-6s %-50s %6s %6s %6s\n", 'Head', 'Description', 'Miss', 'Stale', 'Work'
+    puts '-' * 90
+    print_gap_heading_rows(heading_stats, context[:chapter_descs], heading_descs)
+    puts
+    print_gap_work_rows(context)
+  end
+
+  def gap_heading_stats(context)
+    goods_nomenclatures_table = context[:goods_nomenclatures_table]
+    self_texts_table = context[:self_texts_table]
+    context[:needing_work].select_group(
+      Sequel.function(:substr, goods_nomenclatures_table[:goods_nomenclature_item_id], 1, 2).as(:ch),
+      Sequel.function(:substr, goods_nomenclatures_table[:goods_nomenclature_item_id], 1, 4).as(:hd),
+    )
+      .select_append { count(Sequel.case([[{ self_texts_table[:goods_nomenclature_sid] => nil }, 1]], nil)).as(missing) }
+      .select_append { count(Sequel.case([[{ self_texts_table[:stale] => true }, 1]], nil)).as(stale) }
+      .order(:ch, :hd)
+      .all
+  end
+
+  def gap_heading_descriptions
+    Heading.actual
+      .eager(:goods_nomenclature_descriptions)
+      .all
+      .to_h { |heading| [heading.goods_nomenclature_item_id.first(4), heading.description&.truncate(50)] }
+  end
+
+  def print_gap_heading_rows(heading_stats, chapter_descs, heading_descs)
+    current_chapter = nil
+    heading_stats.each do |row|
+      current_chapter = print_gap_heading_chapter(row[:ch], current_chapter, chapter_descs)
+      work = row[:missing] + row[:stale]
+      printf "  %-4s %-48s %6d %6d %6d\n", row[:hd], heading_descs[row[:hd]] || '?', row[:missing], row[:stale], work
+    end
+  end
+
+  def print_gap_heading_chapter(chapter, current_chapter, chapter_descs)
+    return current_chapter if chapter == current_chapter
+
+    puts "-- Chapter #{chapter}: #{chapter_descs[chapter] || '?'} --"
+    chapter
+  end
+
+  def print_gap_work_rows(context)
+    work_rows = gap_work_rows(context)
+    puts 'All Goods Nomenclatures Needing Work (ordered by item_id, producline_suffix)'
+    puts '=' * 110
+    printf "%-12s %-4s %-7s %-80s\n", 'Item ID', 'PLS', 'Reason', 'Description'
+    puts '-' * 110
+    print_gap_work_row_details(work_rows) if work_rows.any?
+    puts '-' * 110
+    puts "Total needing work: #{work_rows.size}"
+  end
+
+  def gap_work_rows(context)
+    goods_nomenclatures_table = context[:goods_nomenclatures_table]
+    self_texts_table = context[:self_texts_table]
+    context[:needing_work].select(
+      goods_nomenclatures_table[:goods_nomenclature_sid],
+      goods_nomenclatures_table[:goods_nomenclature_item_id],
+      goods_nomenclatures_table[:producline_suffix],
+      Sequel.case([[{ self_texts_table[:goods_nomenclature_sid] => nil }, 'missing']], 'stale').as(:reason),
+    )
+      .order(goods_nomenclatures_table[:goods_nomenclature_item_id], goods_nomenclatures_table[:producline_suffix])
+      .all
+  end
+
+  def print_gap_work_row_details(work_rows)
+    descriptions = gap_work_descriptions(work_rows)
+    work_rows.each do |row|
+      printf "%-12s %-4s %-7s %-80s\n",
+             row[:goods_nomenclature_item_id], row[:producline_suffix], row[:reason], descriptions[row[:goods_nomenclature_sid]] || '?'
+    end
+  end
+
+  def gap_work_descriptions(work_rows)
+    work_sids = work_rows.map { |row| row[:goods_nomenclature_sid] }
+    GoodsNomenclature.actual
+      .where(goods_nomenclature_sid: work_sids)
+      .eager(:goods_nomenclature_descriptions)
+      .all
+      .to_h { |item| [item.goods_nomenclature_sid, item.description&.truncate(80) || '?'] }
+  end
+
+  def validate
     threshold = ENV.fetch('THRESHOLD', '0.7').to_f
     flag_below = ENV.key?('THRESHOLD')
+    validate_similarity(threshold, flag_below)
+    validate_coherence(threshold)
+  end
 
-    # Part A: EU comparison (similarity_score)
+  def validate_similarity(threshold, flag_below)
     puts '=' * 80
     puts 'PART A: EU Reference Comparison (similarity_score)'
     puts '=' * 80
+    pairs = GoodsNomenclatureSelfText.exclude(similarity_score: nil).order(:similarity_score).all
 
-    pairs = GoodsNomenclatureSelfText
-      .exclude(similarity_score: nil)
-      .order(:similarity_score)
-      .all
+    return puts 'No similarity scores found. Run self_texts:score first.' if pairs.empty?
 
-    if pairs.any?
-      similarities = pairs.map(&:similarity_score)
+    similarities = pairs.map(&:similarity_score)
+    print_score_summary('pairs', similarities, threshold)
+    print_low_similarity_pairs(pairs)
+    puts "Below threshold: #{similarities.count { |score| score < threshold }} records" if flag_below
+  end
 
-      puts "Total pairs: #{pairs.size}"
-      puts "Mean similarity: #{(similarities.sum / similarities.size).round(4)}"
-      puts "Median: #{self_text_percentile(similarities, 50).round(4)}"
-      puts "P5: #{self_text_percentile(similarities, 5).round(4)}"
-      puts "P95: #{self_text_percentile(similarities, 95).round(4)}"
-      puts "Below #{threshold}: #{similarities.count { |s| s < threshold }}"
-      puts
-
-      puts 'Bottom 20 lowest-similarity pairs:'
-      puts '-' * 80
-
-      pairs.first(20).each_with_index do |row, i|
-        puts "#{i + 1}. [#{row.goods_nomenclature_item_id}] similarity=#{row.similarity_score.round(4)}"
-        puts "   Generated: #{row.self_text&.truncate(120)}"
-        puts "   EU:        #{row.eu_self_text&.truncate(120)}"
-        puts
-      end
-
-      if flag_below
-        puts "Below threshold: #{similarities.count { |s| s < threshold }} records"
-      end
-    else
-      puts 'No similarity scores found. Run self_texts:score first.'
-    end
-
-    # Part B: Coherence check (coherence_score)
+  def validate_coherence(threshold)
     puts
     puts '=' * 80
     puts 'PART B: Coherence Check (no EU reference)'
     puts '=' * 80
+    gap_nodes = GoodsNomenclatureSelfText.exclude(coherence_score: nil).order(:coherence_score).all
 
-    gap_nodes = GoodsNomenclatureSelfText
-      .exclude(coherence_score: nil)
-      .order(:coherence_score)
-      .all
+    return puts 'No coherence scores found. Run self_texts:score first.' if gap_nodes.empty?
 
-    if gap_nodes.any?
-      scores = gap_nodes.map(&:coherence_score)
+    scores = gap_nodes.map(&:coherence_score)
+    print_score_summary('gap nodes', scores, threshold, score_name: 'coherence')
+    print_low_coherence_nodes(gap_nodes)
+  end
 
-      puts "Total gap nodes: #{gap_nodes.size}"
-      puts "Mean coherence: #{(scores.sum / scores.size).round(4)}"
-      puts "Median: #{self_text_percentile(scores, 50).round(4)}"
-      puts "P5: #{self_text_percentile(scores, 5).round(4)}"
-      puts "P95: #{self_text_percentile(scores, 95).round(4)}"
-      puts "Below #{threshold}: #{scores.count { |s| s < threshold }}"
+  def print_score_summary(label, scores, threshold, score_name: 'similarity')
+    puts "Total #{label}: #{scores.size}"
+    puts "Mean #{score_name}: #{(scores.sum / scores.size).round(4)}"
+    puts "Median: #{percentile(scores, 50).round(4)}"
+    puts "P5: #{percentile(scores, 5).round(4)}"
+    puts "P95: #{percentile(scores, 95).round(4)}"
+    puts "Below #{threshold}: #{scores.count { |score| score < threshold }}"
+    puts
+  end
+
+  def print_low_similarity_pairs(pairs)
+    puts 'Bottom 20 lowest-similarity pairs:'
+    puts '-' * 80
+    pairs.first(20).each_with_index do |row, index|
+      puts "#{index + 1}. [#{row.goods_nomenclature_item_id}] similarity=#{row.similarity_score.round(4)}"
+      puts "   Generated: #{row.self_text&.truncate(120)}"
+      puts "   EU:        #{row.eu_self_text&.truncate(120)}"
       puts
-
-      puts 'Bottom 20 lowest-coherence gap nodes:'
-      puts '-' * 80
-
-      gap_nodes.first(20).each_with_index do |row, i|
-        puts "#{i + 1}. [#{row.goods_nomenclature_item_id}] coherence=#{row.coherence_score.round(4)}"
-        puts "   Generated: #{row.self_text&.truncate(120)}"
-        puts
-      end
-    else
-      puts 'No coherence scores found. Run self_texts:score first.'
     end
+  end
+
+  def print_low_coherence_nodes(gap_nodes)
+    puts 'Bottom 20 lowest-coherence gap nodes:'
+    puts '-' * 80
+    gap_nodes.first(20).each_with_index do |row, index|
+      puts "#{index + 1}. [#{row.goods_nomenclature_item_id}] coherence=#{row.coherence_score.round(4)}"
+      puts "   Generated: #{row.self_text&.truncate(120)}"
+      puts
+    end
+  end
+
+  def percentile(values, pct)
+    return 0.0 if values.empty?
+
+    sorted = values.sort
+    percentile_index = (pct / 100.0) * (sorted.size - 1)
+    floor = percentile_index.floor
+    ceiling = percentile_index.ceil
+
+    return sorted[floor] if floor == ceiling
+
+    sorted[floor] + (percentile_index - floor) * (sorted[ceiling] - sorted[floor])
   end
 end
 
-def self_text_percentile(values, pct)
-  return 0.0 if values.empty?
+namespace :self_texts do
+  desc 'Show self-text coverage statistics'
+  task(coverage: :environment) { SelfTextsTasks.coverage }
 
-  sorted = values.sort
-  k = (pct / 100.0) * (sorted.size - 1)
-  f = k.floor
-  c = k.ceil
+  desc 'Regenerate all self-texts by marking them stale and re-enqueuing'
+  task(regenerate: :environment) { SelfTextsTasks.regenerate }
 
-  return sorted[f] if f == c
+  desc 'Generate self-texts for all chapters (background) or a single chapter (inline with CHAPTER=XX)'
+  task(generate: :environment) { SelfTextsTasks.generate }
 
-  sorted[f] + (k - f) * (sorted[c] - sorted[f])
+  desc 'Populate EU reference self-texts from CSV into existing generated rows'
+  task(populate_eu_references: :environment) { SelfTextsTasks.populate_eu_references }
+
+  desc 'Generate embeddings for self-texts and EU references via OpenAI'
+  task(generate_embeddings: :environment) { SelfTextsTasks.generate_embeddings }
+
+  desc 'Fix encoding artefacts (e.g. pure9e -> puree) in existing AI-generated self-texts'
+  task(fix_encoding_artefacts: :environment) { SelfTextsTasks.fix_encoding_artefacts }
+
+  desc 'Score all self-texts (populate EU refs, generate embeddings, compute confidence)'
+  task(score: :environment) { SelfTextsTasks.score }
+
+  desc 'Show busy and queued self-text generation workers with chapter details'
+  task(status: :environment) { SelfTextsTasks.status }
+
+  desc 'Show self-text gaps and stale records grouped by chapter and heading (CHAPTER=XX to filter)'
+  task(gaps: :environment) { SelfTextsTasks.gaps }
+
+  desc 'Validate generated self-texts - report similarity and coherence scores'
+  task(validate: :environment) { SelfTextsTasks.validate }
 end


### PR DESCRIPTION
## What:
- [x] Extract self-text rake task bodies into `SelfTextsTasks` helpers in `lib/tasks/self_texts.rake`
- [x] Keep rake task names (`self_texts:*`) and behaviour unchanged
- [x] Preserve `AiUsage::Instrumentation.embedding_api_call` wrappers and `event_kind` values for both embedding backfill passes
- [x] Structure-only shortening of long task blocks (coverage, gaps, embeddings, validate, etc.)

## Why:
Long task blocks keep Metrics cops unenforceable. Extracting helpers is a low-risk structural step for the AI self-text rake surface without changing offline task behaviour or embedding instrumentation.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Behaviour-preserving structural extraction of rake task helpers only. No intentional API or data behaviour change. Embedding API call paths retain main's AiUsage wrappers (`self_text_embedding_backfill` / `eu_self_text_embedding_backfill`).

───────────────────────────────────────────────────

Rate the overall risk of deploying this change:

🟢 Green  – Low risk. Good to go, standard review applies.

🟠 Amber  – Medium risk. Socialise with the team before merging.

🔴 Red    – High risk. Requires explicit approval from Thor or Neil before merging.

───────────────────────────────────────────────────
