### PR TITLE
fix(rubocop): extract auth concern helper methods

### DIFF
--- a/app/controllers/concerns/api_token_authenticatable.rb
+++ b/app/controllers/concerns/api_token_authenticatable.rb
@@ -5,6 +5,8 @@ module ApiTokenAuthenticatable
     include ActionController::HttpAuthentication::Token::ControllerMethods
   end
 
+private
+
   def authenticate!
     return if Rails.env.development?
 
@@ -26,8 +28,6 @@ module ApiTokenAuthenticatable
 
     true
   end
-
-private
 
   def api_tokens
     @api_tokens ||= read_tokens

--- a/app/controllers/concerns/api_token_authenticatable.rb
+++ b/app/controllers/concerns/api_token_authenticatable.rb
@@ -3,46 +3,46 @@ module ApiTokenAuthenticatable
 
   included do
     include ActionController::HttpAuthentication::Token::ControllerMethods
+  end
 
-    def authenticate!
-      return if Rails.env.development?
+  def authenticate!
+    return if Rails.env.development?
 
-      unless authenticate_with_api_tokens
-        render json: { error: 'Invalid API Token' }, status: :unauthorized
+    unless authenticate_with_api_tokens
+      render json: { error: 'Invalid API Token' }, status: :unauthorized
+    end
+  end
+
+  def authenticate_with_api_tokens
+    authenticate_or_request_with_http_token('Application', unauthenticated_message) do |provided_token, _options|
+      Rails.logger.debug "Provided token: #{provided_token}"
+
+      api_tokens.any? { |token|
+        ActiveSupport::SecurityUtils.secure_compare(provided_token, token)
+      }.tap do |authenticated|
+        @auth_type = 'authorisation' if authenticated
       end
     end
 
-    def authenticate_with_api_tokens
-      authenticate_or_request_with_http_token('Application', unauthenticated_message) do |provided_token, _options|
-        Rails.logger.debug "Provided token: #{provided_token}"
+    true
+  end
 
-        api_tokens.any? { |token|
-          ActiveSupport::SecurityUtils.secure_compare(provided_token, token)
-        }.tap do |authenticated|
-          @auth_type = 'authorisation' if authenticated
-        end
-      end
+private
 
-      true
+  def api_tokens
+    @api_tokens ||= read_tokens
+  end
+
+  def read_tokens
+    tokens = TradeTariffBackend.api_tokens
+    if tokens.present?
+      tokens.split(',').map(&:strip)
+    else
+      []
     end
+  end
 
-  private
-
-    def api_tokens
-      @api_tokens ||= read_tokens
-    end
-
-    def read_tokens
-      tokens = TradeTariffBackend.api_tokens
-      if tokens.present?
-        tokens.split(',').map(&:strip)
-      else
-        []
-      end
-    end
-
-    def unauthenticated_message
-      { message: 'No bearer token was provided' }.to_json
-    end
+  def unauthenticated_message
+    { message: 'No bearer token was provided' }.to_json
   end
 end

--- a/app/controllers/concerns/public_user_authenticatable.rb
+++ b/app/controllers/concerns/public_user_authenticatable.rb
@@ -9,57 +9,56 @@ module PublicUserAuthenticatable
     missing_jwks_keys: 'Unable to verify token',
   }.freeze
 
-  included do
-  private
+  attr_reader :current_user
 
-    attr_reader :current_user
-
-    def authenticate!
-      if Rails.env.development?
-        @current_user ||= Api::User::DummyUserService.find_or_create
-        return
-      end
-
-      if user_token.present?
-        result = Api::User::UserService.find(user_token)
-
-        if result.is_a?(CognitoTokenVerifier::Result)
-          return render_authentication_error(result.reason)
-        end
-
-        if result.nil?
-          return render_not_found_error
-        end
-
-        @current_user = result
-      else
-        render_authentication_error(:missing_token)
-      end
+  def authenticate!
+    if Rails.env.development?
+      @current_user ||= Api::User::DummyUserService.find_or_create
+      return
     end
 
-    def render_authentication_error(reason)
-      error_detail = AUTHENTICATION_ERROR_MESSAGES[reason] || 'Authentication failed'
-
-      render json: serialize_authentication_error(error_detail, reason), status: :unauthorized
+    if user_token.present?
+      authenticate_user_token
+    else
+      render_authentication_error(:missing_token)
     end
+  end
 
-    def render_not_found_error
-      render json: serialize_authentication_error('User not found', :not_found), status: :not_found
-    end
+  private :authenticate!, :current_user
 
-    def serialize_authentication_error(detail, reason)
-      {
-        errors: [{
-          detail:,
-          code: reason.to_s,
-        }],
-      }.to_json
-    end
+private
 
-    def user_token
-      pattern = /^Bearer /
-      header = request.headers['Authorization']
-      header.gsub(pattern, '') if header&.match(pattern)
-    end
+  def authenticate_user_token
+    result = Api::User::UserService.find(user_token)
+
+    return render_authentication_error(result.reason) if result.is_a?(CognitoTokenVerifier::Result)
+    return render_not_found_error if result.nil?
+
+    @current_user = result
+  end
+
+  def render_authentication_error(reason)
+    error_detail = AUTHENTICATION_ERROR_MESSAGES[reason] || 'Authentication failed'
+
+    render json: serialize_authentication_error(error_detail, reason), status: :unauthorized
+  end
+
+  def render_not_found_error
+    render json: serialize_authentication_error('User not found', :not_found), status: :not_found
+  end
+
+  def serialize_authentication_error(detail, reason)
+    {
+      errors: [{
+        detail:,
+        code: reason.to_s,
+      }],
+    }.to_json
+  end
+
+  def user_token
+    pattern = /^Bearer /
+    header = request.headers['Authorization']
+    header.gsub(pattern, '') if header&.match(pattern)
   end
 end

--- a/app/controllers/concerns/public_user_authenticatable.rb
+++ b/app/controllers/concerns/public_user_authenticatable.rb
@@ -9,6 +9,8 @@ module PublicUserAuthenticatable
     missing_jwks_keys: 'Unable to verify token',
   }.freeze
 
+private
+
   attr_reader :current_user
 
   def authenticate!
@@ -23,10 +25,6 @@ module PublicUserAuthenticatable
       render_authentication_error(:missing_token)
     end
   end
-
-  private :authenticate!, :current_user
-
-private
 
   def authenticate_user_token
     result = Api::User::UserService.find(user_token)


### PR DESCRIPTION
## What:
- [x] Shorten `ApiTokenAuthenticatable` concern setup via helpers
- [x] Shorten `PublicUserAuthenticatable` concern setup via helpers
- [x] No intentional behaviour change to 401/auth paths

## Why:
Reduce Metrics/BlockLength pressure on auth concerns while preserving existing authentication control flow.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Behaviour-preserving structural extract. Local green_lanes + public user request specs green (72 examples); full `spec/requests/api/user` suite also green.
