### PR TITLE
AI-997: Parse chapter note structure into definition blocks

### DIFF
--- a/app/services/tariff_knowledge/note_block_parser.rb
+++ b/app/services/tariff_knowledge/note_block_parser.rb
@@ -1,0 +1,104 @@
+module TariffKnowledge
+  class NoteBlockParser
+    Block = Data.define(:key, :title, :content, :metadata, :fragment_keys)
+
+    def self.call(...) = new(...).call
+
+    def initialize(source_type:, source_id:, source_version:, fragments:, structure_parser: NoteStructureParser)
+      @source_type = source_type
+      @source_id = source_id.to_s
+      @source_version = source_version.to_s
+      @fragments = fragments
+      @structure_parser = structure_parser
+    end
+
+    def call
+      tree = structure_parser.call(
+        source_type:,
+        source_id:,
+        source_version:,
+        fragments:,
+      )
+
+      uniquify_duplicate_paths(flatten_nodes(tree.nodes).filter_map { |node| block_for(node) })
+    end
+
+  private
+
+    attr_reader :source_type, :source_id, :source_version, :fragments, :structure_parser
+
+    def flatten_nodes(nodes)
+      nodes.flat_map { |node| [node, *flatten_nodes(node.children)] }
+    end
+
+    def block_for(node)
+      return unless %i[alpha roman].include?(node.kind)
+
+      path = node.path.map(&:to_s)
+      return unless definition_path?(path)
+
+      marker = node.marker.to_s
+      term = node.title.to_s.squish
+      return if term.blank?
+
+      fragment_keys = descendant_fragment_keys(node)
+      metadata = {
+        'path' => path,
+        'marker' => marker,
+        'block_type' => 'definition',
+        'term' => term.downcase,
+        'marker_kind' => node.kind.to_s,
+      }
+      metadata['section'] = section_slug(path) if section_slug(path)
+
+      Block.new(
+        key: "note_block:#{source_type}:#{source_version}:#{source_id}:#{path.join(':')}",
+        title: term,
+        content: descendant_content(node),
+        metadata:,
+        fragment_keys:,
+      )
+    end
+
+    def section_slug(path)
+      path.first unless path.first.to_s.match?(/\A\d+\z/)
+    end
+
+    def uniquify_duplicate_paths(blocks)
+      key_counts = Hash.new(0)
+
+      blocks.map do |block|
+        key_counts[block.key] += 1
+        next block if key_counts[block.key] == 1
+
+        with_path_scope(block, "repeat_#{key_counts[block.key]}")
+      end
+    end
+
+    def with_path_scope(block, scope)
+      path = block.metadata.fetch('path')
+      scoped_path = [*path[0...-1], scope, path.last]
+      metadata = block.metadata.merge('path' => scoped_path)
+
+      Block.new(
+        key: "note_block:#{source_type}:#{source_version}:#{source_id}:#{scoped_path.join(':')}",
+        title: block.title,
+        content: block.content,
+        metadata:,
+        fragment_keys: block.fragment_keys,
+      )
+    end
+
+    def definition_path?(path)
+      path.any? { |segment| segment.match?(/\A\d+\z/) }
+    end
+
+    def descendant_content(node)
+      [node.content, *node.children.map { |child| descendant_content(child) }].join(' ').squish
+    end
+
+    def descendant_fragment_keys(node)
+      [node.fragment_keys, *node.children.map { |child| descendant_fragment_keys(child) }].flatten
+    end
+  end
+end

--- a/app/services/tariff_knowledge/note_fragment_splitter.rb
+++ b/app/services/tariff_knowledge/note_fragment_splitter.rb
@@ -1,0 +1,74 @@
+module TariffKnowledge
+  class NoteFragmentSplitter
+    LIST_MARKER_PATTERN = /\A(?:ij|\(?[a-z]\)?|[ivx]+|\d+)\.\z/i
+    TRAILING_LIST_MARKER_PATTERN = /\A(.+?)\s+((?:ij|\(?[a-z]\)?|[ivx]+|\d+)\.)\z/im
+
+    def self.call(...) = new(...).call
+
+    def initialize(content)
+      @content = content
+    end
+
+    def call
+      content
+        .to_s
+        .split(/\n{2,}|(?<=[.!?])\s+/)
+        .map(&:strip)
+        .reject(&:blank?)
+        .then { |split_fragments| merge_orphaned_list_markers(split_fragments) }
+        .then { |split_fragments| merge_dangling_numeric_references(split_fragments) }
+    end
+
+  private
+
+    attr_reader :content
+
+    def merge_orphaned_list_markers(split_fragments)
+      split_fragments.each_with_object([]) do |fragment, merged|
+        fragment = "#{merged.pop} #{fragment}" if list_marker_sequence?(merged.last)
+        match = fragment.match(TRAILING_LIST_MARKER_PATTERN)
+        text, marker = match&.captures
+
+        if match && !list_marker_sequence?(text.strip)
+          merged.push(text.strip, marker)
+        else
+          merged << (match ? "#{text.strip} #{marker}" : fragment)
+        end
+      end
+    end
+
+    def list_marker_sequence?(fragment)
+      fragment.present? && fragment.split.all? { |part| part.match?(LIST_MARKER_PATTERN) }
+    end
+
+    def merge_dangling_numeric_references(split_fragments)
+      split_fragments.each_with_object([]) do |fragment, merged|
+        if merged.last && dangling_numeric_reference?(merged.last, fragment)
+          attach_reference_fragment(fragment, merged)
+        else
+          merged << fragment
+        end
+      end
+    end
+
+    def dangling_numeric_reference?(previous_fragment, fragment)
+      numeric_reference_context?(previous_fragment, fragment) ||
+        (fragment.match?(/\AC\.(?:\s+.+)?\z/i) && previous_fragment.match?(/\d\z/))
+    end
+
+    def attach_reference_fragment(fragment, merged)
+      reference, remaining_fragment = fragment.match(/\A((?:\d{1,4}|C)\.)\s*(.*)\z/i).captures
+      merged[-1] = "#{merged.last} #{reference}"
+      merged << remaining_fragment.strip if remaining_fragment.present?
+    end
+
+    def numeric_reference_context?(previous_fragment, fragment)
+      fragment.match?(/\A\d{1,4}\.(?:\s+.+)?\z/) &&
+        (
+          previous_fragment.match?(/\b(?:heading|headings|chapter|chapters|rule|rules|and|or|to)\z/i) ||
+            previous_fragment.match?(/\d\z/) ||
+            fragment.match?(/\A(?:19|20)\d{2}\.(?:\s+.+)?\z/)
+        )
+    end
+  end
+end

--- a/app/services/tariff_knowledge/note_marker_classifier.rb
+++ b/app/services/tariff_knowledge/note_marker_classifier.rb
@@ -1,0 +1,154 @@
+module TariffKnowledge
+  class NoteMarkerClassifier
+    Event = Data.define(:fragment, :kind, :marker, :depth, :path_segment, :title, :body, :raw_text)
+
+    HEADING_MARKER = /\A#+\s+(?<title>.+)\z/
+    BULLET_ALPHA_SECTION = /\A\((?<marker>[A-Z])\)\.?\s+(?<body>.+)\z/
+    ALPHA_SECTION_MARKER = /\A\((?<marker>[A-Z])\)\.\z/
+
+    def self.call(...) = new(...).call
+
+    def initialize(fragment, trie: NoteMarkerTrie.default)
+      @fragment = fragment
+      @trie = trie
+    end
+
+    def call
+      text = fragment.content.to_s.squish
+      heading_match = text.match(HEADING_MARKER)
+
+      return heading_event(heading_match[:title].squish, text) if heading_match
+
+      token, body = text.split(/\s+/, 2)
+      alpha_section_match = token.to_s.match(ALPHA_SECTION_MARKER)
+
+      return alpha_section_event(alpha_section_match[:marker], body.to_s.squish, text) if alpha_section_match
+
+      marker_match = trie.match(token)
+
+      return continuation_event(text) unless marker_match
+      return continuation_event(text) unless valid_marker_boundary?(token, marker_match)
+
+      marker_body = marker_body(token, marker_match, body)
+      embedded_section = embedded_bullet_alpha_section(marker_match, marker_body)
+
+      return alpha_section_event(embedded_section[:marker], embedded_section[:body], text) if embedded_section
+
+      marker_event(marker_match, marker_body, text)
+    end
+
+  private
+
+    attr_reader :fragment, :trie
+
+    def heading_event(title, raw_text)
+      path_segment = title.parameterize(separator: '_')
+
+      Event.new(
+        fragment:,
+        kind: :heading,
+        marker: path_segment,
+        depth: 0,
+        path_segment:,
+        title:,
+        body: '',
+        raw_text:,
+      )
+    end
+
+    def marker_event(marker_match, body, raw_text)
+      kind = marker_kind(marker_match)
+      marker = marker(marker_match)
+      title, event_body = title_and_body(kind, marker_match, body)
+
+      Event.new(
+        fragment:,
+        kind:,
+        marker:,
+        depth: marker_match.depth,
+        path_segment: marker,
+        title:,
+        body: event_body,
+        raw_text:,
+      )
+    end
+
+    def alpha_section_event(marker, body, raw_text)
+      Event.new(
+        fragment:,
+        kind: :alpha_section,
+        marker:,
+        depth: 2,
+        path_segment: marker,
+        title: body.presence,
+        body: '',
+        raw_text:,
+      )
+    end
+
+    def continuation_event(raw_text)
+      Event.new(
+        fragment:,
+        kind: :continuation,
+        marker: nil,
+        depth: nil,
+        path_segment: nil,
+        title: nil,
+        body: raw_text,
+        raw_text:,
+      )
+    end
+
+    def title_and_body(kind, marker_match, body)
+      case kind
+      when :numeric
+        [marker_match.marker, body]
+      when :alpha, :alpha_section
+        [body.presence, '']
+      else
+        [nil, body]
+      end
+    end
+
+    def marker_body(token, marker_match, body)
+      suffix = token[marker_match.length..]
+
+      [suffix, body].compact_blank.join(' ').squish
+    end
+
+    def marker_kind(marker_match)
+      return :alpha_section if uppercase_alpha_marker?(marker_match)
+
+      marker_match.kind
+    end
+
+    def marker(marker_match)
+      return marker_match.marker.upcase if uppercase_alpha_marker?(marker_match)
+
+      marker_match.marker
+    end
+
+    def uppercase_alpha_marker?(marker_match)
+      marker_match.kind == :alpha && marker_text(marker_match).match?(/[A-Z]/)
+    end
+
+    def marker_text(marker_match)
+      fragment.content.to_s.squish.first(marker_match.length)
+    end
+
+    def embedded_bullet_alpha_section(marker_match, body)
+      return unless marker_match.kind == :bullet
+
+      body.match(BULLET_ALPHA_SECTION)
+    end
+
+    def valid_marker_boundary?(token, marker_match)
+      suffix = token[marker_match.length..].to_s
+
+      # Exact marker tokens are always valid. Compact prefixes are deliberately
+      # narrow: only numeric markers may absorb an alphabetic suffix such as
+      # "1.foo"; decimals and abbreviation-like alpha/roman prefixes stay prose.
+      suffix.blank? || marker_match.kind == :numeric && suffix.match?(/\A[[:alpha:]]/)
+    end
+  end
+end

--- a/app/services/tariff_knowledge/note_marker_trie.rb
+++ b/app/services/tariff_knowledge/note_marker_trie.rb
@@ -1,0 +1,81 @@
+module TariffKnowledge
+  class NoteMarkerTrie
+    Match = Data.define(:kind, :marker, :depth, :token, :length)
+
+    ROMAN_MARKERS = %w[i ii iii iv v vi vii viii ix x xi xii].freeze
+    DOTTED_ALPHA_MARKERS = ('a'..'z').map { |letter| "#{letter}." }.freeze
+    ALPHA_MARKERS = (
+      DOTTED_ALPHA_MARKERS +
+      ((('a'..'z').to_a - %w[i v x]) + %w[ij]).flat_map { |letter| ["(#{letter})", "#{letter})"] } +
+      %w[ij.]
+    ).freeze
+    ROMAN_MARKER_TOKENS = (
+      (ROMAN_MARKERS - %w[i v x]).flat_map { |roman| ["#{roman}.", "(#{roman})", "#{roman})"] } +
+      %w[i v x].flat_map { |roman| ["(#{roman})", "#{roman})"] }
+    ).freeze
+
+    DEFAULT_MARKERS = {
+      numeric: { depth: 1, tokens: (1..99).map { |number| "#{number}." } },
+      roman: { depth: 3, tokens: ROMAN_MARKER_TOKENS },
+      alpha: { depth: 2, tokens: ALPHA_MARKERS },
+      bullet: { depth: 4, tokens: ['-', '–', '—'] },
+    }.freeze
+
+    def self.default = @default ||= new(DEFAULT_MARKERS)
+
+    def initialize(marker_families)
+      @root = {}
+
+      marker_families.each do |kind, definition|
+        definition.fetch(:tokens).each do |token|
+          register(token, kind, definition.fetch(:depth))
+        end
+      end
+    end
+
+    def match(token)
+      node = root
+      best_match = nil
+      normalized_token = token.to_s.strip.downcase
+
+      normalized_token.each_char do |character|
+        node = node[character]
+        break unless node
+
+        best_match = node[:match] if node[:match]
+      end
+
+      best_match
+    end
+
+  private
+
+    attr_reader :root
+
+    def register(token, kind, depth)
+      node = root
+      normalized_token = token.downcase
+
+      normalized_token.each_char do |character|
+        node[character] ||= {}
+        node = node[character]
+      end
+
+      node[:match] = Match.new(
+        kind:,
+        marker: normalize_marker(token),
+        depth:,
+        token:,
+        length: token.length,
+      )
+    end
+
+    def normalize_marker(token)
+      marker = token.downcase
+
+      return marker if DEFAULT_MARKERS.fetch(:bullet).fetch(:tokens).include?(marker)
+
+      marker.delete_prefix('(').delete_suffix('.').delete_suffix(')').delete_suffix(')')
+    end
+  end
+end

--- a/app/services/tariff_knowledge/note_marker_trie.rb
+++ b/app/services/tariff_knowledge/note_marker_trie.rb
@@ -75,7 +75,7 @@ module TariffKnowledge
 
       return marker if DEFAULT_MARKERS.fetch(:bullet).fetch(:tokens).include?(marker)
 
-      marker.delete_prefix('(').delete_suffix('.').delete_suffix(')').delete_suffix(')')
+      marker.delete_prefix('(').delete_suffix('.').delete_suffix(')')
     end
   end
 end

--- a/app/services/tariff_knowledge/note_structure_parser.rb
+++ b/app/services/tariff_knowledge/note_structure_parser.rb
@@ -1,0 +1,151 @@
+module TariffKnowledge
+  class NoteStructureParser
+    Tree = Data.define(:nodes, :events, :orphans)
+    Node = Data.define(:kind, :marker, :path, :title, :content, :fragment_keys, :children)
+
+    BLOCK_CANDIDATE_KINDS = %i[alpha_section alpha roman].freeze
+
+    def self.call(...) = new(...).call
+
+    def initialize(source_type:, source_id:, source_version:, fragments:, classifier: NoteMarkerClassifier)
+      @source_type = source_type
+      @source_id = source_id.to_s
+      @source_version = source_version.to_s
+      @fragments = fragments
+      @classifier = classifier
+      @events = []
+      @orphans = []
+      @root_nodes = []
+      @path_segments = {}
+      @active_blocks = {}
+    end
+
+    def call
+      fragments.each do |fragment|
+        event = classifier.call(fragment)
+        events << event
+
+        process(event)
+      end
+
+      Tree.new(
+        nodes: root_nodes.map(&:to_node),
+        events:,
+        orphans:,
+      )
+    end
+
+  private
+
+    attr_reader :classifier, :events, :fragments, :orphans, :root_nodes, :path_segments, :active_blocks
+
+    def process(event)
+      case event.kind
+      when :heading
+        reset_context
+        path_segments[event.depth] = event.path_segment
+      when :numeric
+        reset_at_depth(event.depth)
+        path_segments[event.depth] = event.path_segment
+      when *BLOCK_CANDIDATE_KINDS
+        add_block_candidate(event)
+      when :bullet, :continuation
+        append_to_active_block(event)
+      end
+    end
+
+    def add_block_candidate(event)
+      depth = block_depth(event)
+      reset_at_depth(depth)
+      path_segments[depth] = event.path_segment
+
+      block = MutableNode.new(event, path)
+      parent = nearest_active_block(depth - 1)
+
+      if parent
+        parent.children.push(block)
+      else
+        root_nodes << block
+      end
+
+      active_blocks[depth] = block
+    end
+
+    def append_to_active_block(event)
+      block = nearest_active_block
+
+      if block
+        block.append(event)
+      else
+        orphans << event
+      end
+    end
+
+    def reset_context
+      path_segments.clear
+      active_blocks.clear
+    end
+
+    def reset_at_depth(depth)
+      path_segments.delete_if { |segment_depth, _| segment_depth >= depth }
+      active_blocks.delete_if { |block_depth, _| block_depth >= depth }
+    end
+
+    def path
+      path_segments.sort_by { |depth, _| depth }.map(&:last)
+    end
+
+    def nearest_active_block(max_depth = nil)
+      active_blocks
+        .select { |depth, _| max_depth.nil? || depth <= max_depth }
+        .max_by { |depth, _| depth }
+        &.last
+    end
+
+    def block_depth(event)
+      case event.kind
+      when :alpha
+        active_blocks[event.depth]&.kind == :alpha_section ? event.depth + 1 : event.depth
+      when :roman
+        active_blocks[event.depth]&.kind == :alpha ? event.depth + 1 : event.depth
+      else
+        event.depth
+      end
+    end
+
+    class MutableNode
+      attr_reader :kind, :marker, :path, :title, :children
+
+      def initialize(event, path)
+        @kind = event.kind
+        @marker = event.marker
+        @path = path
+        @title = event.title || event.body.presence
+        @content_parts = [event.raw_text]
+        @fragment_keys = [event.fragment.key]
+        @children = []
+      end
+
+      def append(event)
+        content_parts << event.raw_text
+        fragment_keys << event.fragment.key
+      end
+
+      def to_node
+        Node.new(
+          kind:,
+          marker:,
+          path: path.dup.freeze,
+          title:,
+          content: content_parts.join(' ').squish,
+          fragment_keys: fragment_keys.dup.freeze,
+          children: children.map(&:to_node).freeze,
+        )
+      end
+
+    private
+
+      attr_reader :content_parts, :fragment_keys
+    end
+  end
+end

--- a/app/services/tariff_knowledge/note_structure_validator.rb
+++ b/app/services/tariff_knowledge/note_structure_validator.rb
@@ -1,0 +1,142 @@
+module TariffKnowledge
+  class NoteStructureValidator
+    Result = Data.define(
+      :source_type,
+      :source_id,
+      :source_version,
+      :fragment_count,
+      :event_count,
+      :root_node_count,
+      :total_node_count,
+      :orphan_event_count,
+      :orphan_event_keys,
+      :duplicate_block_keys,
+      :uncontained_fragment_keys,
+      :issues,
+    )
+    Issue = Data.define(:severity, :code, :message, :details)
+    Fragment = Data.define(:key, :content)
+
+    def self.call(...) = new(...).call
+
+    def initialize(
+      source_type:,
+      source_id:,
+      source_version:,
+      fragments: nil,
+      content: nil,
+      structure_parser: NoteStructureParser,
+      block_parser: NoteBlockParser
+    )
+      @source_type = source_type.to_s
+      @source_id = source_id.to_s
+      @source_version = source_version.to_s
+      @fragments = fragments
+      @content = content
+      @structure_parser = structure_parser
+      @block_parser = block_parser
+    end
+
+    def call
+      source_fragments = fragments || fragments_from_content
+      tree = parse_tree(source_fragments)
+      blocks = parse_blocks(source_fragments)
+      issues = []
+
+      orphan_event_keys = tree.orphans.map { |event| event.fragment.key }
+      duplicate_block_keys = duplicate_keys(blocks.map(&:key))
+      uncontained_fragment_keys = uncontained_fragment_keys(source_fragments, blocks, tree.events)
+
+      issues << issue('warning', 'orphan_events', "#{orphan_event_keys.count} events could not attach to a note block", 'fragment_keys' => orphan_event_keys) if orphan_event_keys.any?
+      issues << issue('error', 'duplicate_block_keys', "#{duplicate_block_keys.count} duplicate note block keys were emitted", 'block_keys' => duplicate_block_keys) if duplicate_block_keys.any?
+      if uncontained_fragment_keys.any?
+        issues << issue(
+          'warning',
+          'uncontained_fragments',
+          "#{uncontained_fragment_keys.count} fragments were not contained by any emitted note block",
+          'fragment_keys' => uncontained_fragment_keys,
+        )
+      end
+
+      Result.new(
+        source_type:,
+        source_id:,
+        source_version:,
+        fragment_count: source_fragments.count,
+        event_count: tree.events.count,
+        root_node_count: tree.nodes.count,
+        total_node_count: total_node_count(tree.nodes),
+        orphan_event_count: orphan_event_keys.count,
+        orphan_event_keys:,
+        duplicate_block_keys:,
+        uncontained_fragment_keys:,
+        issues:,
+      )
+    end
+
+  private
+
+    attr_reader :source_type, :source_id, :source_version, :fragments, :content, :structure_parser, :block_parser
+
+    def parse_tree(source_fragments)
+      structure_parser.call(
+        source_type:,
+        source_id:,
+        source_version:,
+        fragments: source_fragments,
+      )
+    end
+
+    def parse_blocks(source_fragments)
+      block_parser.call(
+        source_type:,
+        source_id:,
+        source_version:,
+        fragments: source_fragments,
+      )
+    end
+
+    def fragments_from_content
+      split_content.map.with_index(1) do |fragment_content, index|
+        Fragment.new(
+          key: "note_fragment:#{source_type}:#{source_version}:#{source_id}:#{sprintf('%04d', index)}",
+          content: fragment_content,
+        )
+      end
+    end
+
+    def split_content
+      NoteFragmentSplitter.call(content)
+    end
+
+    def duplicate_keys(keys)
+      keys.tally.select { |_, count| count > 1 }.keys
+    end
+
+    def uncontained_fragment_keys(_source_fragments, blocks, events)
+      block_fragment_keys = blocks.flat_map(&:fragment_keys).uniq
+
+      containable_event_keys(events)
+        .excluding(*block_fragment_keys)
+    end
+
+    def containable_event_keys(events)
+      events
+        .select { |event| %i[alpha roman bullet].include?(event.kind) }
+        .map { |event| event.fragment.key }
+    end
+
+    def total_node_count(nodes)
+      nodes.sum { |node| 1 + total_node_count(node.children) }
+    end
+
+    def issue(severity, code, message, details)
+      Issue.new(
+        severity:,
+        code:,
+        message:,
+        details:,
+      )
+    end
+  end
+end

--- a/app/services/tariff_knowledge/note_structure_validator.rb
+++ b/app/services/tariff_knowledge/note_structure_validator.rb
@@ -45,16 +45,16 @@ module TariffKnowledge
 
       orphan_event_keys = tree.orphans.map { |event| event.fragment.key }
       duplicate_block_keys = duplicate_keys(blocks.map(&:key))
-      uncontained_fragment_keys = uncontained_fragment_keys(source_fragments, blocks, tree.events)
+      uncontained_keys = uncontained_fragment_keys(source_fragments, blocks, tree.events)
 
       issues << issue('warning', 'orphan_events', "#{orphan_event_keys.count} events could not attach to a note block", 'fragment_keys' => orphan_event_keys) if orphan_event_keys.any?
       issues << issue('error', 'duplicate_block_keys', "#{duplicate_block_keys.count} duplicate note block keys were emitted", 'block_keys' => duplicate_block_keys) if duplicate_block_keys.any?
-      if uncontained_fragment_keys.any?
+      if uncontained_keys.any?
         issues << issue(
           'warning',
           'uncontained_fragments',
-          "#{uncontained_fragment_keys.count} fragments were not contained by any emitted note block",
-          'fragment_keys' => uncontained_fragment_keys,
+          "#{uncontained_keys.count} fragments were not contained by any emitted note block",
+          'fragment_keys' => uncontained_keys,
         )
       end
 
@@ -69,7 +69,7 @@ module TariffKnowledge
         orphan_event_count: orphan_event_keys.count,
         orphan_event_keys:,
         duplicate_block_keys:,
-        uncontained_fragment_keys:,
+        uncontained_fragment_keys: uncontained_keys,
         issues:,
       )
     end

--- a/spec/services/tariff_knowledge/note_block_parser_spec.rb
+++ b/spec/services/tariff_knowledge/note_block_parser_spec.rb
@@ -1,0 +1,206 @@
+RSpec.describe TariffKnowledge::NoteBlockParser do
+  describe '.call' do
+    it 'groups a definition label with its definition body and child composition bullets' do
+      fragments = [
+        build_fragment('0001', '1. In this chapter the following expressions have the meanings hereby assigned to them:'),
+        build_fragment('0002', 'a. pig Iron'),
+        build_fragment('0003', 'Iron-carbon alloys not usefully malleable, containing more than 2 % by weight of carbon and which may contain by weight one or more other elements within the following limits:'),
+        build_fragment('0004', '- not more than 10 % of chromium'),
+        build_fragment('0005', '- not more than 6 % of manganese'),
+        build_fragment('0006', '- not more than 3 % of phosphorus'),
+        build_fragment('0007', '- not more than 8 % of silicon'),
+        build_fragment('0008', '- a total of not more than 10 % of other elements.'),
+        build_fragment('0009', 'b. spiegeleisen'),
+        build_fragment('0010', 'Iron-carbon alloys containing by weight more than 6 % but not more than 30 % of manganese and otherwise conforming to the specification at (a) above.'),
+      ]
+
+      blocks = described_class.call(
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '72',
+        source_version: '1.31',
+        fragments:,
+      )
+
+      pig_iron = blocks.find { |block| block.metadata['term'] == 'pig iron' }
+      expect(pig_iron).to have_attributes(
+        key: 'note_block:customs_tariff_chapter_note:1.31:72:1:a',
+        title: 'pig Iron',
+        content: a_string_including('Iron-carbon alloys not usefully malleable'),
+      )
+      expect(pig_iron.content).to include('not more than 10 % of chromium')
+      expect(pig_iron.content).to include('not more than 6 % of manganese')
+      expect(pig_iron.fragment_keys).to eq(
+        %w[
+          note_fragment:customs_tariff_chapter_note:1.31:72:0002
+          note_fragment:customs_tariff_chapter_note:1.31:72:0003
+          note_fragment:customs_tariff_chapter_note:1.31:72:0004
+          note_fragment:customs_tariff_chapter_note:1.31:72:0005
+          note_fragment:customs_tariff_chapter_note:1.31:72:0006
+          note_fragment:customs_tariff_chapter_note:1.31:72:0007
+          note_fragment:customs_tariff_chapter_note:1.31:72:0008
+        ],
+      )
+
+      spiegeleisen = blocks.find { |block| block.metadata['term'] == 'spiegeleisen' }
+      expect(spiegeleisen.content).to include('more than 6 % but not more than 30 % of manganese')
+      expect(spiegeleisen.fragment_keys).to eq(
+        %w[
+          note_fragment:customs_tariff_chapter_note:1.31:72:0009
+          note_fragment:customs_tariff_chapter_note:1.31:72:0010
+        ],
+      )
+    end
+
+    it 'scopes repeated marker paths under markdown headings' do
+      fragments = [
+        build_fragment('0001', '1. In this chapter and, in the case of notes (d), (e) and (f) throughout the nomenclature, the following expressions have the meanings hereby assigned to them:'),
+        build_fragment('0002', 'a. pig Iron'),
+        build_fragment('0003', 'Iron-carbon alloys not usefully malleable, containing more than 2 % by weight of carbon.'),
+        build_fragment('0072', '### Subheading notes'),
+        build_fragment('0073', '1. In this chapter, the following expressions have the meanings hereby assigned to them:'),
+        build_fragment('0074', 'a. alloy pig iron'),
+        build_fragment('0075', 'Pig iron containing, by weight, one or more of the following elements in the specified proportions:'),
+      ]
+
+      blocks = described_class.call(
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '72',
+        source_version: '1.31',
+        fragments:,
+      )
+
+      pig_iron = blocks.find { |block| block.metadata['term'] == 'pig iron' }
+      alloy_pig_iron = blocks.find { |block| block.metadata['term'] == 'alloy pig iron' }
+
+      aggregate_failures do
+        expect(pig_iron).to have_attributes(
+          key: 'note_block:customs_tariff_chapter_note:1.31:72:1:a',
+          content: a_string_including('Iron-carbon alloys not usefully malleable'),
+        )
+        expect(alloy_pig_iron).to have_attributes(
+          key: 'note_block:customs_tariff_chapter_note:1.31:72:subheading_notes:1:a',
+          content: a_string_including('Pig iron containing'),
+        )
+        expect(pig_iron.key).not_to eq(alloy_pig_iron.key)
+        expect(pig_iron.metadata['path']).to eq(%w[1 a])
+        expect(alloy_pig_iron.metadata['path']).to eq(%w[subheading_notes 1 a])
+      end
+    end
+
+    it 'emits nested roman block candidates with distinct scoped keys and paths' do
+      fragments = [
+        build_fragment('0001', '1. In this chapter the following expressions have the meanings hereby assigned to them:'),
+        build_fragment('0002', 'a. stainless steel'),
+        build_fragment('0003', 'Alloy steels containing chromium.'),
+        build_fragment('0004', '(i) cold-rolled stainless steel'),
+        build_fragment('0005', 'Flat-rolled products further worked than hot-rolled.'),
+      ]
+
+      blocks = described_class.call(
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '72',
+        source_version: '1.31',
+        fragments:,
+      )
+
+      stainless_steel = blocks.find { |block| block.metadata['term'] == 'stainless steel' }
+      cold_rolled = blocks.find { |block| block.metadata['term'] == 'cold-rolled stainless steel' }
+
+      aggregate_failures do
+        expect(stainless_steel).to have_attributes(
+          key: 'note_block:customs_tariff_chapter_note:1.31:72:1:a',
+          content: a_string_including('Alloy steels containing chromium.'),
+        )
+        expect(stainless_steel.content).to include('cold-rolled stainless steel')
+        expect(stainless_steel.content).to include('Flat-rolled products further worked than hot-rolled.')
+        expect(stainless_steel.fragment_keys).to eq(
+          %w[
+            note_fragment:customs_tariff_chapter_note:1.31:72:0002
+            note_fragment:customs_tariff_chapter_note:1.31:72:0003
+            note_fragment:customs_tariff_chapter_note:1.31:72:0004
+            note_fragment:customs_tariff_chapter_note:1.31:72:0005
+          ],
+        )
+        expect(cold_rolled).to have_attributes(
+          key: 'note_block:customs_tariff_chapter_note:1.31:72:1:a:i',
+          content: a_string_including('Flat-rolled products further worked than hot-rolled.'),
+        )
+        expect(stainless_steel.metadata['path']).to eq(%w[1 a])
+        expect(cold_rolled.metadata['path']).to eq(%w[1 a i])
+        expect(cold_rolled.metadata['marker_kind']).to eq('roman')
+        expect(stainless_steel.key).not_to eq(cold_rolled.key)
+      end
+    end
+
+    it 'does not emit standalone marker lists outside numeric note paths as definition blocks' do
+      fragments = [
+        build_fragment('0001', '(a) goods wholly obtained in a country'),
+        build_fragment('0002', 'including mineral products extracted there.'),
+      ]
+
+      blocks = described_class.call(
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '72',
+        source_version: '1.31',
+        fragments:,
+      )
+
+      expect(blocks).to be_empty
+    end
+
+    it 'scopes repeated lower alpha blocks below uppercase section markers without emitting the section markers' do
+      fragments = [
+        build_fragment('0001', '1. Definitions:'),
+        build_fragment('0002', '(A) General rule'),
+        build_fragment('0003', 'a. first condition'),
+        build_fragment('0004', '(B) Exceptions'),
+        build_fragment('0005', 'a. second condition'),
+      ]
+
+      blocks = described_class.call(
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '72',
+        source_version: '1.31',
+        fragments:,
+      )
+
+      expect(blocks.map(&:key)).to contain_exactly(
+        'note_block:customs_tariff_chapter_note:1.31:72:1:A:a',
+        'note_block:customs_tariff_chapter_note:1.31:72:1:B:a',
+      )
+      expect(blocks.map { |block| block.metadata['term'] }).to contain_exactly('first condition', 'second condition')
+    end
+
+    it 'adds a repeat scope when the same marker path is reused without an explicit section marker' do
+      fragments = [
+        build_fragment('0001', '5. The expression applies only to:'),
+        build_fragment('0002', 'a. included product'),
+        build_fragment('0003', 'b. included mixture'),
+        build_fragment('0004', 'The heading does not apply to:'),
+        build_fragment('0005', '(a) excluded product'),
+        build_fragment('0006', '(b) excluded mixture'),
+      ]
+
+      blocks = described_class.call(
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '34',
+        source_version: '1.31',
+        fragments:,
+      )
+
+      expect(blocks.map(&:key)).to contain_exactly(
+        'note_block:customs_tariff_chapter_note:1.31:34:5:a',
+        'note_block:customs_tariff_chapter_note:1.31:34:5:b',
+        'note_block:customs_tariff_chapter_note:1.31:34:5:repeat_2:a',
+        'note_block:customs_tariff_chapter_note:1.31:34:5:repeat_2:b',
+      )
+    end
+
+    def build_fragment(sequence, content)
+      Data.define(:key, :content).new(
+        "note_fragment:customs_tariff_chapter_note:1.31:72:#{sequence}",
+        content,
+      )
+    end
+  end
+end

--- a/spec/services/tariff_knowledge/note_block_parser_spec.rb
+++ b/spec/services/tariff_knowledge/note_block_parser_spec.rb
@@ -198,8 +198,8 @@ RSpec.describe TariffKnowledge::NoteBlockParser do
 
     def build_fragment(sequence, content)
       Data.define(:key, :content).new(
-        "note_fragment:customs_tariff_chapter_note:1.31:72:#{sequence}",
-        content,
+        key: "note_fragment:customs_tariff_chapter_note:1.31:72:#{sequence}",
+        content:,
       )
     end
   end

--- a/spec/services/tariff_knowledge/note_fragment_splitter_spec.rb
+++ b/spec/services/tariff_knowledge/note_fragment_splitter_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe TariffKnowledge::NoteFragmentSplitter do
+  describe '.call' do
+    it 'merges orphaned list markers into the following fragment' do
+      fragments = described_class.call("1. Definitions:\n\na.\n\npig iron")
+
+      expect(fragments).to eq(['1. Definitions:', 'a. pig iron'])
+    end
+
+    it 'preserves dangling numeric references with their introducing fragment' do
+      fragments = described_class.call("Goods of heading\n8481. C. Further text.")
+
+      expect(fragments).to eq(['Goods of heading 8481.', 'C. Further text.'])
+    end
+
+    it 'does not merge ordinary numbered note markers into preceding prose' do
+      fragments = described_class.call("This chapter covers goods.\n\n1. Definitions.")
+
+      expect(fragments).to eq(['This chapter covers goods.', '1. Definitions.'])
+    end
+  end
+end

--- a/spec/services/tariff_knowledge/note_marker_classifier_spec.rb
+++ b/spec/services/tariff_knowledge/note_marker_classifier_spec.rb
@@ -1,0 +1,189 @@
+RSpec.describe TariffKnowledge::NoteMarkerClassifier do
+  describe '.call' do
+    def fragment(key, content)
+      Data.define(:key, :content).new(key, content)
+    end
+
+    it 'classifies markdown headings' do
+      event = described_class.call(fragment('f1', '### Subheading notes'))
+
+      expect(event).to have_attributes(
+        kind: :heading,
+        marker: 'subheading_notes',
+        depth: 0,
+        path_segment: 'subheading_notes',
+        title: 'Subheading notes',
+        body: '',
+      )
+    end
+
+    it 'classifies numeric markers with trailing body' do
+      event = described_class.call(fragment('f1', '1. In this chapter, the following expressions have meanings:'))
+
+      expect(event).to have_attributes(
+        kind: :numeric,
+        marker: '1',
+        depth: 1,
+        path_segment: '1',
+        title: '1',
+        body: 'In this chapter, the following expressions have meanings:',
+      )
+    end
+
+    it 'classifies definition-like alpha markers' do
+      event = described_class.call(fragment('f2', 'a. pig Iron'))
+
+      expect(event).to have_attributes(
+        kind: :alpha,
+        marker: 'a',
+        depth: 2,
+        path_segment: 'a',
+        title: 'pig Iron',
+        body: '',
+      )
+    end
+
+    it 'classifies single-letter roman-looking markers as alpha definitions' do
+      event = described_class.call(fragment('f2', 'i. insulating materials'))
+
+      expect(event).to have_attributes(
+        kind: :alpha,
+        marker: 'i',
+        depth: 2,
+        path_segment: 'i',
+        title: 'insulating materials',
+        body: '',
+      )
+    end
+
+    it 'reattaches compact marker suffixes to the body' do
+      event = described_class.call(fragment('f2', '1.foo bar'))
+
+      expect(event).to have_attributes(
+        kind: :numeric,
+        marker: '1',
+        depth: 1,
+        path_segment: '1',
+        title: '1',
+        body: 'foo bar',
+      )
+    end
+
+    it 'does not classify decimals as compact marker prefixes' do
+      event = described_class.call(fragment('f2', '1.23 % by weight'))
+
+      expect(event).to have_attributes(
+        kind: :continuation,
+        marker: nil,
+        depth: nil,
+        title: nil,
+        body: '1.23 % by weight',
+      )
+    end
+
+    it 'does not classify abbreviations as compact marker prefixes' do
+      event = described_class.call(fragment('f2', 'i.e. examples'))
+
+      expect(event).to have_attributes(
+        kind: :continuation,
+        marker: nil,
+        depth: nil,
+        title: nil,
+        body: 'i.e. examples',
+      )
+    end
+
+    it 'does not classify compact alpha prefixes' do
+      event = described_class.call(fragment('f2', 'a.foo bar'))
+
+      expect(event).to have_attributes(
+        kind: :continuation,
+        marker: nil,
+        body: 'a.foo bar',
+      )
+    end
+
+    it 'does not classify compact roman prefixes' do
+      event = described_class.call(fragment('f2', 'ii.foo bar'))
+
+      expect(event).to have_attributes(
+        kind: :continuation,
+        marker: nil,
+        body: 'ii.foo bar',
+      )
+    end
+
+    it 'classifies uppercase alpha markers as structural section scopes' do
+      event = described_class.call(fragment('f2', 'A. The following'))
+
+      expect(event).to have_attributes(
+        kind: :alpha_section,
+        marker: 'A',
+        depth: 2,
+        path_segment: 'A',
+        title: 'The following',
+        body: '',
+      )
+    end
+
+    it 'classifies parenthesized uppercase alpha markers with trailing periods as section scopes' do
+      event = described_class.call(fragment('f2', '(A). For paper or paperboard weighing not more than 150 g/m2:'))
+
+      expect(event).to have_attributes(
+        kind: :alpha_section,
+        marker: 'A',
+        depth: 2,
+        path_segment: 'A',
+        title: 'For paper or paperboard weighing not more than 150 g/m2:',
+        body: '',
+      )
+    end
+
+    it 'does not classify lowercase parenthesized cross-references with trailing periods as list markers' do
+      event = described_class.call(fragment('f2', '(b). Strip and the like are not considered fibres.'))
+
+      expect(event).to have_attributes(
+        kind: :continuation,
+        marker: nil,
+        body: '(b). Strip and the like are not considered fibres.',
+      )
+    end
+
+    it 'classifies bullet-prefixed uppercase alpha markers as section scopes' do
+      event = described_class.call(fragment('f2', '- (B) Heading 8422 does not cover:'))
+
+      expect(event).to have_attributes(
+        kind: :alpha_section,
+        marker: 'B',
+        depth: 2,
+        path_segment: 'B',
+        title: 'Heading 8422 does not cover:',
+        body: '',
+      )
+    end
+
+    it 'classifies bullets without treating them as definitions' do
+      event = described_class.call(fragment('f3', '- not more than 10 % of chromium'))
+
+      expect(event).to have_attributes(
+        kind: :bullet,
+        marker: '-',
+        depth: 4,
+        title: nil,
+        body: 'not more than 10 % of chromium',
+      )
+    end
+
+    it 'classifies unmatched text as continuation' do
+      event = described_class.call(fragment('f4', 'Iron-carbon alloys not usefully malleable.'))
+
+      expect(event).to have_attributes(
+        kind: :continuation,
+        marker: nil,
+        depth: nil,
+        title: nil,
+        body: 'Iron-carbon alloys not usefully malleable.',
+      )
+    end
+  end
+end

--- a/spec/services/tariff_knowledge/note_marker_classifier_spec.rb
+++ b/spec/services/tariff_knowledge/note_marker_classifier_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe TariffKnowledge::NoteMarkerClassifier do
   describe '.call' do
     def fragment(key, content)
-      Data.define(:key, :content).new(key, content)
+      Data.define(:key, :content).new(key:, content:)
     end
 
     it 'classifies markdown headings' do

--- a/spec/services/tariff_knowledge/note_marker_trie_spec.rb
+++ b/spec/services/tariff_knowledge/note_marker_trie_spec.rb
@@ -1,0 +1,47 @@
+RSpec.describe TariffKnowledge::NoteMarkerTrie do
+  describe '#match' do
+    it 'classifies exact marker tokens by longest registered match' do
+      trie = described_class.default
+
+      expect(trie.match('ij.')).to have_attributes(kind: :alpha, marker: 'ij')
+      expect(trie.match('ii.')).to have_attributes(kind: :roman, marker: 'ii')
+      expect(trie.match('(a)')).to have_attributes(kind: :alpha, marker: 'a')
+      expect(trie.match('—')).to have_attributes(kind: :bullet, marker: '—')
+    end
+
+    it 'classifies single-letter roman-looking tokens as alpha markers' do
+      trie = described_class.default
+
+      expect(trie.match('i.')).to have_attributes(kind: :alpha, marker: 'i')
+      expect(trie.match('v.')).to have_attributes(kind: :alpha, marker: 'v')
+      expect(trie.match('x.')).to have_attributes(kind: :alpha, marker: 'x')
+    end
+
+    it 'classifies parenthesized and suffix single-letter roman tokens as roman markers' do
+      trie = described_class.default
+
+      expect(trie.match('(i)')).to have_attributes(kind: :roman, marker: 'i')
+      expect(trie.match('i)')).to have_attributes(kind: :roman, marker: 'i')
+      expect(trie.match('(v)')).to have_attributes(kind: :roman, marker: 'v')
+      expect(trie.match('v)')).to have_attributes(kind: :roman, marker: 'v')
+      expect(trie.match('(x)')).to have_attributes(kind: :roman, marker: 'x')
+      expect(trie.match('x)')).to have_attributes(kind: :roman, marker: 'x')
+    end
+
+    it 'classifies multi-letter roman tokens as roman markers' do
+      trie = described_class.default
+
+      expect(trie.match('ii.')).to have_attributes(kind: :roman, marker: 'ii')
+      expect(trie.match('iv.')).to have_attributes(kind: :roman, marker: 'iv')
+      expect(trie.match('xii.')).to have_attributes(kind: :roman, marker: 'xii')
+    end
+
+    it 'classifies the longest registered prefix before prose starts' do
+      expect(described_class.default.match('1.foo')).to have_attributes(kind: :numeric, marker: '1')
+    end
+
+    it 'returns nil for prose that is not a registered marker' do
+      expect(described_class.default.match('Iron-carbon')).to be_nil
+    end
+  end
+end

--- a/spec/services/tariff_knowledge/note_structure_parser_spec.rb
+++ b/spec/services/tariff_knowledge/note_structure_parser_spec.rb
@@ -1,0 +1,158 @@
+RSpec.describe TariffKnowledge::NoteStructureParser do
+  describe '.call' do
+    def fragment(sequence, content)
+      Data.define(:key, :content).new("note_fragment:customs_tariff_chapter_note:1.31:72:#{sequence}", content)
+    end
+
+    it 'builds scoped trees for repeated marker paths under headings' do
+      tree = described_class.call(
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '72',
+        source_version: '1.31',
+        fragments: [
+          fragment('0001', '1. In this chapter the following expressions have meanings:'),
+          fragment('0002', 'a. pig Iron'),
+          fragment('0003', 'Iron-carbon alloys not usefully malleable.'),
+          fragment('0004', '- not more than 10 % of chromium'),
+          fragment('0072', '### Subheading notes'),
+          fragment('0073', '1. In this chapter, the following expressions have meanings:'),
+          fragment('0074', 'a. alloy pig iron'),
+          fragment('0075', 'Pig iron containing one or more specified elements.'),
+        ],
+      )
+
+      pig_iron = tree.nodes.find { |node| node.title == 'pig Iron' }
+      alloy_pig_iron = tree.nodes.find { |node| node.title == 'alloy pig iron' }
+
+      expect(pig_iron.path).to eq(%w[1 a])
+      expect(pig_iron.fragment_keys).to contain_exactly(
+        'note_fragment:customs_tariff_chapter_note:1.31:72:0002',
+        'note_fragment:customs_tariff_chapter_note:1.31:72:0003',
+        'note_fragment:customs_tariff_chapter_note:1.31:72:0004',
+      )
+      expect(pig_iron.content).to include('Iron-carbon alloys not usefully malleable.')
+      expect(pig_iron.content).to include('not more than 10 % of chromium')
+      expect(alloy_pig_iron.path).to eq(%w[subheading_notes 1 a])
+      expect(alloy_pig_iron.fragment_keys).to contain_exactly(
+        'note_fragment:customs_tariff_chapter_note:1.31:72:0074',
+        'note_fragment:customs_tariff_chapter_note:1.31:72:0075',
+      )
+      expect(alloy_pig_iron.content).to include('Pig iron containing one or more specified elements.')
+    end
+
+    it 'attaches continuations and bullets to the nearest active structural node' do
+      tree = described_class.call(
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '72',
+        source_version: '1.31',
+        fragments: [
+          fragment('0001', '1. Definitions:'),
+          fragment('0002', 'a. steel'),
+          fragment('0003', 'Ferrous materials usefully malleable.'),
+          fragment('0004', '- with carbon limits'),
+          fragment('0005', '- with chromium exceptions'),
+        ],
+      )
+
+      steel = tree.nodes.find { |node| node.title == 'steel' }
+      expect(steel.content).to include('Ferrous materials usefully malleable.')
+      expect(steel.content).to include('with carbon limits')
+      expect(steel.content).to include('with chromium exceptions')
+    end
+
+    it 'nests roman block candidates under active alpha block candidates' do
+      tree = described_class.call(
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '72',
+        source_version: '1.31',
+        fragments: [
+          fragment('0001', '1. Definitions:'),
+          fragment('0002', 'a. steel'),
+          fragment('0003', '(i) stainless steel'),
+          fragment('0004', 'Containing chromium.'),
+        ],
+      )
+
+      steel = tree.nodes.find { |node| node.title == 'steel' }
+      stainless_steel = steel.children.find { |node| node.title == 'stainless steel' }
+
+      expect(tree.nodes.map(&:title)).to include('steel')
+      expect(tree.nodes.map(&:title)).not_to include('stainless steel')
+      expect(steel.children.map(&:title)).to include('stainless steel')
+      expect(stainless_steel.path).to eq(%w[1 a i])
+      expect(stainless_steel.content).to include('Containing chromium.')
+      expect(stainless_steel.fragment_keys).to contain_exactly(
+        'note_fragment:customs_tariff_chapter_note:1.31:72:0003',
+        'note_fragment:customs_tariff_chapter_note:1.31:72:0004',
+      )
+    end
+
+    it 'does not attach sibling continuations to stale nested block candidates' do
+      tree = described_class.call(
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '72',
+        source_version: '1.31',
+        fragments: [
+          fragment('0001', '1. Definitions:'),
+          fragment('0002', 'a. steel'),
+          fragment('0003', '(i) stainless steel'),
+          fragment('0004', 'Containing chromium.'),
+          fragment('0005', 'b. iron'),
+          fragment('0006', 'Containing carbon.'),
+        ],
+      )
+
+      steel = tree.nodes.find { |node| node.title == 'steel' }
+      iron = tree.nodes.find { |node| node.title == 'iron' }
+      stainless_steel = steel.children.find { |node| node.title == 'stainless steel' }
+
+      expect(tree.nodes.map(&:title)).to contain_exactly('steel', 'iron')
+      expect(iron.content).to include('Containing carbon.')
+      expect(stainless_steel.content).to include('Containing chromium.')
+      expect(stainless_steel.content).not_to include('Containing carbon.')
+    end
+
+    it 'uses uppercase alpha markers as section scopes for repeated lower alpha lists' do
+      tree = described_class.call(
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '72',
+        source_version: '1.31',
+        fragments: [
+          fragment('0001', '1. Definitions:'),
+          fragment('0002', '(A) General rule'),
+          fragment('0003', 'a. first condition'),
+          fragment('0004', '(B) Exceptions'),
+          fragment('0005', 'a. second condition'),
+        ],
+      )
+
+      general_rule = tree.nodes.find { |node| node.title == 'General rule' }
+      exceptions = tree.nodes.find { |node| node.title == 'Exceptions' }
+      first_condition = general_rule.children.find { |node| node.title == 'first condition' }
+      second_condition = exceptions.children.find { |node| node.title == 'second condition' }
+
+      expect(general_rule).to have_attributes(kind: :alpha_section, path: %w[1 A])
+      expect(exceptions).to have_attributes(kind: :alpha_section, path: %w[1 B])
+      expect(first_condition.path).to eq(%w[1 A a])
+      expect(second_condition.path).to eq(%w[1 B a])
+    end
+
+    it 'reports orphan events that cannot attach to a block candidate' do
+      tree = described_class.call(
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '72',
+        source_version: '1.31',
+        fragments: [
+          fragment('0001', '- orphan bullet'),
+          fragment('0002', '1. Definitions:'),
+          fragment('0003', 'a. steel'),
+        ],
+      )
+
+      expect(tree.orphans.map { |event| event.fragment.key }).to contain_exactly(
+        'note_fragment:customs_tariff_chapter_note:1.31:72:0001',
+      )
+      expect(tree.nodes.map(&:title)).to include('steel')
+    end
+  end
+end

--- a/spec/services/tariff_knowledge/note_structure_parser_spec.rb
+++ b/spec/services/tariff_knowledge/note_structure_parser_spec.rb
@@ -1,7 +1,10 @@
 RSpec.describe TariffKnowledge::NoteStructureParser do
   describe '.call' do
     def fragment(sequence, content)
-      Data.define(:key, :content).new("note_fragment:customs_tariff_chapter_note:1.31:72:#{sequence}", content)
+      Data.define(:key, :content).new(
+        key: "note_fragment:customs_tariff_chapter_note:1.31:72:#{sequence}",
+        content:,
+      )
     end
 
     it 'builds scoped trees for repeated marker paths under headings' do

--- a/spec/services/tariff_knowledge/note_structure_validator_spec.rb
+++ b/spec/services/tariff_knowledge/note_structure_validator_spec.rb
@@ -1,0 +1,112 @@
+RSpec.describe TariffKnowledge::NoteStructureValidator do
+  describe '.call' do
+    def fragment(sequence, content)
+      Data.define(:key, :content).new(
+        "note_fragment:customs_tariff_chapter_note:1.31:72:#{sequence}",
+        content,
+      )
+    end
+
+    it 'reports a clean parsed note structure' do
+      result = described_class.call(
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '72',
+        source_version: '1.31',
+        fragments: [
+          fragment('0001', '1. In this chapter the following expressions have meanings:'),
+          fragment('0002', 'a. pig Iron'),
+          fragment('0003', 'Iron-carbon alloys not usefully malleable.'),
+        ],
+      )
+
+      aggregate_failures do
+        expect(result).to have_attributes(
+          source_type: 'customs_tariff_chapter_note',
+          source_id: '72',
+          source_version: '1.31',
+          fragment_count: 3,
+          event_count: 3,
+          root_node_count: 1,
+          total_node_count: 1,
+          orphan_event_count: 0,
+          orphan_event_keys: [],
+          duplicate_block_keys: [],
+          uncontained_fragment_keys: [],
+          issues: [],
+        )
+      end
+    end
+
+    it 'reports orphan and uncontained fragments without raising' do
+      result = described_class.call(
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '72',
+        source_version: '1.31',
+        fragments: [
+          fragment('0001', '- orphan bullet'),
+          fragment('0002', '1. Definitions:'),
+          fragment('0003', 'a. steel'),
+        ],
+      )
+
+      expect(result.orphan_event_keys).to contain_exactly('note_fragment:customs_tariff_chapter_note:1.31:72:0001')
+      expect(result.uncontained_fragment_keys).to contain_exactly(
+        'note_fragment:customs_tariff_chapter_note:1.31:72:0001',
+      )
+      expect(result.issues.map(&:code)).to include('orphan_events', 'uncontained_fragments')
+    end
+
+    it 'does not report ordinary continuation prose as an uncontained definition fragment' do
+      result = described_class.call(
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '72',
+        source_version: '1.31',
+        fragments: [
+          fragment('0001', '1. General provisions:'),
+          fragment('0002', 'This chapter covers goods of iron or steel.'),
+        ],
+      )
+
+      expect(result.uncontained_fragment_keys).to be_empty
+      expect(result.issues.map(&:code)).not_to include('uncontained_fragments')
+    end
+
+    it 'reports duplicate block keys from emitted blocks' do
+      first_block = TariffKnowledge::NoteBlockParser::Block.new(
+        key: 'note_block:customs_tariff_chapter_note:1.31:72:1:a',
+        title: 'steel',
+        content: 'steel',
+        metadata: {},
+        fragment_keys: ['note_fragment:customs_tariff_chapter_note:1.31:72:0002'],
+      )
+      second_block = first_block.with(title: 'steel duplicate')
+
+      result = described_class.call(
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '72',
+        source_version: '1.31',
+        fragments: [
+          fragment('0001', '1. Definitions:'),
+          fragment('0002', 'a. steel'),
+        ],
+        block_parser: class_double(TariffKnowledge::NoteBlockParser, call: [first_block, second_block]),
+      )
+
+      expect(result.duplicate_block_keys).to contain_exactly('note_block:customs_tariff_chapter_note:1.31:72:1:a')
+      expect(result.issues.map(&:code)).to include('duplicate_block_keys')
+    end
+
+    it 'can split content into source fragments for generic callers' do
+      result = described_class.call(
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '72',
+        source_version: '1.31',
+        content: "1. Definitions:\n\na. steel\n\nGoods of heading\n8481. C. Further text.",
+      )
+
+      expect(result.fragment_count).to eq(4)
+      expect(result.source_id).to eq('72')
+      expect(result.issues.map(&:code)).not_to include('missing_fragments')
+    end
+  end
+end

--- a/spec/services/tariff_knowledge/note_structure_validator_spec.rb
+++ b/spec/services/tariff_knowledge/note_structure_validator_spec.rb
@@ -2,8 +2,8 @@ RSpec.describe TariffKnowledge::NoteStructureValidator do
   describe '.call' do
     def fragment(sequence, content)
       Data.define(:key, :content).new(
-        "note_fragment:customs_tariff_chapter_note:1.31:72:#{sequence}",
-        content,
+        key: "note_fragment:customs_tariff_chapter_note:1.31:72:#{sequence}",
+        content:,
       )
     end
 


### PR DESCRIPTION
### Jira link

[AI-997](https://transformuk.atlassian.net/browse/AI-997)

### What?

- [x] Add marker trie and classifier for note list markers
- [x] Parse chapter notes into a structure tree
- [x] Emit definition-shaped note blocks (term, path, content)
- [x] Add structure/block validator for offline inspection
- [x] Unit specs for each parser stage

### Why?

Chapter notes encode nested legal definitions. Without a dedicated parse stage, downstream graph loading cannot keep definition units (e.g. pig iron composition limits) together as coherent blocks.

This PR only introduces pure parsing services and tests. No graph write path and no search behaviour change.

### Risk

**Risk level:** 🟢

**Reason for rating:** New pure-Ruby parser classes with unit coverage. No runtime call sites wired yet; no migrations, sync, or public API changes.