### PR TITLE
fix(rubocop): shorten user and news datasets

### DIFF
--- a/app/models/news/item.rb
+++ b/app/models/news/item.rb
@@ -66,7 +66,7 @@ module News
       URI.join(TradeTariffBackend.frontend_host, '/news/stories/', slug).to_s
     end
 
-    dataset_module do
+    module DatasetFilters
       def descending
         order(Sequel.desc(:start_date), Sequel.desc(:id))
       end
@@ -139,6 +139,10 @@ module News
       def latest_change
         order(Sequel.desc(:updated_at)).first
       end
+    end
+
+    dataset_module do
+      include DatasetFilters
     end
 
   private

--- a/app/models/public_users/user.rb
+++ b/app/models/public_users/user.rb
@@ -11,7 +11,7 @@ module PublicUsers
 
     attr_writer :email
 
-    dataset_module do
+    module DatasetFilters
       def active
         where(deleted: false)
       end
@@ -54,6 +54,10 @@ module PublicUsers
           .exclude(Sequel[:users][:id] => PublicUsers::Subscription.select(:user_id))
           .where { created_at < 72.hours.ago }
       end
+    end
+
+    dataset_module do
+      include DatasetFilters
     end
 
     def email


### PR DESCRIPTION
## What:
- [x] Extract `DatasetFilters` modules for `News::Item` and `PublicUsers::User` (warehouse `b7a841502`)
- [x] Keep public dataset methods via `dataset_module { include DatasetFilters }` — same filter/query behaviour
- [x] Tiny Metrics-friendly extract only (+10/−2, 2 files)

## Why:
Shortens long `dataset_module` blocks so Metrics limits stay green without changing Sequel dataset APIs used by news and public-user queries.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Behaviour-preserving structural extract only. Method bodies and query logic are unchanged. Diff is 12 lines total. No auth, measures, sync, nested set, or engine route changes.

───────────────────────────────────────────────────

Rate the overall risk of deploying this change:

🟢 Green  – Low risk. Good to go, standard review applies.

🟠 Amber  – Medium risk. Socialise with the team before merging.

🔴 Red    – High risk. Requires explicit approval from Thor or Neil before merging.
