### PR TITLE
fix(rubocop): extract BaseUpdate dataset filters module

### DIFF
--- a/app/lib/tariff_synchronizer/base_update.rb
+++ b/app/lib/tariff_synchronizer/base_update.rb
@@ -25,7 +25,7 @@ module TariffSynchronizer
       presence_of :filename, :issue_date
     end
 
-    dataset_module do
+    module DatasetFilters
       def by_filename(filename_without_suffix)
         filename = if TradeTariffBackend.uk?
                      "#{filename_without_suffix}.gzip"
@@ -97,6 +97,10 @@ module TariffSynchronizer
           .select(Sequel.expr(:tariff_updates).*)
           .descending.applied.order_prepend(:update_type)
       end
+    end
+
+    dataset_module do
+      include DatasetFilters
     end
 
     def applied?


### PR DESCRIPTION
## What:
- [x] Extract `TariffSynchronizer::BaseUpdate` dataset filters into `DatasetFilters`
- [x] Include via `dataset_module { include DatasetFilters }`
- [x] No intentional behaviour change

## Why:
Reduce Metrics/BlockLength pressure on BaseUpdate with a pure structural extract. Combative review marked this LOW_OK; `base_update_spec` covers `by_filename` and pending/applied filters.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Behaviour-preserving dataset_module include pattern already used elsewhere on main. Focused unit specs green locally.

───────────────────────────────────────────────────
Rate the overall risk of deploying this change:
🟢 Green – Low risk. Good to go, standard review applies.