### PR TITLE
HMRC-2435: Write TARIC destroy/update ops without matview lookup

### DIFF
--- a/app/lib/sequel/plugins/oplog.rb
+++ b/app/lib/sequel/plugins/oplog.rb
@@ -128,8 +128,14 @@ module Sequel
           nil
         end
 
-        def _insert_raw(_dataset)
-          self.operation = :create
+        # Append a create/update/destroy row to the model's oplog table from the
+        # current in-memory attributes. Does not require a row in any current
+        # projection (plain table or materialized view).
+        #
+        # Prefer this over calling Sequel private hooks when hydrating from an
+        # inbound feed (TARIC/CDS) that already carries the full operation.
+        def write_oplog_operation!(operation)
+          self.operation = operation
 
           values = self.values.slice(*operation_klass.columns).except(:oid)
           if operation_klass.columns.include?(:created_at)
@@ -137,28 +143,18 @@ module Sequel
           end
 
           operation_klass.insert(values)
+        end
+
+        def _insert_raw(_dataset)
+          write_oplog_operation!(:create)
         end
 
         def _destroy_delete
-          self.operation = :destroy
-
-          values = self.values.slice(*operation_klass.columns).except(:oid)
-          if operation_klass.columns.include?(:created_at)
-            values[:created_at] = operation_klass.dataset.current_datetime
-          end
-
-          operation_klass.insert(values)
+          write_oplog_operation!(:destroy)
         end
 
         def _update_columns(_columns)
-          self.operation = :update
-
-          values = self.values.slice(*operation_klass.columns).except(:oid)
-          if operation_klass.columns.include?(:created_at)
-            values[:created_at] = operation_klass.dataset.current_datetime
-          end
-
-          operation_klass.insert(values)
+          write_oplog_operation!(:update)
         end
 
         # NOTE: This method is called by Sequel::Model#_refresh after we save a new record.

--- a/app/lib/sequel/plugins/oplog.rb
+++ b/app/lib/sequel/plugins/oplog.rb
@@ -128,12 +128,6 @@ module Sequel
           nil
         end
 
-        # Append a create/update/destroy row to the model's oplog table from the
-        # current in-memory attributes. Does not require a row in any current
-        # projection (plain table or materialized view).
-        #
-        # Prefer this over calling Sequel private hooks when hydrating from an
-        # inbound feed (TARIC/CDS) that already carries the full operation.
         def write_oplog_operation!(operation)
           self.operation = operation
 

--- a/app/lib/taric_importer.rb
+++ b/app/lib/taric_importer.rb
@@ -24,7 +24,6 @@ class TaricImporter
         create: { count: 0, duration: 0 },
         update: { count: 0, duration: 0 },
         destroy: { count: 0, duration: 0 },
-        destroy_missing: { count: 0, duration: 0 },
         skipped: { count: 0, duration: 0 },
       },
       total_count: 0,

--- a/app/lib/taric_importer/record_processor/create_operation.rb
+++ b/app/lib/taric_importer/record_processor/create_operation.rb
@@ -2,6 +2,10 @@ class TaricImporter
   class RecordProcessor
     class CreateOperation < Operation
       def call
+        # Use Sequel save so the normal create path (_insert_raw) runs. In test,
+        # that also refreshes materialized projections via _refresh_get; production
+        # skips mid-file refreshes. Update/destroy use write_oplog_operation!
+        # instead so they never depend on a live projection.
         klass.new(attributes).save(validate: false, transaction: false)
       end
 

--- a/app/lib/taric_importer/record_processor/create_operation.rb
+++ b/app/lib/taric_importer/record_processor/create_operation.rb
@@ -8,12 +8,6 @@ class TaricImporter
       def to_oplog_operation
         :create
       end
-
-    private
-
-      def get_model_record
-        klass.new
-      end
     end
   end
 end

--- a/app/lib/taric_importer/record_processor/create_operation.rb
+++ b/app/lib/taric_importer/record_processor/create_operation.rb
@@ -2,10 +2,6 @@ class TaricImporter
   class RecordProcessor
     class CreateOperation < Operation
       def call
-        # Use Sequel save so the normal create path (_insert_raw) runs. In test,
-        # that also refreshes materialized projections via _refresh_get; production
-        # skips mid-file refreshes. Update/destroy use write_oplog_operation!
-        # instead so they never depend on a live projection.
         klass.new(attributes).save(validate: false, transaction: false)
       end
 

--- a/app/lib/taric_importer/record_processor/destroy_operation.rb
+++ b/app/lib/taric_importer/record_processor/destroy_operation.rb
@@ -2,13 +2,7 @@ class TaricImporter
   class RecordProcessor
     class DestroyOperation < Operation
       def call
-        # Build from the inbound TARIC attributes and write a destroy oplog entry.
-        # Do not look up the current materialized projection first: same-file
-        # create/destroy sequences are valid and the create is not visible until
-        # views are refreshed after the full update file is applied.
-        model = klass.new(attributes)
-        model.destroy
-        model
+        write_from_transaction
       end
 
       def to_oplog_operation

--- a/app/lib/taric_importer/record_processor/destroy_operation.rb
+++ b/app/lib/taric_importer/record_processor/destroy_operation.rb
@@ -2,13 +2,12 @@ class TaricImporter
   class RecordProcessor
     class DestroyOperation < Operation
       def call
-        model = get_model_record
-        if model
-          model.set(attributes.except(*primary_key).symbolize_keys)
-          model.destroy
-        else
-          log_presence_error
-        end
+        # Build from the inbound TARIC attributes and write a destroy oplog entry.
+        # Do not look up the current materialized projection first: same-file
+        # create/destroy sequences are valid and the create is not visible until
+        # views are refreshed after the full update file is applied.
+        model = klass.new(attributes)
+        model.destroy
         model
       end
 

--- a/app/lib/taric_importer/record_processor/operation.rb
+++ b/app/lib/taric_importer/record_processor/operation.rb
@@ -29,14 +29,6 @@ class TaricImporter
 
     private
 
-      # Hydrate from the inbound TARIC snapshot and append an oplog row.
-      # Does not look up the current projection: same-file create then
-      # update/destroy is valid and the create is not visible until views
-      # refresh after the full update file is applied.
-      #
-      # Omitted optional attributes are nil-filled by Record#default_attributes
-      # (same as create). TARIC supplies the non-null snapshot fields for the
-      # entity; it does not always list every DB column in the XML.
       def write_from_transaction
         ensure_primary_key_present!
 

--- a/app/lib/taric_importer/record_processor/operation.rb
+++ b/app/lib/taric_importer/record_processor/operation.rb
@@ -27,34 +27,6 @@ class TaricImporter
       def to_oplog_operation
         raise NotImplementedError
       end
-
-    private
-
-      def ignore_presence_errors?
-        TaricSynchronizer.ignore_presence_errors
-      end
-
-      # Sometimes update operations go in wrong order (not chronologically, e.g. 'update' operation goes before 'create').
-      # We decided to have ability to not break import process:
-      #   set env TARIFF_IGNORE_PRESENCE_ERRORS=1 to ignore Sequel::RecordNotFound on update
-      # We also decided to create new record if it does not exist
-      def get_model_record
-        filters = attributes.slice(*primary_key).symbolize_keys
-        if ignore_presence_errors?
-          klass.filter(filters).first
-        else
-          klass.filter(filters).take
-        end
-      end
-
-      def log_presence_error
-        details = record.attributes.merge(
-          transaction_id: record.transaction_id,
-          operation_date:,
-          operation: to_oplog_operation,
-        )
-        instrument('presence_error.taric_importer', klass: klass.to_s, details:)
-      end
     end
   end
 end

--- a/app/lib/taric_importer/record_processor/operation.rb
+++ b/app/lib/taric_importer/record_processor/operation.rb
@@ -38,7 +38,7 @@ class TaricImporter
       end
 
       def ensure_primary_key_present!
-        missing = Array(primary_key).select { |key| attributes[key].nil? }
+        missing = Array(primary_key).select { |key| attributes[key].blank? }
         return if missing.empty?
 
         raise ArgumentError,

--- a/app/lib/taric_importer/record_processor/operation.rb
+++ b/app/lib/taric_importer/record_processor/operation.rb
@@ -3,8 +3,7 @@ class TaricImporter
     class Operation
       attr_reader :record, :operation_date
 
-      delegate :primary_key, :klass, to: :record
-      delegate :instrument, to: ActiveSupport::Notifications
+      delegate :klass, to: :record
 
       def initialize(record, operation_date)
         @record = record
@@ -26,6 +25,18 @@ class TaricImporter
 
       def to_oplog_operation
         raise NotImplementedError
+      end
+
+    private
+
+      # Hydrate from the inbound TARIC snapshot and append an oplog row.
+      # Does not look up the current projection: same-file create then
+      # update/destroy is valid and the create is not visible until views
+      # refresh after the full update file is applied.
+      def write_from_transaction
+        model = klass.new(attributes)
+        model.write_oplog_operation!(to_oplog_operation)
+        model
       end
     end
   end

--- a/app/lib/taric_importer/record_processor/operation.rb
+++ b/app/lib/taric_importer/record_processor/operation.rb
@@ -3,7 +3,7 @@ class TaricImporter
     class Operation
       attr_reader :record, :operation_date
 
-      delegate :klass, to: :record
+      delegate :klass, :primary_key, to: :record
 
       def initialize(record, operation_date)
         @record = record
@@ -33,10 +33,24 @@ class TaricImporter
       # Does not look up the current projection: same-file create then
       # update/destroy is valid and the create is not visible until views
       # refresh after the full update file is applied.
+      #
+      # Omitted optional attributes are nil-filled by Record#default_attributes
+      # (same as create). TARIC supplies the non-null snapshot fields for the
+      # entity; it does not always list every DB column in the XML.
       def write_from_transaction
+        ensure_primary_key_present!
+
         model = klass.new(attributes)
         model.write_oplog_operation!(to_oplog_operation)
         model
+      end
+
+      def ensure_primary_key_present!
+        missing = Array(primary_key).select { |key| attributes[key].nil? }
+        return if missing.empty?
+
+        raise ArgumentError,
+              "TARIC #{to_oplog_operation} for #{klass} missing primary key fields: #{missing.join(', ')}"
       end
     end
   end

--- a/app/lib/taric_importer/record_processor/record.rb
+++ b/app/lib/taric_importer/record_processor/record.rb
@@ -19,11 +19,7 @@ class TaricImporter
       # Sanitized and processed attributes
       attr_reader :attributes
 
-      # TARIC transaction ID
-      attr_accessor :transaction_id
-
       def initialize(record_hash)
-        self.transaction_id = record_hash['transaction_id']
         self.klass = record_hash.keys.last.classify.constantize
         self.primary_key = [klass.primary_key].flatten.map(&:to_s)
         self.attributes = record_hash.values.last

--- a/app/lib/taric_importer/record_processor/update_operation.rb
+++ b/app/lib/taric_importer/record_processor/update_operation.rb
@@ -2,13 +2,11 @@ class TaricImporter
   class RecordProcessor
     class UpdateOperation < Operation
       def call
-        model = get_model_record
-        if model
-          model.update(attributes.except(*primary_key).symbolize_keys)
-        else
-          log_presence_error
-          model = TaricImporter::RecordProcessor::CreateOperation.new(record, @operation_date).call
-        end
+        # Write the update from the inbound TARIC attributes without requiring a
+        # row in the current materialized projection. TARIC update records carry
+        # a full attribute set for the logical entity.
+        model = klass.new(attributes)
+        model.send(:_update_columns, nil)
         model
       end
 

--- a/app/lib/taric_importer/record_processor/update_operation.rb
+++ b/app/lib/taric_importer/record_processor/update_operation.rb
@@ -2,12 +2,7 @@ class TaricImporter
   class RecordProcessor
     class UpdateOperation < Operation
       def call
-        # Write the update from the inbound TARIC attributes without requiring a
-        # row in the current materialized projection. TARIC update records carry
-        # a full attribute set for the logical entity.
-        model = klass.new(attributes)
-        model.send(:_update_columns, nil)
-        model
+        write_from_transaction
       end
 
       def to_oplog_operation

--- a/spec/integration/taric_importer/record_processor/destroy_operation_spec.rb
+++ b/spec/integration/taric_importer/record_processor/destroy_operation_spec.rb
@@ -30,10 +30,12 @@ RSpec.describe TaricImporter::RecordProcessor::DestroyOperation do
         LanguageDescription.unrestrict_primary_key
       end
 
-      it 'identifies as create operation' do
+      it 'writes a destroy operation for the record' do
         operation.call
 
-        expect(LanguageDescription.count).to eq 0
+        expect(
+          LanguageDescription::Operation.where(operation: 'D').count,
+        ).to eq 1
       end
 
       it 'sets destroy operation date to operation_date' do
@@ -50,8 +52,73 @@ RSpec.describe TaricImporter::RecordProcessor::DestroyOperation do
     end
 
     context 'when record missing for destroy' do
-      it 'raises Sequel::RecordNotFound exception' do
-        expect { operation.call }.to raise_error(Sequel::RecordNotFound)
+      before do
+        LanguageDescription.unrestrict_primary_key
+      end
+
+      it 'writes a destroy operation from inbound attributes' do
+        expect { operation.call }
+          .to change { LanguageDescription::Operation.where(operation: 'D').count }.from(0).to(1)
+      end
+
+      it 'does not raise Sequel::RecordNotFound' do
+        expect { operation.call }.not_to raise_error
+      end
+    end
+
+    context 'when create is not yet visible in a materialized projection' do
+      # Production TARIC apply writes create ops to the oplog without refreshing
+      # materialized views between records. Seed a create row in measures_oplog
+      # only, so the current measures projection does not contain the record.
+      let!(:seed_measure) { create(:measure) }
+      let(:measure_sid) { seed_measure.measure_sid }
+      let(:operation_date) { Date.new(2026, 5, 9) }
+
+      let(:destroy_record) do
+        TaricImporter::RecordProcessor::Record.new(
+          'transaction_id' => '2',
+          'record_code' => '430',
+          'subrecord_code' => '00',
+          'record_sequence_number' => '2',
+          'update_type' => '2',
+          'measure' => measure_attributes,
+        )
+      end
+
+      let(:measure_attributes) do
+        seed_measure
+          .values
+          .except(:oid, :operation, :operation_date, :filename, :created_at)
+          .transform_keys(&:to_s)
+          .merge(
+            'measure_sid' => measure_sid.to_s,
+            'validity_start_date' => seed_measure.validity_start_date&.iso8601,
+            'validity_end_date' => seed_measure.validity_end_date&.iso8601,
+          )
+      end
+
+      before do
+        Measure.unrestrict_primary_key
+
+        # Replace factory state with an oplog-only create (no matview row).
+        create_values = seed_measure
+          .values
+          .slice(*Measure.operation_klass.columns)
+          .except(:oid)
+          .merge(operation: 'C', operation_date:)
+
+        Measure::Operation.where(measure_sid:).delete
+        Measure.refresh!(concurrently: false)
+        Measure::Operation.insert(create_values)
+      end
+
+      it 'preserves same-file create then destroy as ordered oplog operations', :aggregate_failures do
+        expect(Measure.where(measure_sid:).first).to be_nil
+
+        described_class.new(destroy_record, operation_date).call
+
+        operations = Measure::Operation.where(measure_sid:).order(:oid).select_map(:operation)
+        expect(operations).to eq(%w[C D])
       end
     end
   end

--- a/spec/integration/taric_importer/record_processor/destroy_operation_spec.rb
+++ b/spec/integration/taric_importer/record_processor/destroy_operation_spec.rb
@@ -62,10 +62,7 @@ RSpec.describe TaricImporter::RecordProcessor::DestroyOperation do
       end
     end
 
-    context 'when create is not yet visible in a materialized projection' do
-      # In test, Measure#save refreshes the matview. Insert create into the
-      # oplog only so the measures projection stays empty, matching production
-      # mid-file TARIC apply (no refresh between records).
+    context 'when create is only present in the oplog' do
       let!(:seed_measure) { create(:measure) }
       let(:measure_sid) { seed_measure.measure_sid }
       let(:operation_date) { Date.new(2026, 5, 9) }

--- a/spec/integration/taric_importer/record_processor/destroy_operation_spec.rb
+++ b/spec/integration/taric_importer/record_processor/destroy_operation_spec.rb
@@ -60,16 +60,12 @@ RSpec.describe TaricImporter::RecordProcessor::DestroyOperation do
         expect { operation.call }
           .to change { LanguageDescription::Operation.where(operation: 'D').count }.from(0).to(1)
       end
-
-      it 'does not raise Sequel::RecordNotFound' do
-        expect { operation.call }.not_to raise_error
-      end
     end
 
     context 'when create is not yet visible in a materialized projection' do
-      # Production TARIC apply writes create ops to the oplog without refreshing
-      # materialized views between records. Seed a create row in measures_oplog
-      # only, so the current measures projection does not contain the record.
+      # In test, Measure#save refreshes the matview. Insert create into the
+      # oplog only so the measures projection stays empty, matching production
+      # mid-file TARIC apply (no refresh between records).
       let!(:seed_measure) { create(:measure) }
       let(:measure_sid) { seed_measure.measure_sid }
       let(:operation_date) { Date.new(2026, 5, 9) }
@@ -100,7 +96,6 @@ RSpec.describe TaricImporter::RecordProcessor::DestroyOperation do
       before do
         Measure.unrestrict_primary_key
 
-        # Replace factory state with an oplog-only create (no matview row).
         create_values = seed_measure
           .values
           .slice(*Measure.operation_klass.columns)
@@ -119,6 +114,10 @@ RSpec.describe TaricImporter::RecordProcessor::DestroyOperation do
 
         operations = Measure::Operation.where(measure_sid:).order(:oid).select_map(:operation)
         expect(operations).to eq(%w[C D])
+
+        destroy_op = Measure::Operation.where(measure_sid:, operation: 'D').order(Sequel.desc(:oid)).first
+        expect(destroy_op.operation_date).to eq(operation_date)
+        expect(destroy_op.measure_sid).to eq(measure_sid)
       end
     end
   end

--- a/spec/integration/taric_importer/record_processor/update_operation_spec.rb
+++ b/spec/integration/taric_importer/record_processor/update_operation_spec.rb
@@ -64,10 +64,7 @@ RSpec.describe TaricImporter::RecordProcessor::UpdateOperation do
       end
     end
 
-    context 'when create is not yet visible in a materialized projection' do
-      # In test, Measure#save refreshes the matview. Insert create into the
-      # oplog only so the measures projection stays empty, matching production
-      # mid-file TARIC apply (no refresh between records).
+    context 'when create is only present in the oplog' do
       let!(:seed_measure) { create(:measure) }
       let(:measure_sid) { seed_measure.measure_sid }
       let(:operation_date) { Date.new(2026, 5, 9) }

--- a/spec/integration/taric_importer/record_processor/update_operation_spec.rb
+++ b/spec/integration/taric_importer/record_processor/update_operation_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe TaricImporter::RecordProcessor::UpdateOperation do
   describe '#call' do
     let(:operation_date) { Date.new(2013, 8, 1) }
     let(:record) { TaricImporter::RecordProcessor::Record.new(record_hash) }
-    let(:operation) { build_update_operation }
+    let(:operation) { described_class.new(record, operation_date) }
 
     before do
       LanguageDescription.unrestrict_primary_key
@@ -22,7 +22,7 @@ RSpec.describe TaricImporter::RecordProcessor::UpdateOperation do
 
     context 'when record for update present' do
       before do
-        create_language_description_record
+        create :language_description, language_code_id: 'FR', language_id: 'EN', description: 'French'
       end
 
       it 'writes an update operation with the new attributes' do
@@ -50,10 +50,6 @@ RSpec.describe TaricImporter::RecordProcessor::UpdateOperation do
           .to change { LanguageDescription::Operation.where(operation: 'U').count }.from(0).to(1)
       end
 
-      it 'does not raise Sequel::RecordNotFound' do
-        expect { operation.call }.not_to raise_error
-      end
-
       it 'does not fall back to CreateOperation' do
         allow(TaricImporter::RecordProcessor::CreateOperation).to receive(:new)
 
@@ -62,26 +58,72 @@ RSpec.describe TaricImporter::RecordProcessor::UpdateOperation do
         expect(TaricImporter::RecordProcessor::CreateOperation).not_to have_received(:new)
       end
 
-      it 'does not send presence error events' do
-        events = []
-        subscriber = ActiveSupport::Notifications.subscribe(/presence_error/) do |*args|
-          events << ActiveSupport::Notifications::Event.new(*args)
-        end
-
-        operation.call
-
-        expect(events).to be_empty
-      ensure
-        ActiveSupport::Notifications.unsubscribe(subscriber)
+      it 'does not create a create oplog row' do
+        expect { operation.call }
+          .not_to(change { LanguageDescription::Operation.where(operation: 'C').count })
       end
     end
 
-    def build_update_operation
-      TaricImporter::RecordProcessor::UpdateOperation.new(record, operation_date)
-    end
+    context 'when create is not yet visible in a materialized projection' do
+      # In test, Measure#save refreshes the matview. Insert create into the
+      # oplog only so the measures projection stays empty, matching production
+      # mid-file TARIC apply (no refresh between records).
+      let!(:seed_measure) { create(:measure) }
+      let(:measure_sid) { seed_measure.measure_sid }
+      let(:operation_date) { Date.new(2026, 5, 9) }
+      let(:updated_end_date) { Date.new(2026, 12, 31) }
 
-    def create_language_description_record
-      create :language_description, language_code_id: 'FR', language_id: 'EN', description: 'French'
+      let(:update_record) do
+        TaricImporter::RecordProcessor::Record.new(
+          'transaction_id' => '2',
+          'record_code' => '430',
+          'subrecord_code' => '00',
+          'record_sequence_number' => '2',
+          'update_type' => '1',
+          'measure' => measure_attributes.merge(
+            'validity_end_date' => updated_end_date.iso8601,
+          ),
+        )
+      end
+
+      let(:measure_attributes) do
+        seed_measure
+          .values
+          .except(:oid, :operation, :operation_date, :filename, :created_at)
+          .transform_keys(&:to_s)
+          .merge(
+            'measure_sid' => measure_sid.to_s,
+            'validity_start_date' => seed_measure.validity_start_date&.iso8601,
+            'validity_end_date' => seed_measure.validity_end_date&.iso8601,
+          )
+      end
+
+      before do
+        Measure.unrestrict_primary_key
+
+        create_values = seed_measure
+          .values
+          .slice(*Measure.operation_klass.columns)
+          .except(:oid)
+          .merge(operation: 'C', operation_date:)
+
+        Measure::Operation.where(measure_sid:).delete
+        Measure.refresh!(concurrently: false)
+        Measure::Operation.insert(create_values)
+      end
+
+      it 'preserves same-file create then update as ordered oplog operations', :aggregate_failures do
+        expect(Measure.where(measure_sid:).first).to be_nil
+
+        described_class.new(update_record, operation_date).call
+
+        operations = Measure::Operation.where(measure_sid:).order(:oid).select_map(:operation)
+        expect(operations).to eq(%w[C U])
+
+        update_op = Measure::Operation.where(measure_sid:, operation: 'U').order(Sequel.desc(:oid)).first
+        expect(update_op.operation_date).to eq(operation_date)
+        expect(update_op.validity_end_date.to_date).to eq(updated_end_date)
+      end
     end
   end
 end

--- a/spec/integration/taric_importer/record_processor/update_operation_spec.rb
+++ b/spec/integration/taric_importer/record_processor/update_operation_spec.rb
@@ -25,9 +25,11 @@ RSpec.describe TaricImporter::RecordProcessor::UpdateOperation do
         create_language_description_record
       end
 
-      it 'identifies as create operation' do
+      it 'writes an update operation with the new attributes' do
         operation.call
-        expect(LanguageDescription.first.description).to eq 'French!'
+        expect(
+          LanguageDescription::Operation.where(operation: 'U').order(Sequel.desc(:oid)).first.description,
+        ).to eq 'French!'
       end
 
       it 'returns model instance' do
@@ -43,33 +45,34 @@ RSpec.describe TaricImporter::RecordProcessor::UpdateOperation do
     end
 
     context 'when record for update is missing' do
-      it 'raises Sequel::RecordNotFound exception' do
-        expect { operation.call }.to raise_error(Sequel::RecordNotFound)
+      it 'writes an update operation from inbound attributes' do
+        expect { operation.call }
+          .to change { LanguageDescription::Operation.where(operation: 'U').count }.from(0).to(1)
       end
 
-      context 'with ignoring presence errors' do
-        before do
-          allow(TaricSynchronizer).to receive(:ignore_presence_errors).and_return(true)
+      it 'does not raise Sequel::RecordNotFound' do
+        expect { operation.call }.not_to raise_error
+      end
+
+      it 'does not fall back to CreateOperation' do
+        allow(TaricImporter::RecordProcessor::CreateOperation).to receive(:new)
+
+        operation.call
+
+        expect(TaricImporter::RecordProcessor::CreateOperation).not_to have_received(:new)
+      end
+
+      it 'does not send presence error events' do
+        events = []
+        subscriber = ActiveSupport::Notifications.subscribe(/presence_error/) do |*args|
+          events << ActiveSupport::Notifications::Event.new(*args)
         end
 
-        it 'creates new record' do
-          expect { operation.call }.to change(LanguageDescription, :count).from(0).to(1)
-        end
+        operation.call
 
-        it 'sends presence error events' do
-          allow(operation).to receive(:log_presence_error)
-          operation.call
-          expect(operation).to have_received(:log_presence_error)
-        end
-
-        it 'invokes CreateOperation' do
-          instance = instance_double(TaricImporter::RecordProcessor::CreateOperation)
-          allow(TaricImporter::RecordProcessor::CreateOperation).to receive(:new).and_return(instance)
-          allow(instance).to receive(:call)
-          operation.call
-
-          expect(instance).to have_received(:call)
-        end
+        expect(events).to be_empty
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber)
       end
     end
 

--- a/spec/lib/sequel/plugins/oplog_spec.rb
+++ b/spec/lib/sequel/plugins/oplog_spec.rb
@@ -387,14 +387,9 @@ RSpec.describe Sequel::Plugins::Oplog do
 
   describe '#write_oplog_operation!' do
     it 'appends create, update, and destroy rows without requiring a projection hit', :aggregate_failures do
-      create_model = TestRecord.new(id: 7, name: 'Seven', description: 'created', operation_date: Time.zone.today)
-      create_model.write_oplog_operation!(:create)
-
-      update_model = TestRecord.new(id: 7, name: 'Seven updated', description: 'updated', operation_date: Time.zone.today)
-      update_model.write_oplog_operation!(:update)
-
-      destroy_model = TestRecord.new(id: 7, name: 'Seven updated', description: 'updated', operation_date: Time.zone.today)
-      destroy_model.write_oplog_operation!(:destroy)
+      TestRecord.new(id: 7, name: 'Seven', description: 'created').write_oplog_operation!(:create)
+      TestRecord.new(id: 7, name: 'Seven updated', description: 'updated').write_oplog_operation!(:update)
+      TestRecord.new(id: 7, name: 'Seven updated', description: 'updated').write_oplog_operation!(:destroy)
 
       expect(TestRecord::Operation.where(id: 7).order(:oid).select_map(:operation)).to eq(%w[C U D])
       expect(TestRecord::Operation.where(id: 7, operation: 'U').first.name).to eq('Seven updated')

--- a/spec/lib/sequel/plugins/oplog_spec.rb
+++ b/spec/lib/sequel/plugins/oplog_spec.rb
@@ -384,6 +384,22 @@ RSpec.describe Sequel::Plugins::Oplog do
       end
     end
   end
+
+  describe '#write_oplog_operation!' do
+    it 'appends create, update, and destroy rows without requiring a projection hit', :aggregate_failures do
+      create_model = TestRecord.new(id: 7, name: 'Seven', description: 'created', operation_date: Time.zone.today)
+      create_model.write_oplog_operation!(:create)
+
+      update_model = TestRecord.new(id: 7, name: 'Seven updated', description: 'updated', operation_date: Time.zone.today)
+      update_model.write_oplog_operation!(:update)
+
+      destroy_model = TestRecord.new(id: 7, name: 'Seven updated', description: 'updated', operation_date: Time.zone.today)
+      destroy_model.write_oplog_operation!(:destroy)
+
+      expect(TestRecord::Operation.where(id: 7).order(:oid).select_map(:operation)).to eq(%w[C U D])
+      expect(TestRecord::Operation.where(id: 7, operation: 'U').first.name).to eq('Seven updated')
+    end
+  end
 end
 
 # rubocop:enable Style/ConstantDefinitionInBlock

--- a/spec/unit/taric_importer/record_processor/destroy_operation_spec.rb
+++ b/spec/unit/taric_importer/record_processor/destroy_operation_spec.rb
@@ -49,42 +49,12 @@ RSpec.describe TaricImporter::RecordProcessor::DestroyOperation do
       it 'returns the model record' do
         expect(operation.call).to be_a(LanguageDescription)
       end
-
-      it 'returns the model record code id' do
-        expect(operation.call.language_code_id).to eq('FR')
-      end
-
-      it 'does not send presence error events' do
-        events = []
-        subscriber = ActiveSupport::Notifications.subscribe(/presence_error/) do |*args|
-          events << ActiveSupport::Notifications::Event.new(*args)
-        end
-
-        operation.call
-
-        expect(events).to be_empty
-      ensure
-        ActiveSupport::Notifications.unsubscribe(subscriber)
-      end
     end
 
     context 'when no current record is present' do
       it 'still writes a destroy oplog operation from the inbound attributes' do
         expect { operation.call }
           .to change { LanguageDescription::Operation.where(operation: 'D').count }.from(0).to(1)
-      end
-
-      it 'does not send presence error events' do
-        events = []
-        subscriber = ActiveSupport::Notifications.subscribe(/presence_error/) do |*args|
-          events << ActiveSupport::Notifications::Event.new(*args)
-        end
-
-        operation.call
-
-        expect(events).to be_empty
-      ensure
-        ActiveSupport::Notifications.unsubscribe(subscriber)
       end
 
       it 'returns the model record' do

--- a/spec/unit/taric_importer/record_processor/destroy_operation_spec.rb
+++ b/spec/unit/taric_importer/record_processor/destroy_operation_spec.rb
@@ -27,132 +27,23 @@ RSpec.describe TaricImporter::RecordProcessor::DestroyOperation do
     end
   end
 
-  describe '#ignore_presence_errors?' do
-    let(:date) { nil }
-    let(:record) { nil }
-
-    it 'returns true if presence ignored' do
-      allow(TaricSynchronizer).to receive(:ignore_presence_errors).and_return(true)
-      expect(operation.send(:ignore_presence_errors?)).to be_truthy
-    end
-  end
-
-  describe '#get_model_record' do
-    context 'with ignoring presence on destroy' do
-      before do
-        allow(TaricSynchronizer).to receive(:ignore_presence_errors).and_return(true)
-      end
-
-      it 'gets model filtered record' do
-        filter_result = double
-        allow(LanguageDescription).to receive(:filter).and_return(filter_result)
-        allow(filter_result).to receive(:first)
-
-        operation.send(:get_model_record)
-
-        expect(LanguageDescription).to have_received(:filter)
-      end
-
-      it 'gets model first record' do
-        filter_result = double
-        allow(LanguageDescription).to receive(:filter).and_return(filter_result)
-        allow(filter_result).to receive(:first)
-
-        operation.send(:get_model_record)
-
-        expect(filter_result).to have_received(:first)
-      end
-
-      context 'when record is NOT found' do
-        it 'returns nil' do
-          record = operation.send(:get_model_record)
-          expect(record).to be_nil
-        end
-      end
-
-      context 'when record is found' do
-        before do
-          LanguageDescription.unrestrict_primary_key
-          LanguageDescription.create('language_code_id' => 'FR',
-                                     'language_id' => 'EN',
-                                     'description' => 'French')
-        end
-
-        it 'returns a model record', :aggregate_failures do
-          record = operation.send(:get_model_record)
-          expect(record).to be_a(LanguageDescription)
-        end
-
-        it 'returns a model record code id' do
-          record = operation.send(:get_model_record)
-          expect(record.language_code_id).to eq('FR')
-        end
-      end
-    end
-
-    context 'with NOT ignoring presence on destroy' do
-      before do
-        allow(TaricSynchronizer).to receive(:ignore_presence_errors).and_return(false)
-      end
-
-      it 'gets model record and filter' do
-        filter_result = double
-        allow(LanguageDescription).to receive(:filter).and_return(filter_result)
-        allow(filter_result).to receive(:take)
-
-        operation.send(:get_model_record)
-
-        expect(LanguageDescription).to have_received(:filter)
-      end
-
-      it 'gets model record and called take' do
-        filter_result = double
-        allow(LanguageDescription).to receive(:filter).and_return(filter_result)
-        allow(filter_result).to receive(:take)
-
-        operation.send(:get_model_record)
-
-        expect(filter_result).to have_received(:take)
-      end
-
-      context 'when record is NOT found' do
-        it 'returns a model record' do
-          expect { operation.send(:get_model_record) }.to raise_exception(Sequel::RecordNotFound)
-        end
-      end
-
-      context 'when record is found' do
-        before do
-          LanguageDescription.unrestrict_primary_key
-          LanguageDescription.create('language_code_id' => 'FR',
-                                     'language_id' => 'EN',
-                                     'description' => 'French')
-        end
-
-        it 'returns a model record', :aggregate_failures do
-          record = operation.send(:get_model_record)
-          expect(record).to be_a(LanguageDescription)
-        end
-
-        it 'returns a model record code id' do
-          record = operation.send(:get_model_record)
-          expect(record.language_code_id).to eq('FR')
-        end
-      end
-    end
-  end
-
   describe '#call' do
-    context 'when record is found' do
+    before do
+      LanguageDescription.unrestrict_primary_key
+    end
+
+    context 'when a current record is present' do
       before do
-        LanguageDescription.unrestrict_primary_key
-        LanguageDescription.create('language_code_id' => 'FR',
-                                   'language_id' => 'EN',
-                                   'description' => 'French')
+        LanguageDescription.create(
+          'language_code_id' => 'FR',
+          'language_id' => 'EN',
+          'description' => 'French',
+        )
       end
 
-      it 'destroys the record' do
-        expect { operation.call }.to change(LanguageDescription, :count).from(1).to(0)
+      it 'writes a destroy oplog operation' do
+        expect { operation.call }
+          .to change { LanguageDescription::Operation.where(operation: 'D').count }.by(1)
       end
 
       it 'returns the model record' do
@@ -160,32 +51,44 @@ RSpec.describe TaricImporter::RecordProcessor::DestroyOperation do
       end
 
       it 'returns the model record code id' do
-        record = operation.call
-        expect(record.language_code_id).to eq('FR')
+        expect(operation.call.language_code_id).to eq('FR')
       end
 
-      # rubocop:disable RSpec/SubjectStub
-      it 'does not sends presence error events' do
-        allow(operation).to receive(:log_presence_error)
+      it 'does not send presence error events' do
+        events = []
+        subscriber = ActiveSupport::Notifications.subscribe(/presence_error/) do |*args|
+          events << ActiveSupport::Notifications::Event.new(*args)
+        end
+
         operation.call
-        expect(operation).not_to have_received(:log_presence_error)
+
+        expect(events).to be_empty
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber)
       end
     end
 
-    context 'when record is not found' do
-      before do
-        allow(TaricSynchronizer).to receive(:ignore_presence_errors).and_return(true)
+    context 'when no current record is present' do
+      it 'still writes a destroy oplog operation from the inbound attributes' do
+        expect { operation.call }
+          .to change { LanguageDescription::Operation.where(operation: 'D').count }.from(0).to(1)
       end
 
-      it 'sends presence error events' do
-        allow(operation).to receive(:log_presence_error)
+      it 'does not send presence error events' do
+        events = []
+        subscriber = ActiveSupport::Notifications.subscribe(/presence_error/) do |*args|
+          events << ActiveSupport::Notifications::Event.new(*args)
+        end
+
         operation.call
-        expect(operation).to have_received(:log_presence_error)
-      end
-      # rubocop:enable RSpec/SubjectStub
 
-      it 'returns nil' do
-        expect(operation.call).to be_nil
+        expect(events).to be_empty
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber)
+      end
+
+      it 'returns the model record' do
+        expect(operation.call).to be_a(LanguageDescription)
       end
     end
   end

--- a/spec/unit/taric_importer/record_processor/record_spec.rb
+++ b/spec/unit/taric_importer/record_processor/record_spec.rb
@@ -14,10 +14,6 @@ RSpec.describe TaricImporter::RecordProcessor::Record do
   describe 'initialization' do
     subject(:record) { described_class.new(record_hash) }
 
-    it 'assigns transaction id' do
-      expect(record.transaction_id).to eq '31946'
-    end
-
     it 'assigns model class' do
       expect(record.klass).to eq LanguageDescription
     end

--- a/spec/unit/taric_importer/record_processor/update_operation_spec.rb
+++ b/spec/unit/taric_importer/record_processor/update_operation_spec.rb
@@ -43,15 +43,29 @@ RSpec.describe TaricImporter::RecordProcessor::UpdateOperation do
           'record_sequence_number' => '1',
           'update_type' => '1',
           'language_description' => {
-            'language_code_id' => nil,
+            'language_code_id' => language_code_id,
             'language_id' => 'EN',
             'description' => 'French!',
           },
         )
       end
 
-      it 'raises rather than writing a partial oplog row' do
-        expect { operation.call }.to raise_error(ArgumentError, /missing primary key fields/)
+      shared_examples 'rejects incomplete primary key' do
+        it 'raises rather than writing a partial oplog row' do
+          expect { operation.call }.to raise_error(ArgumentError, /missing primary key fields/)
+        end
+      end
+
+      context 'when the field is nil' do
+        let(:language_code_id) { nil }
+
+        include_examples 'rejects incomplete primary key'
+      end
+
+      context 'when the field is blank' do
+        let(:language_code_id) { '' }
+
+        include_examples 'rejects incomplete primary key'
       end
     end
   end

--- a/spec/unit/taric_importer/record_processor/update_operation_spec.rb
+++ b/spec/unit/taric_importer/record_processor/update_operation_spec.rb
@@ -33,18 +33,5 @@ RSpec.describe TaricImporter::RecordProcessor::UpdateOperation do
       expect { operation.call }
         .to change { LanguageDescription::Operation.where(operation: 'U').count }.by(1)
     end
-
-    it 'does not send presence error events' do
-      events = []
-      subscriber = ActiveSupport::Notifications.subscribe(/presence_error/) do |*args|
-        events << ActiveSupport::Notifications::Event.new(*args)
-      end
-
-      operation.call
-
-      expect(events).to be_empty
-    ensure
-      ActiveSupport::Notifications.unsubscribe(subscriber)
-    end
   end
 end

--- a/spec/unit/taric_importer/record_processor/update_operation_spec.rb
+++ b/spec/unit/taric_importer/record_processor/update_operation_spec.rb
@@ -33,5 +33,26 @@ RSpec.describe TaricImporter::RecordProcessor::UpdateOperation do
       expect { operation.call }
         .to change { LanguageDescription::Operation.where(operation: 'U').count }.by(1)
     end
+
+    context 'when a primary key field is missing from the inbound attributes' do
+      let(:record) do
+        TaricImporter::RecordProcessor::Record.new(
+          'transaction_id' => '31946',
+          'record_code' => '130',
+          'subrecord_code' => '05',
+          'record_sequence_number' => '1',
+          'update_type' => '1',
+          'language_description' => {
+            'language_code_id' => nil,
+            'language_id' => 'EN',
+            'description' => 'French!',
+          },
+        )
+      end
+
+      it 'raises rather than writing a partial oplog row' do
+        expect { operation.call }.to raise_error(ArgumentError, /missing primary key fields/)
+      end
+    end
   end
 end

--- a/spec/unit/taric_importer/record_processor/update_operation_spec.rb
+++ b/spec/unit/taric_importer/record_processor/update_operation_spec.rb
@@ -5,4 +5,46 @@ RSpec.describe TaricImporter::RecordProcessor::UpdateOperation do
       expect(empty_operation.to_oplog_operation).to eq :update
     end
   end
+
+  describe '#call' do
+    subject(:operation) { described_class.new(record, date) }
+
+    let(:date) { Time.zone.today }
+    let(:record) do
+      TaricImporter::RecordProcessor::Record.new(
+        'transaction_id' => '31946',
+        'record_code' => '130',
+        'subrecord_code' => '05',
+        'record_sequence_number' => '1',
+        'update_type' => '1',
+        'language_description' => {
+          'language_code_id' => 'FR',
+          'language_id' => 'EN',
+          'description' => 'French!',
+        },
+      )
+    end
+
+    before do
+      LanguageDescription.unrestrict_primary_key
+    end
+
+    it 'writes an update oplog operation from inbound attributes' do
+      expect { operation.call }
+        .to change { LanguageDescription::Operation.where(operation: 'U').count }.by(1)
+    end
+
+    it 'does not send presence error events' do
+      events = []
+      subscriber = ActiveSupport::Notifications.subscribe(/presence_error/) do |*args|
+        events << ActiveSupport::Notifications::Event.new(*args)
+      end
+
+      operation.call
+
+      expect(events).to be_empty
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber)
+    end
+  end
 end


### PR DESCRIPTION
### Jira link

[HMRC-2435](https://transformuk.atlassian.net/browse/HMRC-2435)

### What?

- [x] Write TARIC `DestroyOperation` from inbound attributes without looking up the current materialized projection
- [x] Write TARIC `UpdateOperation` from inbound attributes without falling back to create-on-missing
- [x] Stop logging TARIC presence errors from destroy/update when the projection is stale mid-file
- [x] Add a production-like Measure test where a create exists only in the oplog and destroy still writes `D`
- [x] Remove dead `get_model_record` / presence-error helpers now unused by the operation path

### Why?

XI/TARIC destroy and update previously required `get_model_record` to find the logical entity in the current materialized view. After oplog materialized views, create operations are not visible until the post-file refresh, so same-file create/destroy sequences logged presence errors and skipped the destroy. That left stale XI measures (for example safeguard duties on commodity `7306408000` after `TGB26129`).

This change hydrates the model from the inbound TARIC attributes and writes the oplog operation directly, matching CDS behaviour of not depending on a live projection mid-import.

### Risk

**Risk level:** 🟢

**Reason for rating:** Targeted TARIC write-path fix with unit/integration coverage (including no mid-file matview refresh). Full UK/XI rollback-reapply validation against a fresh production dump is the remaining gate before merge; CDS path unchanged.

### Have you?

- [x] Added tests for missing-current-record destroy/update paths
- [x] Simulated production materialized-view refresh timing for Measure create/destroy