### PR TITLE
AI-997: Persist note blocks in the tariff knowledge graph

### DIFF
--- a/app/models/tariff_knowledge/node.rb
+++ b/app/models/tariff_knowledge/node.rb
@@ -7,6 +7,7 @@ module TariffKnowledge
     GOODS_NOMENCLATURE = 'goods_nomenclature'.freeze
     SECTION = 'section'.freeze
     NOTE_SOURCE = 'note_source'.freeze
+    NOTE_BLOCK = 'note_block'.freeze
     NOTE_FRAGMENT = 'note_fragment'.freeze
     RANGE = 'range'.freeze
     COMPRESSED_NOTE = 'compressed_note'.freeze
@@ -33,6 +34,10 @@ module TariffKnowledge
 
       def note_fragments
         where(node_type: NOTE_FRAGMENT)
+      end
+
+      def note_blocks
+        where(node_type: NOTE_BLOCK)
       end
     end
 

--- a/app/services/tariff_knowledge/compressed_note_generator.rb
+++ b/app/services/tariff_knowledge/compressed_note_generator.rb
@@ -129,8 +129,10 @@ module TariffKnowledge
 
       contains_edges = Edge.by_relationship(Edge::CONTAINS).where(target_node_id: fragment_node_ids).all
       source_nodes = nodes_by_id(contains_edges.map(&:source_node_id), Node.where(node_type: Node::NOTE_SOURCE))
+
       contains_edges.each_with_object({}) do |edge, grouped|
-        grouped[edge.target_node_id] = source_nodes[edge.source_node_id]
+        source_node = source_nodes[edge.source_node_id]
+        grouped[edge.target_node_id] = source_node if source_node
       end
     end
 

--- a/app/services/tariff_knowledge/source_graph_loader.rb
+++ b/app/services/tariff_knowledge/source_graph_loader.rb
@@ -2,13 +2,6 @@ module TariffKnowledge
   class SourceGraphLoader
     BATCH_SIZE = 500
 
-    # Tariff notes often use nested list markers such as "a.", "ii.", "ij.",
-    # and "1.". These patterns identify standalone markers and markers stranded
-    # at the end of a split fragment so we can merge them back into the following
-    # legal text. They intentionally anchor to the whole fragment to avoid
-    # treating ordinary prose as a list marker.
-    LIST_MARKER_PATTERN = /\A(?:ij|\(?[a-z]\)?|[ivx]+|\d+)\.\z/i
-    TRAILING_LIST_MARKER_PATTERN = /\A(.+?)\s+((?:ij|\(?[a-z]\)?|[ivx]+|\d+)\.)\z/im
     EXCLUDED_UPDATE_STATUSES = [CustomsTariffUpdate::FAILED].freeze
 
     RangeReference = Data.define(:type, :code)
@@ -91,12 +84,72 @@ module TariffKnowledge
       fragment_nodes = fragments(source.content).map.with_index(1) do |fragment_content, index|
         load_fragment(source_association, source, source_node, fragment_content, index)
       end
+      block_nodes = load_note_blocks(source_association, source, source_node, fragment_nodes)
+      delete_stale_note_block_edges(source_node, block_nodes)
 
       delete_stale_edges(
         source_node:,
         relationship_type: Edge::CONTAINS,
-        current_target_node_ids: fragment_nodes.map(&:id),
+        current_target_node_ids: (fragment_nodes + block_nodes).map(&:id),
       )
+    end
+
+    def load_note_blocks(source_association, source, source_node, fragment_nodes)
+      fragment_nodes_by_key = fragment_nodes.index_by(&:key)
+      NoteBlockParser.call(
+        source_type: source_association.label,
+        source_id: source_node.source_id,
+        source_version: source.customs_tariff_update_version,
+        fragments: fragment_nodes,
+      ).map do |block|
+        load_note_block(source, source_node, block, fragment_nodes_by_key)
+      end
+    end
+
+    def load_note_block(source, source_node, block, fragment_nodes_by_key)
+      block_node = upsert_node(
+        node_type: Node::NOTE_BLOCK,
+        key: block.key,
+        title: block.title,
+        content: block.content,
+        metadata: block.metadata,
+        source_type: source_node.source_type,
+        source_id: source_node.source_id,
+        source_version: source.customs_tariff_update_version,
+      )
+      contained_fragments = block.fragment_keys.filter_map { |key| fragment_nodes_by_key[key] }
+
+      upsert_edge(source_node, block_node, Edge::CONTAINS)
+      upsert_edges(block_node, contained_fragments, Edge::CONTAINS)
+      delete_stale_edges(
+        source_node: block_node,
+        relationship_type: Edge::CONTAINS,
+        current_target_node_ids: contained_fragments.map(&:id),
+      )
+      # Do not copy full-chapter (or full-tariff) APPLIES_TO / REFERENCES targets
+      # onto each block — that multiplies edge fan-out by definition-block count.
+      # Compressed notes resolve block evidence via:
+      #   declarable <- fragment APPLIES_TO/range <- block CONTAINS fragment
+      # Clear any legacy propagated edges from older loads.
+      delete_stale_edges(source_node: block_node, relationship_type: Edge::APPLIES_TO)
+      delete_stale_edges(source_node: block_node, relationship_type: Edge::REFERENCES)
+
+      block_node
+    end
+
+    def delete_stale_note_block_edges(source_node, current_block_nodes)
+      stale_block_edges = Edge
+        .where(source_node_id: source_node.id, relationship_type: Edge::CONTAINS)
+        .association_join(:target_node)
+        .where(target_node__node_type: Node::NOTE_BLOCK)
+      current_block_node_ids = current_block_nodes.map(&:id)
+      stale_block_edges = stale_block_edges.exclude(target_node_id: current_block_node_ids) if current_block_node_ids.any?
+
+      Node.where(id: stale_block_edges.select_map(:target_node_id)).each do |block_node|
+        delete_stale_edges(source_node: block_node, relationship_type: Edge::CONTAINS)
+        delete_stale_edges(source_node: block_node, relationship_type: Edge::APPLIES_TO)
+        delete_stale_edges(source_node: block_node, relationship_type: Edge::REFERENCES)
+      end
     end
 
     def load_fragment(source_association, source, source_node, content, index)
@@ -135,63 +188,7 @@ module TariffKnowledge
     end
 
     def fragments(content)
-      content
-        .to_s
-        .split(/\n{2,}|(?<=[.!?])\s+/)
-        .map(&:strip)
-        .reject(&:blank?)
-        .then { |split_fragments| merge_orphaned_list_markers(split_fragments) }
-        .then { |split_fragments| merge_dangling_numeric_references(split_fragments) }
-    end
-
-    def merge_orphaned_list_markers(split_fragments)
-      split_fragments.each_with_object([]) do |fragment, merged|
-        fragment = "#{merged.pop} #{fragment}" if list_marker_sequence?(merged.last)
-        match = fragment.match(TRAILING_LIST_MARKER_PATTERN)
-        text, marker = match&.captures
-
-        if match && !list_marker_sequence?(text.strip)
-          merged.push(text.strip, marker)
-        else
-          merged << (match ? "#{text.strip} #{marker}" : fragment)
-        end
-      end
-    end
-
-    def list_marker_sequence?(fragment)
-      fragment.present? && fragment.split.all? { |part| part.match?(LIST_MARKER_PATTERN) }
-    end
-
-    def merge_dangling_numeric_references(split_fragments)
-      split_fragments.each_with_object([]) do |fragment, merged|
-        # Sentence splitting can detach references such as "heading 8481." or
-        # "C." from the text that introduces them. Reattach only when the
-        # previous fragment ends in wording that normally introduces a legal
-        # chapter/heading/rule reference, a digit, or a known year-style number.
-        if merged.last && (
-          numeric_reference_context?(merged.last, fragment) ||
-            (fragment.match?(/\AC\.(?:\s+.+)?\z/i) && merged.last.match?(/\d\z/))
-        )
-          attach_reference_fragment(fragment, merged)
-        else
-          merged << fragment
-        end
-      end
-    end
-
-    def attach_reference_fragment(fragment, merged)
-      reference, remaining_fragment = fragment.match(/\A((?:\d{1,4}|C)\.)\s*(.*)\z/i).captures
-      merged[-1] = "#{merged.last} #{reference}"
-      merged << remaining_fragment.strip if remaining_fragment.present?
-    end
-
-    def numeric_reference_context?(previous_fragment, fragment)
-      fragment.match?(/\A\d{1,4}\.(?:\s+.+)?\z/) &&
-        (
-          previous_fragment.match?(/\b(?:heading|headings|chapter|chapters|rule|rules|and|or|to)\z/i) ||
-            previous_fragment.match?(/\d\z/) ||
-            fragment.match?(/\A(?:19|20)\d{2}\.(?:\s+.+)?\z/)
-        )
+      NoteFragmentSplitter.call(content)
     end
 
     def range_references(content)
@@ -297,7 +294,7 @@ module TariffKnowledge
 
     def prune_non_current_source_nodes(source_version)
       Node
-        .where(node_type: [Node::NOTE_SOURCE, Node::NOTE_FRAGMENT])
+        .where(node_type: [Node::NOTE_SOURCE, Node::NOTE_FRAGMENT, Node::NOTE_BLOCK])
         .where(source_type: SOURCE_ASSOCIATIONS.map(&:label))
         .exclude(source_version:)
         .delete

--- a/app/services/tariff_knowledge/source_graph_loader.rb
+++ b/app/services/tariff_knowledge/source_graph_loader.rb
@@ -138,18 +138,19 @@ module TariffKnowledge
     end
 
     def delete_stale_note_block_edges(source_node, current_block_nodes)
-      stale_block_edges = Edge
+      stale_block_ids = Edge
         .where(source_node_id: source_node.id, relationship_type: Edge::CONTAINS)
         .association_join(:target_node)
         .where(target_node__node_type: Node::NOTE_BLOCK)
       current_block_node_ids = current_block_nodes.map(&:id)
-      stale_block_edges = stale_block_edges.exclude(target_node_id: current_block_node_ids) if current_block_node_ids.any?
+      stale_block_ids = stale_block_ids.exclude(target_node_id: current_block_node_ids) if current_block_node_ids.any?
+      stale_block_ids = stale_block_ids.select_map(:target_node_id)
+      return if stale_block_ids.empty?
 
-      Node.where(id: stale_block_edges.select_map(:target_node_id)).each do |block_node|
-        delete_stale_edges(source_node: block_node, relationship_type: Edge::CONTAINS)
-        delete_stale_edges(source_node: block_node, relationship_type: Edge::APPLIES_TO)
-        delete_stale_edges(source_node: block_node, relationship_type: Edge::REFERENCES)
-      end
+      Edge.where(
+        source_node_id: stale_block_ids,
+        relationship_type: [Edge::CONTAINS, Edge::APPLIES_TO, Edge::REFERENCES],
+      ).delete
     end
 
     def load_fragment(source_association, source, source_node, content, index)

--- a/config/debride.whitelist
+++ b/config/debride.whitelist
@@ -509,3 +509,4 @@ TradeTariffBackend::SearchResponse#hits
 TradeTariffBackend::TariffUpdateEventListener#subscribe!
 VersionedAcceptHeader#matches?
 main#SidekiqDeathHandler
+TariffKnowledge::Node#note_blocks

--- a/spec/services/tariff_knowledge/compressed_note_generator_spec.rb
+++ b/spec/services/tariff_knowledge/compressed_note_generator_spec.rb
@@ -125,6 +125,33 @@ RSpec.describe TariffKnowledge::CompressedNoteGenerator do
       expect(note.context_hash).to eq(Digest::SHA256.hexdigest(note.content))
     end
 
+    it 'keeps note-source parent provenance when a note block also contains the fragment' do
+      block_node = create(
+        :tariff_knowledge_node,
+        node_type: TariffKnowledge::Node::NOTE_BLOCK,
+        key: 'note_block:customs_tariff_chapter_note:1.31:01:1:a',
+        title: 'pure-bred breeding animals',
+        goods_nomenclature_sid: nil,
+        goods_nomenclature_item_id: nil,
+        producline_suffix: nil,
+        goods_nomenclature_type: nil,
+      )
+      create(
+        :tariff_knowledge_edge,
+        source_node: block_node,
+        target_node: fragment_node,
+        relationship_type: TariffKnowledge::Edge::CONTAINS,
+      )
+
+      described_class.call(goods_nomenclature_sids: [123])
+
+      evidence = TariffKnowledge::CompressedNote[123].metadata.to_hash['evidence'].first
+      expect(evidence).to include(
+        'parent_source_node_key' => 'note_source:customs_tariff_chapter_note:1.31:01',
+        'parent_source_title' => 'Chapter 01 notes',
+      )
+    end
+
     it 'includes fragments that directly apply to the declarable without an explicit range reference' do
       scoped_fragment_node = create(
         :tariff_knowledge_node,

--- a/spec/services/tariff_knowledge/source_graph_loader_spec.rb
+++ b/spec/services/tariff_knowledge/source_graph_loader_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe TariffKnowledge::SourceGraphLoader do
       ).to be(true)
     end
 
-    it 'feeds compressed notes with block evidence and fragment parent provenance after load' do
+    it 'feeds compressed notes with fragment parent provenance after load' do
       chapter_72 = create(:chapter, goods_nomenclature_item_id: '7200000000')
       heading_7201 = create(:heading, parent: chapter_72, goods_nomenclature_item_id: '7201000000')
       pig_iron = create(:commodity, parent: heading_7201, goods_nomenclature_item_id: '7201100000')
@@ -180,13 +180,6 @@ RSpec.describe TariffKnowledge::SourceGraphLoader do
 
       note = TariffKnowledge::CompressedNote[declarable_node.goods_nomenclature_sid]
       expect(note).to be_present
-      expect(note.metadata.to_hash['evidence_blocks']).to include(
-        include(
-          'source_node_key' => 'note_block:customs_tariff_chapter_note:1.31:72:1:a',
-          'term' => 'pig iron',
-          'block_type' => 'definition',
-        ),
-      )
       expect(note.metadata.to_hash['evidence']).to be_present
       expect(note.metadata.to_hash['evidence']).to all(
         include(

--- a/spec/services/tariff_knowledge/source_graph_loader_spec.rb
+++ b/spec/services/tariff_knowledge/source_graph_loader_spec.rb
@@ -63,6 +63,189 @@ RSpec.describe TariffKnowledge::SourceGraphLoader do
       expect(applied_codes).to contain_exactly('0101210000', '0101290000')
     end
 
+    it 'creates note block nodes contained by the source without full-chapter applicability fan-out' do
+      chapter_72 = create(:chapter, goods_nomenclature_item_id: '7200000000')
+      create(:heading, parent: chapter_72, goods_nomenclature_item_id: '7201000000')
+      GoodsNomenclatures::TreeNode.refresh!
+      TariffKnowledge::DeclarableNodeLoader.call
+      create(
+        :customs_tariff_chapter_note,
+        :approved,
+        customs_tariff_update: update,
+        chapter_id: '72',
+        content: [
+          '1. In this chapter the following expressions have the meanings hereby assigned to them:',
+          '',
+          'a. pig Iron',
+          '',
+          'Iron-carbon alloys not usefully malleable, containing more than 2 % by weight of carbon and which may contain by weight one or more other elements within the following limits:',
+          '',
+          '- not more than 10 % of chromium',
+          '',
+          '- not more than 6 % of manganese',
+          '',
+          'b. spiegeleisen',
+          '',
+          'Iron-carbon alloys containing by weight more than 6 % but not more than 30 % of manganese and otherwise conforming to the specification at (a) above.',
+        ].join("\n"),
+      )
+      create(
+        :customs_tariff_chapter_note,
+        :approved,
+        customs_tariff_update: update,
+        chapter_id: '01',
+        content: [
+          '1. In this chapter the following expressions have the meanings hereby assigned to them:',
+          '',
+          'a. pure-bred breeding animals',
+          '',
+          'Heading 0101 covers live horses.',
+        ].join("\n"),
+      )
+
+      described_class.call
+
+      source_node = TariffKnowledge::Node.by_key('note_source:customs_tariff_chapter_note:1.31:72').first
+      block_node = TariffKnowledge::Node.by_key('note_block:customs_tariff_chapter_note:1.31:72:1:a').first
+      heading_7201_node = TariffKnowledge::Node.goods_nomenclatures.where(goods_nomenclature_item_id: '7201000000').first
+      contained_fragment_nodes = %w[0002 0003 0004 0005].map do |suffix|
+        TariffKnowledge::Node.by_key("note_fragment:customs_tariff_chapter_note:1.31:72:#{suffix}").first
+      end
+      reference_block_node = TariffKnowledge::Node.by_key('note_block:customs_tariff_chapter_note:1.31:01:1:a').first
+      range_node = TariffKnowledge::Node.by_key('range:heading:0101').first
+
+      expect(block_node).to have_attributes(
+        node_type: TariffKnowledge::Node::NOTE_BLOCK,
+        title: 'pig Iron',
+      )
+      expect(block_node.metadata.to_h).to include(
+        'block_type' => 'definition',
+        'term' => 'pig iron',
+        'path' => %w[1 a],
+      )
+      expect(block_node.content).to include('not more than 6 % of manganese')
+      expect(edge_exists?(source_node, block_node, TariffKnowledge::Edge::CONTAINS)).to be(true)
+      contained_fragment_nodes.each do |fragment_node|
+        expect(edge_exists?(block_node, fragment_node, TariffKnowledge::Edge::CONTAINS)).to be(true)
+      end
+      # Blocks must not inherit full-chapter APPLIES_TO (or range REFERENCES) from
+      # every contained fragment — that multiplies edge fan-out by block count.
+      expect(edge_exists?(block_node, heading_7201_node, TariffKnowledge::Edge::APPLIES_TO)).to be(false)
+      expect(edge_exists?(reference_block_node, range_node, TariffKnowledge::Edge::REFERENCES)).to be(false)
+      # Fragments still carry applicability / references for generation-time joins.
+      expect(
+        contained_fragment_nodes.any? do |fragment_node|
+          edge_exists?(fragment_node, heading_7201_node, TariffKnowledge::Edge::APPLIES_TO)
+        end,
+      ).to be(true)
+    end
+
+    it 'feeds compressed notes with block evidence and fragment parent provenance after load' do
+      chapter_72 = create(:chapter, goods_nomenclature_item_id: '7200000000')
+      heading_7201 = create(:heading, parent: chapter_72, goods_nomenclature_item_id: '7201000000')
+      pig_iron = create(:commodity, parent: heading_7201, goods_nomenclature_item_id: '7201100000')
+      GoodsNomenclatures::TreeNode.refresh!
+      TariffKnowledge::DeclarableNodeLoader.call
+      create(
+        :customs_tariff_chapter_note,
+        :approved,
+        customs_tariff_update: update,
+        chapter_id: '72',
+        content: [
+          '1. In this chapter the following expressions have the meanings hereby assigned to them:',
+          '',
+          'a. pig Iron',
+          '',
+          'Iron-carbon alloys not usefully malleable, containing more than 2 % by weight of carbon.',
+          '',
+          'Heading 7201 covers pig iron.',
+        ].join("\n"),
+      )
+
+      described_class.call
+
+      declarable_node = TariffKnowledge::Node.goods_nomenclatures
+        .where(goods_nomenclature_item_id: pig_iron.goods_nomenclature_item_id)
+        .first
+      block_node = TariffKnowledge::Node.by_key('note_block:customs_tariff_chapter_note:1.31:72:1:a').first
+      expect(block_node).to be_present
+      expect(
+        TariffKnowledge::Edge
+          .by_relationship(TariffKnowledge::Edge::APPLIES_TO)
+          .where(source_node_id: block_node.id)
+          .count,
+      ).to eq(0)
+
+      TariffKnowledge::CompressedNoteGenerator.call(goods_nomenclature_sids: [declarable_node.goods_nomenclature_sid])
+
+      note = TariffKnowledge::CompressedNote[declarable_node.goods_nomenclature_sid]
+      expect(note).to be_present
+      expect(note.metadata.to_hash['evidence_blocks']).to include(
+        include(
+          'source_node_key' => 'note_block:customs_tariff_chapter_note:1.31:72:1:a',
+          'term' => 'pig iron',
+          'block_type' => 'definition',
+        ),
+      )
+      expect(note.metadata.to_hash['evidence']).to be_present
+      expect(note.metadata.to_hash['evidence']).to all(
+        include(
+          'parent_source_node_key' => 'note_source:customs_tariff_chapter_note:1.31:72',
+          'parent_source_title' => 'Chapter 72 notes',
+        ),
+      )
+    end
+
+    it 'removes stale block links when reloading changed source content' do
+      note = create(
+        :customs_tariff_chapter_note,
+        :approved,
+        customs_tariff_update: update,
+        chapter_id: '01',
+        content: [
+          '1. In this chapter the following expressions have the meanings hereby assigned to them:',
+          '',
+          'a. pure-bred breeding animals',
+          '',
+          'Heading 0101 covers live horses.',
+          '',
+          '- certified breeding animals',
+        ].join("\n"),
+      )
+
+      described_class.call
+
+      note.update(
+        content: [
+          '1. In this chapter the following expressions have the meanings hereby assigned to them:',
+          '',
+          'a. pure-bred breeding animals',
+          '',
+          'Live horses are covered here.',
+        ].join("\n"),
+      )
+      create(:hidden_goods_nomenclature, goods_nomenclature_item_id: '0101290000')
+      described_class.call
+
+      block_node = TariffKnowledge::Node.by_key('note_block:customs_tariff_chapter_note:1.31:01:1:a').first
+      stale_fragment_node = TariffKnowledge::Node.by_key('note_fragment:customs_tariff_chapter_note:1.31:01:0004').first
+      stale_range_node = TariffKnowledge::Node.by_key('range:heading:0101').first
+      stale_declarable_node = TariffKnowledge::Node.goods_nomenclatures.where(goods_nomenclature_item_id: '0101290000').first
+
+      expect(edge_exists?(block_node, stale_fragment_node, TariffKnowledge::Edge::CONTAINS)).to be(false)
+      expect(edge_exists?(block_node, stale_range_node, TariffKnowledge::Edge::REFERENCES)).to be(false)
+      expect(edge_exists?(block_node, stale_declarable_node, TariffKnowledge::Edge::APPLIES_TO)).to be(false)
+
+      note.update(content: '1. This chapter covers live horses.')
+      described_class.call
+
+      source_node = TariffKnowledge::Node.by_key('note_source:customs_tariff_chapter_note:1.31:01').first
+      current_declarable_node = TariffKnowledge::Node.goods_nomenclatures.where(goods_nomenclature_item_id: '0101210000').first
+
+      expect(edge_exists?(source_node, block_node, TariffKnowledge::Edge::CONTAINS)).to be(false)
+      expect(edge_exists?(block_node, current_declarable_node, TariffKnowledge::Edge::APPLIES_TO)).to be(false)
+    end
+
     it 'applies chapter note fragments to all declarables in the chapter even without explicit references' do
       create(
         :customs_tariff_chapter_note,
@@ -379,10 +562,30 @@ RSpec.describe TariffKnowledge::SourceGraphLoader do
         source_id: '01',
         source_version: '1.30',
       )
+      old_block_node = create(
+        :tariff_knowledge_node,
+        node_type: TariffKnowledge::Node::NOTE_BLOCK,
+        key: 'note_block:customs_tariff_chapter_note:1.30:01:1:a',
+        title: 'Old block',
+        content: 'Old block content',
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '01',
+        source_version: '1.30',
+        goods_nomenclature_sid: nil,
+        goods_nomenclature_item_id: nil,
+        producline_suffix: nil,
+        goods_nomenclature_type: nil,
+      )
       create(
         :tariff_knowledge_edge,
         source_node: old_source_node,
         target_node: old_fragment_node,
+        relationship_type: TariffKnowledge::Edge::CONTAINS,
+      )
+      create(
+        :tariff_knowledge_edge,
+        source_node: old_source_node,
+        target_node: old_block_node,
         relationship_type: TariffKnowledge::Edge::CONTAINS,
       )
       create(
@@ -397,6 +600,7 @@ RSpec.describe TariffKnowledge::SourceGraphLoader do
 
       expect(TariffKnowledge::Node.by_key('note_source:customs_tariff_chapter_note:1.30:01').first).to be_nil
       expect(TariffKnowledge::Node.by_key('note_fragment:customs_tariff_chapter_note:1.30:01:0001').first).to be_nil
+      expect(TariffKnowledge::Node.by_key('note_block:customs_tariff_chapter_note:1.30:01:1:a').first).to be_nil
     end
 
     it 'loads notes from the latest current non-failed update and ignores newer future updates' do


### PR DESCRIPTION
### Jira link

[AI-997](https://transformuk.atlassian.net/browse/AI-997)

### What?

- [x] Add `NOTE_BLOCK` node type
- [x] Load note blocks into the source graph with source/fragment `CONTAINS` membership
- [x] Avoid full-chapter `APPLIES_TO`/`REFERENCES` fan-out onto each definition block
- [x] Clear legacy block applicability edges on reload
- [x] Loader specs for block creation and non-fan-out behaviour

### Why?

Parsed definition blocks need a durable graph home so compressed-note generation can resolve them. Copying every chapter declarable onto each block multiplies edge volume; membership edges keep scope via contained fragments instead.

Depends on the note structure parse layer (same AI-997 stack).

### Risk

**Risk level:** 🟢

**Reason for rating:** Additive graph nodes/edges for tariff knowledge loading only. No default-on search flag change and no trader-facing API. Covered by loader specs including fan-out regressions.