### PR TITLE
HMRC-2435: Roll back XI oplog rows by operation_date

### DIFF
--- a/app/lib/tariff_synchronizer.rb
+++ b/app/lib/tariff_synchronizer.rb
@@ -72,9 +72,7 @@ module TariffSynchronizer
 
       Sequel::Model.db.transaction do
         oplog_based_models.each do |model|
-          model.operation_klass
-               .where(filename: update_filenames)
-               .delete
+          delete_oplog_rows_for_rollback(model, update_type, update_filenames, date)
         end
 
         TariffChangesJobStatus.find(operation_date: date)&.mark_changes_pending!
@@ -159,6 +157,18 @@ module TariffSynchronizer
   def oplog_based_models
     sequel_models.select do |model|
       model.plugins.include?(Sequel::Plugins::Oplog)
+    end
+  end
+
+  # CDS stamps filename on oplog inserts and rolls back by filename.
+  # TARIC does not populate filename; roll back by operation_date (indexed).
+  def delete_oplog_rows_for_rollback(model, update_type, update_filenames, date)
+    dataset = model.operation_klass
+
+    if update_type == TaricUpdate
+      dataset.where(Sequel[:operation_date] > date).delete
+    else
+      dataset.where(filename: update_filenames).delete
     end
   end
 

--- a/app/lib/tariff_synchronizer.rb
+++ b/app/lib/tariff_synchronizer.rb
@@ -68,7 +68,10 @@ module TariffSynchronizer
 
       date = Date.parse(rollback_date.to_s)
       updates = update_type.where { issue_date > date }
-      update_filenames = updates.pluck(:filename)
+      # Count before the transaction — updates may be deleted when keep is false.
+      files_count = updates.count
+      # TARIC deletes by operation_date; only CDS needs filenames in memory.
+      update_filenames = update_type == TaricUpdate ? [] : updates.pluck(:filename)
 
       Sequel::Model.db.transaction do
         oplog_based_models.each do |model|
@@ -91,7 +94,7 @@ module TariffSynchronizer
       TariffSynchronizer::Instrumentation.rollback_completed(
         rollback_date: date.iso8601,
         duration_ms:,
-        files_count: update_filenames.size,
+        files_count:,
       )
     end
   rescue Redlock::LockError

--- a/spec/factories/base_update_factory.rb
+++ b/spec/factories/base_update_factory.rb
@@ -40,9 +40,10 @@ FactoryBot.define do
       applied
 
       after(:create) do |update, _evaluator|
+        # CDS stamps filename; TARIC leaves it null and relies on operation_date for rollback.
         create(
           :measure,
-          filename: update.filename,
+          filename: update.is_a?(TariffSynchronizer::TaricUpdate) ? nil : update.filename,
           operation_date: update.issue_date,
         )
       end

--- a/spec/factories/taric_update_factory.rb
+++ b/spec/factories/taric_update_factory.rb
@@ -26,7 +26,8 @@ FactoryBot.define do
 
     trait :with_measure do
       after :create do |taric_update, _evaluator|
-        create :measure, operation_date: taric_update.issue_date, filename: taric_update.filename
+        # TARIC imports leave filename null on oplog rows; rollback uses operation_date.
+        create :measure, operation_date: taric_update.issue_date, filename: nil
       end
     end
   end

--- a/spec/integration/taric_synchronizer_spec.rb
+++ b/spec/integration/taric_synchronizer_spec.rb
@@ -95,13 +95,21 @@ RSpec.describe TaricSynchronizer do
       end
 
       context 'when successful run' do
+        let!(:measure_today) do
+          create :measure, operation_date: Time.zone.today, filename: nil
+        end
+        let!(:measure_older) do
+          create :measure, operation_date: 2.days.ago.to_date, filename: nil
+        end
+
         before do
           data_migrations
           described_class.rollback(Time.zone.yesterday, keep: true)
         end
 
-        it_with_refresh_materialized_view 'removes entries from oplog tables' do
-          expect(Measure).to be_none
+        it_with_refresh_materialized_view 'removes oplog rows with operation_date after the rollback date' do
+          expect(Measure::Operation.where(measure_sid: measure_today.measure_sid)).to be_none
+          expect(Measure::Operation.where(measure_sid: measure_older.measure_sid)).to be_present
         end
 
         it 'marks Taric updates as pending' do

--- a/spec/support/matchers/have_rolled_back.rb
+++ b/spec/support/matchers/have_rolled_back.rb
@@ -1,7 +1,14 @@
 RSpec::Matchers.define :have_rolled_back do |update|
   MaterializeViewHelper.refresh_materialized_view
   match do |_actual|
-    Measure.where(filename: update.filename).none? && update.reload
+    corresponding_measures = if update.is_a?(TariffSynchronizer::TaricUpdate)
+                               # TARIC does not stamp filename on oplog rows; match by operation_date.
+                               Measure.where(operation_date: update.issue_date)
+                             else
+                               Measure.where(filename: update.filename)
+                             end
+
+    corresponding_measures.none? && update.reload
   rescue Sequel::NoExistingObject
     true
   end


### PR DESCRIPTION
### Jira

[HMRC-2435](https://transformuk.atlassian.net/browse/HMRC-2435)

### What?

- [x] TARIC/XI rollback deletes oplog rows by `operation_date > date` (indexed)
- [x] CDS/UK still deletes by stamped `filename`

### Why?

HMRC-2029 unified rollback onto filename deletes. CDS stamps `filename`; TARIC never does, so XI rollback was a no-op. Restores pre-unify TARIC semantics in a single pass (same final state as the old day-by-day loop).

### Risk

**Risk level:** 🟢

**Reason for rating:** Targeted defect fix; CDS path unchanged; specs + restored-dump rollback/reapply validation.

### Verification

- Specs: TARIC + CDS rollback integration — 23 examples, 0 failures
- Restored dump (`current.sql`, `SERVICE=xi`): filename path removes **0** rows; `operation_date` clears the window; after matview refresh, reapply restores matching C/D counts and totals