### PR TITLE
fix(rubocop): extract Measure and GoodsNomenclature dataset filters

### DIFF
--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -144,7 +144,7 @@ class GoodsNomenclature < Sequel::Model
     '_' * (10 - suffix.length) + suffix
   end
 
-  dataset_module do
+  module DatasetFilters
     def by_codes(codes)
       where(goods_nomenclatures__goods_nomenclature_item_id: codes)
     end
@@ -196,6 +196,10 @@ class GoodsNomenclature < Sequel::Model
 
       where(combined_conditions)
     end
+  end
+
+  dataset_module do
+    include DatasetFilters
   end
 
   def number_indents

--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -218,7 +218,7 @@ class Measure < Sequel::Model
     result.compact
   end
 
-  dataset_module do
+  module DatasetFilters
     def with_additional_code_sid(additional_code_sid)
       return self if additional_code_sid.blank?
 
@@ -438,6 +438,10 @@ class Measure < Sequel::Model
       conditions = pairs.map { |a, b| Sequel.expr(col_a => a) & Sequel.expr(col_b => b) }
       where(conditions.reduce(:|))
     end
+  end
+
+  dataset_module do
+    include DatasetFilters
   end
 
   def_column_accessor :effective_end_date, :effective_start_date

--- a/config/debride.whitelist
+++ b/config/debride.whitelist
@@ -225,10 +225,6 @@ Measure#meursing
 Measure#origin
 Measure#resolved_duty_expression
 Measure#suspending_regulation_id
-Measure#terminated
-Measure#valid_to
-Measure#with_geographical_area
-Measure#with_measure_type
 Measure::DatasetFilters#terminated
 Measure::DatasetFilters#valid_to
 Measure::DatasetFilters#with_geographical_area

--- a/config/debride.whitelist
+++ b/config/debride.whitelist
@@ -229,6 +229,10 @@ Measure#terminated
 Measure#valid_to
 Measure#with_geographical_area
 Measure#with_measure_type
+Measure::DatasetFilters#terminated
+Measure::DatasetFilters#valid_to
+Measure::DatasetFilters#with_geographical_area
+Measure::DatasetFilters#with_measure_type
 MeasureCondition#before_create
 MeasureCondition#condition
 MeasureCondition#measure_condition_component_ids


### PR DESCRIPTION
## What:
- [x] Extract `Measure` dataset filters into `DatasetFilters`
- [x] Extract `GoodsNomenclature` dataset filters into `DatasetFilters`
- [x] Include via `dataset_module { include DatasetFilters }`
- [x] Update debride whitelist for moved Measure filter methods
- [x] No intentional behaviour change

## Why:
Reduce Metrics/BlockLength pressure on large models with a pure structural extract, matching the BaseUpdate `dataset_module` include pattern already on main (#3446).

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Behaviour-preserving dataset_module include pattern. Local `measure_spec` + `goods_nomenclature_spec` green (243 examples). No query or association logic changes.

───────────────────────────────────────────────────
Rate the overall risk of deploying this change:
🟢 Green – Low risk. Good to go, standard review applies.