### PR TITLE
fix(rubocop): extract optimized many-to-many eager loader helpers

### DIFF
--- a/app/lib/sequel/plugins/optimized_many_to_many.rb
+++ b/app/lib/sequel/plugins/optimized_many_to_many.rb
@@ -2,6 +2,8 @@
 module Sequel
   module Plugins
     module OptimizedManyToMany
+      EagerLoadQuery = Data.define(:sql, :bind_args, :left_keys, :left_pks)
+
     module_function
 
       def join_conditions(right_key, right_pk, join_table, target_table, db = Sequel::Model.db)
@@ -54,6 +56,77 @@ module Sequel
           table.table
         else
           table
+        end
+      end
+
+      def eager_loader_query(reflection, ids)
+        associated_class = reflection.associated_class
+        left_pks = Array(reflection[:left_primary_key])
+        join_table = reflection[:join_table]
+        left_keys = Array(reflection[:left_key])
+        right_keys = Array(reflection[:right_key])
+        target_table = associated_class.table_name
+        right_pks = Array(reflection[:right_primary_key])
+        order = reflection[:order]
+        join_conditions = join_conditions(right_keys, right_pks, join_table, target_table)
+        order_sql = qualify_order(order, target_table, associated_class)
+        fk_selects = left_keys.map { |lk| "#{join_table}.#{lk} AS x_fk_#{lk}" }.join(', ')
+
+        if left_pks.size == 1
+          simple_eager_loader_query(join_table, left_keys, left_pks, target_table, fk_selects, join_conditions, order_sql, ids)
+        else
+          composite_eager_loader_query(join_table, left_keys, left_pks, target_table, fk_selects, join_conditions, order_sql, ids)
+        end
+      end
+
+      def simple_eager_loader_query(join_table, left_keys, left_pks, target_table, fk_selects, join_conditions, order_sql, ids)
+        sql = <<~SQL.strip
+          SELECT #{target_table}.*, #{fk_selects}
+          FROM #{table_ref(join_table)}
+          JOIN #{target_table} ON #{join_conditions}
+          WHERE #{join_table}.#{left_keys.first} = ANY(?)
+          #{order_sql ? "ORDER BY #{order_sql}" : ''}
+        SQL
+
+        EagerLoadQuery.new(sql, [Sequel.pg_array(ids)], left_keys, left_pks)
+      end
+
+      def composite_eager_loader_query(join_table, left_keys, left_pks, target_table, fk_selects, join_conditions, order_sql, ids)
+        cte_columns = left_pks.map(&:to_s).join(', ')
+        unnest_args = left_pks.map { 'unnest(?)' }.join(', ')
+        bind_args = left_pks.map.with_index { |_pk, i| Sequel.pg_array(ids.map { |key| Array(key)[i] }) }
+        join_predicates = left_keys.zip(left_pks).map { |lk, pk| "filter_ids.#{pk} = #{join_table}.#{lk}" }.join(' AND ')
+
+        sql = <<~SQL.strip
+          WITH filter_ids (#{cte_columns}) AS (
+            SELECT #{unnest_args}
+          )
+          SELECT #{target_table}.*, #{fk_selects}
+          FROM #{target_table}
+          JOIN #{table_ref(join_table)} ON #{join_conditions}
+          JOIN filter_ids ON #{join_predicates}
+          #{order_sql ? "ORDER BY #{order_sql}" : ''}
+        SQL
+
+        EagerLoadQuery.new(sql, bind_args, left_keys, left_pks)
+      end
+
+      def eager_load_nested_associations(associated_class, associations, records)
+        return unless associations && records.any?
+
+        associated_class.eager(associations).send(:eager_load, records)
+      end
+
+      def assign_eager_loaded_associations(rows, records, assoc_name, left_keys, left_pks)
+        grouped = Hash.new { |h, k| h[k] = [] }
+        records.each do |record|
+          key_values = left_keys.map { |lk| record.values.delete("x_fk_#{lk}".to_sym) }
+          grouped[key_values] << record
+        end
+
+        rows.each do |parent|
+          parent_key = Array(left_pks).map { |pk| parent.send(pk) }
+          parent.associations[assoc_name] = grouped[parent_key] || []
         end
       end
 
@@ -111,65 +184,12 @@ module Sequel
           proc do |eo|
             refl = model_class.association_reflection(assoc_name)
             associated_class = refl.associated_class
-            left_pks = Array(refl[:left_primary_key])
-            ids = eo[:id_map].keys
-            join_table = refl[:join_table]
-            left_keys = Array(refl[:left_key])
-            right_keys = Array(refl[:right_key])
-            target_table = associated_class.table_name
-            right_pks = Array(refl[:right_primary_key])
-            order = refl[:order]
-
-            join_conditions = OptimizedManyToMany.join_conditions(right_keys, right_pks, join_table, target_table)
-            order_sql = OptimizedManyToMany.qualify_order(order, target_table, associated_class)
-            fk_selects = left_keys.map { |lk| "#{join_table}.#{lk} AS x_fk_#{lk}" }.join(', ')
-
-            if left_pks.size == 1
-              sql = <<~SQL.strip
-                SELECT #{target_table}.*, #{fk_selects}
-                FROM #{OptimizedManyToMany.table_ref(join_table)}
-                JOIN #{target_table} ON #{join_conditions}
-                WHERE #{join_table}.#{left_keys.first} = ANY(?)
-                #{order_sql ? "ORDER BY #{order_sql}" : ''}
-              SQL
-
-              bind_args = [Sequel.pg_array(ids)]
-            else
-              cte_name = 'filter_ids'
-              cte_columns = left_pks.map(&:to_s).join(', ')
-              unnest_args = left_pks.map { 'unnest(?)' }.join(', ')
-
-              sql = <<~SQL.strip
-                WITH #{cte_name} (#{cte_columns}) AS (
-                  SELECT #{unnest_args}
-                )
-                SELECT #{target_table}.*, #{fk_selects}
-                FROM #{target_table}
-                JOIN #{OptimizedManyToMany.table_ref(join_table)} ON #{join_conditions}
-                JOIN #{cte_name} fm ON #{left_keys.zip(left_pks).map { |lk, pk| "fm.#{pk} = #{join_table}.#{lk}" }.join(' AND ')}
-                #{order_sql ? "ORDER BY #{order_sql}" : ''}
-              SQL
-
-              bind_args = left_pks.map.with_index do |_pk, i|
-                Sequel.pg_array(ids.map { |k| Array(k)[i] })
-              end
-            end
-
-            dataset = associated_class.with_sql(sql, *bind_args)
+            query = OptimizedManyToMany.eager_loader_query(refl, eo[:id_map].keys)
+            dataset = associated_class.with_sql(query.sql, *query.bind_args)
             records = dataset.all
 
-            associated_class.eager(eo[:associations]).send(:eager_load, records) if eo[:associations] && records.any?
-
-            grouped = Hash.new { |h, k| h[k] = [] }
-            records.each do |rec|
-              key_values = left_keys.map { |lk| rec.values.delete("x_fk_#{lk}".to_sym) }
-              grouped[key_values] << rec
-            end
-
-            eo[:rows].each do |parent|
-              parent_key = Array(left_pks).map { |pk| parent.send(pk) }
-              parent.associations[assoc_name] = grouped[parent_key] || []
-            end
+            OptimizedManyToMany.eager_load_nested_associations(associated_class, eo[:associations], records)
+            OptimizedManyToMany.assign_eager_loaded_associations(eo[:rows], records, assoc_name, query.left_keys, query.left_pks)
           end
         end
       end


### PR DESCRIPTION
## What:
- [x] Extract eager-load SQL construction into `eager_loader_query` / simple / composite helpers
- [x] Extract nested eager load + association assignment helpers
- [x] Introduce `EagerLoadQuery = Data.define(...)` value object
- [x] No intentional SQL or behaviour change

## Why:
Reduce Metrics/BlockLength pressure on the optimized many-to-many Sequel plugin while keeping the same simple-key and composite-key SQL shapes covered by `optimized_many_to_many_spec`.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Behaviour-preserving structural extract. Full `optimized_many_to_many_spec` green locally (14 examples). SQL semantics for simple and composite keys retained.

───────────────────────────────────────────────────
Rate the overall risk of deploying this change:
🟢 Green – Low risk. Good to go, standard review applies.