### PR TITLE
AI-997: Validate chapter note structure offline

### DIFF
--- a/lib/tasks/tariff_knowledge.rake
+++ b/lib/tasks/tariff_knowledge.rake
@@ -95,6 +95,52 @@ module_function
   rescue ArgumentError
     raise ArgumentError, "#{name} must be numeric"
   end
+
+  def validate_note_structures
+    update = TimeMachine.at(Time.current) do
+      CustomsTariffUpdate
+        .actual
+        .exclude(status: CustomsTariffUpdate::FAILED)
+        .order(Sequel.desc(:validity_start_date))
+        .first
+    end
+    results = update ? validate_chapter_notes(update) : []
+
+    print_note_structure_report(results)
+    abort 'Note structure validation reported issues.' if ENV['FAIL_ON_ISSUES'] == 'true' && results.any? { |result| result.issues.any? }
+  end
+
+  def validate_chapter_notes(update)
+    TimeMachine.at(Time.current) do
+      update.customs_tariff_chapter_notes_dataset.order(:chapter_id).map do |note|
+        TariffKnowledge::NoteStructureValidator.call(
+          source_type: 'customs_tariff_chapter_note',
+          source_id: note.chapter_id,
+          source_version: update.version,
+          content: note.content,
+        )
+      end
+    end
+  end
+
+  def print_note_structure_report(results)
+    issues = results.flat_map(&:issues)
+    puts "Validated #{results.count} tariff knowledge note sources"
+    puts "Issues: #{issues.count}"
+    print_issue_counts('Severity', issues.map(&:severity))
+    print_issue_counts('Code', issues.map(&:code))
+
+    issues.first(10).each_with_index do |issue, index|
+      result = results.find { |candidate| candidate.issues.include?(issue) }
+      puts "#{index + 1}. Chapter #{result.source_id} #{issue.severity}/#{issue.code}: #{issue.message}"
+    end
+  end
+
+  def print_issue_counts(label, values)
+    counts = values.tally
+    puts "#{label}: none" if counts.empty?
+    counts.sort.each { |value, count| puts "#{value}: #{count}" }
+  end
 end
 
 desc 'Enqueue the full tariff knowledge graph population pipeline'
@@ -145,4 +191,9 @@ end
 desc 'Enqueue public ATAR ruling import'
 task 'tariff_knowledge:atars:enqueue' => :environment do
   TariffKnowledgeRakeTasks.enqueue_atar_import
+end
+
+desc 'Validate parsed tariff knowledge note structures. Set FAIL_ON_ISSUES=true to fail when issues are reported.'
+task 'tariff_knowledge:note_structures:validate' => :environment do
+  TariffKnowledgeRakeTasks.validate_note_structures
 end

--- a/spec/lib/tasks/tariff_knowledge_rake_spec.rb
+++ b/spec/lib/tasks/tariff_knowledge_rake_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe 'tariff_knowledge rake tasks' do
       tariff_knowledge:atars:preload
       tariff_knowledge:atars:import
       tariff_knowledge:atars:enqueue
+      tariff_knowledge:note_structures:validate
     ].each { |task| Rake::Task[task].reenable if Rake::Task.task_defined?(task) }
   end
 
@@ -165,6 +166,60 @@ RSpec.describe 'tariff_knowledge rake tasks' do
 
       expect(ImportPublicAtarRulingsWorker).to have_received(:perform_async)
     end
+  end
+
+  describe 'tariff_knowledge:note_structures:validate' do
+    it 'validates current chapter notes and prints a concise report' do
+      update = create(:customs_tariff_update, version: '1.31', validity_start_date: 1.day.ago)
+      create(:customs_tariff_update, :failed, version: '1.32', validity_start_date: Time.zone.today)
+      note = create(:customs_tariff_chapter_note, customs_tariff_update: update, chapter_id: '72', content: '1. Definitions.')
+      result = TariffKnowledge::NoteStructureValidator::Result.new(
+        source_type: 'customs_tariff_chapter_note',
+        source_id: '72',
+        source_version: '1.31',
+        fragment_count: 1,
+        event_count: 1,
+        root_node_count: 0,
+        total_node_count: 0,
+        orphan_event_count: 0,
+        orphan_event_keys: [],
+        duplicate_block_keys: [],
+        uncontained_fragment_keys: %w[fragment-key],
+        issues: [
+          TariffKnowledge::NoteStructureValidator::Issue.new(
+            severity: 'warning',
+            code: 'uncontained_fragments',
+            message: '1 fragments were not contained by any emitted note block',
+            details: { 'fragment_keys' => %w[fragment-key] },
+          ),
+        ],
+      )
+
+      allow(TariffKnowledge::NoteStructureValidator).to receive(:call).and_return(result)
+
+      output = capture_output { Rake::Task['tariff_knowledge:note_structures:validate'].invoke }
+
+      expect(TariffKnowledge::NoteStructureValidator).to have_received(:call).with(
+        source_type: 'customs_tariff_chapter_note',
+        source_id: note.chapter_id,
+        source_version: update.version,
+        content: note.content,
+      )
+      expect(output).to include('Validated 1 tariff knowledge note sources')
+      expect(output).to include('warning: 1')
+      expect(output).to include('uncontained_fragments: 1')
+      expect(output).to include('Chapter 72')
+    end
+  end
+
+  def capture_output
+    original_stdout = $stdout
+    output = StringIO.new
+    $stdout = output
+    yield
+    output.string
+  ensure
+    $stdout = original_stdout
   end
 end
 # rubocop:enable RSpec/DescribeClass


### PR DESCRIPTION
### Jira link

[AI-997](https://transformuk.atlassian.net/browse/AI-997)

### What?

- [x] Add `tariff_knowledge:note_structures:validate` rake task
- [x] Report severity/code tallies for structure/block parse issues
- [x] Rake task specs

### Why?

Operators need an offline way to inspect how chapter notes parse into structure and definition blocks before relying on graph load or search evidence packs.

Depends on the structure parsers (same AI-997 stack). No runtime search path change.

### Risk

**Risk level:** 🟢

**Reason for rating:** Offline rake-only tooling with specs. No production request path or data migration.