### PR TITLE
fix(rubocop): shorten model dataset blocks

### DIFF
--- a/app/models/description_intercept.rb
+++ b/app/models/description_intercept.rb
@@ -7,7 +7,7 @@ class DescriptionIntercept < Sequel::Model
   plugin :has_paper_trail
   skip_auto_validations(:not_null)
 
-  dataset_module do
+  module DatasetFilters
     def search(query)
       return self if query.blank?
 
@@ -56,6 +56,10 @@ class DescriptionIntercept < Sequel::Model
     def boolean_filter_enabled?(value)
       ActiveModel::Type::Boolean.new.cast(value)
     end
+  end
+
+  dataset_module do
+    include DatasetFilters
   end
 
   def self.for_search(query, source:)

--- a/app/models/exchange_rate_currency_rate.rb
+++ b/app/models/exchange_rate_currency_rate.rb
@@ -26,7 +26,7 @@ class ExchangeRateCurrencyRate < Sequel::Model
     sprintf('%.4f', rate)
   end
 
-  dataset_module do
+  module DatasetMethods
     def with_applicable_date
       with(
         :exchange_rate_currency_rates,
@@ -108,6 +108,10 @@ class ExchangeRateCurrencyRate < Sequel::Model
       )
       .order(Sequel.desc(:applicable_date))
     end
+  end
+
+  dataset_module do
+    include DatasetMethods
   end
 
   class << self

--- a/app/models/full_chemical.rb
+++ b/app/models/full_chemical.rb
@@ -19,7 +19,7 @@ class FullChemical < Sequel::Model
     validates_presence :name
   end
 
-  dataset_module do
+  module DatasetFilters
     def with_filter(filters)
       return [] if filters.empty?
 
@@ -71,5 +71,9 @@ class FullChemical < Sequel::Model
     end
 
     delegate :table_name, to: :model
+  end
+
+  dataset_module do
+    include DatasetFilters
   end
 end

--- a/app/models/goods_nomenclature_label.rb
+++ b/app/models/goods_nomenclature_label.rb
@@ -19,7 +19,7 @@ class GoodsNomenclatureLabel < Sequel::Model
     validates_presence :labels
   end
 
-  dataset_module do
+  module DatasetMethods
     include AdminListingDataset
 
     def by_sid(sid)
@@ -92,6 +92,10 @@ class GoodsNomenclatureLabel < Sequel::Model
         END
       SQL
     end
+  end
+
+  dataset_module do
+    include DatasetMethods
   end
 
   def score

--- a/app/models/goods_nomenclature_self_text.rb
+++ b/app/models/goods_nomenclature_self_text.rb
@@ -12,7 +12,7 @@ class GoodsNomenclatureSelfText < Sequel::Model
   many_to_one :goods_nomenclature, key: :goods_nomenclature_sid,
                                    primary_key: :goods_nomenclature_sid
 
-  dataset_module do
+  module DatasetMethods
     include AdminListingDataset
 
     def stale
@@ -93,6 +93,10 @@ class GoodsNomenclatureSelfText < Sequel::Model
         nil,
       )
     end
+  end
+
+  dataset_module do
+    include DatasetMethods
   end
 
   def validate

--- a/app/models/search_suggestion.rb
+++ b/app/models/search_suggestion.rb
@@ -50,7 +50,7 @@ class SearchSuggestion < Sequel::Model
                                      ds.with_actual(GoodsNomenclature)
                                    end
 
-  dataset_module do
+  module DatasetMethods
     def without_labels
       exclude(type: LABEL_TYPES)
     end
@@ -168,6 +168,10 @@ class SearchSuggestion < Sequel::Model
     def with_score(query)
       select_append(Sequel.function(:similarity, :value, query).as(:score))
     end
+  end
+
+  dataset_module do
+    include DatasetMethods
   end
 
   class << self

--- a/app/models/tariff_change.rb
+++ b/app/models/tariff_change.rb
@@ -49,7 +49,7 @@ class TariffChange < Sequel::Model
     end
   end
 
-  dataset_module do
+  module DatasetMethods
     def on_date(date)
       where(operation_date: date)
     end
@@ -89,6 +89,10 @@ class TariffChange < Sequel::Model
         Sequel.lit("metadata->'measure'->>'measure_type_id'") => measure_type_id,
       )
     end
+  end
+
+  dataset_module do
+    include DatasetMethods
   end
 
   def measure_metadata

--- a/config/debride.whitelist
+++ b/config/debride.whitelist
@@ -196,6 +196,7 @@ GoodsNomenclature#has_chemicals
 GoodsNomenclatureLabel#before_validation
 GoodsNomenclatureLabel#goods_nomenclature=
 GoodsNomenclatureSelfText#needs_review
+GoodsNomenclatureSelfText::DatasetMethods#needs_review
 GreenLanes::CategoryAssessment#latest
 GreenLanes::CategoryAssessment#regulation=
 GreenLanes::CategoryAssessmentJson#additional_codes=
@@ -433,6 +434,7 @@ SearchService#persisted?
 SearchService#q=
 SearchService#resource_id=
 SearchSuggestion#goods_nomenclature_autocomplete
+SearchSuggestion::DatasetMethods#goods_nomenclature_autocomplete
 SearchValidator#code=
 Section#chapter_from
 Section#chapter_to
@@ -462,6 +464,7 @@ TaricImporter::XmlParser::Reader#characters
 TaricImporter::XmlParser::Reader#end_element
 TaricImporter::XmlParser::Reader#start_element
 TariffChange#with_measure_type
+TariffChange::DatasetMethods#with_measure_type
 TariffChanges::GroupedCommodityChange#tariff_change_ids
 TariffChangesJobStatus#changes_pending?
 TariffChangesService::BaseChanges#change=


### PR DESCRIPTION
## What:
- [x] Extract `DatasetMethods` / `DatasetFilters` modules from long `dataset_module` blocks on seven models (warehouse `3fe54d57f` rebuild on main post-#3440)
- [x] Keep public dataset APIs via `dataset_module { include … }` — same filter/query behaviour
- [x] Preserve `AiUsage` embedding instrumentation on `GoodsNomenclatureSelfText` (not dropped as in raw warehouse)
- [x] Add debride whitelist entries for moved dataset method names only

**Files:**
- `app/models/description_intercept.rb`
- `app/models/exchange_rate_currency_rate.rb`
- `app/models/full_chemical.rb`
- `app/models/goods_nomenclature_label.rb`
- `app/models/goods_nomenclature_self_text.rb`
- `app/models/search_suggestion.rb`
- `app/models/tariff_change.rb`
- `config/debride.whitelist`

## Why:
Long `dataset_module` blocks made Metrics cops unenforceable. Named modules keep each extract reviewable and behaviour-preserving, matching the user/news dataset pattern from #3440.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Behaviour-preserving structural extract only. Method bodies and query logic are unchanged; only module placement moves. No measures, sync, nested set, auth, or engine route changes. Diff under 800 lines.

───────────────────────────────────────────────────

Rate the overall risk of deploying this change:

🟢 Green  – Low risk. Good to go, standard review applies.

🟠 Amber  – Medium risk. Socialise with the team before merging.

🔴 Red    – High risk. Requires explicit approval from Thor or Neil before merging.

───────────────────────────────────────────────────

🟢 GREEN – things that are typically low risk:
───────────────────────────────────────────────────
- Dependency bumps with no API changes (e.g. minor/patch gems, npm packages)
- Copy or content changes in GOV.UK-style UI components
- Adding or updating CloudWatch alarms or dashboards (read-only observability)
- New tests or improved test coverage with no production code changes
- Config/env var additions that are purely additive and have safe defaults
- Refactors with full test coverage and no behaviour change
- Terraform formatting or variable renaming with no resource recreation
- S3 lifecycle rule additions (non-destructive, time-delayed effect)

🟠 AMBER – things that need a team conversation first:
───────────────────────────────────────────────────
- Changes to commodity code lookups, measure type logic, or duty calculation
- Modifications to the search indexing pipeline (OpenSearch mappings, synonyms, stop words)
- Changes to declarable goods or quota logic
- New or modified API endpoints that other services (backend, frontend, admin) consume
- Adding or changing feature flags that affect live user journeys
- Infrastructure changes that alter networking, security groups, or IAM permissions in non-production first
- Terraform changes that will cause a resource replacement (check plan output carefully)
- Changes to CI/CD pipeline steps or deployment order dependencies
- S3 bucket policy or access control changes
- Removing or deprecating an endpoint or field that may still be consumed

🔴 RED – requires explicit approval from Thor or Neil:
───────────────────────────────────────────────────
- Dangerous database migrations, especially destructive ones (dropping columns/tables, removing indexes)
- Modifications to how measures, conditions, or footnotes are processed or surfaced
- Changes to the synchronisation mechanism from CDS or HMRC upstream data feeds
- Any change to production AWS infrastructure that cannot be easily rolled back (e.g. RDS parameter groups, KMS key policy, removal of resources)
- Secrets rotation or changes to how credentials are stored, scoped, or accessed
- Changes that affect trader-facing regulatory content or legally significant data (e.g. trade remedies, licensing, prohibitions)
- Significant architectural shifts (e.g. new service boundaries, queue/event topology changes)
