### PR TITLE
HMRC-2326: Route public search between classic and internal implementations by feature flag

### DIFF
--- a/app/controllers/api/internal/search_controller.rb
+++ b/app/controllers/api/internal/search_controller.rb
@@ -18,7 +18,7 @@ module Api
     private
 
       def search_params
-        params.permit(:q, :as_of, :request_id, :expanded_query, answers: %i[question answer options])
+        params.permit(:q, :as_of, :request_id, :expanded_query, :skip_question, answers: %i[question answer options])
       end
     end
   end

--- a/app/lib/search/instrumentation/result_events.rb
+++ b/app/lib/search/instrumentation/result_events.rb
@@ -32,12 +32,13 @@ module Search
         )
       end
 
-      def interactive_configuration_used(request_id:, query:, configuration:)
+      def interactive_configuration_used(request_id:, query:, skip_question:, configuration:)
         instrument(
           'interactive_configuration_used',
           request_id:,
           search_type: 'interactive',
           query:,
+          skip_question:,
           details: configuration,
         )
       end

--- a/app/lib/search/logger.rb
+++ b/app/lib/search/logger.rb
@@ -103,6 +103,7 @@ module Search
         request_id: event.payload[:request_id],
         search_type: event.payload[:search_type],
         query: event.payload[:query],
+        skip_question: event.payload[:skip_question],
         details: event.payload[:details],
       }, event)
     end

--- a/app/services/api/internal/search_service.rb
+++ b/app/services/api/internal/search_service.rb
@@ -22,6 +22,7 @@ module Api
         @request_id = params[:request_id].presence || TradeTariffRequest.request_id.presence || SecureRandom.uuid
         TradeTariffRequest.request_id ||= @request_id
         @expanded_query = params[:expanded_query].to_s.strip.presence
+        @skip_question = params[:skip_question]
       end
 
       def call
@@ -40,6 +41,7 @@ module Api
         ::Search::Instrumentation.interactive_configuration_used(
           request_id:,
           query: q,
+          skip_question: @skip_question,
           configuration: diagnostics_configuration,
         )
 
@@ -81,10 +83,14 @@ module Api
       end
 
       def interactive_search_response(retrieval)
-        interactive_result = run_interactive_search(
-          retrieval.goods_nomenclatures,
-          retrieval.expanded_query,
-        )
+        interactive_result = if @skip_question
+                               nil
+                             else
+                               run_interactive_search(
+                                 retrieval.goods_nomenclatures,
+                                 retrieval.expanded_query,
+                                 )
+                             end
 
         response = build_response(
           retrieval.goods_nomenclatures,

--- a/app/services/api/internal/search_service.rb
+++ b/app/services/api/internal/search_service.rb
@@ -89,7 +89,7 @@ module Api
                                run_interactive_search(
                                  retrieval.goods_nomenclatures,
                                  retrieval.expanded_query,
-                                 )
+                               )
                              end
 
         response = build_response(

--- a/app/services/api/internal/search_service.rb
+++ b/app/services/api/internal/search_service.rb
@@ -22,7 +22,7 @@ module Api
         @request_id = params[:request_id].presence || TradeTariffRequest.request_id.presence || SecureRandom.uuid
         TradeTariffRequest.request_id ||= @request_id
         @expanded_query = params[:expanded_query].to_s.strip.presence
-        @skip_question = params[:skip_question]
+        @skip_question = params[:skip_question].nil? ? nil : ActiveModel::Type::Boolean.new.cast(params[:skip_question])
       end
 
       def call

--- a/spec/lib/search/instrumentation_spec.rb
+++ b/spec/lib/search/instrumentation_spec.rb
@@ -545,6 +545,7 @@ RSpec.describe Search::Instrumentation do
       described_class.interactive_configuration_used(
         request_id: 'req-1',
         query: 'horse',
+        skip_question: false,
         configuration: { retrieval_method: 'hybrid', rrf_k: 60 },
       )
 

--- a/spec/services/api/internal/search_service_spec.rb
+++ b/spec/services/api/internal/search_service_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe Api::Internal::SearchService do
       expect(Search::Instrumentation).to have_received(:interactive_configuration_used).with(
         request_id: anything,
         query: 'multimeter leads',
+        skip_question: nil,
         configuration: hash_including(
           interactive_search_duplicate_question_guard_enabled: true,
           interactive_search_duplicate_question_guard_model: {
@@ -1164,6 +1165,41 @@ RSpec.describe Api::Internal::SearchService do
         described_class.new(q: 'handbag').call
 
         expect(Search::Instrumentation).not_to have_received(:evaluation_trace_returned)
+      end
+    end
+
+    context 'when skip_question is true' do
+      let(:opensearch_response) do
+        {
+          'hits' => {
+            'hits' => [
+              {
+                '_score' => 10.0,
+                '_source' => {
+                  'goods_nomenclature_sid' => 1,
+                  'goods_nomenclature_item_id' => '4202210000',
+                  'producline_suffix' => '80',
+                  'goods_nomenclature_class' => 'Commodity',
+                  'description' => 'leather handbags',
+                  'formatted_description' => 'Leather handbags',
+                  'declarable' => true,
+                },
+              },
+            ],
+          },
+        }
+      end
+
+      before do
+        allow(TradeTariffBackend.search_client).to receive(:search).and_return(opensearch_response)
+        allow(InteractiveSearchService).to receive(:call).and_return(nil)
+      end
+
+      it 'skips interactive search and omits interactive meta' do
+        result = described_class.new(q: 'handbag', skip_question: true).call
+
+        expect(InteractiveSearchService).not_to have_received(:call)
+        expect(result[:meta]).to be_nil
       end
     end
 


### PR DESCRIPTION
## What:
Skip OpenaiClient interactive search step based on skip_question parameter

## Why:
Classic public search use the backend internal search to produce enriched search results. This is controlled by FlagSmith feature flag on front end.

## Ticket:
https://transformuk.atlassian.net/browse/HMRC-2326

## Risk:
**Risk level:** 🟢 

**Reason for rating:**
Changes are in internal search route which is not live yet