### PR TITLE
HMRC-2451: Cover exchange rate redirect URL

### DIFF
--- a/spec/requests/api/v2/exchange_rates/files_controller_spec.rb
+++ b/spec/requests/api/v2/exchange_rates/files_controller_spec.rb
@@ -169,6 +169,14 @@ RSpec.describe Api::V2::ExchangeRates::FilesController, :v2 do
       end
     end
 
+    context 'when requesting the public frontend redirect URL' do
+      before { get "/uk/api/exchange_rates/files/monthly_csv_#{year}-#{month}/redirect.csv" }
+
+      it 'redirects to the presigned S3 URL' do
+        expect(response).to redirect_to(presigned_url)
+      end
+    end
+
     context 'when requesting an invalid type' do
       before { api_get redirect_api_exchange_rates_file_path("non_existing_type_#{year}-#{month}", format: :csv) }
 


### PR DESCRIPTION
### Jira link

[HMRC-2451](https://transformuk.atlassian.net/browse/HMRC-2451)

### What?

- [x] Add request coverage for the public exchange-rate redirect URL used by the frontend
- [x] Confirm the literal `/uk/api/exchange_rates/files/:id/redirect.csv` path redirects to the presigned S3 URL

### Why?

The frontend switched to the new exchange-rate redirect URL, but production returned `404` for `https://www.trade-tariff.service.gov.uk/uk/api/exchange_rates/files/monthly_csv_2026-7/redirect.csv` while the old proxy URL still returned `200`.

The backend route works on current `main`; this adds the missing request coverage and gives us a backend commit to deploy fully.

### Verification

```sh
bundle exec rspec spec/requests/api/v2/exchange_rates/files_controller_spec.rb
```

Result: 25 examples, 0 failures.

### Risk

**Risk level:** 🟢

**Reason for rating:** Test-only change covering an existing additive endpoint. Needs full deployment so production serves the current backend route set.
