### PR TITLE
AI-997: Attach note-block evidence to compressed notes

### DIFF
--- a/app/services/tariff_knowledge/compressed_note_generator.rb
+++ b/app/services/tariff_knowledge/compressed_note_generator.rb
@@ -118,8 +118,10 @@ module TariffKnowledge
       return {} if declarable_nodes.empty?
 
       # Blocks are not given full-chapter APPLIES_TO edges. Resolve them through
-      # contained fragments that already apply (or expand) to the declarable:
-      #   declarable <- APPLIES_TO/range <- fragment <- CONTAINS <- block
+      # contained fragments that already APPLIES_TO the declarable:
+      #   declarable <- APPLIES_TO <- fragment <- CONTAINS <- block
+      # Range REFERENCES/EXPANDS_TO is used for fragment evidence context elsewhere,
+      # not for block applicability here.
       apply_edges_by_target_id = apply_edges.group_by(&:target_node_id)
       fragment_nodes = current_fragment_nodes(apply_edges.map(&:source_node_id))
       return {} if fragment_nodes.empty?

--- a/app/services/tariff_knowledge/compressed_note_generator.rb
+++ b/app/services/tariff_knowledge/compressed_note_generator.rb
@@ -10,10 +10,18 @@ module TariffKnowledge
 
     def call
       nodes = declarable_nodes
-      evidence_by_node_id = evidence_by_declarable_node_id(nodes)
+      apply_edges = apply_edges_for_declarable_nodes(nodes)
+      evidence_by_node_id = evidence_by_declarable_node_id(nodes, apply_edges)
+      block_evidence_by_node_id = block_evidence_by_declarable_node_id(nodes, apply_edges)
+      contained_fragment_key_lookup = contained_fragment_keys_by_block_node_id(block_evidence_by_node_id.values.flatten)
 
       nodes.filter_map do |declarable_node|
-        generate_for(declarable_node, evidence_by_node_id.fetch(declarable_node.id, []))
+        generate_for(
+          declarable_node,
+          evidence_by_node_id.fetch(declarable_node.id, []),
+          block_evidence_by_node_id.fetch(declarable_node.id, []),
+          contained_fragment_key_lookup,
+        )
       end
     end
 
@@ -27,16 +35,16 @@ module TariffKnowledge
           .all
     end
 
-    def generate_for(declarable_node, evidence)
-      return mark_existing_note_stale(declarable_node) if evidence.empty?
+    def generate_for(declarable_node, evidence, block_evidence, contained_fragment_keys_by_block_node_id)
+      return mark_existing_note_stale(declarable_node) if evidence.empty? && block_evidence.empty?
 
-      content = content_for(declarable_node, evidence)
+      content = evidence.any? ? content_for(declarable_node, evidence) : block_content_for(block_evidence)
       attributes = {
         goods_nomenclature_item_id: declarable_node.goods_nomenclature_item_id,
         producline_suffix: declarable_node.producline_suffix,
         goods_nomenclature_type: declarable_node.goods_nomenclature_type,
         content:,
-        metadata: Sequel.pg_jsonb(metadata_for(evidence)),
+        metadata: Sequel.pg_jsonb(metadata_for(evidence, block_evidence, contained_fragment_keys_by_block_node_id)),
         context_hash: Digest::SHA256.hexdigest(content),
         generated_at: Time.zone.now,
         # Pipeline generation resets lifecycle flags. Reviewers can later mark
@@ -51,7 +59,14 @@ module TariffKnowledge
       upsert_note(declarable_node, attributes)
     end
 
-    def evidence_by_declarable_node_id(declarable_nodes)
+    def apply_edges_for_declarable_nodes(declarable_nodes)
+      declarable_node_ids = declarable_nodes.map(&:id)
+      return [] if declarable_node_ids.empty?
+
+      Edge.by_relationship(Edge::APPLIES_TO).where(target_node_id: declarable_node_ids).all
+    end
+
+    def evidence_by_declarable_node_id(declarable_nodes, apply_edges)
       declarable_node_ids = declarable_nodes.map(&:id)
       return {} if declarable_node_ids.empty?
 
@@ -65,7 +80,6 @@ module TariffKnowledge
       expansion_edges = Edge.by_relationship(Edge::EXPANDS_TO).where(target_node_id: declarable_node_ids).all
       range_nodes = nodes_by_id(expansion_edges.map(&:source_node_id), Node.where(node_type: Node::RANGE))
       reference_edges = Edge.by_relationship(Edge::REFERENCES).where(target_node_id: range_nodes.keys).all
-      apply_edges = Edge.by_relationship(Edge::APPLIES_TO).where(target_node_id: declarable_node_ids).all
       fragment_nodes = current_fragment_nodes((reference_edges + apply_edges).map(&:source_node_id))
       expansion_edges_by_target_id = expansion_edges.group_by(&:target_node_id)
       reference_edges_by_range_id = reference_edges.group_by(&:target_node_id)
@@ -100,6 +114,42 @@ module TariffKnowledge
       end
     end
 
+    def block_evidence_by_declarable_node_id(declarable_nodes, apply_edges)
+      return {} if declarable_nodes.empty?
+
+      # Blocks are not given full-chapter APPLIES_TO edges. Resolve them through
+      # contained fragments that already apply (or expand) to the declarable:
+      #   declarable <- APPLIES_TO/range <- fragment <- CONTAINS <- block
+      apply_edges_by_target_id = apply_edges.group_by(&:target_node_id)
+      fragment_nodes = current_fragment_nodes(apply_edges.map(&:source_node_id))
+      return {} if fragment_nodes.empty?
+
+      contains_edges = Edge.by_relationship(Edge::CONTAINS).where(target_node_id: fragment_nodes.keys).all
+      block_nodes = current_block_nodes(contains_edges.map(&:source_node_id))
+      return {} if block_nodes.empty?
+
+      block_ids_by_fragment_id = contains_edges.each_with_object(Hash.new { |h, k| h[k] = [] }) do |edge, grouped|
+        next unless block_nodes[edge.source_node_id]
+
+        grouped[edge.target_node_id] << edge.source_node_id
+      end
+
+      declarable_nodes.each_with_object({}) do |declarable_node, grouped|
+        applicable_fragment_ids = apply_edges_by_target_id
+          .fetch(declarable_node.id, [])
+          .map(&:source_node_id)
+          .select { |source_node_id| fragment_nodes[source_node_id] }
+
+        block_evidence = applicable_fragment_ids
+          .flat_map { |fragment_id| block_ids_by_fragment_id.fetch(fragment_id, []) }
+          .uniq
+          .filter_map { |block_id| block_nodes[block_id] }
+          .sort_by { |block_node| [block_node.source_type.to_s, block_node.source_id.to_s, block_node.key.to_s] }
+
+        grouped[declarable_node.id] = block_evidence if block_evidence.any?
+      end
+    end
+
     def nodes_by_id(ids, dataset)
       ids = ids.compact.uniq
       ids.empty? ? {} : dataset.where(id: ids).all.index_by(&:id)
@@ -107,6 +157,12 @@ module TariffKnowledge
 
     def current_fragment_nodes(ids)
       dataset = Node.note_fragments
+      dataset = dataset.where(source_version: current_source_version) if current_source_version.present?
+      nodes_by_id(ids, dataset)
+    end
+
+    def current_block_nodes(ids)
+      dataset = Node.note_blocks
       dataset = dataset.where(source_version: current_source_version) if current_source_version.present?
       nodes_by_id(ids, dataset)
     end
@@ -127,6 +183,9 @@ module TariffKnowledge
       fragment_node_ids = fragment_nodes.map(&:id).uniq
       return {} if fragment_node_ids.empty?
 
+      # Fragments may also be CONTAINED by note blocks. Only NOTE_SOURCE parents
+      # are provenance for evidence metadata; block membership must not overwrite
+      # (or nil out) that parent when multi-parent CONTAINS edges exist.
       contains_edges = Edge.by_relationship(Edge::CONTAINS).where(target_node_id: fragment_node_ids).all
       source_nodes = nodes_by_id(contains_edges.map(&:source_node_id), Node.where(node_type: Node::NOTE_SOURCE))
 
@@ -154,6 +213,12 @@ module TariffKnowledge
       content.compact.join("\n\n")
     end
 
+    def block_content_for(block_evidence)
+      block_evidence.map { |block_node| "#{block_node.title}\n#{block_node.content}" }
+                    .uniq
+                    .join("\n\n")
+    end
+
     def general_rule_fragment?(fragment_node)
       fragment_node.source_type == 'customs_tariff_general_rule' ||
         fragment_node.key.include?(':customs_tariff_general_rule:')
@@ -165,11 +230,12 @@ module TariffKnowledge
         'The full rule fragments are retained in this note provenance.'
     end
 
-    def metadata_for(evidence)
+    def metadata_for(evidence, block_evidence, contained_fragment_keys_by_block_node_id)
       {
         'source_node_keys' => evidence.map { |fragment_node, _range_node, _source_node| fragment_node.key }.uniq,
         'range_node_keys' => evidence.filter_map { |_fragment_node, range_node, _source_node| range_node&.key }.uniq,
         'evidence' => evidence.map { |fragment_node, range_node, source_node| evidence_metadata(fragment_node, range_node, source_node) },
+        'evidence_blocks' => block_evidence.map { |block_node| block_evidence_metadata(block_node, contained_fragment_keys_by_block_node_id) },
       }
     end
 
@@ -193,6 +259,43 @@ module TariffKnowledge
         'range_title' => range_node&.title,
         'relationships' => relationships_for(range_node),
       }
+    end
+
+    def block_evidence_metadata(block_node, contained_fragment_keys_by_block_node_id)
+      block_metadata = block_node.metadata.to_h
+
+      {
+        'source_node_key' => block_node.key,
+        'source_type' => block_node.source_type.to_s.underscore,
+        'source_id' => block_node.source_id,
+        'source_version' => block_node.source_version,
+        'source_title' => block_node.title,
+        'source_context' => block_node.content.to_s.squish,
+        'block_type' => block_metadata['block_type'],
+        'term' => block_metadata['term'],
+        'path' => block_metadata['path'],
+        'fragment_node_keys' => contained_fragment_keys_by_block_node_id.fetch(block_node.id, []),
+      }
+    end
+
+    def contained_fragment_keys_by_block_node_id(block_nodes)
+      block_node_ids = block_nodes.map(&:id).uniq
+      return {} if block_node_ids.empty?
+
+      contains_edges = Edge.by_relationship(Edge::CONTAINS).where(source_node_id: block_node_ids).all
+      fragment_nodes = current_fragment_nodes(contains_edges.map(&:target_node_id))
+
+      contains_edges.each_with_object({}) { |edge, grouped|
+        fragment_node = fragment_nodes[edge.target_node_id]
+        next unless fragment_node
+
+        grouped[edge.source_node_id] ||= []
+        grouped[edge.source_node_id] << fragment_node
+      }.transform_values do |fragment_nodes_for_block|
+        fragment_nodes_for_block
+          .sort_by { |fragment_node| [fragment_sequence(fragment_node), fragment_node.key.to_s, fragment_node.id] }
+          .map(&:key)
+      end
     end
 
     def relationships_for(range_node) = range_node ? [Edge::REFERENCES, Edge::EXPANDS_TO, Edge::APPLIES_TO] : [Edge::APPLIES_TO]

--- a/spec/services/tariff_knowledge/compressed_note_generator_spec.rb
+++ b/spec/services/tariff_knowledge/compressed_note_generator_spec.rb
@@ -53,6 +53,27 @@ RSpec.describe TariffKnowledge::CompressedNoteGenerator do
         content: 'Heading 0101 covers live horses.',
       )
     end
+    let(:note_block_node) do
+      create(
+        :tariff_knowledge_node,
+        node_type: TariffKnowledge::Node::NOTE_BLOCK,
+        key: 'note_block:customs_tariff_chapter_note:1.31:01:1:a',
+        title: 'pure-bred breeding animals',
+        content: 'pure-bred breeding animals means animals certified as breeding stock.',
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '01',
+        source_version: '1.31',
+        metadata: Sequel.pg_jsonb_wrap(
+          'block_type' => 'definition',
+          'term' => 'pure-bred breeding animals',
+          'path' => %w[1 a],
+        ),
+        goods_nomenclature_sid: nil,
+        goods_nomenclature_item_id: nil,
+        producline_suffix: nil,
+        goods_nomenclature_type: nil,
+      )
+    end
 
     before do
       create(
@@ -125,20 +146,53 @@ RSpec.describe TariffKnowledge::CompressedNoteGenerator do
       expect(note.context_hash).to eq(Digest::SHA256.hexdigest(note.content))
     end
 
-    it 'keeps note-source parent provenance when a note block also contains the fragment' do
-      block_node = create(
-        :tariff_knowledge_node,
-        node_type: TariffKnowledge::Node::NOTE_BLOCK,
-        key: 'note_block:customs_tariff_chapter_note:1.31:01:1:a',
-        title: 'pure-bred breeding animals',
-        goods_nomenclature_sid: nil,
-        goods_nomenclature_item_id: nil,
-        producline_suffix: nil,
-        goods_nomenclature_type: nil,
+    it 'stores coherent note block evidence resolved through contained applying fragments' do
+      create(
+        :tariff_knowledge_edge,
+        source_node: note_block_node,
+        target_node: lead_in_fragment_node,
+        relationship_type: TariffKnowledge::Edge::CONTAINS,
       )
       create(
         :tariff_knowledge_edge,
-        source_node: block_node,
+        source_node: note_block_node,
+        target_node: fragment_node,
+        relationship_type: TariffKnowledge::Edge::CONTAINS,
+      )
+
+      described_class.call(goods_nomenclature_sids: [123])
+
+      note = TariffKnowledge::CompressedNote[123]
+      expect(note.metadata.to_hash['evidence_blocks']).to contain_exactly(
+        include(
+          'source_node_key' => 'note_block:customs_tariff_chapter_note:1.31:01:1:a',
+          'source_type' => 'customs_tariff_chapter_note',
+          'source_id' => '01',
+          'source_version' => '1.31',
+          'source_title' => 'pure-bred breeding animals',
+          'source_context' => 'pure-bred breeding animals means animals certified as breeding stock.',
+          'block_type' => 'definition',
+          'term' => 'pure-bred breeding animals',
+          'path' => %w[1 a],
+          'fragment_node_keys' => [
+            'note_fragment:customs_tariff_chapter_note:1.31:01:0001',
+            'note_fragment:customs_tariff_chapter_note:1.31:01:0002',
+          ],
+        ),
+      )
+      expect(note.metadata.to_hash['evidence']).to be_present
+    end
+
+    it 'keeps fragment parent provenance when a note block also contains the fragment' do
+      create(
+        :tariff_knowledge_edge,
+        source_node: note_block_node,
+        target_node: lead_in_fragment_node,
+        relationship_type: TariffKnowledge::Edge::CONTAINS,
+      )
+      create(
+        :tariff_knowledge_edge,
+        source_node: note_block_node,
         target_node: fragment_node,
         relationship_type: TariffKnowledge::Edge::CONTAINS,
       )
@@ -149,6 +203,217 @@ RSpec.describe TariffKnowledge::CompressedNoteGenerator do
       expect(evidence).to include(
         'parent_source_node_key' => 'note_source:customs_tariff_chapter_note:1.31:01',
         'parent_source_title' => 'Chapter 01 notes',
+        'source_context' => '1. This chapter includes: Heading 0101 covers live horses.',
+        'context_type' => 'inclusion',
+      )
+    end
+
+    it 'does not attach block evidence from legacy block applicability edges alone' do
+      TariffKnowledge::Edge
+        .where(
+          source_node_id: fragment_node.id,
+          target_node_id: declarable_node.id,
+          relationship_type: TariffKnowledge::Edge::APPLIES_TO,
+        )
+        .delete
+      TariffKnowledge::Edge
+        .where(
+          source_node_id: fragment_node.id,
+          target_node_id: range_node.id,
+          relationship_type: TariffKnowledge::Edge::REFERENCES,
+        )
+        .delete
+      TariffKnowledge::Edge
+        .where(
+          source_node_id: range_node.id,
+          target_node_id: declarable_node.id,
+          relationship_type: TariffKnowledge::Edge::EXPANDS_TO,
+        )
+        .delete
+      create(
+        :tariff_knowledge_edge,
+        source_node: note_block_node,
+        target_node: fragment_node,
+        relationship_type: TariffKnowledge::Edge::CONTAINS,
+      )
+      create(
+        :tariff_knowledge_edge,
+        source_node: note_block_node,
+        target_node: declarable_node,
+        relationship_type: TariffKnowledge::Edge::APPLIES_TO,
+      )
+
+      described_class.call(goods_nomenclature_sids: [123])
+
+      note = TariffKnowledge::CompressedNote[123]
+      expect(note.nil? || note.stale).to be(true)
+    end
+
+    it 'ignores old source version block evidence' do
+      create(
+        :customs_tariff_update,
+        :approved,
+        version: '1.30',
+        validity_start_date: 2.months.ago,
+        validity_end_date: 1.month.ago,
+      )
+      create(
+        :customs_tariff_update,
+        version: '1.31',
+        validity_start_date: 1.day.ago,
+      )
+      old_block_node = create(
+        :tariff_knowledge_node,
+        node_type: TariffKnowledge::Node::NOTE_BLOCK,
+        key: 'note_block:customs_tariff_chapter_note:1.30:01:1:a',
+        title: 'Old definition block',
+        content: 'Old version block evidence should not be used.',
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '01',
+        source_version: '1.30',
+        goods_nomenclature_sid: nil,
+        goods_nomenclature_item_id: nil,
+        producline_suffix: nil,
+        goods_nomenclature_type: nil,
+      )
+      create(
+        :tariff_knowledge_edge,
+        source_node: old_block_node,
+        target_node: fragment_node,
+        relationship_type: TariffKnowledge::Edge::CONTAINS,
+      )
+      create(
+        :tariff_knowledge_edge,
+        source_node: note_block_node,
+        target_node: fragment_node,
+        relationship_type: TariffKnowledge::Edge::CONTAINS,
+      )
+
+      described_class.call(goods_nomenclature_sids: [123])
+
+      expect(TariffKnowledge::CompressedNote[123].metadata.to_hash['evidence_blocks'])
+        .to contain_exactly(include('source_node_key' => 'note_block:customs_tariff_chapter_note:1.31:01:1:a'))
+    end
+
+    it 'ignores old source version fragments contained by current block evidence' do
+      create(
+        :customs_tariff_update,
+        :approved,
+        version: '1.30',
+        validity_start_date: 2.months.ago,
+        validity_end_date: 1.month.ago,
+      )
+      create(
+        :customs_tariff_update,
+        version: '1.31',
+        validity_start_date: 1.day.ago,
+      )
+      old_fragment_node = create(
+        :tariff_knowledge_node,
+        :note_fragment,
+        key: 'note_fragment:customs_tariff_chapter_note:1.30:01:0001',
+        title: 'Old Chapter 01 notes fragment 1',
+        content: 'Old version contained evidence should not be used.',
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '01',
+        source_version: '1.30',
+      )
+      create(
+        :tariff_knowledge_edge,
+        source_node: note_block_node,
+        target_node: old_fragment_node,
+        relationship_type: TariffKnowledge::Edge::CONTAINS,
+      )
+      create(
+        :tariff_knowledge_edge,
+        source_node: note_block_node,
+        target_node: fragment_node,
+        relationship_type: TariffKnowledge::Edge::CONTAINS,
+      )
+
+      described_class.call(goods_nomenclature_sids: [123])
+
+      evidence_block = TariffKnowledge::CompressedNote[123].metadata.to_hash['evidence_blocks'].first
+      expect(evidence_block['fragment_node_keys']).to eq(['note_fragment:customs_tariff_chapter_note:1.31:01:0002'])
+    end
+
+    it 'preloads block fragment evidence for the requested goods nomenclatures' do
+      second_declarable_node = create(
+        :tariff_knowledge_node,
+        key: 'goods_nomenclature:456',
+        goods_nomenclature_sid: 456,
+        goods_nomenclature_item_id: '0101290000',
+      )
+      third_declarable_node = create(
+        :tariff_knowledge_node,
+        key: 'goods_nomenclature:789',
+        goods_nomenclature_sid: 789,
+        goods_nomenclature_item_id: '0101300000',
+      )
+      second_fragment = create(
+        :tariff_knowledge_node,
+        :note_fragment,
+        key: 'note_fragment:customs_tariff_chapter_note:1.31:01:0004',
+        title: 'Chapter 01 notes fragment 4',
+        content: 'Second declarable fragment.',
+      )
+      third_fragment = create(
+        :tariff_knowledge_node,
+        :note_fragment,
+        key: 'note_fragment:customs_tariff_chapter_note:1.31:01:0005',
+        title: 'Chapter 01 notes fragment 5',
+        content: 'Third declarable fragment.',
+      )
+      block_nodes = [
+        [declarable_node, fragment_node, 1],
+        [second_declarable_node, second_fragment, 2],
+        [third_declarable_node, third_fragment, 3],
+      ].map do |node, contained_fragment, index|
+        block_node = create(
+          :tariff_knowledge_node,
+          node_type: TariffKnowledge::Node::NOTE_BLOCK,
+          key: "note_block:customs_tariff_chapter_note:1.31:01:#{index}:a",
+          title: "Definition block #{index}",
+          content: "Block #{index} context.",
+          source_type: 'customs_tariff_chapter_note',
+          source_id: '01',
+          source_version: '1.31',
+          goods_nomenclature_sid: nil,
+          goods_nomenclature_item_id: nil,
+          producline_suffix: nil,
+          goods_nomenclature_type: nil,
+        )
+        create(
+          :tariff_knowledge_edge,
+          source_node: block_node,
+          target_node: contained_fragment,
+          relationship_type: TariffKnowledge::Edge::CONTAINS,
+        )
+        unless TariffKnowledge::Edge.where(
+          source_node_id: contained_fragment.id,
+          target_node_id: node.id,
+          relationship_type: TariffKnowledge::Edge::APPLIES_TO,
+        ).any?
+          create(
+            :tariff_knowledge_edge,
+            source_node: contained_fragment,
+            target_node: node,
+            relationship_type: TariffKnowledge::Edge::APPLIES_TO,
+          )
+        end
+        block_node
+      end
+
+      queries = sql_queries do
+        described_class.call(goods_nomenclature_sids: [123, 456, 789])
+      end
+
+      contains_edge_queries = queries.grep(/FROM "tariff_knowledge_edges".*"relationship_type" = 'contains'/)
+      # Parent resolution, block membership, and per-block contained fragment keys —
+      # batched once for the call, not once per goods nomenclature.
+      expect(contains_edge_queries.size).to be <= 4
+      expect(block_nodes.map(&:key)).to match_array(
+        [123, 456, 789].map { |sid| TariffKnowledge::CompressedNote[sid].metadata.to_hash.dig('evidence_blocks', 0, 'source_node_key') },
       )
     end
 
@@ -391,7 +656,8 @@ RSpec.describe TariffKnowledge::CompressedNoteGenerator do
         described_class.call(goods_nomenclature_sids: [123, 456])
       end
 
-      expect(queries.grep(/FROM "tariff_knowledge_edges"/).size).to be <= 5
+      # APPLIES_TO + REFERENCES + EXPANDS_TO + fragment CONTAINS parents + block membership CONTAINS
+      expect(queries.grep(/FROM "tariff_knowledge_edges"/).size).to be <= 7
     end
 
     it 'uses source note context to identify exclusion evidence' do


### PR DESCRIPTION
### Jira link

[AI-997](https://transformuk.atlassian.net/browse/AI-997)

### What?

- [x] Resolve block evidence via contained applying fragments (not block-level full-chapter edges)
- [x] Keep `NOTE_SOURCE` parent provenance when blocks also `CONTAIN` fragments
- [x] Store `evidence_blocks` metadata on compressed notes
- [x] Regressions for parent provenance, legacy fan-out isolation, and loader→generator path

### Why?

Interactive search needs block-level legal definitions in compressed-note metadata. Multi-parent `CONTAINS` previously risked wiping fragment parent source metadata; generation must only treat note sources as parents.

Depends on graph note-block persistence (same AI-997 stack).

### Risk

**Risk level:** 🟢

**Reason for rating:** Changes compressed-note generation only. Search still requires `search_compressed_notes_enabled` (default off). Specs cover provenance and block resolution paths.