### PR TITLE
fix(rubocop): shorten customs tariff note imports

### DIFF
--- a/app/lib/customs_tariff_importer/importer.rb
+++ b/app/lib/customs_tariff_importer/importer.rb
@@ -48,35 +48,7 @@ module CustomsTariffImporter
           document_created_on: fetched.published_on,
         )
 
-        extracted.chapters.each do |chapter_id, content|
-          CustomsTariffChapterNote.create(
-            customs_tariff_update_version: update.version,
-            chapter_id:,
-            content:,
-            validity_start_date: update.validity_start_date,
-            status: CustomsTariffChapterNote::PENDING,
-          )
-        end
-
-        extracted.sections.each do |section_id, content|
-          CustomsTariffSectionNote.create(
-            customs_tariff_update_version: update.version,
-            section_id:,
-            content:,
-            validity_start_date: update.validity_start_date,
-            status: CustomsTariffSectionNote::PENDING,
-          )
-        end
-
-        extracted.general_rules.each do |rule_label, content|
-          CustomsTariffGeneralRule.create(
-            customs_tariff_update_version: update.version,
-            rule_label:,
-            content:,
-            validity_start_date: update.validity_start_date,
-            status: CustomsTariffGeneralRule::PENDING,
-          )
-        end
+        create_notes(update, extracted)
       end
 
       duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000).round(2)
@@ -91,6 +63,48 @@ module CustomsTariffImporter
       )
       record_failure(fetched&.version, e.message)
       Result.new(status: :failed, version: fetched&.version, error: e.message)
+    end
+
+    def create_notes(update, extracted)
+      create_chapter_notes(update, extracted.chapters)
+      create_section_notes(update, extracted.sections)
+      create_general_rules(update, extracted.general_rules)
+    end
+
+    def create_chapter_notes(update, chapters)
+      chapters.each do |chapter_id, content|
+        CustomsTariffChapterNote.create(
+          customs_tariff_update_version: update.version,
+          chapter_id:,
+          content:,
+          validity_start_date: update.validity_start_date,
+          status: CustomsTariffChapterNote::PENDING,
+        )
+      end
+    end
+
+    def create_section_notes(update, sections)
+      sections.each do |section_id, content|
+        CustomsTariffSectionNote.create(
+          customs_tariff_update_version: update.version,
+          section_id:,
+          content:,
+          validity_start_date: update.validity_start_date,
+          status: CustomsTariffSectionNote::PENDING,
+        )
+      end
+    end
+
+    def create_general_rules(update, general_rules)
+      general_rules.each do |rule_label, content|
+        CustomsTariffGeneralRule.create(
+          customs_tariff_update_version: update.version,
+          rule_label:,
+          content:,
+          validity_start_date: update.validity_start_date,
+          status: CustomsTariffGeneralRule::PENDING,
+        )
+      end
     end
 
     def record_failure(version, message)

--- a/app/lib/customs_tariff_importer/reimporter.rb
+++ b/app/lib/customs_tariff_importer/reimporter.rb
@@ -23,35 +23,49 @@ module CustomsTariffImporter
         CustomsTariffChapterNote.where(customs_tariff_update_version: update.version).delete
         CustomsTariffGeneralRule.where(customs_tariff_update_version: update.version).delete
 
-        extracted.sections.each do |section_id, note_content|
-          CustomsTariffSectionNote.create(
-            customs_tariff_update_version: update.version,
-            section_id:,
-            content: note_content,
-            validity_start_date: update.validity_start_date,
-            status: CustomsTariffSectionNote::PENDING,
-          )
-        end
+        create_notes(update, extracted)
+      end
+    end
 
-        extracted.chapters.each do |chapter_id, note_content|
-          CustomsTariffChapterNote.create(
-            customs_tariff_update_version: update.version,
-            chapter_id:,
-            content: note_content,
-            validity_start_date: update.validity_start_date,
-            status: CustomsTariffChapterNote::PENDING,
-          )
-        end
+    def create_notes(update, extracted)
+      create_section_notes(update, extracted.sections)
+      create_chapter_notes(update, extracted.chapters)
+      create_general_rules(update, extracted.general_rules)
+    end
 
-        extracted.general_rules.each do |rule_label, note_content|
-          CustomsTariffGeneralRule.create(
-            customs_tariff_update_version: update.version,
-            rule_label:,
-            content: note_content,
-            validity_start_date: update.validity_start_date,
-            status: CustomsTariffGeneralRule::PENDING,
-          )
-        end
+    def create_section_notes(update, sections)
+      sections.each do |section_id, note_content|
+        CustomsTariffSectionNote.create(
+          customs_tariff_update_version: update.version,
+          section_id:,
+          content: note_content,
+          validity_start_date: update.validity_start_date,
+          status: CustomsTariffSectionNote::PENDING,
+        )
+      end
+    end
+
+    def create_chapter_notes(update, chapters)
+      chapters.each do |chapter_id, note_content|
+        CustomsTariffChapterNote.create(
+          customs_tariff_update_version: update.version,
+          chapter_id:,
+          content: note_content,
+          validity_start_date: update.validity_start_date,
+          status: CustomsTariffChapterNote::PENDING,
+        )
+      end
+    end
+
+    def create_general_rules(update, general_rules)
+      general_rules.each do |rule_label, note_content|
+        CustomsTariffGeneralRule.create(
+          customs_tariff_update_version: update.version,
+          rule_label:,
+          content: note_content,
+          validity_start_date: update.validity_start_date,
+          status: CustomsTariffGeneralRule::PENDING,
+        )
       end
     end
   end


### PR DESCRIPTION
## What:
- [x] Extract `create_notes` / `create_chapter_notes` / `create_section_notes` / `create_general_rules` from `CustomsTariffImporter::Importer#import_document`
- [x] Extract the same helpers from `CustomsTariffImporter::Reimporter#reimport`
- [x] Preserve create attribute sets, PENDING status, and transaction boundaries
- [x] Rebuilt from current `main` (post-#3432 / #3427); reclassified low-risk for this structural split

## Why:
Long import/reimport methods blocked honest Metrics enforcement. Private helper extraction keeps note creation reviewable without changing import outcomes.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Behaviour-preserving private method extraction in customs tariff note import/reimport only. No API, sync, measures, or auth surface changes; create payloads and transaction flow are unchanged.

───────────────────────────────────────────────────

Rate the overall risk of deploying this change:

🟢 Green  – Low risk. Good to go, standard review applies.

🟠 Amber  – Medium risk. Socialise with the team before merging.

🔴 Red    – High risk. Requires explicit approval from Thor or Neil before merging.
