### PR TITLE
Fix search analytics selection query request_source grouping

### DIFF
--- a/app/services/search_analytics/cloudwatch_snapshot_query.rb
+++ b/app/services/search_analytics/cloudwatch_snapshot_query.rb
@@ -165,9 +165,10 @@ module SearchAnalytics
         | fields if(ispresent(request_source), request_source, "unknown") as request_source
         | stats sum(result_selection_marker) as result_selections,
             sum(selectable_search_marker) as selectable_searches,
-            earliest(request_source) as request_source by request_id
+            earliest(request_source) as source by request_id
         | filter selectable_searches > 0
-        | stats sum(result_selections) as selected, sum(selectable_searches) as selectable by request_source
+        | stats sum(result_selections) as selected, sum(selectable_searches) as selectable by source
+        | fields selected, selectable, source as request_source
       QUERY
     end
 
@@ -175,11 +176,11 @@ module SearchAnalytics
       selection_queries.transform_values do |query|
         query
           .sub(
-            'earliest(request_source) as request_source by request_id',
-            'earliest(request_source) as request_source, max(@timestamp) as @t by request_id',
+            'earliest(request_source) as source by request_id',
+            'earliest(request_source) as source, max(@timestamp) as @t by request_id',
           )
           .sub(
-            '| stats sum(result_selections) as selected, sum(selectable_searches) as selectable by request_source',
+            "| stats sum(result_selections) as selected, sum(selectable_searches) as selectable by source\n| fields selected, selectable, source as request_source",
             "| stats sum(result_selections) as selected by datefloor(@t, #{bucket_period}) as @timestamp",
           )
       end

--- a/spec/services/search_analytics/cloudwatch_snapshot_query_spec.rb
+++ b/spec/services/search_analytics/cloudwatch_snapshot_query_spec.rb
@@ -113,14 +113,39 @@ RSpec.describe SearchAnalytics::CloudwatchSnapshotQuery do
     ).twice
     expect(client).to have_received(:start_query).with(
       hash_including(
-        query_string: a_string_including('earliest(request_source) as request_source'),
+        query_string: a_string_including('earliest(request_source) as source by request_id'),
       ),
-    ).exactly(4).times
+    ).exactly(2).times
+    expect(client).to have_received(:start_query).with(
+      hash_including(
+        query_string: a_string_including('earliest(request_source) as source, max(@timestamp) as @t by request_id'),
+      ),
+    ).twice
+    expect(client).to have_received(:start_query).with(
+      hash_including(
+        query_string: a_string_including('| stats sum(result_selections) as selected, sum(selectable_searches) as selectable by source'),
+      ),
+    ).twice
+    expect(client).to have_received(:start_query).with(
+      hash_including(
+        query_string: a_string_including('| fields selected, selectable, source as request_source'),
+      ),
+    ).twice
     expect(client).to have_received(:start_query).with(
       hash_including(
         query_string: a_string_including('datefloor(@t, 1h) as @timestamp'),
       ),
     ).twice
+    expect(client).not_to have_received(:start_query).with(
+      hash_including(
+        query_string: a_string_including('earliest(request_source) as request_source by request_id'),
+      ),
+    )
+    expect(client).not_to have_received(:start_query).with(
+      hash_including(
+        query_string: a_string_including('sum(selectable_searches) as selectable by request_source'),
+      ),
+    )
     expect(client).to have_received(:start_query).with(
       hash_including(
         query_string: a_string_matching(/stats pct\(total_duration_ms, 90\) as p90_latency_ms\s*$/),


### PR DESCRIPTION
## What:

- [x] Stop CloudWatch selection stats from regrouping by an aggregate alias named `request_source`
- [x] Alias the per-request source as `source`, then rename it back to `request_source` after the final stats
- [x] Keep selection trend query substitutions aligned with the new query shape
- [x] Cover the fixed query fragments in the snapshot query specs

## Why:

Search analytics snapshot refresh was failing with `MalformedQueryException: Unknown symbols found in or after stats: request_source`. CloudWatch Logs Insights rejects a second `stats ... by request_source` when `request_source` only exists as an aggregate output from `earliest(request_source) as request_source`. That broke selection-rate queries introduced with request-source classification.

## Ticket:

N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:** Narrow CloudWatch Insights query rewrite for admin search analytics only. No public API, tariff data, or sync path changes; covered by existing unit specs.