### PR TITLE
HMRC-2435: Queue CDN invalidation immediately on clear cache

### DIFF
--- a/app/workers/clear_cache_worker.rb
+++ b/app/workers/clear_cache_worker.rb
@@ -18,9 +18,8 @@ class ClearCacheWorker
     Sidekiq::Client.enqueue(PrewarmCommoditiesWorker)
     Sidekiq::Client.enqueue(ReindexModelsWorker)
 
-    # NOTE: Make sure caches have been refreshed before invalidating the CDN
-    #       otherwise we serve up stale responses.
-    Sidekiq::Client.enqueue_in(1.minute, InvalidateCacheWorker)
+    # Queue CDN invalidation as part of clear cache (after local caches are flushed).
+    InvalidateCacheWorker.perform_async
   end
 
 private

--- a/spec/workers/clear_cache_worker_spec.rb
+++ b/spec/workers/clear_cache_worker_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ClearCacheWorker, type: :worker do
     allow(cache_store).to receive(:clear)
     allow(TradeTariffBackend.frontend_redis).to receive(:flushdb)
     allow(Sidekiq::Client).to receive(:enqueue)
-    allow(Sidekiq::Client).to receive(:enqueue_in)
+    allow(InvalidateCacheWorker).to receive(:perform_async)
     allow(ActiveSupport::Notifications).to receive(:instrument).and_call_original
     allow(ActiveSupport::Notifications).to receive(:instrument).with(
       TradeTariffBackend::TariffUpdateEventListener::TARIFF_CACHE_CLEARED,
@@ -81,7 +81,7 @@ RSpec.describe ClearCacheWorker, type: :worker do
   it { expect(Sidekiq::Client).to have_received(:enqueue).with(PrewarmQuotaOrderNumbersWorker) }
   it { expect(Sidekiq::Client).to have_received(:enqueue).with(PrewarmCommoditiesWorker) }
   it { expect(Sidekiq::Client).to have_received(:enqueue).with(ReindexModelsWorker) }
-  it { expect(Sidekiq::Client).to have_received(:enqueue_in).with(1.minute, InvalidateCacheWorker) }
+  it { expect(InvalidateCacheWorker).to have_received(:perform_async) }
 
   it 'instruments the tariff cache cleared event' do
     expect(ActiveSupport::Notifications).to have_received(:instrument).with(


### PR DESCRIPTION
### Jira link

[HMRC-2435](https://transformuk.atlassian.net/browse/HMRC-2435)

### What?

- [x] Enqueue `InvalidateCacheWorker` with `perform_async` from `ClearCacheWorker` instead of a 1 minute delay

### Why?

Apply & clear cache already flushes Rails and frontend Redis, then waited a minute before CloudFront invalidation. After the XI rollback/reapply repair, the matview was correct but the CDN could keep serving stale commodity API responses. Queue CDN invalidation as soon as local caches are cleared.

### Risk

**Risk level:** 🟢

**Reason for rating:** Small Sidekiq scheduling change only. Invalidation paths are unchanged; they just run immediately after clear instead of delayed.