### PR TITLE
fix(rubocop): share timed instrumentation helper

### DIFF
--- a/app/lib/label_generator/instrumentation.rb
+++ b/app/lib/label_generator/instrumentation.rb
@@ -2,7 +2,7 @@ require 'active_support/notifications'
 
 module LabelGenerator
   module Instrumentation
-  module_function
+    module_function
 
     def instrument(event_name, payload = {}, &block)
       ActiveSupport::Notifications.instrument("#{event_name}.label_generator", payload, &block)

--- a/app/lib/label_generator/instrumentation.rb
+++ b/app/lib/label_generator/instrumentation.rb
@@ -35,43 +35,25 @@ module LabelGenerator
       )
     end
 
-    def api_call(batch_size:, model:, page_number:)
-      instrument('api_call_started', batch_size:, model:, page_number:)
-
-      start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      result = yield
-      duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
-
-      results_count = result.is_a?(Hash) ? Array.wrap(result['data']).size : 0
-
-      instrument(
-        'api_call_completed',
-        {
-          batch_size:,
-          model:,
-          page_number:,
-          results_count:,
-          duration_ms: (duration * 1000).round(2),
-          event_kind: 'label_generation',
-        }.merge(AiUsage.payload_from(result)),
+    def api_call(batch_size:, model:, page_number:, &block)
+      TimedInstrumentation.call(
+        instrumenter: method(:instrument),
+        started_event: 'api_call_started',
+        completed_event: 'api_call_completed',
+        failed_event: 'api_call_failed',
+        payload: { batch_size:, model:, page_number:, event_kind: 'label_generation' },
+        completed_payload: lambda { |result|
+          {
+            results_count: result.is_a?(Hash) ? Array.wrap(result['data']).size : 0,
+          }.merge(AiUsage.payload_from(result))
+        },
+        failed_payload: lambda { |error|
+          {
+            error_message: AiUsage.safe_error_message(error),
+          }.merge(AiUsage.payload_from_error(error))
+        },
+        &block
       )
-
-      result
-    rescue StandardError => e
-      duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
-      instrument(
-        'api_call_failed',
-        {
-          batch_size:,
-          model:,
-          page_number:,
-          error_class: e.class.name,
-          error_message: AiUsage.safe_error_message(e),
-          duration_ms: (duration * 1000).round(2),
-          event_kind: 'label_generation',
-        }.merge(AiUsage.payload_from_error(e)),
-      )
-      raise
     end
 
     def label_saved(label, page_number:)

--- a/app/lib/label_generator/instrumentation.rb
+++ b/app/lib/label_generator/instrumentation.rb
@@ -41,15 +41,17 @@ module LabelGenerator
         started_event: 'api_call_started',
         completed_event: 'api_call_completed',
         failed_event: 'api_call_failed',
-        payload: { batch_size:, model:, page_number:, event_kind: 'label_generation' },
+        payload: { batch_size:, model:, page_number: },
         completed_payload: lambda { |result|
           {
             results_count: result.is_a?(Hash) ? Array.wrap(result['data']).size : 0,
+            event_kind: 'label_generation',
           }.merge(AiUsage.payload_from(result))
         },
         failed_payload: lambda { |error|
           {
             error_message: AiUsage.safe_error_message(error),
+            event_kind: 'label_generation',
           }.merge(AiUsage.payload_from_error(error))
         },
         &block

--- a/app/lib/label_generator/instrumentation.rb
+++ b/app/lib/label_generator/instrumentation.rb
@@ -2,7 +2,7 @@ require 'active_support/notifications'
 
 module LabelGenerator
   module Instrumentation
-    module_function
+  module_function
 
     def instrument(event_name, payload = {}, &block)
       ActiveSupport::Notifications.instrument("#{event_name}.label_generator", payload, &block)

--- a/app/lib/self_text_generator/instrumentation.rb
+++ b/app/lib/self_text_generator/instrumentation.rb
@@ -40,8 +40,10 @@ module SelfTextGenerator
         started_event: 'api_call_started',
         completed_event: 'api_call_completed',
         failed_event: 'api_call_failed',
-        payload: { batch_size:, model:, chapter_code:, event_kind: },
-        completed_payload: ->(result) { AiUsage.payload_from(result) },
+        payload: { batch_size:, model:, chapter_code: },
+        completed_payload: lambda { |result|
+          { event_kind: }.merge(AiUsage.payload_from(result))
+        },
         failed_payload: lambda { |error|
           http_status = if error.respond_to?(:http_status)
                           error.http_status
@@ -51,6 +53,7 @@ module SelfTextGenerator
           {
             error_message: AiUsage.safe_error_message(error),
             http_status:,
+            event_kind:,
           }.merge(AiUsage.payload_from_error(error))
         },
         &block

--- a/app/lib/self_text_generator/instrumentation.rb
+++ b/app/lib/self_text_generator/instrumentation.rb
@@ -34,47 +34,27 @@ module SelfTextGenerator
       )
     end
 
-    def api_call(batch_size:, model:, chapter_code:, event_kind: 'self_text_generation_ai')
-      instrument('api_call_started', batch_size:, model:, chapter_code:)
-
-      start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      result = yield
-      duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
-
-      instrument(
-        'api_call_completed',
-        {
-          batch_size:,
-          model:,
-          chapter_code:,
-          duration_ms: (duration * 1000).round(2),
-          event_kind:,
-        }.merge(AiUsage.payload_from(result)),
+    def api_call(batch_size:, model:, chapter_code:, event_kind: 'self_text_generation_ai', &block)
+      TimedInstrumentation.call(
+        instrumenter: method(:instrument),
+        started_event: 'api_call_started',
+        completed_event: 'api_call_completed',
+        failed_event: 'api_call_failed',
+        payload: { batch_size:, model:, chapter_code:, event_kind: },
+        completed_payload: ->(result) { AiUsage.payload_from(result) },
+        failed_payload: lambda { |error|
+          http_status = if error.respond_to?(:http_status)
+                          error.http_status
+                        else
+                          error.respond_to?(:response) ? error.response&.dig(:status) : nil
+                        end
+          {
+            error_message: AiUsage.safe_error_message(error),
+            http_status:,
+          }.merge(AiUsage.payload_from_error(error))
+        },
+        &block
       )
-
-      result
-    rescue StandardError => e
-      duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
-      http_status = if e.respond_to?(:http_status)
-                      e.http_status
-                    else
-                      e.respond_to?(:response) ? e.response&.dig(:status) : nil
-                    end
-
-      instrument(
-        'api_call_failed',
-        {
-          batch_size:,
-          model:,
-          chapter_code:,
-          error_class: e.class.name,
-          error_message: AiUsage.safe_error_message(e),
-          duration_ms: (duration * 1000).round(2),
-          http_status:,
-          event_kind:,
-        }.merge(AiUsage.payload_from_error(e)),
-      )
-      raise
     end
 
     def scoring_started(chapter_code:, total_records:)

--- a/app/lib/self_text_generator/instrumentation.rb
+++ b/app/lib/self_text_generator/instrumentation.rb
@@ -2,7 +2,7 @@ require 'active_support/notifications'
 
 module SelfTextGenerator
   module Instrumentation
-  module_function
+    module_function
 
     def instrument(event_name, payload = {}, &block)
       ActiveSupport::Notifications.instrument("#{event_name}.self_text_generator", payload, &block)

--- a/app/lib/self_text_generator/instrumentation.rb
+++ b/app/lib/self_text_generator/instrumentation.rb
@@ -2,7 +2,7 @@ require 'active_support/notifications'
 
 module SelfTextGenerator
   module Instrumentation
-    module_function
+  module_function
 
     def instrument(event_name, payload = {}, &block)
       ActiveSupport::Notifications.instrument("#{event_name}.self_text_generator", payload, &block)

--- a/app/lib/timed_instrumentation.rb
+++ b/app/lib/timed_instrumentation.rb
@@ -2,8 +2,9 @@ module TimedInstrumentation
   module_function
 
   def call(instrumenter:, started_event:, completed_event:, failed_event:, payload:, completed_payload: nil, failed_payload: nil)
-    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    start_time = nil
     instrumenter.call(started_event, payload)
+    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
     result = yield
     duration_ms = duration_since(start_time)
@@ -36,6 +37,8 @@ module TimedInstrumentation
   end
 
   def duration_since(start_time)
+    return 0.0 if start_time.nil?
+
     ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000).round(2)
   end
 end

--- a/app/lib/timed_instrumentation.rb
+++ b/app/lib/timed_instrumentation.rb
@@ -2,9 +2,9 @@ module TimedInstrumentation
   module_function
 
   def call(instrumenter:, started_event:, completed_event:, failed_event:, payload:, completed_payload: nil, failed_payload: nil)
+    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     instrumenter.call(started_event, payload)
 
-    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     result = yield
     duration_ms = duration_since(start_time)
 
@@ -25,10 +25,14 @@ module TimedInstrumentation
   end
 
   def completed_payload_for(payload, result)
+    return {} if payload.nil?
+
     payload.respond_to?(:call) ? payload.call(result) : payload.to_h
   end
 
   def payload_for(payload, error)
+    return {} if payload.nil?
+
     payload.respond_to?(:call) ? payload.call(error) : payload.to_h
   end
 

--- a/app/lib/timed_instrumentation.rb
+++ b/app/lib/timed_instrumentation.rb
@@ -9,16 +9,19 @@ module TimedInstrumentation
     result = yield
     duration_ms = duration_since(start_time)
 
-    instrumenter.call(completed_event, payload.merge(duration_ms:, **completed_payload_for(completed_payload, result)))
+    instrumenter.call(
+      completed_event,
+      payload.merge(**completed_payload_for(completed_payload, result), duration_ms:),
+    )
 
     result
   rescue StandardError => e
     instrumenter.call(
       failed_event,
       payload.merge(
+        **payload_for(failed_payload, e),
         error_class: e.class.name,
         duration_ms: duration_since(start_time),
-        **payload_for(failed_payload, e),
       ),
     )
     raise

--- a/app/lib/timed_instrumentation.rb
+++ b/app/lib/timed_instrumentation.rb
@@ -11,7 +11,7 @@ module TimedInstrumentation
 
     instrumenter.call(
       completed_event,
-      payload.merge(**completed_payload_for(completed_payload, result), duration_ms:),
+      payload.merge(completed_payload_for(completed_payload, result), duration_ms:),
     )
 
     result
@@ -19,7 +19,7 @@ module TimedInstrumentation
     instrumenter.call(
       failed_event,
       payload.merge(
-        **payload_for(failed_payload, e),
+        payload_for(failed_payload, e),
         error_class: e.class.name,
         duration_ms: duration_since(start_time),
       ),

--- a/app/lib/timed_instrumentation.rb
+++ b/app/lib/timed_instrumentation.rb
@@ -1,5 +1,5 @@
 module TimedInstrumentation
-  module_function
+module_function
 
   def call(instrumenter:, started_event:, completed_event:, failed_event:, payload:, completed_payload: nil, failed_payload: nil)
     start_time = nil

--- a/app/lib/timed_instrumentation.rb
+++ b/app/lib/timed_instrumentation.rb
@@ -1,0 +1,38 @@
+module TimedInstrumentation
+  module_function
+
+  def call(instrumenter:, started_event:, completed_event:, failed_event:, payload:, completed_payload: nil, failed_payload: nil)
+    instrumenter.call(started_event, payload)
+
+    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    result = yield
+    duration_ms = duration_since(start_time)
+
+    instrumenter.call(completed_event, payload.merge(duration_ms:, **completed_payload_for(completed_payload, result)))
+
+    result
+  rescue StandardError => e
+    instrumenter.call(
+      failed_event,
+      payload.merge(
+        error_class: e.class.name,
+        error_message: e.message,
+        duration_ms: duration_since(start_time),
+        **payload_for(failed_payload, e),
+      ),
+    )
+    raise
+  end
+
+  def completed_payload_for(payload, result)
+    payload.respond_to?(:call) ? payload.call(result) : payload.to_h
+  end
+
+  def payload_for(payload, error)
+    payload.respond_to?(:call) ? payload.call(error) : payload.to_h
+  end
+
+  def duration_since(start_time)
+    ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000).round(2)
+  end
+end

--- a/app/lib/timed_instrumentation.rb
+++ b/app/lib/timed_instrumentation.rb
@@ -16,7 +16,6 @@ module TimedInstrumentation
       failed_event,
       payload.merge(
         error_class: e.class.name,
-        error_message: e.message,
         duration_ms: duration_since(start_time),
         **payload_for(failed_payload, e),
       ),


### PR DESCRIPTION
## What:
- [x] Add shared `TimedInstrumentation` helper for started/completed/failed API timing
- [x] Use it in label generator and self-text generator `api_call` paths
- [x] Preserve AiUsage cost/error payload fields (`payload_from`, `payload_from_error`, `safe_error_message`, `event_kind`)
- [x] Leave `embedding_api_call` paths unchanged (still AiUsage-complete)
- [x] Rebuilt from current `main` (post-#3433); not a blind warehouse cherry-pick

## Why:
Duplicated timing blocks inflate instrumentation modules. Sharing one helper shortens the modules without dropping AI cost telemetry.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Behaviour-preserving extraction of timing boilerplate only. AiUsage payload merges and event kinds are retained on completed/failed events; embedding instrumentation is untouched.

───────────────────────────────────────────────────

Rate the overall risk of deploying this change:

🟢 Green  – Low risk. Good to go, standard review applies.

🟠 Amber  – Medium risk. Socialise with the team before merging.

🔴 Red    – High risk. Requires explicit approval from Thor or Neil before merging.
