### PR TITLE
fix(rubocop): extract componentable and ten-digit concern helpers

### DIFF
--- a/app/models/concerns/componentable.rb
+++ b/app/models/concerns/componentable.rb
@@ -37,77 +37,82 @@ module Componentable
     delegate :description, :abbreviation, to: :duty_expression, prefix: true
     delegate :abbreviation, to: :monetary_unit, prefix: true, allow_nil: true
     delegate :description, to: :monetary_unit, prefix: true, allow_nil: true
+  end
 
-    alias_method :measurement_unit_id, :measurement_unit_code
-    alias_method :measurement_unit_qualifier_id, :measurement_unit_qualifier_code
+  def measurement_unit_id
+    measurement_unit_code
+  end
 
-    def unit_for(measure)
-      # The excise SPQ type has two variants that determine what units need
-      # to be surfaced for the duty calculator.
-      #
-      # When the SPQ is based on litres of pure alcohol, the duty
-      # calculator needs to surface the SPR and LPA compound units.
-      #
-      # When the SPQ is based on percentage alcohol and volume per hectolitre,
-      # the duty calculator needs to surface the SPR, ASV and LTR compound units.
-      #
-      # This enables proper calculation of the duty and is essentially the result of a broken understanding of SPQ between CDS and other stakeholders.
-      if measure.excise? && small_producers_quotient?
-        if measure.all_components.find(&:liters_of_pure_alcohol?)
-          {
-            measurement_unit_code: SMALL_PRODUCERS_QUOTIENT,
-            measurement_unit_qualifier_code: LITERS_OF_PURE_ALCOHOL_QUALIFIER,
-          }
-        elsif measure.all_components.find(&:percentage_alcohol_and_volume_per_hl?)
-          {
-            measurement_unit_code: SMALL_PRODUCERS_QUOTIENT,
-            measurement_unit_qualifier_code: LITERS_QUALIFIER,
-          }
-        else
-          {
-            measurement_unit_code:,
-            measurement_unit_qualifier_code:,
-          }
-        end
+  def measurement_unit_qualifier_id
+    measurement_unit_qualifier_code
+  end
+
+  def unit_for(measure)
+    # The excise SPQ type has two variants that determine what units need
+    # to be surfaced for the duty calculator.
+    #
+    # When the SPQ is based on litres of pure alcohol, the duty
+    # calculator needs to surface the SPR and LPA compound units.
+    #
+    # When the SPQ is based on percentage alcohol and volume per hectolitre,
+    # the duty calculator needs to surface the SPR, ASV and LTR compound units.
+    #
+    # This enables proper calculation of the duty and is essentially the result of a broken understanding of SPQ between CDS and other stakeholders.
+    if measure.excise? && small_producers_quotient?
+      if measure.all_components.find(&:liters_of_pure_alcohol?)
+        {
+          measurement_unit_code: SMALL_PRODUCERS_QUOTIENT,
+          measurement_unit_qualifier_code: LITERS_OF_PURE_ALCOHOL_QUALIFIER,
+        }
+      elsif measure.all_components.find(&:percentage_alcohol_and_volume_per_hl?)
+        {
+          measurement_unit_code: SMALL_PRODUCERS_QUOTIENT,
+          measurement_unit_qualifier_code: LITERS_QUALIFIER,
+        }
       else
         {
           measurement_unit_code:,
           measurement_unit_qualifier_code:,
         }
       end
+    else
+      {
+        measurement_unit_code:,
+        measurement_unit_qualifier_code:,
+      }
     end
+  end
 
-    def id
-      pk.join('-')
-    end
+  def id
+    pk.join('-')
+  end
 
-    def expresses_unit?
-      measurement_unit_code.present?
-    end
+  def expresses_unit?
+    measurement_unit_code.present?
+  end
 
-    def small_producers_quotient?
-      measurement_unit_code == SMALL_PRODUCERS_QUOTIENT
-    end
+  def small_producers_quotient?
+    measurement_unit_code == SMALL_PRODUCERS_QUOTIENT
+  end
 
-    def percentage_alcohol_and_volume_per_hl?
-      measurement_unit_code == 'ASV' && measurement_unit_qualifier_code == 'X'
-    end
+  def percentage_alcohol_and_volume_per_hl?
+    measurement_unit_code == 'ASV' && measurement_unit_qualifier_code == 'X'
+  end
 
-    def liters_of_pure_alcohol?
-      measurement_unit_code == 'LPA'
-    end
+  def liters_of_pure_alcohol?
+    measurement_unit_code == 'LPA'
+  end
 
-    def ad_valorem?
-      monetary_unit_code.nil? &&
-        measurement_unit_code.nil?
-    end
+  def ad_valorem?
+    monetary_unit_code.nil? &&
+      measurement_unit_code.nil?
+  end
 
-    def zero_duty?
-      duty_amount&.zero?
-    end
+  def zero_duty?
+    duty_amount&.zero?
+  end
 
-    def meursing?
-      duty_expression_id.in?(DutyExpression::MEURSING_DUTY_EXPRESSION_IDS)
-    end
+  def meursing?
+    duty_expression_id.in?(DutyExpression::MEURSING_DUTY_EXPRESSION_IDS)
   end
 end

--- a/app/models/concerns/ten_digit_goods_nomenclature.rb
+++ b/app/models/concerns/ten_digit_goods_nomenclature.rb
@@ -28,37 +28,39 @@ module TenDigitGoodsNomenclature
     end
 
     delegate :section, :section_id, to: :chapter, allow_nil: true
+  end
 
-    # See oplog sequel plugin
-    def operation=(operation)
-      self[:operation] = operation.to_s.first.upcase
-    end
+  # See oplog sequel plugin
+  def operation=(operation)
+    self[:operation] = operation.to_s.first.upcase
+  end
 
-    def to_param
-      code
-    end
+  def to_param
+    code
+  end
 
-    def code
+  def code
+    goods_nomenclature_item_id
+  end
+
+  def short_code
+    if declarable?
       goods_nomenclature_item_id
+    else
+      specific_system_short_code
     end
+  end
 
-    def short_code
-      if declarable?
-        goods_nomenclature_item_id
-      else
-        specific_system_short_code
-      end
+  def specific_system_short_code
+    case goods_nomenclature_item_id
+    when /^\d+0000$/ then harmonised_system_code
+    when /^\d+00$/ then combined_nomenclature_code
+    else taric_code
     end
+  end
 
-    def specific_system_short_code
-      case goods_nomenclature_item_id
-      when /^\d+0000$/ then harmonised_system_code
-      when /^\d+00$/ then combined_nomenclature_code
-      else taric_code
-      end
-    end
-
-    def self.changes_for(depth = 0, conditions = {})
+  class_methods do
+    def changes_for(depth = 0, conditions = {})
       operation_klass.select(
         Sequel.as(Sequel.cast_string('Commodity'), :model),
         :oid,
@@ -70,52 +72,52 @@ module TenDigitGoodsNomenclature
         .limit(TradeTariffBackend.change_count)
         .order(Sequel.desc(:operation_date, nulls: :last))
     end
+  end
 
-    def changes(depth = 1)
-      operation_klass.select(
-        Sequel.as(Sequel.cast_string('GoodsNomenclature'), :model),
-        :oid,
-        :operation_date,
-        :operation,
-        Sequel.as(depth, :depth),
-      ).where(pk_hash)
-        .union(
-          Measure.changes_for(
-            depth + 1,
-            Sequel.qualify(:measures_oplog, :goods_nomenclature_item_id) => goods_nomenclature_item_id,
-          ),
-        )
-            .from_self
-            .where(Sequel.~(operation_date: nil))
-            .tap! { |criteria|
-              # if Commodity did not come from initial seed, filter by its
-              # create/update date
-              criteria.where { |o| o.>=(:operation_date, operation_date) } if operation_date.present?
-            }
-              .limit(TradeTariffBackend.change_count)
-              .order(Sequel.desc(:operation_date, nulls: :last), Sequel.desc(:depth))
-    end
+  def changes(depth = 1)
+    operation_klass.select(
+      Sequel.as(Sequel.cast_string('GoodsNomenclature'), :model),
+      :oid,
+      :operation_date,
+      :operation,
+      Sequel.as(depth, :depth),
+    ).where(pk_hash)
+      .union(
+        Measure.changes_for(
+          depth + 1,
+          Sequel.qualify(:measures_oplog, :goods_nomenclature_item_id) => goods_nomenclature_item_id,
+        ),
+      )
+          .from_self
+          .where(Sequel.~(operation_date: nil))
+          .tap! { |criteria|
+            # if Commodity did not come from initial seed, filter by its
+            # create/update date
+            criteria.where { |o| o.>=(:operation_date, operation_date) } if operation_date.present?
+          }
+            .limit(TradeTariffBackend.change_count)
+            .order(Sequel.desc(:operation_date, nulls: :last), Sequel.desc(:depth))
+  end
 
-    def goods_nomenclature_class
-      declarable? ? 'Commodity' : 'Subheading'
-    end
+  def goods_nomenclature_class
+    declarable? ? 'Commodity' : 'Subheading'
+  end
 
-    def to_admin_param
-      goods_nomenclature_item_id
-    end
+  def to_admin_param
+    goods_nomenclature_item_id
+  end
 
-  private
+private
 
-    def harmonised_system_code
-      goods_nomenclature_item_id.first(6)
-    end
+  def harmonised_system_code
+    goods_nomenclature_item_id.first(6)
+  end
 
-    def combined_nomenclature_code
-      goods_nomenclature_item_id.first(8)
-    end
+  def combined_nomenclature_code
+    goods_nomenclature_item_id.first(8)
+  end
 
-    def taric_code
-      goods_nomenclature_item_id
-    end
+  def taric_code
+    goods_nomenclature_item_id
   end
 end

--- a/app/models/concerns/ten_digit_goods_nomenclature.rb
+++ b/app/models/concerns/ten_digit_goods_nomenclature.rb
@@ -28,11 +28,11 @@ module TenDigitGoodsNomenclature
     end
 
     delegate :section, :section_id, to: :chapter, allow_nil: true
-  end
 
-  # See oplog sequel plugin
-  def operation=(operation)
-    self[:operation] = operation.to_s.first.upcase
+    # See oplog sequel plugin
+    def operation=(operation)
+      self[:operation] = operation.to_s.first.upcase
+    end
   end
 
   def to_param

--- a/app/models/concerns/ten_digit_goods_nomenclature.rb
+++ b/app/models/concerns/ten_digit_goods_nomenclature.rb
@@ -82,21 +82,21 @@ module TenDigitGoodsNomenclature
       :operation,
       Sequel.as(depth, :depth),
     ).where(pk_hash)
-      .union(
-        Measure.changes_for(
-          depth + 1,
-          Sequel.qualify(:measures_oplog, :goods_nomenclature_item_id) => goods_nomenclature_item_id,
-        ),
-      )
-          .from_self
-          .where(Sequel.~(operation_date: nil))
-          .tap! { |criteria|
-            # if Commodity did not come from initial seed, filter by its
-            # create/update date
-            criteria.where { |o| o.>=(:operation_date, operation_date) } if operation_date.present?
-          }
-            .limit(TradeTariffBackend.change_count)
-            .order(Sequel.desc(:operation_date, nulls: :last), Sequel.desc(:depth))
+     .union(
+       Measure.changes_for(
+         depth + 1,
+         Sequel.qualify(:measures_oplog, :goods_nomenclature_item_id) => goods_nomenclature_item_id,
+       ),
+     )
+     .from_self
+     .where(Sequel.~(operation_date: nil))
+     .tap! { |criteria|
+       # if Commodity did not come from initial seed, filter by its
+       # create/update date
+       criteria.where { |o| o.>=(:operation_date, operation_date) } if operation_date.present?
+     }
+     .limit(TradeTariffBackend.change_count)
+     .order(Sequel.desc(:operation_date, nulls: :last), Sequel.desc(:depth))
   end
 
   def goods_nomenclature_class


### PR DESCRIPTION
## What:
- [x] Shorten `Componentable` concern setup via extracted helpers
- [x] Shorten `TenDigitGoodsNomenclature` concern setup via extracted helpers
- [x] No intentional behaviour change

## Why:
Reduce Metrics/BlockLength pressure on model concern setup blocks.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Behaviour-preserving structural extract. Local component/commodity related specs green (43 examples). No duty formula or association semantics changed.

───────────────────────────────────────────────────
Rate the overall risk of deploying this change:
🟢 Green – Low risk. Good to go, standard review applies.