### PR TITLE
AI-997: Select note-block evidence for classification search

### DIFF
--- a/app/services/tariff_knowledge/relevant_note_fragment_selector.rb
+++ b/app/services/tariff_knowledge/relevant_note_fragment_selector.rb
@@ -23,6 +23,11 @@ module TariffKnowledge
     QUERY_TERM_SCORE = 2
     MAX_QUERY_TERM_SCORE = 10
     SAME_CHAPTER_SCORE = 1
+    EXACT_PHRASE_SCORE = 14
+    EXACT_TERM_SCORE = 4
+    DEFINITION_BLOCK_SCORE = 4
+    BM25_SCORE_MULTIPLIER = 2
+    MAX_BM25_SCORE = 8
     MAX_REASON_CODES = 4
     MAX_REASON_TERMS = 5
 
@@ -33,6 +38,7 @@ module TariffKnowledge
       ->(evidence_record, _text) { range_match_rule(evidence_record) },
       ->(_evidence, text) { mentioned_range_rule(text) },
       ->(_evidence, text) { query_term_rule(text) },
+      ->(_evidence, text) { bm25_rule(text) },
       ->(evidence_record, _text) { same_chapter_rule(evidence_record) },
     ].freeze
     STOP_WORDS = %w[above an and are article articles as at be by chapter chapters code codes for from goods has have heading headings in into is it its kind made nomenclature of on or other purposes than that the this to use used with without].to_set.freeze
@@ -81,6 +87,28 @@ module TariffKnowledge
     end
 
     def scored_fragments(note)
+      scored_block_records(note) + scored_fragment_records(note)
+    end
+
+    def scored_block_records(note)
+      block_evidence_records(note).filter_map do |evidence_block|
+        source_text = evidence_block['source_context'].to_s.squish
+        next if source_text.blank?
+
+        score, reasons = score_block(evidence_block, source_text)
+        {
+          key: evidence_block['source_node_key'],
+          source: evidence_block['source_title'],
+          source_ref: source_reference(evidence_block),
+          type: evidence_block['block_type'],
+          text: source_text.truncate(MAX_FRAGMENT_CHARS, omission: '...'),
+          score:,
+          why_relevant: reasons.join('; '),
+        }
+      end
+    end
+
+    def scored_fragment_records(note)
       # Each record is compressed-note metadata pointing to a source fragment and
       # explaining the relationship that made that fragment evidence for a code.
       fragment_evidence_records(note).filter_map do |evidence_record|
@@ -92,6 +120,7 @@ module TariffKnowledge
         {
           key: evidence_record['source_node_key'],
           source: evidence_record['source_title'] || fragment_node&.title,
+          source_ref: source_reference(evidence_record),
           type: evidence_record['context_type'],
           text: text.truncate(MAX_FRAGMENT_CHARS, omission: '...'),
           score:,
@@ -135,6 +164,37 @@ module TariffKnowledge
       [score, reasons]
     end
 
+    def score_block(evidence_block, text)
+      score = 0
+      reasons = []
+
+      if exact_query_term?(evidence_block['term'])
+        score, reasons = add_score(score, reasons, EXACT_TERM_SCORE, "exact term match #{query_phrase}")
+      end
+
+      suppressed_single_word_match = suppress_single_word_block_match?(evidence_block['term'])
+
+      if exact_query_phrase?(evidence_block['term']) && block_term_phrase_match?(evidence_block['term'])
+        score, reasons = add_score(score, reasons, EXACT_PHRASE_SCORE, "exact phrase match #{query_phrase} in term")
+      elsif !suppressed_single_word_match && exact_query_phrase?(text)
+        score, reasons = add_score(score, reasons, EXACT_PHRASE_SCORE, "exact phrase match #{query_phrase}")
+      end
+
+      if evidence_block['block_type'] == 'definition'
+        score, reasons = add_score(score, reasons, DEFINITION_BLOCK_SCORE, 'definition block')
+      end
+
+      [
+        range_match_rule(evidence_block),
+        mentioned_range_rule(text),
+        query_term_rule(block_query_text(text, suppressed_single_word_match)),
+        bm25_rule(block_query_text(text, suppressed_single_word_match)),
+        same_chapter_rule(evidence_block),
+      ].compact.each { |points, reason| score, reasons = add_score(score, reasons, points, reason) }
+
+      [score, reasons]
+    end
+
     def add_score(score, reasons, points, reason) = [score + points, reasons + [reason]]
 
     def range_match_rule(evidence_record)
@@ -165,11 +225,37 @@ module TariffKnowledge
       ]
     end
 
+    def bm25_rule(text)
+      return if bm25_query_tokens.empty?
+
+      matched_terms = bm25_query_tokens.intersection(tokenize(text)).to_a
+      return if matched_terms.size < 2
+
+      bm25_score = bm25_scorer.score(text)
+      return unless bm25_score.positive?
+
+      [
+        [[(bm25_score * BM25_SCORE_MULTIPLIER).round, 1].max, MAX_BM25_SCORE].min,
+        "BM25 lexical match #{matched_terms.first(MAX_REASON_TERMS).join(', ')}",
+      ]
+    end
+
     def same_chapter_rule(evidence_record)
       return unless evidence_record['source_node_key'].to_s.include?(':customs_tariff_chapter_note:')
       return unless candidate_chapters.include?(evidence_record['source_id'].to_s.rjust(2, '0'))
 
       [SAME_CHAPTER_SCORE, 'same chapter as retrieved candidate']
+    end
+
+    def source_reference(evidence_record)
+      case evidence_record['source_type'].to_s
+      when 'customs_tariff_chapter_note'
+        "chapter #{evidence_record['source_id'].to_s.rjust(2, '0')} note"
+      when 'customs_tariff_section_note'
+        "section #{evidence_record['source_id']} note"
+      when 'customs_tariff_general_rule'
+        "GIR #{evidence_record['source_id']}"
+      end
     end
 
     def range_match?(evidence_record)
@@ -197,6 +283,8 @@ module TariffKnowledge
 
     def fragment_evidence_records(note) = Array(note.metadata.to_h['evidence'])
 
+    def block_evidence_records(note) = Array(note.metadata.to_h['evidence_blocks'])
+
     def fallback_fragment_keys(note)
       fragment_evidence_records(note).filter_map do |evidence_record|
         evidence_record['source_node_key'] if evidence_record['source_context'].blank? || evidence_record['source_title'].blank?
@@ -205,10 +293,70 @@ module TariffKnowledge
 
     def relevance_tokens = @relevance_tokens ||= tokenize(query)
 
+    def bm25_query_tokens = @bm25_query_tokens ||= relevance_tokens
+
+    def query_phrase = @query_phrase ||= query.to_s.squish.downcase
+
+    def exact_query_term?(term)
+      query_phrase.present? && term.to_s.squish.downcase == query_phrase
+    end
+
+    def exact_query_phrase?(text)
+      phrase = query_phrase
+      return false if phrase.blank?
+
+      text.to_s.squish.downcase.include?(phrase)
+    end
+
+    def block_term_phrase_match?(term)
+      return true unless single_relevance_token?
+
+      exact_query_term?(term) || head_term_match?(term)
+    end
+
+    def block_query_text(text, suppressed_modifier_match)
+      return text unless suppressed_modifier_match
+
+      ''
+    end
+
+    def suppress_single_word_block_match?(term)
+      single_relevance_token? && !block_term_phrase_match?(term)
+    end
+
+    def single_relevance_token?
+      relevance_tokens.one?
+    end
+
+    def single_relevance_token
+      relevance_tokens.first
+    end
+
+    def head_term_match?(term)
+      ordered_tokens(term).last == single_relevance_token
+    end
+
     # Keep token matching intentionally coarse: legal fragments and trader
     # queries use different grammar, so this only rewards shared meaningful
     # words/numbers after dropping common tariff/search glue words.
     def tokenize(text) = text.to_s.downcase.scan(/[a-z0-9]{3,}/).reject { |token| STOP_WORDS.include?(token) }.to_set
+
+    def ordered_tokens(text) = text.to_s.downcase.scan(/[a-z0-9]{3,}/).reject { |token| STOP_WORDS.include?(token) }
+
+    def bm25_scorer
+      @bm25_scorer ||= Bm25Scorer.new(
+        documents: evidence_corpus,
+        query_tokens: bm25_query_tokens,
+        stop_words: STOP_WORDS,
+      )
+    end
+
+    def evidence_corpus
+      @evidence_corpus ||= notes_by_item_id.values.flat_map do |note|
+        block_evidence_records(note).map { |record| record['source_context'].to_s } +
+          fragment_evidence_records(note).map { |record| record['source_context'].to_s }
+      end
+    end
 
     def candidate_chapters = @candidate_chapters ||= candidate_item_ids.map { |item_id| item_id.first(2) }.uniq
 
@@ -217,5 +365,60 @@ module TariffKnowledge
     def candidate_ranges = @candidate_ranges ||= (candidate_chapters + candidate_headings).uniq
 
     def candidate_item_ids = @candidate_item_ids ||= search_results.map(&:goods_nomenclature_item_id).compact_blank.uniq
+
+    class Bm25Scorer
+      K1 = 1.2
+      B = 0.75
+
+      def initialize(documents:, query_tokens:, stop_words:)
+        @stop_words = stop_words
+        @query_tokens = query_tokens.to_a
+        @document_tokens = documents.map { |document| tokenize(document) }.reject(&:empty?)
+        @average_document_length = calculate_average_document_length
+        @document_frequencies = calculate_document_frequencies
+      end
+
+      def score(document)
+        tokens = tokenize(document)
+        return 0.0 if tokens.empty? || query_tokens.empty? || document_tokens.empty?
+
+        term_frequencies = tokens.tally
+        query_tokens.sum do |term|
+          next 0.0 unless term_frequencies[term]
+
+          idf(term) * term_weight(term_frequencies[term], tokens.length)
+        end
+      end
+
+    private
+
+      attr_reader :query_tokens, :document_tokens, :average_document_length, :document_frequencies, :stop_words
+
+      def tokenize(text) = text.to_s.downcase.scan(/[a-z0-9]{3,}/).reject { |token| stop_words.include?(token) }
+
+      def calculate_average_document_length
+        return 0.0 if document_tokens.empty?
+
+        document_tokens.sum(&:length).fdiv(document_tokens.length)
+      end
+
+      def calculate_document_frequencies
+        document_tokens.each_with_object(Hash.new(0)) do |tokens, frequencies|
+          tokens.uniq.each { |token| frequencies[token] += 1 }
+        end
+      end
+
+      def idf(term)
+        document_count = document_tokens.length
+        frequency = document_frequencies.fetch(term, 0)
+
+        Math.log(1 + ((document_count - frequency + 0.5) / (frequency + 0.5)))
+      end
+
+      def term_weight(term_frequency, document_length)
+        denominator = term_frequency + K1 * (1 - B + (B * document_length / average_document_length))
+        (term_frequency * (K1 + 1)) / denominator
+      end
+    end
   end
 end

--- a/app/services/tariff_knowledge/relevant_note_fragment_selector.rb
+++ b/app/services/tariff_knowledge/relevant_note_fragment_selector.rb
@@ -305,7 +305,7 @@ module TariffKnowledge
       phrase = query_phrase
       return false if phrase.blank?
 
-      text.to_s.squish.downcase.include?(phrase)
+      text.to_s.squish.downcase.match?(/\b#{Regexp.escape(phrase)}\b/)
     end
 
     def block_term_phrase_match?(term)

--- a/spec/services/tariff_knowledge/relevant_note_fragment_selector_spec.rb
+++ b/spec/services/tariff_knowledge/relevant_note_fragment_selector_spec.rb
@@ -77,6 +77,283 @@ RSpec.describe TariffKnowledge::RelevantNoteFragmentSelector do
     expect(fragment_texts).not_to include(a_string_including('candles'))
   end
 
+  it 'prefers exact query definition blocks over generic chapter exclusions' do
+    pig_iron_note = create(
+      :tariff_knowledge_compressed_note,
+      goods_nomenclature_item_id: '7201200000',
+      content: 'compressed note 7201200000',
+      context_hash: Digest::SHA256.hexdigest('compressed note 7201200000'),
+      metadata: Sequel.pg_jsonb_wrap(
+        'evidence_blocks' => [
+          {
+            'source_node_key' => 'note_block:customs_tariff_chapter_note:1.31:72:1:a',
+            'source_title' => 'pig Iron',
+            'source_context' => 'pig Iron: Iron-carbon alloys not usefully malleable, containing more than 2 % carbon; not more than 10 % chromium; not more than 6 % manganese.',
+            'block_type' => 'definition',
+            'term' => 'pig iron',
+            'path' => %w[1 a],
+            'source_type' => 'customs_tariff_chapter_note',
+            'source_id' => '72',
+            'source_version' => '1.31',
+            'fragment_node_keys' => [],
+          },
+        ],
+        'evidence' => [
+          evidence_for(
+            'note_fragment:customs_tariff_chapter_note:1.31:72:0069',
+            'Chapter 72 does not include products of heading 7301 or 7302.',
+            'exclusion',
+            source_id: '72',
+          ),
+        ],
+      ),
+    )
+
+    contexts = described_class.call(
+      query: 'pig iron',
+      search_results: [
+        search_result_class.new(
+          goods_nomenclature_item_id: '7201200000',
+          description: 'Non-alloy pig iron in pigs, blocks or other primary forms',
+          full_description: nil,
+          score: 10,
+        ),
+      ],
+      notes_by_item_id: { '7201200000' => pig_iron_note },
+    )
+
+    first_fragment = contexts.first[:fragments].first
+    expect(first_fragment[:text]).to include('pig Iron')
+    expect(first_fragment[:text]).to include('not more than 10 % chromium')
+    expect(first_fragment[:text]).not_to eq('Chapter 72 does not include products of heading 7301 or 7302.')
+    expect(first_fragment[:source_ref]).to eq('chapter 72 note')
+    expect(first_fragment[:why_relevant]).to include('exact phrase match pig iron')
+    expect(first_fragment[:why_relevant].scan(/exact phrase match pig iron/).size).to eq(1)
+    expect(first_fragment[:why_relevant]).to include('definition block')
+    expect(first_fragment[:why_relevant]).to include('BM25 lexical match pig, iron')
+    expect(first_fragment[:score]).to be > described_class::MIN_SCORE
+  end
+
+  it 'ranks exact term definition blocks ahead of longer phrase-containing terms' do
+    pig_iron_note = create(
+      :tariff_knowledge_compressed_note,
+      goods_nomenclature_item_id: '7201200000',
+      content: 'compressed note pig iron equality',
+      context_hash: Digest::SHA256.hexdigest('compressed note pig iron equality'),
+      metadata: Sequel.pg_jsonb_wrap(
+        'evidence_blocks' => [
+          {
+            'source_node_key' => 'note_block:customs_tariff_chapter_note:1.31:72:1:a',
+            'source_title' => 'pig Iron',
+            'source_context' => 'pig Iron: Iron-carbon alloys not usefully malleable, containing more than 2 % carbon; not more than 10 % chromium.',
+            'block_type' => 'definition',
+            'term' => 'pig iron',
+            'source_type' => 'customs_tariff_chapter_note',
+            'source_id' => '72',
+            'fragment_node_keys' => [],
+          },
+          {
+            'source_node_key' => 'note_block:customs_tariff_chapter_note:1.31:72:1:b',
+            'source_title' => 'alloy pig iron',
+            'source_context' => 'alloy pig iron: Pig iron containing, by mass, one or more alloy elements in specified proportions.',
+            'block_type' => 'definition',
+            'term' => 'alloy pig iron',
+            'source_type' => 'customs_tariff_chapter_note',
+            'source_id' => '72',
+            'fragment_node_keys' => [],
+          },
+        ],
+      ),
+    )
+
+    contexts = described_class.call(
+      query: 'pig iron',
+      search_results: [
+        search_result_class.new(
+          goods_nomenclature_item_id: '7201200000',
+          description: 'Non-alloy pig iron in pigs, blocks or other primary forms',
+          full_description: nil,
+          score: 10,
+        ),
+      ],
+      notes_by_item_id: { '7201200000' => pig_iron_note },
+    )
+
+    fragments = contexts.first[:fragments]
+
+    expect(fragments.first[:source]).to eq('pig Iron')
+    expect(fragments.second[:source]).to eq('alloy pig iron')
+    expect(fragments.first[:why_relevant]).to include('exact term match pig iron')
+    expect(fragments.second[:why_relevant]).to include('exact phrase match pig iron in term')
+    expect(fragments.second[:why_relevant]).not_to include('exact term match pig iron')
+  end
+
+  it 'does not select a compound definition block for a single-word modifier query' do
+    pig_iron_note = create(
+      :tariff_knowledge_compressed_note,
+      goods_nomenclature_item_id: '7201200000',
+      content: 'compressed note pig modifier',
+      context_hash: Digest::SHA256.hexdigest('compressed note pig modifier'),
+      metadata: Sequel.pg_jsonb_wrap(
+        'evidence_blocks' => [
+          {
+            'source_node_key' => 'note_block:customs_tariff_chapter_note:1.31:72:1:a',
+            'source_title' => 'pig Iron',
+            'source_context' => 'pig Iron: Iron-carbon alloys not usefully malleable.',
+            'block_type' => 'definition',
+            'term' => 'pig iron',
+            'source_type' => 'customs_tariff_chapter_note',
+            'source_id' => '72',
+            'fragment_node_keys' => [],
+          },
+        ],
+      ),
+    )
+
+    contexts = described_class.call(
+      query: 'pig',
+      search_results: [
+        search_result_class.new(
+          goods_nomenclature_item_id: '7201200000',
+          description: 'Non-alloy pig iron',
+          full_description: nil,
+          score: 10,
+        ),
+      ],
+      notes_by_item_id: { '7201200000' => pig_iron_note },
+    )
+
+    expect(contexts).to be_empty
+  end
+
+  it 'does not select an unrelated definition block because aggregate text contains a single-word query' do
+    aggregate_note = create(
+      :tariff_knowledge_compressed_note,
+      goods_nomenclature_item_id: '7201200000',
+      content: 'compressed note aggregate pig',
+      context_hash: Digest::SHA256.hexdigest('compressed note aggregate pig'),
+      metadata: Sequel.pg_jsonb_wrap(
+        'evidence_blocks' => [
+          {
+            'source_node_key' => 'note_block:customs_tariff_chapter_note:1.31:72:1:d',
+            'source_title' => 'remelting scrap ingots of iron or steel',
+            'source_context' => 'remelting scrap ingots of iron or steel: Parent aggregate text also includes the pig iron definition below it.',
+            'block_type' => 'definition',
+            'term' => 'remelting scrap ingots of iron or steel',
+            'source_type' => 'customs_tariff_chapter_note',
+            'source_id' => '72',
+            'fragment_node_keys' => [],
+          },
+        ],
+      ),
+    )
+
+    contexts = described_class.call(
+      query: 'pig',
+      search_results: [
+        search_result_class.new(
+          goods_nomenclature_item_id: '7201200000',
+          description: 'Non-alloy pig iron',
+          full_description: nil,
+          score: 10,
+        ),
+      ],
+      notes_by_item_id: { '7201200000' => aggregate_note },
+    )
+
+    expect(contexts).to be_empty
+  end
+
+  it 'uses BM25 lexical scoring to rank relevant definition blocks ahead of repeated generic text' do
+    lexical_note = create(
+      :tariff_knowledge_compressed_note,
+      goods_nomenclature_item_id: '7201200000',
+      content: 'compressed note lexical pig iron',
+      context_hash: Digest::SHA256.hexdigest('compressed note lexical pig iron'),
+      metadata: Sequel.pg_jsonb_wrap(
+        'evidence_blocks' => [
+          {
+            'source_node_key' => 'note_block:customs_tariff_chapter_note:1.31:72:1:a',
+            'source_title' => 'pig Iron',
+            'source_context' => 'pig Iron: Iron-carbon alloys not usefully malleable, containing more than 2 % carbon and cast in pigs, blocks or other primary forms.',
+            'block_type' => 'definition',
+            'term' => 'pig iron',
+            'source_type' => 'customs_tariff_chapter_note',
+            'source_id' => '72',
+            'fragment_node_keys' => [],
+          },
+          {
+            'source_node_key' => 'note_block:customs_tariff_chapter_note:1.31:72:1:z',
+            'source_title' => 'generic chapter 72 exclusions',
+            'source_context' => 'Chapter 72 does not include iron articles of heading 7301. Iron articles of heading 7302 are also excluded. Iron waste is handled elsewhere.',
+            'block_type' => 'exclusion',
+            'term' => nil,
+            'source_type' => 'customs_tariff_chapter_note',
+            'source_id' => '72',
+            'fragment_node_keys' => [],
+          },
+        ],
+      ),
+    )
+
+    contexts = described_class.call(
+      query: 'pig iron',
+      search_results: [
+        search_result_class.new(
+          goods_nomenclature_item_id: '7201200000',
+          description: 'Non-alloy pig iron in pigs, blocks or other primary forms',
+          full_description: nil,
+          score: 10,
+        ),
+      ],
+      notes_by_item_id: { '7201200000' => lexical_note },
+    )
+
+    fragments = contexts.first[:fragments]
+    expect(fragments.first[:source]).to eq('pig Iron')
+    expect(fragments.first[:why_relevant]).to include('BM25 lexical match pig, iron')
+    expect(fragments.second[:source]).to eq('generic chapter 72 exclusions')
+  end
+
+  it 'selects a compound definition block for a single-word head-term query' do
+    pig_iron_note = create(
+      :tariff_knowledge_compressed_note,
+      goods_nomenclature_item_id: '7201200000',
+      content: 'compressed note iron head',
+      context_hash: Digest::SHA256.hexdigest('compressed note iron head'),
+      metadata: Sequel.pg_jsonb_wrap(
+        'evidence_blocks' => [
+          {
+            'source_node_key' => 'note_block:customs_tariff_chapter_note:1.31:72:1:a',
+            'source_title' => 'pig Iron',
+            'source_context' => 'pig Iron: Iron-carbon alloys not usefully malleable.',
+            'block_type' => 'definition',
+            'term' => 'pig iron',
+            'source_type' => 'customs_tariff_chapter_note',
+            'source_id' => '72',
+            'fragment_node_keys' => [],
+          },
+        ],
+      ),
+    )
+
+    contexts = described_class.call(
+      query: 'iron',
+      search_results: [
+        search_result_class.new(
+          goods_nomenclature_item_id: '7201200000',
+          description: 'Non-alloy pig iron',
+          full_description: nil,
+          score: 10,
+        ),
+      ],
+      notes_by_item_id: { '7201200000' => pig_iron_note },
+    )
+
+    expect(contexts.first[:fragments].first[:source]).to eq('pig Iron')
+    expect(contexts.first[:fragments].first[:why_relevant]).to include('exact phrase match iron in term')
+  end
+
   it 'does not emit full compressed note content' do
     contexts = described_class.call(
       query:,
@@ -94,6 +371,46 @@ RSpec.describe TariffKnowledge::RelevantNoteFragmentSelector do
         query:,
         search_results:,
         notes_by_item_id: { '9506911000' => note },
+      )
+    end
+
+    expect(queries.grep(/FROM "tariff_knowledge_nodes"/)).to be_empty
+  end
+
+  it 'does not load fragment nodes for block evidence with metadata context and title' do
+    block_only_note = create(
+      :tariff_knowledge_compressed_note,
+      goods_nomenclature_item_id: '7201200000',
+      content: 'compressed note block only',
+      context_hash: Digest::SHA256.hexdigest('compressed note block only'),
+      metadata: Sequel.pg_jsonb_wrap(
+        'evidence_blocks' => [
+          {
+            'source_node_key' => 'note_block:customs_tariff_chapter_note:1.31:72:1:a',
+            'source_title' => 'pig Iron',
+            'source_context' => 'pig Iron: Iron-carbon alloys not usefully malleable.',
+            'block_type' => 'definition',
+            'term' => 'pig iron',
+            'source_type' => 'customs_tariff_chapter_note',
+            'source_id' => '72',
+            'fragment_node_keys' => [],
+          },
+        ],
+      ),
+    )
+
+    queries = sql_queries do
+      described_class.call(
+        query: 'pig iron',
+        search_results: [
+          search_result_class.new(
+            goods_nomenclature_item_id: '7201200000',
+            description: 'Non-alloy pig iron in pigs, blocks or other primary forms',
+            full_description: nil,
+            score: 10,
+          ),
+        ],
+        notes_by_item_id: { '7201200000' => block_only_note },
       )
     end
 
@@ -130,6 +447,34 @@ RSpec.describe TariffKnowledge::RelevantNoteFragmentSelector do
     )
 
     expect(contexts.first[:fragments].first[:why_relevant]).to include('references retrieved heading 9506')
+  end
+
+  it 'includes source references for fragment evidence sent to the classifier context' do
+    source_note = create_note_with_evidence(
+      '9506911000',
+      evidence_for(
+        'note_fragment:customs_tariff_chapter_note:1.31:95:source',
+        'Heading 9506 includes articles and equipment for general physical exercise.',
+        'inclusion',
+        range_type: 'heading',
+        range_code: '9506',
+      ),
+    )
+
+    contexts = described_class.call(
+      query: 'exercise apparatus',
+      search_results: [
+        search_result_class.new(
+          goods_nomenclature_item_id: '9506911000',
+          description: 'Articles and equipment for general physical exercise',
+          full_description: nil,
+          score: 10,
+        ),
+      ],
+      notes_by_item_id: { '9506911000' => source_note },
+    )
+
+    expect(contexts.first[:fragments].first[:source_ref]).to eq('chapter 95 note')
   end
 
   it 'caps total emitted fragments across all selected notes' do
@@ -199,11 +544,11 @@ RSpec.describe TariffKnowledge::RelevantNoteFragmentSelector do
     expect(contexts).to be_empty
   end
 
-  def evidence_for(key, text, context_type, range_type: nil, range_code: nil, source_type: 'customs_tariff_chapter_note')
+  def evidence_for(key, text, context_type, range_type: nil, range_code: nil, source_type: 'customs_tariff_chapter_note', source_id: '95')
     {
       'source_node_key' => key,
       'source_type' => source_type,
-      'source_id' => '95',
+      'source_id' => source_id,
       'source_title' => key.split(':').last,
       'source_context' => text,
       'context_type' => context_type,

--- a/spec/services/tariff_knowledge/relevant_note_fragment_selector_spec.rb
+++ b/spec/services/tariff_knowledge/relevant_note_fragment_selector_spec.rb
@@ -354,6 +354,85 @@ RSpec.describe TariffKnowledge::RelevantNoteFragmentSelector do
     expect(contexts.first[:fragments].first[:why_relevant]).to include('exact phrase match iron in term')
   end
 
+  it 'does not award exact phrase score when a single-word query only matches inside a longer word' do
+    ironic_note = create(
+      :tariff_knowledge_compressed_note,
+      goods_nomenclature_item_id: '7201200000',
+      content: 'compressed note ironic substring',
+      context_hash: Digest::SHA256.hexdigest('compressed note ironic substring'),
+      metadata: Sequel.pg_jsonb_wrap(
+        'evidence_blocks' => [
+          {
+            'source_node_key' => 'note_block:customs_tariff_chapter_note:1.31:72:1:z',
+            'source_title' => 'ironic',
+            'source_context' => 'ironic: A longer word that only contains the query as a substring.',
+            'block_type' => 'definition',
+            'term' => 'ironic',
+            'source_type' => 'customs_tariff_chapter_note',
+            'source_id' => '72',
+            'fragment_node_keys' => [],
+          },
+        ],
+      ),
+    )
+
+    contexts = described_class.call(
+      query: 'iron',
+      search_results: [
+        search_result_class.new(
+          goods_nomenclature_item_id: '7201200000',
+          description: 'Non-alloy pig iron',
+          full_description: nil,
+          score: 10,
+        ),
+      ],
+      notes_by_item_id: { '7201200000' => ironic_note },
+    )
+
+    why_relevant = contexts.flat_map { |context| context[:fragments] }.map { |fragment| fragment[:why_relevant] }
+    expect(why_relevant).not_to include(a_string_including('exact phrase match iron'))
+
+    # Multi-token queries do not suppress block matches, so a prefix phrase such as
+    # "iron plate" would still receive EXACT_PHRASE_SCORE against "iron plated" under
+    # String#include?. Word-boundary matching rejects that false positive.
+    plated_note = create(
+      :tariff_knowledge_compressed_note,
+      goods_nomenclature_item_id: '7201500000',
+      content: 'compressed note iron plated substring',
+      context_hash: Digest::SHA256.hexdigest('compressed note iron plated substring'),
+      metadata: Sequel.pg_jsonb_wrap(
+        'evidence_blocks' => [
+          {
+            'source_node_key' => 'note_block:customs_tariff_chapter_note:1.31:72:1:y',
+            'source_title' => 'iron plated',
+            'source_context' => 'iron plated: Products finished by iron plating.',
+            'block_type' => 'definition',
+            'term' => 'iron plated',
+            'source_type' => 'customs_tariff_chapter_note',
+            'source_id' => '72',
+            'fragment_node_keys' => [],
+          },
+        ],
+      ),
+    )
+
+    plated_contexts = described_class.call(
+      query: 'iron plate',
+      search_results: [
+        search_result_class.new(
+          goods_nomenclature_item_id: '7201500000',
+          description: 'Iron plate products',
+          full_description: nil,
+          score: 10,
+        ),
+      ],
+      notes_by_item_id: { '7201500000' => plated_note },
+    )
+
+    plated_why = plated_contexts.flat_map { |context| context[:fragments] }.map { |fragment| fragment[:why_relevant] }
+    expect(plated_why.join('; ')).not_to include('exact phrase match iron plate')
+  end
+
   it 'does not emit full compressed note content' do
     contexts = described_class.call(
       query:,


### PR DESCRIPTION
### Jira link

[AI-997](https://transformuk.atlassian.net/browse/AI-997)

### What?

- [x] Prefer definition blocks when scoring evidence for interactive search
- [x] Exact term/phrase matching for block heads
- [x] In-memory BM25 lexical score for pack selection
- [x] Concise `source_ref` provenance (e.g. `chapter 72 note`)
- [x] Selector specs for ranking and suppression behaviour

### Why?

Compressed notes may carry many fragments and blocks. The selector must pick a small, high-signal pack so classification prompts get complete definition units without dumping whole chapter notes.

Depends on compressed-note block evidence (same AI-997 stack). Note injection remains behind `search_compressed_notes_enabled` (default off).

### Risk

**Risk level:** 🟢

**Reason for rating:** Prompt evidence selection only; flag default off. No OpenSearch mapping or public API changes. Unit coverage on selection behaviour.