### PR TITLE
fix(rubocop): shorten reporting workbook blocks

### DIFF
--- a/app/lib/reporting/declarable_duties.rb
+++ b/app/lib/reporting/declarable_duties.rb
@@ -114,69 +114,78 @@ module Reporting
     class << self
       def generate
         with_report_logging do
-          workbook = instrument_report_step('open_workbook') do
-            if Rails.env.development?
-              FileUtils.rm(File.basename(object_key)) if File.exist?(File.basename(object_key))
-
-              FastExcel.open(
-                File.basename(object_key),
-                constant_memory: true,
-              )
-            else
-              FastExcel.open(
-                constant_memory: true,
-              )
-            end
-          end
-
+          workbook = open_workbook
           bold_format = instrument_report_step('add_format') { workbook.add_format(bold: true) }
-
-          worksheet = instrument_report_step('setup_worksheet') do
-            sheet = workbook.add_worksheet(Time.zone.today.iso8601)
-
-            COLUMN_WIDTHS.each_with_index do |width, index|
-              sheet.set_column_width(index, width)
-            end
-
-            sheet.append_row(HEADER_ROW, bold_format)
-            sheet.freeze_panes(1, 0)
-            sheet.autofilter(0, 1, 1, 25)
-            sheet
-          end
-
-          rows_written = instrument_report_step('append_rows') do
-            count = 0
-
-            each_declarable_and_measure do |declarable, measure|
-              row = build_row_for(declarable, measure)
-              worksheet.append_row(row)
-              count += 1
-            end
-
-            count
-          end
+          worksheet = setup_worksheet(workbook, bold_format)
+          rows_written = append_rows(worksheet)
 
           log_report_metric('rows_written', rows_written)
 
-          workbook_data = instrument_report_step('close_workbook', rows_written:) do
-            workbook.close
-            Rails.env.production? ? workbook.read_string : nil
-          end
-
-          if workbook_data
-            log_report_metric('output_bytes', workbook_data.bytesize)
-
-            instrument_report_step('upload', rows_written:, output_bytes: workbook_data.bytesize) do
-              object.put(
-                body: workbook_data,
-                content_type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-              )
-            end
-          end
+          workbook_data = close_workbook(workbook, rows_written)
+          upload_workbook(workbook_data, rows_written) if workbook_data
         end
       end
 
     private
+
+      def open_workbook
+        instrument_report_step('open_workbook') do
+          if Rails.env.development?
+            FileUtils.rm(File.basename(object_key)) if File.exist?(File.basename(object_key))
+
+            FastExcel.open(File.basename(object_key), constant_memory: true)
+          else
+            FastExcel.open(constant_memory: true)
+          end
+        end
+      end
+
+      def setup_worksheet(workbook, bold_format)
+        instrument_report_step('setup_worksheet') do
+          sheet = workbook.add_worksheet(Time.zone.today.iso8601)
+
+          COLUMN_WIDTHS.each_with_index do |width, index|
+            sheet.set_column_width(index, width)
+          end
+
+          sheet.append_row(HEADER_ROW, bold_format)
+          sheet.freeze_panes(1, 0)
+          sheet.autofilter(0, 1, 1, 25)
+          sheet
+        end
+      end
+
+      def append_rows(worksheet)
+        instrument_report_step('append_rows') do
+          count = 0
+
+          each_declarable_and_measure do |declarable, measure|
+            row = build_row_for(declarable, measure)
+            worksheet.append_row(row)
+            count += 1
+          end
+
+          count
+        end
+      end
+
+      def close_workbook(workbook, rows_written)
+        instrument_report_step('close_workbook', rows_written:) do
+          workbook.close
+          Rails.env.production? ? workbook.read_string : nil
+        end
+      end
+
+      def upload_workbook(workbook_data, rows_written)
+        log_report_metric('output_bytes', workbook_data.bytesize)
+
+        instrument_report_step('upload', rows_written:, output_bytes: workbook_data.bytesize) do
+          object.put(
+            body: workbook_data,
+            content_type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+          )
+        end
+      end
 
       def build_row_for(declarable, measure)
         HEADER_ROW.map do |header|

--- a/app/lib/reporting/differences/renderers/overview.rb
+++ b/app/lib/reporting/differences/renderers/overview.rb
@@ -172,7 +172,24 @@ module Reporting
         end
 
         def add_worksheet(data) # rubocop:disable Lint/UnusedMethodArgument
-          dashboard_styles = {
+          worksheet = workbook.get_worksheet_by_name(name)
+          dashboard_styles = build_dashboard_styles
+
+          OVERVIEW_SECTION_CONFIG.each do |section, config|
+            append_overview_section(worksheet, section, config, dashboard_styles)
+          end
+
+          COLUMN_WIDTHS.each_with_index do |width, index|
+            worksheet.set_column_width(index, width)
+          end
+        end
+
+      private
+
+        attr_reader :report
+
+        def build_dashboard_styles
+          {
             'C02814' => workbook.add_format(bg_color: 0xC02814, font_color: 0xFFFFFF),
             '48C83F' => workbook.add_format(bg_color: 0x48C83F, font_color: 0xFFFFFF),
             '666666' => workbook.add_format(bg_color: 0x666666, font_color: 0xFFFFFF),
@@ -207,75 +224,64 @@ module Reporting
               font_size: 11,
             ),
           }
-
-          worksheet = workbook.get_worksheet_by_name(name)
-          OVERVIEW_SECTION_CONFIG.each do |section, config|
-            colour = config[:section_colour]
-
-            worksheet.append_row(
-              [
-                nil,
-                section,
-                'Count',
-                'New Items',
-                'About this metric',
-                nil,
-              ],
-              [
-                dashboard_styles[colour],
-                dashboard_styles['header_section'],
-                dashboard_styles['header_count'],
-                dashboard_styles['header_count'],
-                dashboard_styles['header_about'],
-                dashboard_styles['header_view'],
-              ],
-            )
-
-            config[:worksheets].each do |sheet, worksheet_config|
-              report_date = report.as_of.to_date.to_fs(:govuk)
-              worksheet_description = worksheet_config[:description].sub('as_of', report_date)
-              worksheet_name = worksheet_config[:worksheet_name]
-
-              worksheet.append_row(
-                [
-                  nil,
-                  sheet,
-                  FastExcel::Formula.new("COUNTA('#{worksheet_name}'!A2:A1048576)"),
-                  FastExcel::Formula.new(worksheet_config.fetch(:new_items_formula, nil)),
-                  worksheet_description,
-                  nil,
-                ],
-                [
-                  nil,
-                  regular_style,
-                  centered_style,
-                  centered_style,
-                  regular_style,
-                  centered_style,
-                ],
-              )
-
-              worksheet.write_url_opt(
-                worksheet.last_row_number,
-                5,
-                "internal:'#{worksheet_name}'!A1",
-                nil,
-                'View issues',
-                nil,
-              )
-            end
-
-            worksheet.append_row([])
-          end
-
-          COLUMN_WIDTHS.each_with_index do |width, index|
-            worksheet.set_column_width(index, width)
-          end
         end
 
-      private
+        def append_overview_section(worksheet, section, config, dashboard_styles)
+          append_section_header(worksheet, section, config[:section_colour], dashboard_styles)
 
-        attr_reader :report
+          config[:worksheets].each do |sheet, worksheet_config|
+            append_worksheet_summary(worksheet, sheet, worksheet_config)
+          end
+
+          worksheet.append_row([])
+        end
+
+        def append_section_header(worksheet, section, colour, dashboard_styles)
+          worksheet.append_row(
+            [nil, section, 'Count', 'New Items', 'About this metric', nil],
+            [
+              dashboard_styles[colour],
+              dashboard_styles['header_section'],
+              dashboard_styles['header_count'],
+              dashboard_styles['header_count'],
+              dashboard_styles['header_about'],
+              dashboard_styles['header_view'],
+            ],
+          )
+        end
+
+        def append_worksheet_summary(worksheet, sheet, worksheet_config)
+          worksheet_name = worksheet_config[:worksheet_name]
+
+          worksheet.append_row(
+            worksheet_summary_row(sheet, worksheet_config),
+            [nil, regular_style, centered_style, centered_style, regular_style, centered_style],
+          )
+
+          worksheet.write_url_opt(
+            worksheet.last_row_number,
+            5,
+            "internal:'#{worksheet_name}'!A1",
+            nil,
+            'View issues',
+            nil,
+          )
+        end
+
+        def worksheet_summary_row(sheet, worksheet_config)
+          worksheet_name = worksheet_config[:worksheet_name]
+          report_date = report.as_of.to_date.to_fs(:govuk)
+          worksheet_description = worksheet_config[:description].sub('as_of', report_date)
+
+          [
+            nil,
+            sheet,
+            FastExcel::Formula.new("COUNTA('#{worksheet_name}'!A2:A1048576)"),
+            FastExcel::Formula.new(worksheet_config.fetch(:new_items_formula, nil)),
+            worksheet_description,
+            nil,
+          ]
+        end
 
         def name
           WORKSHEET_NAME


### PR DESCRIPTION
## What:
- [x] Extract helpers in `Reporting::DeclarableDuties` (`open_workbook`, `setup_worksheet`, `append_rows`, `close_workbook`, `upload_workbook`)
- [x] Extract helpers in `Reporting::Differences::Renderers::Overview` (`build_dashboard_styles`, `append_overview_section`, `append_section_header`, `append_worksheet_summary`, `worksheet_summary_row`)
- [x] Rebuild from current `main` (post-#3434) using warehouse design `88696eb56` content only

## Why:
Long generate/render methods trip Metrics/MethodLength. Helper extraction shortens methods without changing workbook content or report behaviour.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Behaviour-preserving extraction of private helpers only. No API, sync, measure, or schema changes. Diff well under 800 lines.

───────────────────────────────────────────────────

Rate the overall risk of deploying this change:

🟢 Green  – Low risk. Good to go, standard review applies.

🟠 Amber  – Medium risk. Socialise with the team before merging.

🔴 Red    – High risk. Requires explicit approval from Thor or Neil before merging.
