### PR TITLE
Fix search analytics post-stats fields rename

### DIFF
--- a/app/services/search_analytics/cloudwatch_snapshot_query.rb
+++ b/app/services/search_analytics/cloudwatch_snapshot_query.rb
@@ -168,7 +168,6 @@ module SearchAnalytics
             earliest(request_source) as source by request_id
         | filter selectable_searches > 0
         | stats sum(result_selections) as selected, sum(selectable_searches) as selectable by source
-        | fields selected, selectable, source as request_source
       QUERY
     end
 
@@ -180,7 +179,7 @@ module SearchAnalytics
             'earliest(request_source) as source, max(@timestamp) as @t by request_id',
           )
           .sub(
-            "| stats sum(result_selections) as selected, sum(selectable_searches) as selectable by source\n| fields selected, selectable, source as request_source",
+            '| stats sum(result_selections) as selected, sum(selectable_searches) as selectable by source',
             "| stats sum(result_selections) as selected by datefloor(@t, #{bucket_period}) as @timestamp",
           )
       end
@@ -457,7 +456,9 @@ module SearchAnalytics
         rows.select { |row| row_matches_view?(row, view) }
       end
 
-      def source_key(row) = row['request_source'].presence || 'unknown'
+      # Selection queries return `source` because CloudWatch rejects regrouping by
+      # an aggregate alias that reuses the original field name `request_source`.
+      def source_key(row) = row['request_source'].presence || row['source'].presence || 'unknown'
 
       def row_matches_view?(row, view) = VIEW_SEARCH_TYPES.fetch(view, [view]).include?(row_search_type(row))
 

--- a/spec/services/search_analytics/cloudwatch_snapshot_query_spec.rb
+++ b/spec/services/search_analytics/cloudwatch_snapshot_query_spec.rb
@@ -56,11 +56,11 @@ RSpec.describe SearchAnalytics::CloudwatchSnapshotQuery do
         result_row('search_type' => 'interactive', 'request_source' => 'frontend', 'p90_latency_ms' => '2100'),
       ),
       complete_response(
-        result_row('request_source' => 'frontend', 'selected' => '2', 'selectable' => '35'),
-        result_row('request_source' => 'backend_only', 'selected' => '1', 'selectable' => '7'),
+        result_row('source' => 'frontend', 'selected' => '2', 'selectable' => '35'),
+        result_row('source' => 'backend_only', 'selected' => '1', 'selectable' => '7'),
         result_row('selected' => '1', 'selectable' => '5'),
       ),
-      complete_response(result_row('request_source' => 'frontend', 'selected' => '2', 'selectable' => '8')),
+      complete_response(result_row('source' => 'frontend', 'selected' => '2', 'selectable' => '8')),
       complete_response(result_row('@timestamp' => '2026-06-10 09:00:00.000', 'selected' => '4')),
       complete_response(result_row('@timestamp' => '2026-06-10 09:00:00.000', 'selected' => '2')),
       complete_response(
@@ -126,11 +126,11 @@ RSpec.describe SearchAnalytics::CloudwatchSnapshotQuery do
         query_string: a_string_including('| stats sum(result_selections) as selected, sum(selectable_searches) as selectable by source'),
       ),
     ).twice
-    expect(client).to have_received(:start_query).with(
+    expect(client).not_to have_received(:start_query).with(
       hash_including(
         query_string: a_string_including('| fields selected, selectable, source as request_source'),
       ),
-    ).twice
+    )
     expect(client).to have_received(:start_query).with(
       hash_including(
         query_string: a_string_including('datefloor(@t, 1h) as @timestamp'),


### PR DESCRIPTION
## What:

- [x] Remove `| fields selected, selectable, source as request_source` from selection queries
- [x] Align trend query substitutions with the shortened selection query
- [x] Map CloudWatch `source` aggregate field in `source_key`
- [x] Spec selection rows using live field name `source`

## Why:

#3460 fixed regrouping by `request_source`, but left a final `fields` rename that CloudWatch rejects with `MalformedQueryException: Ephemeral field is already defined: selected`. That is the current main failure path for selection-rate snapshot queries.

## Ticket:

N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:** Admin search analytics CloudWatch query rewrite only. No public API or tariff data path changes. Validated against production log group before open.