### PR TITLE
test(nested-set): cover historical_children association loading

### DIFF
--- a/spec/models/goods_nomenclatures/nested_set_spec.rb
+++ b/spec/models/goods_nomenclatures/nested_set_spec.rb
@@ -334,6 +334,45 @@ RSpec.describe GoodsNomenclatures::NestedSet do
         end
       end
 
+      describe '#historical_children' do
+        it 'returns the same immediate children as #children at the current point in time' do
+          expect(tree[:subheading].historical_children.map(&:goods_nomenclature_sid))
+            .to eq(tree[:subheading].children.map(&:goods_nomenclature_sid))
+        end
+
+        it 'returns direct children only (not deeper descendants)' do
+          expect(tree[:heading].historical_children.map(&:goods_nomenclature_sid))
+            .to eq([tree[:subheading].goods_nomenclature_sid])
+        end
+
+        it 'supports eager loading from a real dataset query' do
+          loaded = GoodsNomenclature
+            .where(goods_nomenclature_sid: tree[:subheading].goods_nomenclature_sid)
+            .eager(:historical_children)
+            .all
+            .first
+
+          expect(loaded.associations[:historical_children].map(&:goods_nomenclature_sid))
+            .to match_array(tree[:subheading].children.map(&:goods_nomenclature_sid))
+        end
+
+        context 'when outside of TimeMachine' do
+          before { TradeTariffRequest.time_machine_now = nil }
+
+          around { |example| TimeMachine.no_time_machine { example.run } }
+
+          it 'still loads historical children without requiring a point-in-time date' do
+            expect(tree[:subheading].historical_children.map(&:goods_nomenclature_sid))
+              .to contain_exactly(tree[:subsubheading].goods_nomenclature_sid, tree[:commodity3].goods_nomenclature_sid)
+          end
+
+          it 'does not raise DateNotSet (unlike #children)' do
+            expect { tree[:subheading].historical_children }.not_to raise_error
+            expect { tree[:subheading].children }.to raise_exception described_class::DateNotSet
+          end
+        end
+      end
+
       describe 'with time machine' do
         before do
           create :goods_nomenclature_indent,


### PR DESCRIPTION
## What:
- [x] Add unit coverage for `GoodsNomenclatures::NestedSet#historical_children`
- [x] Exercise real dataset loads (current-time children match, direct children only, eager load)
- [x] Prove historical_children works outside TimeMachine and does not raise `DateNotSet` (unlike `#children`)

## Why:
Combative review of deferred RuboCop nested-set extractions found that `historical_children` was only stubbed in consumer specs. Real association coverage is required before treating nested-set helper extracts as low-risk.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Tests-only change; no production code behaviour change.

───────────────────────────────────────────────────

Rate the overall risk of deploying this change:

🟢 Green  – Low risk. Good to go, standard review applies.

🟠 Amber  – Medium risk. Socialise with the team before merging.

🔴 Red    – High risk. Requires explicit approval from Thor or Neil before merging.