### PR TITLE
AI-895: Add XI Combined Nomenclature ETL pipeline

### DIFF
--- a/app/controllers/api/admin/customs_tariff_updates/reimport_controller.rb
+++ b/app/controllers/api/admin/customs_tariff_updates/reimport_controller.rb
@@ -4,7 +4,8 @@ module Api
       class ReimportController < BaseController
         def create
           # No status guard — reimport is a recovery tool that must work on any update status
-          CustomsTariffReimportWorker.perform_async(customs_tariff_update.version)
+          worker = TradeTariffBackend.xi? ? XiCnReimportWorker : CustomsTariffReimportWorker
+          worker.perform_async(customs_tariff_update.version)
           head :accepted
         end
       end

--- a/app/engines/admin_api.rb
+++ b/app/engines/admin_api.rb
@@ -86,7 +86,7 @@ AdminApi.routes.draw do
       end
 
       get  'customs_tariff_updates',          to: 'customs_tariff_updates#index'
-      get  'customs_tariff_updates/:version', to: 'customs_tariff_updates#show', constraints: { version: /\d+\.\d+/ }
+      get  'customs_tariff_updates/:version', to: 'customs_tariff_updates#show', constraints: { version: /[^\/]+/ }
       get  'customs_tariff_updates/:customs_tariff_update_version/section_notes',      to: 'customs_tariff_updates/section_notes#index',  constraints: { customs_tariff_update_version: /[^\/]+/ }
       get  'customs_tariff_updates/:customs_tariff_update_version/section_notes/:id',  to: 'customs_tariff_updates/section_notes#show',   constraints: { customs_tariff_update_version: /[^\/]+/ }
       patch 'customs_tariff_updates/:customs_tariff_update_version/section_notes/:id', to: 'customs_tariff_updates/section_notes#update', constraints: { customs_tariff_update_version: /[^\/]+/ }

--- a/app/lib/customs_tariff_importer/importer.rb
+++ b/app/lib/customs_tariff_importer/importer.rb
@@ -1,6 +1,6 @@
 module CustomsTariffImporter
   class Importer
-    S3_KEY_PREFIX = 'data/customs_tariff_documents'.freeze
+    S3_KEY_PREFIX = 'data/customs_tariff_documents/uk'.freeze
 
     Result = Data.define(:status, :version, :error) do
       def initialize(status:, version: nil, error: nil)

--- a/app/lib/xi_cn_importer/document_fetcher.rb
+++ b/app/lib/xi_cn_importer/document_fetcher.rb
@@ -1,0 +1,123 @@
+require 'digest'
+require 'json'
+require 'net/http'
+
+module XiCnImporter
+  class DocumentFetcher
+    SPARQL_ENDPOINT      = 'https://publications.europa.eu/webapi/rdf/sparql'.freeze
+    CELLAR_HTML_TEMPLATE = 'http://publications.europa.eu/resource/cellar/%s.0006.03/DOC_1'.freeze
+    CELLAR_PDF_TEMPLATE  = 'http://publications.europa.eu/resource/cellar/%s.0006.01/DOC_1'.freeze
+    MAX_REDIRECTS = 5
+
+    SPARQL_QUERY = <<~SPARQL.freeze
+      PREFIX cdm: <http://publications.europa.eu/ontology/cdm#>
+      PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+      SELECT DISTINCT ?work ?celex ?force_date ?pub_date
+      WHERE {
+        ?work cdm:resource_legal_amends_resource_legal
+              <http://publications.europa.eu/resource/cellar/c5a368fa-fd18-4efb-ae18-e4ac4e83055c> .
+        ?work cdm:resource_legal_id_celex ?celex .
+        ?work cdm:resource_legal_date_entry-into-force ?force_date .
+        OPTIONAL { ?work cdm:resource_legal_date_document ?pub_date . }
+        FILTER(MONTH(?force_date) = 1 && DAY(?force_date) = 1)
+        FILTER(?force_date >= "2024-01-01"^^xsd:date)
+      }
+      ORDER BY DESC(?force_date)
+    SPARQL
+
+    Result = Data.define(
+      :celex,
+      :force_date,
+      :publication_date,
+      :cellar_url,
+      :html_content,
+      :pdf_content,
+      :pdf_checksum,
+    )
+
+    def call
+      bindings = sparql_results
+
+      bindings.filter_map do |binding|
+        celex      = binding.dig('celex', 'value')
+        work_uri   = binding.dig('work', 'value')
+        force_date = Date.parse(binding.dig('force_date', 'value'))
+        pub_date   = binding.dig('pub_date', 'value')&.then { |d| Date.parse(d) }
+
+        next if CustomsTariffUpdate
+                  .exclude(status: CustomsTariffUpdate::FAILED)
+                  .where(version: celex)
+                  .any?
+
+        guid        = work_uri.split('/').last
+        cellar_url  = sprintf(CELLAR_HTML_TEMPLATE, guid)
+        pdf_url     = sprintf(CELLAR_PDF_TEMPLATE, guid)
+
+        start_time   = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        html_content = fetch_html(cellar_url)
+        pdf_content  = fetch_binary(pdf_url)
+        duration_ms  = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000).round(2)
+
+        Instrumentation.document_fetched(celex:, duration_ms:)
+
+        Result.new(
+          celex:,
+          force_date:,
+          publication_date: pub_date,
+          cellar_url:,
+          html_content:,
+          pdf_content:,
+          pdf_checksum: Digest::SHA256.hexdigest(pdf_content),
+        )
+      end
+    rescue StandardError => e
+      Instrumentation.fetch_failed(
+        url: SPARQL_ENDPOINT,
+        error_class: e.class.name,
+        error_message: e.message,
+      )
+      raise
+    end
+
+    private
+
+    def sparql_results
+      uri      = URI(SPARQL_ENDPOINT)
+      response = Net::HTTP.post_form(uri, 'query' => SPARQL_QUERY, 'format' => 'application/sparql-results+json')
+      raise "SPARQL request failed: HTTP #{response.code}" unless response.is_a?(Net::HTTPSuccess)
+
+      JSON.parse(response.body).dig('results', 'bindings') || []
+    end
+
+    def fetch_html(url, redirect_count: 0)
+      raise "Too many redirects fetching #{url}" if redirect_count > MAX_REDIRECTS
+
+      uri      = URI(url)
+      response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
+        http.get(uri.request_uri, 'Accept' => 'application/xhtml+xml')
+      end
+
+      case response
+      when Net::HTTPSuccess     then response.body
+      when Net::HTTPRedirection then fetch_html(response['location'], redirect_count: redirect_count + 1)
+      else raise "Failed to fetch #{url}: HTTP #{response.code}"
+      end
+    end
+
+    def fetch_binary(url, redirect_count: 0)
+      raise "Too many redirects fetching #{url}" if redirect_count > MAX_REDIRECTS
+
+      uri      = URI(url)
+      response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
+        http.get(uri.request_uri)
+      end
+
+      case response
+      when Net::HTTPSuccess     then response.body
+      when Net::HTTPRedirection then fetch_binary(response['location'], redirect_count: redirect_count + 1)
+      else raise "Failed to fetch #{url}: HTTP #{response.code}"
+      end
+    end
+  end
+end

--- a/app/lib/xi_cn_importer/document_fetcher.rb
+++ b/app/lib/xi_cn_importer/document_fetcher.rb
@@ -99,9 +99,13 @@ module XiCnImporter
       end
 
       case response
-      when Net::HTTPSuccess     then response.body
-      when Net::HTTPRedirection then fetch_html(response['location'], redirect_count: redirect_count + 1)
-      else raise "Failed to fetch #{url}: HTTP #{response.code}"
+      when Net::HTTPSuccess
+        response.body
+      when Net::HTTPRedirection
+        location = response['location']
+        fetch_html(URI.join(url, location).to_s, redirect_count: redirect_count + 1)
+      else
+        raise "Failed to fetch #{url}: HTTP #{response.code}"
       end
     end
 
@@ -114,9 +118,13 @@ module XiCnImporter
       end
 
       case response
-      when Net::HTTPSuccess     then response.body
-      when Net::HTTPRedirection then fetch_binary(response['location'], redirect_count: redirect_count + 1)
-      else raise "Failed to fetch #{url}: HTTP #{response.code}"
+      when Net::HTTPSuccess
+        response.body
+      when Net::HTTPRedirection
+        location = response['location']
+        fetch_binary(URI.join(url, location).to_s, redirect_count: redirect_count + 1)
+      else
+        raise "Failed to fetch #{url}: HTTP #{response.code}"
       end
     end
   end

--- a/app/lib/xi_cn_importer/document_fetcher.rb
+++ b/app/lib/xi_cn_importer/document_fetcher.rb
@@ -5,9 +5,11 @@ require 'net/http'
 module XiCnImporter
   class DocumentFetcher
     SPARQL_ENDPOINT      = 'https://publications.europa.eu/webapi/rdf/sparql'.freeze
-    CELLAR_HTML_TEMPLATE = 'http://publications.europa.eu/resource/cellar/%s.0006.03/DOC_1'.freeze
-    CELLAR_PDF_TEMPLATE  = 'http://publications.europa.eu/resource/cellar/%s.0006.01/DOC_1'.freeze
+    CELLAR_HTML_TEMPLATE = 'https://publications.europa.eu/resource/cellar/%s.0006.03/DOC_1'.freeze
+    CELLAR_PDF_TEMPLATE  = 'https://publications.europa.eu/resource/cellar/%s.0006.01/DOC_1'.freeze
     MAX_REDIRECTS = 5
+    OPEN_TIMEOUT  = 10
+    READ_TIMEOUT  = 30
 
     SPARQL_QUERY = <<~SPARQL.freeze
       PREFIX cdm: <http://publications.europa.eu/ontology/cdm#>
@@ -94,7 +96,7 @@ module XiCnImporter
       raise "Too many redirects fetching #{url}" if redirect_count > MAX_REDIRECTS
 
       uri      = URI(url)
-      response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
+      response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https', open_timeout: OPEN_TIMEOUT, read_timeout: READ_TIMEOUT) do |http|
         http.get(uri.request_uri, 'Accept' => 'application/xhtml+xml')
       end
 
@@ -113,7 +115,7 @@ module XiCnImporter
       raise "Too many redirects fetching #{url}" if redirect_count > MAX_REDIRECTS
 
       uri      = URI(url)
-      response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
+      response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https', open_timeout: OPEN_TIMEOUT, read_timeout: READ_TIMEOUT) do |http|
         http.get(uri.request_uri)
       end
 

--- a/app/lib/xi_cn_importer/document_fetcher.rb
+++ b/app/lib/xi_cn_importer/document_fetcher.rb
@@ -84,13 +84,22 @@ module XiCnImporter
 
     private
 
-    def sparql_results
-      uri      = URI(SPARQL_ENDPOINT)
-      response = Net::HTTP.post_form(uri, 'query' => SPARQL_QUERY, 'format' => 'application/sparql-results+json')
-      raise "SPARQL request failed: HTTP #{response.code}" unless response.is_a?(Net::HTTPSuccess)
+def sparql_results
+  uri = URI(SPARQL_ENDPOINT)
 
-      JSON.parse(response.body).dig('results', 'bindings') || []
-    end
+  response = Net::HTTP.start(uri.host, uri.port,
+                             use_ssl: uri.scheme == 'https',
+                             open_timeout: OPEN_TIMEOUT,
+                             read_timeout: READ_TIMEOUT) do |http|
+    request = Net::HTTP::Post.new(uri.request_uri)
+    request.set_form_data('query' => SPARQL_QUERY, 'format' => 'application/sparql-results+json')
+    http.request(request)
+  end
+
+  raise "SPARQL request failed: HTTP #{response.code}" unless response.is_a?(Net::HTTPSuccess)
+
+  JSON.parse(response.body).dig('results', 'bindings') || []
+end
 
     def fetch_html(url, redirect_count: 0)
       raise "Too many redirects fetching #{url}" if redirect_count > MAX_REDIRECTS

--- a/app/lib/xi_cn_importer/document_fetcher.rb
+++ b/app/lib/xi_cn_importer/document_fetcher.rb
@@ -84,22 +84,22 @@ module XiCnImporter
 
     private
 
-def sparql_results
-  uri = URI(SPARQL_ENDPOINT)
+    def sparql_results
+      uri = URI(SPARQL_ENDPOINT)
 
-  response = Net::HTTP.start(uri.host, uri.port,
-                             use_ssl: uri.scheme == 'https',
-                             open_timeout: OPEN_TIMEOUT,
-                             read_timeout: READ_TIMEOUT) do |http|
-    request = Net::HTTP::Post.new(uri.request_uri)
-    request.set_form_data('query' => SPARQL_QUERY, 'format' => 'application/sparql-results+json')
-    http.request(request)
-  end
+      response = Net::HTTP.start(uri.host, uri.port,
+                                 use_ssl: uri.scheme == 'https',
+                                 open_timeout: OPEN_TIMEOUT,
+                                 read_timeout: READ_TIMEOUT) do |http|
+        request = Net::HTTP::Post.new(uri.request_uri)
+        request.set_form_data('query' => SPARQL_QUERY, 'format' => 'application/sparql-results+json')
+        http.request(request)
+      end
 
-  raise "SPARQL request failed: HTTP #{response.code}" unless response.is_a?(Net::HTTPSuccess)
+      raise "SPARQL request failed: HTTP #{response.code}" unless response.is_a?(Net::HTTPSuccess)
 
-  JSON.parse(response.body).dig('results', 'bindings') || []
-end
+      JSON.parse(response.body).dig('results', 'bindings') || []
+    end
 
     def fetch_html(url, redirect_count: 0)
       raise "Too many redirects fetching #{url}" if redirect_count > MAX_REDIRECTS

--- a/app/lib/xi_cn_importer/importer.rb
+++ b/app/lib/xi_cn_importer/importer.rb
@@ -18,8 +18,10 @@ module XiCnImporter
     private
 
     def import_document(fetched)
-      s3_path = "#{S3_KEY_PREFIX}/CN_#{fetched.celex}.pdf"
+      s3_path      = "#{S3_KEY_PREFIX}/CN_#{fetched.celex}.pdf"
+      html_s3_path = "#{S3_KEY_PREFIX}/CN_#{fetched.celex}.xhtml"
       TariffSynchronizer::FileService.write_file(s3_path, fetched.pdf_content)
+      TariffSynchronizer::FileService.write_file(html_s3_path, fetched.html_content)
 
       extracted = NotesExtractor.new(fetched.celex, fetched.html_content).call
 

--- a/app/lib/xi_cn_importer/importer.rb
+++ b/app/lib/xi_cn_importer/importer.rb
@@ -1,0 +1,101 @@
+# Importer for the XI Combined Nomenclature (CN) — the EU tariff schedule
+# published annually in the Official Journal and served via the EU Cellar CDN.
+module XiCnImporter
+  class Importer
+    S3_KEY_PREFIX = 'data/customs_tariff_documents/xi'.freeze
+
+    Result = Data.define(:status, :celex, :error) do
+      def initialize(status:, celex: nil, error: nil)
+        super
+      end
+    end
+
+    def call
+      documents = DocumentFetcher.new.call
+      documents.map { |doc| import_document(doc) }
+    end
+
+    private
+
+    def import_document(fetched)
+      s3_path = "#{S3_KEY_PREFIX}/CN_#{fetched.celex}.pdf"
+      TariffSynchronizer::FileService.write_file(s3_path, fetched.pdf_content)
+
+      extracted = NotesExtractor.new(fetched.celex, fetched.html_content).call
+
+      start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+      CustomsTariffUpdate.db.transaction do
+        CustomsTariffUpdate.failed.where(version: fetched.celex).delete
+
+        update = CustomsTariffUpdate.create(
+          version: fetched.celex,
+          validity_start_date: fetched.force_date,
+          status: CustomsTariffUpdate::PENDING,
+          source_url: fetched.cellar_url,
+          s3_path:,
+          file_checksum: fetched.pdf_checksum,
+          document_created_on: fetched.publication_date,
+        )
+
+        extracted.sections.each do |section_id, content|
+          CustomsTariffSectionNote.create(
+            customs_tariff_update_version: update.version,
+            section_id:,
+            content:,
+            validity_start_date: update.validity_start_date,
+            status: CustomsTariffSectionNote::PENDING,
+          )
+        end
+
+        extracted.chapters.each do |chapter_id, content|
+          CustomsTariffChapterNote.create(
+            customs_tariff_update_version: update.version,
+            chapter_id:,
+            content:,
+            validity_start_date: update.validity_start_date,
+            status: CustomsTariffChapterNote::PENDING,
+          )
+        end
+
+        extracted.general_rules.each do |rule_label, content|
+          CustomsTariffGeneralRule.create(
+            customs_tariff_update_version: update.version,
+            rule_label:,
+            content:,
+            validity_start_date: update.validity_start_date,
+            status: CustomsTariffGeneralRule::PENDING,
+          )
+        end
+      end
+
+      duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000).round(2)
+      Instrumentation.document_imported(celex: fetched.celex, duration_ms:)
+
+      Result.new(status: :imported, celex: fetched.celex)
+    rescue StandardError => e
+      Instrumentation.document_import_failed(
+        celex: fetched&.celex,
+        error_class: e.class.name,
+        error_message: e.message,
+      )
+      record_failure(fetched&.celex, e.message)
+      Result.new(status: :failed, celex: fetched&.celex, error: e.message)
+    end
+
+    def record_failure(celex, message)
+      return if celex.blank?
+      return if CustomsTariffUpdate.exclude(status: CustomsTariffUpdate::FAILED).where(version: celex).any?
+
+      CustomsTariffUpdate.where(version: celex, status: CustomsTariffUpdate::FAILED).delete
+      CustomsTariffUpdate.create(
+        version: celex,
+        validity_start_date: Time.zone.today,
+        status: CustomsTariffUpdate::FAILED,
+        import_error: message,
+      )
+    rescue StandardError => e
+      Rails.logger.error "Failed to record XI import failure: #{e.message}"
+    end
+  end
+end

--- a/app/lib/xi_cn_importer/instrumentation.rb
+++ b/app/lib/xi_cn_importer/instrumentation.rb
@@ -1,0 +1,45 @@
+module XiCnImporter
+  module Instrumentation
+    NAMESPACE = 'xi_cn_importer'.freeze
+
+    extend self
+
+    def import_run_started
+      instrument('import_run_started')
+    end
+
+    def import_run_completed(imported:, skipped:, failed:, duration_ms:, review_backlog:)
+      instrument('import_run_completed', imported:, skipped:, failed:, duration_ms:, review_backlog:)
+    end
+
+    def import_run_failed(error_class:, error_message:)
+      instrument('import_run_failed', error_class:, error_message:)
+    end
+
+    def document_fetched(celex:, duration_ms:)
+      instrument('document_fetched', celex:, duration_ms:)
+    end
+
+    def fetch_failed(url:, error_class:, error_message:)
+      instrument('fetch_failed', url:, error_class:, error_message:)
+    end
+
+    def document_skipped(celex:, reason:)
+      instrument('document_skipped', celex:, reason:)
+    end
+
+    def document_imported(celex:, duration_ms:)
+      instrument('document_imported', celex:, duration_ms:)
+    end
+
+    def document_import_failed(celex:, error_class:, error_message:)
+      instrument('document_import_failed', celex:, error_class:, error_message:)
+    end
+
+    private
+
+    def instrument(event, payload = {})
+      ActiveSupport::Notifications.instrument("#{event}.#{NAMESPACE}", payload)
+    end
+  end
+end

--- a/app/lib/xi_cn_importer/instrumentation.rb
+++ b/app/lib/xi_cn_importer/instrumentation.rb
@@ -8,8 +8,8 @@ module XiCnImporter
       instrument('import_run_started')
     end
 
-    def import_run_completed(imported:, skipped:, failed:, duration_ms:, review_backlog:)
-      instrument('import_run_completed', imported:, skipped:, failed:, duration_ms:, review_backlog:)
+    def import_run_completed(imported:, failed:, duration_ms:, review_backlog:)
+      instrument('import_run_completed', imported:, failed:, duration_ms:, review_backlog:)
     end
 
     def import_run_failed(error_class:, error_message:)
@@ -24,16 +24,16 @@ module XiCnImporter
       instrument('fetch_failed', url:, error_class:, error_message:)
     end
 
-    def document_skipped(celex:, reason:)
-      instrument('document_skipped', celex:, reason:)
-    end
-
     def document_imported(celex:, duration_ms:)
       instrument('document_imported', celex:, duration_ms:)
     end
 
     def document_import_failed(celex:, error_class:, error_message:)
       instrument('document_import_failed', celex:, error_class:, error_message:)
+    end
+
+    def reimport_failed(version:, error_class:, error_message:)
+      instrument('reimport_failed', version:, error_class:, error_message:)
     end
 
     private

--- a/app/lib/xi_cn_importer/logger.rb
+++ b/app/lib/xi_cn_importer/logger.rb
@@ -1,0 +1,10 @@
+module XiCnImporter
+  module Logger
+    module_function
+
+    def log(level, message, **context)
+      formatted = context.map { |k, v| "#{k}=#{v}" }.join(' ')
+      Rails.logger.public_send(level, "[XiCnImporter] #{message} #{formatted}".strip)
+    end
+  end
+end

--- a/app/lib/xi_cn_importer/logger.rb
+++ b/app/lib/xi_cn_importer/logger.rb
@@ -1,10 +1,78 @@
-module XiCnImporter
-  module Logger
-    module_function
+require 'active_support/log_subscriber'
 
-    def log(level, message, **context)
-      formatted = context.map { |k, v| "#{k}=#{v}" }.join(' ')
-      Rails.logger.public_send(level, "[XiCnImporter] #{message} #{formatted}".strip)
+module XiCnImporter
+  class Logger < ActiveSupport::LogSubscriber
+    def import_run_started(_event)
+      info log_entry(event: 'import_run_started')
+    end
+
+    def import_run_completed(event)
+      info log_entry(
+        event: 'import_run_completed',
+        imported: event.payload[:imported],
+        failed: event.payload[:failed],
+        duration_ms: event.payload[:duration_ms],
+        review_backlog: event.payload[:review_backlog],
+      )
+    end
+
+    def import_run_failed(event)
+      error log_entry(
+        event: 'import_run_failed',
+        error_class: event.payload[:error_class],
+        error_message: event.payload[:error_message],
+      )
+    end
+
+    def document_fetched(event)
+      info log_entry(
+        event: 'document_fetched',
+        celex: event.payload[:celex],
+        duration_ms: event.payload[:duration_ms],
+      )
+    end
+
+    def fetch_failed(event)
+      error log_entry(
+        event: 'fetch_failed',
+        url: event.payload[:url],
+        error_class: event.payload[:error_class],
+        error_message: event.payload[:error_message],
+      )
+    end
+
+    def document_imported(event)
+      info log_entry(
+        event: 'document_imported',
+        celex: event.payload[:celex],
+        duration_ms: event.payload[:duration_ms],
+      )
+    end
+
+    def document_import_failed(event)
+      error log_entry(
+        event: 'document_import_failed',
+        celex: event.payload[:celex],
+        error_class: event.payload[:error_class],
+        error_message: event.payload[:error_message],
+      )
+    end
+
+    def reimport_failed(event)
+      error log_entry(
+        event: 'reimport_failed',
+        version: event.payload[:version],
+        error_class: event.payload[:error_class],
+        error_message: event.payload[:error_message],
+      )
+    end
+
+    private
+
+    def log_entry(data)
+      data.merge(service: 'xi_cn_importer', timestamp: Time.current.iso8601).to_json
     end
   end
 end
+
+XiCnImporter::Logger.attach_to :xi_cn_importer unless Rails.env.test?

--- a/app/lib/xi_cn_importer/notes_extractor.rb
+++ b/app/lib/xi_cn_importer/notes_extractor.rb
@@ -1,0 +1,402 @@
+module XiCnImporter
+  class NotesExtractor
+    Result = Data.define(:chapters, :sections, :general_rules)
+
+    PART_ONE_PATTERN              = /\APART\s+ONE\z/i
+    SCHEDULE_PATTERN              = /SCHEDULE\s+OF\s+CUSTOMS\s+DUTIES/i
+    SECTION_HEADING_PATTERN       = /\ASECTION\s+([IVXLCDM]+)\z/i
+    CHAPTER_HEADING_PATTERN       = /\ACHAPTER\s+(\d+)\z/i
+    ADDITIONAL_NOTES_PATTERN      = /\AAdditional\s+[Nn]otes?\z/i
+    SUBHEADING_NOTES_PATTERN      = /\ASubheading\s+[Nn]otes?\z/i
+    COMMODITY_TABLE_CLASS         = 'oj-table'.freeze
+
+    def initialize(celex, html_content)
+      @celex = celex
+      @doc   = Nokogiri::XML(html_content)
+    end
+
+    def call
+      @chapters      = {}
+      @sections      = {}
+      @general_rules = {}
+      @state         = :scanning
+
+      @current_section     = nil
+      @current_chapter     = nil
+      @section_lines       = []
+      @chapter_lines       = []
+      @additional_lines    = []
+      @collecting_additional = false
+
+      body_nodes.each { |node| handle_node(node) }
+
+      finalise_section
+      finalise_chapter
+
+      Result.new(chapters: @chapters, sections: @sections, general_rules: @general_rules)
+    end
+
+    private
+
+    # --- Node dispatch ---
+
+    def body_nodes
+      body = @doc.xpath('//*[local-name()="body"]').first
+      return [] unless body
+
+      collect_content_nodes(body)
+    end
+
+    def collect_content_nodes(node)
+      result = []
+      node.children.select(&:element?).each do |child|
+        case child.name
+        when 'p', 'table'
+          result << child
+        else
+          result.concat(collect_content_nodes(child))
+        end
+      end
+      result
+    end
+
+    def handle_node(node)
+      case @state
+      when :scanning           then handle_scanning(node)
+      when :in_gri             then handle_in_gri(node)
+      when :in_part_two        then handle_in_part_two(node)
+      when :in_section         then handle_in_section(node)
+      when :collecting_section then handle_collecting_section(node)
+      when :in_chapter         then handle_in_chapter(node)
+      when :collecting_chapter then handle_collecting_chapter(node)
+      when :skipping           then handle_skipping(node)
+      end
+    end
+
+    # --- State handlers ---
+
+    def handle_scanning(node)
+      text = grseq_heading(node)
+      @state = :in_gri if text&.match?(PART_ONE_PATTERN)
+    end
+
+    def handle_in_gri(node)
+      text = grseq_heading(node)
+      if text&.match?(SCHEDULE_PATTERN)
+        @state = :in_part_two
+        return
+      end
+
+      extract_gri_rows(node) if note_table?(node)
+    end
+
+    def handle_in_part_two(node)
+      text = grseq_heading(node)
+      return unless text
+
+      if (m = text.match(SECTION_HEADING_PATTERN))
+        @current_section = RomanNumerals::Converter.to_decimal(m[1].upcase)
+        @section_lines   = []
+        @state           = :in_section
+      end
+    end
+
+    def handle_in_section(node)
+      text = grseq_heading(node)
+
+      if (m = text&.match(SECTION_HEADING_PATTERN))
+        finalise_section
+        @current_section = RomanNumerals::Converter.to_decimal(m[1].upcase)
+        @section_lines   = []
+        return
+      end
+
+      if (m = text&.match(CHAPTER_HEADING_PATTERN))
+        finalise_section
+        @current_chapter      = sprintf('%02d', m[1].to_i)
+        @chapter_lines        = []
+        @additional_lines     = []
+        @collecting_additional = false
+        @state = :in_chapter
+        return
+      end
+
+      if annotation_header?(node)
+        @section_lines << '### Subheading notes' if subheading_notes_header?(node)
+        @state = :collecting_section
+      end
+    end
+
+    def handle_collecting_section(node)
+      text = grseq_heading(node)
+
+      if (m = text&.match(SECTION_HEADING_PATTERN))
+        finalise_section
+        @current_section = RomanNumerals::Converter.to_decimal(m[1].upcase)
+        @section_lines   = []
+        @state           = :in_section
+        return
+      end
+
+      if (m = text&.match(CHAPTER_HEADING_PATTERN))
+        finalise_section
+        @current_chapter      = sprintf('%02d', m[1].to_i)
+        @chapter_lines        = []
+        @additional_lines     = []
+        @collecting_additional = false
+        @state = :in_chapter
+        return
+      end
+
+      if annotation_header?(node)
+        @section_lines << '### Additional Notes' if additional_notes_header?(node)
+        @section_lines << '### Subheading notes' if subheading_notes_header?(node)
+        return
+      end
+
+      @section_lines << extract_table_content(node) if note_table?(node)
+    end
+
+    def handle_in_chapter(node)
+      text = grseq_heading(node)
+
+      if (m = text&.match(SECTION_HEADING_PATTERN))
+        finalise_chapter
+        @current_section = RomanNumerals::Converter.to_decimal(m[1].upcase)
+        @section_lines   = []
+        @state           = :in_section
+        return
+      end
+
+      if (m = text&.match(CHAPTER_HEADING_PATTERN))
+        finalise_chapter
+        @current_chapter      = sprintf('%02d', m[1].to_i)
+        @chapter_lines        = []
+        @additional_lines     = []
+        @collecting_additional = false
+        return
+      end
+
+      if annotation_header?(node)
+        @collecting_additional = additional_notes_header?(node)
+        @chapter_lines << '### Subheading notes' if subheading_notes_header?(node)
+        @state = :collecting_chapter
+      end
+    end
+
+    def handle_collecting_chapter(node)
+      if commodity_table?(node)
+        finalise_chapter
+        @state = :skipping
+        return
+      end
+
+      text = grseq_heading(node)
+
+      if (m = text&.match(SECTION_HEADING_PATTERN))
+        finalise_chapter
+        @current_section = RomanNumerals::Converter.to_decimal(m[1].upcase)
+        @section_lines   = []
+        @state           = :in_section
+        return
+      end
+
+      if (m = text&.match(CHAPTER_HEADING_PATTERN))
+        finalise_chapter
+        @current_chapter      = sprintf('%02d', m[1].to_i)
+        @chapter_lines        = []
+        @additional_lines     = []
+        @collecting_additional = false
+        @state = :in_chapter
+        return
+      end
+
+      if annotation_header?(node)
+        @collecting_additional = additional_notes_header?(node)
+        @chapter_lines << '### Subheading notes' if subheading_notes_header?(node)
+        return
+      end
+
+      return unless note_table?(node)
+
+      content = extract_table_content(node)
+      if @collecting_additional
+        @additional_lines << content
+      else
+        @chapter_lines << content
+      end
+    end
+
+    def handle_skipping(node)
+      text = grseq_heading(node)
+
+      if (m = text&.match(CHAPTER_HEADING_PATTERN))
+        @current_chapter      = sprintf('%02d', m[1].to_i)
+        @chapter_lines        = []
+        @additional_lines     = []
+        @collecting_additional = false
+        @state = :in_chapter
+      elsif (m = text&.match(SECTION_HEADING_PATTERN))
+        finalise_section
+        @current_section = RomanNumerals::Converter.to_decimal(m[1].upcase)
+        @section_lines   = []
+        @state           = :in_section
+      end
+    end
+
+    # --- Finalise ---
+
+    def finalise_section
+      return unless @current_section
+
+      content = Formatter.new.call(@section_lines.reject(&:empty?).join("\n\n"))
+      @sections[@current_section] = content if content.present?
+      @current_section = nil
+      @section_lines   = []
+    end
+
+    def finalise_chapter
+      return unless @current_chapter
+
+      parts = [@chapter_lines.reject(&:empty?).join("\n\n")]
+      if @additional_lines.any?
+        parts << '### Additional Notes'
+        parts << @additional_lines.reject(&:empty?).join("\n\n")
+      end
+
+      content = Formatter.new.call(parts.reject(&:empty?).join("\n\n"))
+      @chapters[@current_chapter] = content if content.present?
+      @current_chapter      = nil
+      @chapter_lines        = []
+      @additional_lines     = []
+      @collecting_additional = false
+    end
+
+    # --- Content extraction ---
+
+    def extract_gri_rows(table)
+      rows_of(table).each do |row|
+        cells = element_children(row, 'td')
+        next if cells.length < 2
+
+        label    = cells[0].text.strip
+        rule_num = label.chomp('.').strip
+        next unless rule_num.match?(/\A\d+\z/)
+
+        content = cells[1].text.strip
+        @general_rules[rule_num] = content
+      end
+    end
+
+    def extract_table_content(table, depth: 0)
+      lines = []
+      indent = '    ' * depth
+
+      rows_of(table).each do |row|
+        cells = element_children(row, 'td')
+        next if cells.length < 2
+
+        label   = cells[0].text.strip
+        content = extract_cell_content(cells[1], depth:)
+        next if label.empty? && content.empty?
+
+        # When a parenthetical label like "(h)" has a sub-table as its only content (no
+        # intro <p> text), the sub-table produces leading spaces. Concatenating inline
+        # gives "(h)     1. item", which collapse_internal_spaces then flattens to
+        # "(h) 1. item". Emit them as separate blocks instead so the formatter can place
+        # "(h)" on its own line and number the sub-items at 6 spaces.
+        if label.match?(/\A\([a-z]+\)\z/) && content.start_with?(' ')
+          lines << "#{indent}#{label}".rstrip
+          lines << content
+        else
+          lines << "#{indent}#{label} #{content}".rstrip
+        end
+      end
+
+      lines.join("\n\n")
+    end
+
+    def extract_cell_content(cell, depth:)
+      parts = []
+
+      cell.children.select(&:element?).each do |child|
+        if child.name == 'table'
+          if Formatter::TableFormatter.content_table?(child)
+            markdown = table_formatter.call(child, node_text_fn: method(:paragraph_text_without_footnotes))
+            parts << markdown if markdown.present?
+          else
+            nested = extract_table_content(child, depth: depth + 1)
+            parts << nested if nested.present?
+          end
+        elsif child.name == 'p'
+          text = paragraph_text_without_footnotes(child)
+          parts << text if text.present?
+        elsif child.children.any? { |c| c.element? && c.name == 'table' }
+          # Structural wrapper containing sub-tables (e.g. <span> wrapping (A)/(B) sub-tables
+          # in Ch11 note 2) — recurse transparently at the same depth.
+          nested = extract_cell_content(child, depth:)
+          parts << nested if nested.present?
+        else
+          # Inline text container — may have italic/bold element children but no tables.
+          # Extract all descendant text (including from inline children) via XPath.
+          # Covers: text-only <span>, <span> with <span class="oj-italic"> for species names, etc.
+          text = paragraph_text_without_footnotes(child)
+          parts << text if text.present?
+        end
+      end
+
+      parts.join("\n\n")
+    end
+
+    def table_formatter
+      @table_formatter ||= Formatter::TableFormatter.new
+    end
+
+    # EU OJ XHTML encodes footnote back-references as <a href="#ntr..."> links,
+    # e.g. ...(EU) 2018/150 <a href="#ntr190-...">(<span class="oj-super oj-note-tag">190</span>)</a>.
+    # The href prefix "#ntr" (note-to-reference) is the EU OJ convention.
+    # Plain parenthetical numbers in prose (e.g. "(28) of chromosomes") are bare
+    # text with no such <a> ancestor and are preserved.
+    def paragraph_text_without_footnotes(node)
+      node.xpath('.//text()[not(ancestor::*[local-name()="a" and starts-with(@href, "#ntr")])]').map(&:text).join.gsub(/[\s ]+/, ' ').strip
+    end
+
+    def rows_of(table)
+      tbody = table.children.find { |n| n.element? && n.name == 'tbody' } || table
+      tbody.children.select { |n| n.element? && n.name == 'tr' }
+    end
+
+    def element_children(node, tag)
+      node.children.select { |n| n.element? && n.name == tag }
+    end
+
+    # --- Node predicates ---
+
+    def grseq_heading(node)
+      return unless node.name == 'p'
+      return unless node['class']&.split&.include?('oj-ti-grseq-1')
+
+      node.text.tr(' ', ' ').strip
+    end
+
+    def annotation_header?(node)
+      node.name == 'p' && node['class']&.split&.include?('oj-ti-annotation')
+    end
+
+    def additional_notes_header?(node)
+      paragraph_text_without_footnotes(node).match?(ADDITIONAL_NOTES_PATTERN)
+    end
+
+    def subheading_notes_header?(node)
+      paragraph_text_without_footnotes(node).match?(SUBHEADING_NOTES_PATTERN)
+    end
+
+    def commodity_table?(node)
+      node.name == 'table' && node['class']&.split&.include?(COMMODITY_TABLE_CLASS)
+    end
+
+    def note_table?(node)
+      node.name == 'table' && !commodity_table?(node)
+    end
+  end
+end

--- a/app/lib/xi_cn_importer/notes_extractor/formatter.rb
+++ b/app/lib/xi_cn_importer/notes_extractor/formatter.rb
@@ -1,0 +1,458 @@
+module XiCnImporter
+  class NotesExtractor
+    class Formatter
+      ADDITIONAL_NOTES_DIVIDER = '### Additional Notes'.freeze
+      NUMBERED_UPPERCASE_SUB_PATTERN = /\A\d+\.\s+\([A-Z]+\)\s/
+
+      def call(content)
+        return content if content.blank?
+
+        # Split on the divider string; it may appear at the very start of content.
+        raw_parts = content.split(ADDITIONAL_NOTES_DIVIDER, 2)
+        main_raw = raw_parts[0].rstrip.presence
+        additional_raw = raw_parts[1]&.sub(/\A\n+/, '')
+
+        main_result = main_raw ? format_main_part(main_raw) : nil
+        additional_result = additional_raw ? format_additional_part(additional_raw) : nil
+
+        [
+          main_result,
+          additional_result && "#{ADDITIONAL_NOTES_DIVIDER}\n\n#{additional_result}",
+        ].compact.join("\n\n")
+      end
+
+      private
+
+      # ── Chapter notes (before "### Additional Notes") ───────────────────────
+      # Standard EU formatting artefacts: (a)→a) marker style, punctuation spacing,
+      # double spaces. merge_trailing_list_markers runs first because the EU XHTML
+      # sometimes places the note number and its sub-marker (e.g. "6. (a)") in one
+      # row and the sub-marker's text in the next, producing a dangling marker line.
+
+      def format_main_part(content)
+        return '' if content.blank?
+
+        lines = content.split("\n")
+        lines = normalise_whitespace_lines(lines)
+        lines = normalise_deep_indentation(lines)
+        lines = merge_trailing_list_markers(lines)
+        lines.map! { |l| convert_emdash_bullet(l) }
+        lines = normalise_uppercase_sub_note_indentation(lines)
+        lines.map! { |l| normalise_list_marker(l) }
+        lines = align_orphaned_list_markers(lines)
+        lines = merge_list_item_continuations(lines)
+        lines = indent_note_continuations(lines)
+        lines = collapse_multiple_blanks(lines)
+        lines.map! { |l| strip_punctuation_spacing(l) }
+        lines.map! { |l| collapse_internal_spaces(l) }
+        lines.join("\n")
+      end
+
+      # ── Additional Notes section ──────────────────────────────────────────────
+      # EU XHTML nests Additional Notes in deeply-indented two-column tables.
+      # Markers like (a) stay in their parenthesised form (govspeak convention
+      # for Additional Notes differs from chapter notes).
+
+      def format_additional_part(content)
+        return '' if content.blank?
+
+        lines = content.split("\n")
+        lines = normalise_whitespace_lines(lines)
+        lines = normalise_deep_indentation(lines)
+        lines = merge_isolated_markers(lines)
+        lines = collapse_multiple_blanks(lines)
+        lines.map! { |l| convert_emdash_bullet(l) }
+        lines = normalise_additional_notes_indentation(lines)
+        lines.map! { |l| strip_punctuation_spacing(l) }
+        lines.map! { |l| collapse_internal_spaces(l) }
+        lines.join("\n")
+      end
+
+      # ── Shared helpers ────────────────────────────────────────────────────────
+
+      # EU source uses (a) (b) (c) / (i) (ii) (iii) style; govspeak expects a) b) c) / i) ii) iii)
+      # Applied to chapter notes only — Additional Notes keep the parenthesised form.
+      # The (?:\d+\.\s+)? group also handles markers that follow a note number on the same
+      # line (e.g. "6. (a) text" → "6. a) text") after merge_trailing_list_markers has run.
+      def normalise_list_marker(line)
+        line.gsub(/\A(\s*(?:\d+\.\s+)?)\(([a-z]+)\)(\s)/, '\1\2)\3')
+      end
+
+      # EU publication leaves a space before punctuation after heading refs: "0301 ," → "0301,"
+      # Also catches space before closing parenthesis ("0210 )") and colon.
+      def strip_punctuation_spacing(line)
+        line.gsub(/(\w) +([,;.:)])/, '\1\2')
+      end
+
+      # Collapse double spaces left by stripped heading-ref trailing spaces: "0307  or" → "0307 or"
+      def collapse_internal_spaces(line)
+        line.sub(/\A(\s*)(.+)\z/m) { ::Regexp.last_match(1) + ::Regexp.last_match(2).gsub(/ {2,}/, ' ') }
+      end
+
+      # Treat lines containing only whitespace as blank lines (EU XHTML table whitespace artefact)
+      def normalise_whitespace_lines(lines)
+        lines.map { |l| l.strip.empty? ? '' : l }
+      end
+
+      # EU XHTML uses deeply nested two-column tables; extracted content can have 13+ spaces
+      # of base indentation as an artefact of depth tracking. Strip the common base indent
+      # to restore readable relative nesting.
+      def normalise_deep_indentation(lines)
+        deep_lines = lines.select { |l| l.match?(/\A {13,}\S/) }
+        return lines if deep_lines.empty?
+
+        min_indent = deep_lines.map { |l| l[/\A( *)/, 1].length }.min
+
+        lines.map do |l|
+          current_indent = l[/\A( *)/, 1].length
+          current_indent >= min_indent ? (' ' * (current_indent - min_indent)) + l.lstrip : l
+        end
+      end
+
+      # EU XHTML nests (A)/(B) sub-tables one level deeper than the enclosing note table,
+      # and their contents (a)/(b) sub-items, continuation paragraphs) one level deeper still.
+      # When a note opens with "N. (A) text", items at ≥ 4 spaces of raw indentation are
+      # XHTML artefacts — govspeak wants them at 3 spaces (the standard continuation indent
+      # for a numbered list). Guards: empty lines and table rows (|) pass through unchanged.
+      # Resets on any new numbered note or "### …" header.
+      # First confirmed: Chapter 11 note 2 (cereal milling classification).
+      def normalise_uppercase_sub_note_indentation(lines)
+        inside = false
+        lines.map do |line|
+          stripped = line.lstrip
+          current_indent = line[/\A( *)/, 1].length
+
+          if stripped.empty?
+            line
+          elsif stripped.start_with?('###')
+            inside = false
+            line
+          elsif current_indent.zero? && stripped.match?(NUMBERED_UPPERCASE_SUB_PATTERN)
+            inside = true
+            line
+          elsif current_indent.zero? && stripped.match?(/\A\d+\./)
+            inside = false
+            line
+          elsif inside && current_indent >= 4 && !stripped.start_with?('|')
+            "   #{stripped}"
+          else
+            line
+          end
+        end
+      end
+
+      # After a chapter-note list, EU XHTML can emit a closing paragraph at 0 indent that
+      # belongs to the enclosing numbered note. Track the last seen list indent; any 0-indent
+      # paragraph that isn't a new numbered note or section header gets raised to that indent.
+      # Also raises continuation paragraphs that appear *before* the sub-list (when list_indent
+      # is still 0) — EU XHTML emits these at 0 indent but govspeak needs them at 3 spaces so
+      # the ordered-list counter isn't reset and the following sub-items aren't parsed as a
+      # code block. First confirmed: Chapter 12 notes 3 and 4.
+      # Resets on "2. Next note" (digit) or "### Subheading notes" headers.
+      def indent_note_continuations(lines)
+        list_indent = 0
+        inside_uppercase_sub = false
+        inside_numbered_note = false
+        uppercase_sub_indent = 0
+        uppercase_dot_indent = 0
+        note_indent = 3
+
+        lines.map do |line|
+          stripped       = line.lstrip
+          current_indent = line[/\A( *)/, 1].length
+
+          if stripped.start_with?('###')
+            list_indent = 0
+            inside_uppercase_sub = false
+            inside_numbered_note = false
+            uppercase_sub_indent = 0
+            uppercase_dot_indent = 0
+            note_indent = 3
+            line
+          elsif stripped.match?(NUMBERED_UPPERCASE_SUB_PATTERN) && current_indent.zero?
+            inside_uppercase_sub = true
+            inside_numbered_note = true
+            list_indent = 0
+            uppercase_sub_indent = 0
+            uppercase_dot_indent = 0
+            note_indent = stripped.match(/\A(\d+)\./)[1].length + 2
+            line
+          elsif stripped.match?(/\A\d+\./) && current_indent.zero?
+            list_indent = 0
+            inside_uppercase_sub = false
+            inside_numbered_note = true
+            uppercase_sub_indent = 0
+            uppercase_dot_indent = 0
+            note_indent = stripped.match(/\A(\d+)\./)[1].length + 2
+            line
+          elsif current_indent.zero? && inside_uppercase_sub && stripped.match?(/\A\([A-Z]+\)\s/)
+            "   #{stripped}"
+          elsif current_indent < note_indent && inside_numbered_note && list_indent.zero? && !stripped.empty?
+            if stripped.start_with?('|')
+              line
+            elsif stripped.match?(/\A[a-z]+\) /) && current_indent.zero?
+              # Letter item at column 0 — leave in place (correct position under a
+              # single-digit note, or will be handled by align_orphaned_list_markers).
+              line
+            else
+              ' ' * note_indent + stripped
+            end
+          elsif stripped.match?(/\A\([A-Z]+\)\s/) && current_indent.positive?
+            uppercase_sub_indent = current_indent
+            list_indent = 0
+            line
+          elsif line.match?(/\A {1,}[a-z]+\) /)
+            if uppercase_sub_indent.positive? && current_indent > uppercase_sub_indent
+              list_indent = uppercase_sub_indent
+              ' ' * uppercase_sub_indent + stripped
+            elsif uppercase_dot_indent.positive?
+              # Inside A./B. dot-sub-section: clamp to uppercase_dot_indent + 2 to keep
+              # below the govspeak code-block threshold (8+ spaces inside a numbered list
+              # item triggers a scrollable pre block).
+              list_indent = uppercase_dot_indent + 2
+              inside_uppercase_sub = false
+              ' ' * list_indent + stripped
+            elsif list_indent.positive? && current_indent > list_indent
+              # Letter-list item arrived deeper than the current list level (e.g. roman numeral
+              # ii)/iii) at 8 spaces when the enclosing a)/b) list is at 4 spaces). Pull back.
+              ' ' * list_indent + stripped
+            else
+              list_indent = current_indent
+              inside_uppercase_sub = false
+              line
+            end
+          elsif stripped.match?(/\A[A-Z]\.\s/) && current_indent.positive?
+            uppercase_dot_indent = current_indent
+            line
+          elsif current_indent > list_indent && list_indent.positive? && uppercase_dot_indent.zero? && stripped.match?(/\A\(\d+\) /)
+            # Pull over-deep (N) items back to list_indent — but NOT inside an A./B.
+            # dot-sub-section where they are legitimately one level below the letter-list.
+            ' ' * list_indent + stripped
+          elsif current_indent > list_indent && list_indent.positive? && uppercase_dot_indent.positive? && stripped.match?(/\A\(\d+\) /)
+            # Inside A./B.: clamp (N) items to the same level as the letter-list
+            # (uppercase_dot_indent + 2) so they don't trigger a govspeak code block.
+            ' ' * (uppercase_dot_indent + 2) + stripped
+          elsif current_indent > list_indent && list_indent.positive? && stripped.start_with?('- ')
+            ' ' * list_indent + stripped
+          elsif current_indent > list_indent && list_indent.positive? && !stripped.empty?
+            stripped.start_with?('|') ? line : ' ' * list_indent + stripped
+          elsif current_indent < list_indent && list_indent.positive? && stripped.start_with?('|')
+            ' ' * list_indent + stripped
+          elsif current_indent.zero? && list_indent.positive? && !stripped.empty?
+            if stripped.match?(/\A\([a-z]+\)/) || stripped.start_with?('|')
+              line
+            elsif uppercase_dot_indent.positive?
+              # Inside an A./B. dot-sub-section: raise 0-indent continuation to the
+              # sub-section level rather than all the way to the letter-list indent.
+              ' ' * uppercase_dot_indent + stripped
+            else
+              ' ' * list_indent + stripped
+            end
+          else
+            line
+          end
+        end
+      end
+
+      # EU XHTML can produce the first item in a chapter-note sub-list at 0 indent while
+      # all sibling items are at a consistent positive indent. Walk consecutive list-marker
+      # pairs; if the first is at 0 and the next is at positive indent, raise the first
+      # to match.
+      def align_orphaned_list_markers(lines)
+        markers = lines.each_with_index
+                       .select { |l, _| l.match?(/\A *[a-z]+\) /) }
+                       .map { |l, i| [i, l[/\A( *)/, 1].length] }
+        return lines if markers.empty?
+
+        result = lines.dup
+        markers.each_cons(2) do |(idx_a, indent_a), (_, indent_b)|
+          next unless indent_a.zero? && indent_b.positive?
+
+          result[idx_a] = ' ' * indent_b + result[idx_a]
+        end
+        result
+      end
+
+      # EU XHTML can split a list item's sentence across two table rows: the item text
+      # (e.g. "b) to improve… syrup),") lands in one row and the continuation clause
+      # ("provided that they retain…") lands at 0 indent in the next row. Merge the
+      # continuation back onto the list item line.
+      # Guard: skip if the next non-blank is another list item or a numbered note.
+      def merge_list_item_continuations(lines)
+        result = []
+        i = 0
+        while i < lines.length
+          line = lines[i]
+          if line.match?(/\A {1,}[a-z]+\) /) && line.rstrip.end_with?(',')
+            next_idx = (i + 1...lines.length).find { |j| lines[j].strip.present? }
+            if next_idx
+              next_stripped = lines[next_idx].strip
+              next_indent   = lines[next_idx][/\A( *)/, 1].length
+              if next_indent.zero? &&
+                  !next_stripped.match?(/\A\d+\./) &&
+                  !next_stripped.match?(/\A[a-z]+\) /) &&
+                  !next_stripped.match?(/\A\([a-z]+\)/)
+                result << "#{line.rstrip} #{next_stripped}"
+                i = next_idx + 1
+                next
+              end
+            end
+          end
+          result << line
+          i += 1
+        end
+        result
+      end
+
+      # In chapter notes, the EU XHTML sometimes places a note number and its sub-marker
+      # in the same row ("6. (a)") with no text, and the sub-marker's content in the
+      # next row. This produces a dangling line whose stripped form is exactly a
+      # note-number + parenthetical marker (e.g. "6. (a)") or just a bare "(a)".
+      # Merge it with the following non-empty line so normalise_list_marker can then
+      # convert the whole "6. (a) text" → "6. a) text" in one pass.
+      def merge_trailing_list_markers(lines)
+        result = []
+        i = 0
+        while i < lines.length
+          line = lines[i]
+          if line.rstrip.match?(/\A\s*(?:\d+\.\s+)?\([a-zA-Z]+\)\z/)
+            next_idx = (i + 1...lines.length).find { |j| lines[j].strip.present? }
+            if next_idx
+              result << "#{line.rstrip} #{lines[next_idx].strip}"
+              i = next_idx + 1
+              next
+            end
+          end
+          result << line
+          i += 1
+        end
+        result
+      end
+
+      # EU two-column tables sometimes emit the marker (e.g. "(a)", "B.", "—", "1. A.")
+      # in one row and the content in the next, producing isolated-marker lines.
+      # Merge each such line with the following non-empty line — UNLESS that line is
+      # itself an isolated marker (e.g. (h) followed by 1.), in which case both should
+      # remain on separate lines so each is processed independently.
+      def merge_isolated_markers(lines)
+        result = []
+        i = 0
+        while i < lines.length
+          line = lines[i]
+          if isolated_marker_line?(line)
+            next_idx = (i + 1...lines.length).find { |j| lines[j].present? }
+            # Also skip merging when the next line is an already-populated indented numbered
+            # sub-item (e.g. "    1. 'crop'...") — the extractor placed the parenthetical
+            # label alone on a line and the numbered content on the next, and they must stay
+            # separate so normalise_additional_notes_indentation can place them at 6 spaces.
+            if next_idx && !isolated_marker_line?(lines[next_idx]) && !lines[next_idx].match?(/\A +\d+\./)
+
+              indent = line[/\A( *)/, 1]
+              result << "#{indent}#{line.strip} #{lines[next_idx].strip}"
+              i = next_idx + 1
+              next
+            end
+          end
+          result << line
+          i += 1
+        end
+        result
+      end
+
+      # Collapse runs of consecutive blank lines to a single blank line
+      def collapse_multiple_blanks(lines)
+        result = []
+        prev_blank = false
+        lines.each do |line|
+          if line.empty?
+            result << '' unless prev_blank
+            prev_blank = true
+          else
+            result << line
+            prev_blank = false
+          end
+        end
+        result
+      end
+
+      # In Additional Notes, re-anchor the indentation to govspeak convention.
+      # Stateful: tracks whether we are inside a sub-section so that continuation
+      # paragraphs (XHTML rows with empty label cells, arriving at 0-1 space indent)
+      # are correctly indented to 3 spaces rather than left at the margin.
+      #
+      #   (a)/(b)/… markers                → 3 spaces
+      #   uppercase sub-section B./C./…    → 3 spaces (siblings of A. under the same note)
+      #   N. X. numbered note (e.g. 2. A.) → 0 spaces, resets sub-section context
+      #   indented bullet points (- …)     → 6 spaces (one level inside (a)/(b))
+      #   indented numeric sub-items 1./2. → 6 spaces
+      #   continuation lines at 0-1 spaces while inside a sub-section → 3 spaces
+      #
+      # NOTE: convert_emdash_bullet must run before this method so — bullets are already - .
+      def normalise_additional_notes_indentation(lines)
+        inside_sub_section = false
+        inside_numbered_note = false
+        inside_dash_bullet = false
+        note_indent = 3
+
+        lines.map do |line|
+          stripped = line.lstrip
+          current_indent = line[/\A( *)/, 1].length
+
+          if stripped.match?(/\A\([a-z]+\)(?:[\s,]|\z)/)
+            inside_sub_section = true
+            inside_dash_bullet = false
+            ' ' * note_indent + stripped
+          elsif stripped.match?(/\A[A-Z]\.(?:\s|\z)/)
+            inside_sub_section = true
+            inside_dash_bullet = false
+            ' ' * note_indent + stripped
+          elsif stripped.match?(/\A\d+\.\s+[A-Z]\./)
+            inside_sub_section = false
+            inside_numbered_note = true
+            inside_dash_bullet = false
+            note_indent = stripped.match(/\A(\d+)\./)[1].length + 2
+            line
+          elsif stripped.match?(/\A\d+\.\s/) && current_indent.zero?
+            inside_numbered_note = true
+            inside_sub_section = false
+            inside_dash_bullet = false
+            note_indent = stripped.match(/\A(\d+)\./)[1].length + 2
+            line
+          elsif current_indent.positive? && stripped.start_with?('- ')
+            inside_dash_bullet = true
+            "      #{stripped}"
+          elsif current_indent.positive? && stripped.match?(/\A\d+\./)
+            "      #{stripped}"
+          elsif line.empty?
+            line
+          elsif inside_dash_bullet && !inside_sub_section && !stripped.empty? && current_indent < 6
+            "         #{stripped}"
+          elsif inside_sub_section && current_indent < note_indent && !stripped.match?(/\A\d/)
+            ' ' * note_indent + stripped
+          elsif inside_numbered_note && current_indent < note_indent && !stripped.match?(/\A\d/) && !stripped.start_with?('- ')
+            ' ' * note_indent + stripped
+          elsif current_indent > 6
+            # Over-indented plain text from XHTML nesting artefacts (e.g. continuation
+            # paragraphs nested one level deeper than the bullet list they follow).
+            # Cap at 6 spaces — the deepest meaningful indent in Additional Notes.
+            "      #{stripped}"
+          else
+            line
+          end
+        end
+      end
+
+      # EU source uses — (em-dash) as a list bullet; convert to govspeak markdown dash
+      def convert_emdash_bullet(line)
+        line.gsub(/\A(\s*)— /, '\1- ')
+      end
+
+      ISOLATED_MARKER_PATTERN = /\A(?:\d+\.\s+[A-Z]\.|\d+\.\s+\([a-z]+\)|\([a-z]+\)|[A-Z]\.|—|\d+\.)\z/
+
+      def isolated_marker_line?(line)
+        stripped = line.strip
+        stripped.present? && stripped.match?(ISOLATED_MARKER_PATTERN)
+      end
+    end
+  end
+end

--- a/app/lib/xi_cn_importer/notes_extractor/formatter/table_formatter.rb
+++ b/app/lib/xi_cn_importer/notes_extractor/formatter/table_formatter.rb
@@ -1,0 +1,122 @@
+module XiCnImporter
+  class NotesExtractor
+    class Formatter
+      class TableFormatter
+        INDENT = '   '.freeze
+
+        # Renders a Nokogiri table node (EU OJ XHTML content table) as indented
+        # govspeak markdown lines. Returns nil if no renderable content is found.
+        #
+        # Header merging: consecutive header rows (oj-tbl-hdr cells, excluding
+        # column-numbering rows like "(1)(2)(3)") are merged column-by-column so
+        # that a colspan=2 label row combines with the sub-label row below it to
+        # form complete column headers. Column-numbering rows are emitted as the
+        # first data row below the separator, matching govspeak convention.
+        #
+        # Indentation: every line is prefixed with INDENT (3 spaces) so the table
+        # renders as continuation content of the enclosing numbered note rather
+        # than resetting govspeak's list numbering.
+        def call(table, node_text_fn:)
+          header_rows = []
+          data_rows   = []
+
+          rows_of(table).each do |row|
+            cells    = element_children(row, 'td')
+            expanded = expand_colspan_cells(cells, node_text_fn:)
+            if header_row?(cells) && !column_numbering_row?(cells)
+              header_rows << expanded
+            else
+              data_rows << expanded
+            end
+          end
+
+          return nil if header_rows.empty? && data_rows.empty?
+
+          col_count = (header_rows + data_rows).map(&:length).max || 0
+
+          merged_header = (0...col_count).map do |i|
+            header_rows.map { |row| row[i] || '' }.reject(&:empty?).join(' ')
+          end
+
+          lines = []
+          lines << markdown_row(merged_header)
+          lines << markdown_separator(col_count)
+          data_rows.each do |row|
+            padded = row + Array.new([col_count - row.length, 0].max, '')
+            lines << markdown_row(padded)
+          end
+
+          lines.map { |l| "#{INDENT}#{l}" }.join("\n")
+        end
+
+        # A content table is one whose OWN cells (not nested sub-tables) carry
+        # oj-tbl-hdr or oj-tbl-txt paragraph classes. Uses a shallow check so that
+        # structural two-column (label/content) tables containing a nested oj-table
+        # are not falsely flagged and collapsed by table_formatter.
+        def self.content_table?(node)
+          tbody = node.children.find { |n| n.element? && n.name == 'tbody' } || node
+          tbody.children.select { |n| n.element? && n.name == 'tr' }.any? do |tr|
+            tr.children.select { |n| n.element? && n.name == 'td' }.any? do |td|
+              td.children.select { |n| n.element? && n.name == 'p' }.any? do |p|
+                (%w[oj-tbl-hdr oj-tbl-txt] & (p['class']&.split || [])).any?
+              end
+            end
+          end
+        end
+
+        private
+
+        def header_row?(cells)
+          cells.any? do |cell|
+            cell.xpath('.//*[local-name()="p"]').any? do |p|
+              (p['class']&.split || []).include?('oj-tbl-hdr')
+            end
+          end
+        end
+
+        # A column-numbering row has all non-empty cells containing only
+        # parenthetical integers, e.g. "(1)", "(2)", "(3)".
+        def column_numbering_row?(cells)
+          non_empty = cells.flat_map do |cell|
+            cell.xpath('.//*[local-name()="p"]').map { |p| p.text.strip }.reject(&:empty?)
+          end
+          non_empty.any? && non_empty.all? { |t| t.match?(/\A\(\d+\)\z/) }
+        end
+
+        # Expand cells into a flat array, repeating each cell's text by its
+        # colspan value so column positions line up across rows.
+        def expand_colspan_cells(cells, node_text_fn:)
+          cells.flat_map do |cell|
+            colspan = (cell['colspan'] || '1').to_i
+            text    = cell.xpath('.//*[local-name()="p"]')
+                          .map { |p| node_text_fn.call(p) }
+                          .reject(&:empty?)
+                          .join(' ')
+            Array.new(colspan, text)
+          end
+        end
+
+        def markdown_row(cells)
+          "| #{cells.map { |c| markdown_cell(c) }.join(' | ')} |"
+        end
+
+        def markdown_separator(col_count)
+          "| #{Array.new(col_count, '---').join(' | ')} |"
+        end
+
+        def markdown_cell(text)
+          text.to_s.gsub(/[\\|]/) { |ch| "\\#{ch}" }
+        end
+
+        def rows_of(table)
+          tbody = table.children.find { |n| n.element? && n.name == 'tbody' } || table
+          tbody.children.select { |n| n.element? && n.name == 'tr' }
+        end
+
+        def element_children(node, tag)
+          node.children.select { |n| n.element? && n.name == tag }
+        end
+      end
+    end
+  end
+end

--- a/app/lib/xi_cn_importer/reimporter.rb
+++ b/app/lib/xi_cn_importer/reimporter.rb
@@ -1,10 +1,5 @@
-require 'net/http'
-
 module XiCnImporter
   class Reimporter
-    MAX_REDIRECTS = 5
-    OPEN_TIMEOUT  = 10
-    READ_TIMEOUT  = 30
     S3_KEY_PREFIX = 'data/customs_tariff_documents/xi'.freeze
 
     def call(version: nil)
@@ -29,7 +24,8 @@ module XiCnImporter
     private
 
     def reimport(update)
-      html_content = fetch_html(update.source_url)
+      html_s3_path = "#{S3_KEY_PREFIX}/CN_#{update.version}.xhtml"
+      html_content = TariffSynchronizer::FileService.get(html_s3_path).read
       extracted    = NotesExtractor.new(update.version, html_content).call
 
       if extracted.chapters.empty? && extracted.sections.empty? && extracted.general_rules.empty?
@@ -70,23 +66,6 @@ module XiCnImporter
             status: CustomsTariffGeneralRule::PENDING,
           )
         end
-      end
-    end
-
-    def fetch_html(url, redirect_count: 0)
-      raise 'Too many redirects' if redirect_count > MAX_REDIRECTS
-
-      uri      = URI(url)
-      response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https', open_timeout: OPEN_TIMEOUT, read_timeout: READ_TIMEOUT) do |http|
-        http.get(uri.request_uri, 'Accept' => 'application/xhtml+xml')
-      end
-
-      case response
-      when Net::HTTPSuccess then response.body
-      when Net::HTTPRedirection
-        location = response['location']
-        fetch_html(URI.join(url, location).to_s, redirect_count: redirect_count + 1)
-      else raise "Failed to fetch #{url}: HTTP #{response.code}"
       end
     end
   end

--- a/app/lib/xi_cn_importer/reimporter.rb
+++ b/app/lib/xi_cn_importer/reimporter.rb
@@ -3,13 +3,16 @@ require 'net/http'
 module XiCnImporter
   class Reimporter
     MAX_REDIRECTS = 5
+    S3_KEY_PREFIX = 'data/customs_tariff_documents/xi'.freeze
 
     def call(version: nil)
       if version
         update = CustomsTariffUpdate.first(version:)
-        reimport(update) if update
+        reimport(update) if update && update.s3_path&.start_with?("#{S3_KEY_PREFIX}/")
       else
         CustomsTariffUpdate.exclude(status: CustomsTariffUpdate::FAILED).each do |update|
+          next unless update.s3_path&.start_with?("#{S3_KEY_PREFIX}/")
+
           reimport(update)
         rescue StandardError => e
           XiCnImporter::Logger.log(:error, 'Reimport failed', version: update.version,

--- a/app/lib/xi_cn_importer/reimporter.rb
+++ b/app/lib/xi_cn_importer/reimporter.rb
@@ -75,7 +75,9 @@ module XiCnImporter
 
       case response
       when Net::HTTPSuccess     then response.body
-      when Net::HTTPRedirection then fetch_html(response['location'], redirect_count: redirect_count + 1)
+      when Net::HTTPRedirection
+        location = response['location']
+        fetch_html(URI.join(url, location).to_s, redirect_count: redirect_count + 1)
       else raise "Failed to fetch #{url}: HTTP #{response.code}"
       end
     end

--- a/app/lib/xi_cn_importer/reimporter.rb
+++ b/app/lib/xi_cn_importer/reimporter.rb
@@ -1,0 +1,80 @@
+require 'net/http'
+
+module XiCnImporter
+  class Reimporter
+    MAX_REDIRECTS = 5
+
+    def call(version: nil)
+      if version
+        update = CustomsTariffUpdate.first(version:)
+        reimport(update) if update
+      else
+        CustomsTariffUpdate.exclude(status: CustomsTariffUpdate::FAILED).each do |update|
+          reimport(update)
+        rescue StandardError => e
+          XiCnImporter::Logger.log(:error, 'Reimport failed', version: update.version,
+                                                              error_class: e.class.name,
+                                                              error_message: e.message)
+        end
+      end
+    end
+
+    private
+
+    def reimport(update)
+      html_content = fetch_html(update.source_url)
+      extracted    = NotesExtractor.new(update.version, html_content).call
+
+      CustomsTariffUpdate.db.transaction do
+        CustomsTariffSectionNote.where(customs_tariff_update_version: update.version).delete
+        CustomsTariffChapterNote.where(customs_tariff_update_version: update.version).delete
+        CustomsTariffGeneralRule.where(customs_tariff_update_version: update.version).delete
+
+        extracted.sections.each do |section_id, note_content|
+          CustomsTariffSectionNote.create(
+            customs_tariff_update_version: update.version,
+            section_id:,
+            content: note_content,
+            validity_start_date: update.validity_start_date,
+            status: CustomsTariffSectionNote::PENDING,
+          )
+        end
+
+        extracted.chapters.each do |chapter_id, note_content|
+          CustomsTariffChapterNote.create(
+            customs_tariff_update_version: update.version,
+            chapter_id:,
+            content: note_content,
+            validity_start_date: update.validity_start_date,
+            status: CustomsTariffChapterNote::PENDING,
+          )
+        end
+
+        extracted.general_rules.each do |rule_label, note_content|
+          CustomsTariffGeneralRule.create(
+            customs_tariff_update_version: update.version,
+            rule_label:,
+            content: note_content,
+            validity_start_date: update.validity_start_date,
+            status: CustomsTariffGeneralRule::PENDING,
+          )
+        end
+      end
+    end
+
+    def fetch_html(url, redirect_count: 0)
+      raise 'Too many redirects' if redirect_count > MAX_REDIRECTS
+
+      uri      = URI(url)
+      response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
+        http.get(uri.request_uri, 'Accept' => 'application/xhtml+xml')
+      end
+
+      case response
+      when Net::HTTPSuccess     then response.body
+      when Net::HTTPRedirection then fetch_html(response['location'], redirect_count: redirect_count + 1)
+      else raise "Failed to fetch #{url}: HTTP #{response.code}"
+      end
+    end
+  end
+end

--- a/app/lib/xi_cn_importer/reimporter.rb
+++ b/app/lib/xi_cn_importer/reimporter.rb
@@ -3,6 +3,8 @@ require 'net/http'
 module XiCnImporter
   class Reimporter
     MAX_REDIRECTS = 5
+    OPEN_TIMEOUT  = 10
+    READ_TIMEOUT  = 30
     S3_KEY_PREFIX = 'data/customs_tariff_documents/xi'.freeze
 
     def call(version: nil)
@@ -15,9 +17,11 @@ module XiCnImporter
 
           reimport(update)
         rescue StandardError => e
-          XiCnImporter::Logger.log(:error, 'Reimport failed', version: update.version,
-                                                              error_class: e.class.name,
-                                                              error_message: e.message)
+          XiCnImporter::Instrumentation.reimport_failed(
+            version: update.version,
+            error_class: e.class.name,
+            error_message: e.message,
+          )
         end
       end
     end
@@ -27,6 +31,10 @@ module XiCnImporter
     def reimport(update)
       html_content = fetch_html(update.source_url)
       extracted    = NotesExtractor.new(update.version, html_content).call
+
+      if extracted.chapters.empty? && extracted.sections.empty? && extracted.general_rules.empty?
+        raise "Empty extract for #{update.version} — refusing to wipe notes"
+      end
 
       CustomsTariffUpdate.db.transaction do
         CustomsTariffSectionNote.where(customs_tariff_update_version: update.version).delete
@@ -69,12 +77,12 @@ module XiCnImporter
       raise 'Too many redirects' if redirect_count > MAX_REDIRECTS
 
       uri      = URI(url)
-      response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
+      response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https', open_timeout: OPEN_TIMEOUT, read_timeout: READ_TIMEOUT) do |http|
         http.get(uri.request_uri, 'Accept' => 'application/xhtml+xml')
       end
 
       case response
-      when Net::HTTPSuccess     then response.body
+      when Net::HTTPSuccess then response.body
       when Net::HTTPRedirection
         location = response['location']
         fetch_html(URI.join(url, location).to_s, redirect_count: redirect_count + 1)

--- a/app/workers/customs_tariff_reimport_worker.rb
+++ b/app/workers/customs_tariff_reimport_worker.rb
@@ -4,6 +4,8 @@ class CustomsTariffReimportWorker
   sidekiq_options queue: :sync, retry: false
 
   def perform(version)
+    return unless TradeTariffBackend.uk?
+
     CustomsTariffImporter::Reimporter.new.call(version:)
   end
 end

--- a/app/workers/import_xi_cn_document_worker.rb
+++ b/app/workers/import_xi_cn_document_worker.rb
@@ -13,19 +13,17 @@ class ImportXiCnDocumentWorker
 
     duration_ms    = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000).round(2)
     imported_count = results.count { |r| r.status == :imported }
-    skipped_count  = results.count { |r| r.status == :skipped }
     failed_count   = results.count { |r| r.status == :failed }
     review_backlog = CustomsTariffUpdate.pending.count
 
     XiCnImporter::Instrumentation.import_run_completed(
       imported: imported_count,
-      skipped: skipped_count,
       failed: failed_count,
       duration_ms:,
       review_backlog:,
     )
 
-    notify_completed(imported_count:, skipped_count:, failed_count:, review_backlog:)
+    notify_completed(imported_count:, failed_count:, review_backlog:)
   rescue StandardError => e
     XiCnImporter::Instrumentation.import_run_failed(
       error_class: e.class.name,
@@ -37,14 +35,14 @@ class ImportXiCnDocumentWorker
 
   private
 
-  def notify_completed(imported_count:, skipped_count:, failed_count:, review_backlog:)
+  def notify_completed(imported_count:, failed_count:, review_backlog:)
     return unless imported_count.positive? || failed_count.positive?
 
     status = failed_count.positive? ? 'completed with failures' : 'completed'
 
     notify_slack(
       "XI CN document import #{status}. " \
-      "imported: #{imported_count}, skipped: #{skipped_count}, failed: #{failed_count}, " \
+      "imported: #{imported_count}, failed: #{failed_count}, " \
       "pending review: #{review_backlog}",
     )
   end

--- a/app/workers/import_xi_cn_document_worker.rb
+++ b/app/workers/import_xi_cn_document_worker.rb
@@ -1,26 +1,23 @@
-require_relative '../lib/customs_tariff_importer/instrumentation'
-require_relative '../lib/customs_tariff_importer/logger'
-
-class ImportCustomsTariffDocumentWorker
+class ImportXiCnDocumentWorker
   include Sidekiq::Worker
 
   sidekiq_options queue: :default, retry: false, slack_alerts: false
 
   def perform
-    return unless TradeTariffBackend.uk?
+    return unless TradeTariffBackend.xi?
 
     start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-    CustomsTariffImporter::Instrumentation.import_run_started
+    XiCnImporter::Instrumentation.import_run_started
 
-    results = CustomsTariffImporter::Importer.new.call
+    results = XiCnImporter::Importer.new.call
 
-    duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000).round(2)
+    duration_ms    = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000).round(2)
     imported_count = results.count { |r| r.status == :imported }
-    skipped_count = results.count { |r| %i[skipped duplicate_content].include?(r.status) }
-    failed_count = results.count { |r| r.status == :failed }
+    skipped_count  = results.count { |r| r.status == :skipped }
+    failed_count   = results.count { |r| r.status == :failed }
     review_backlog = CustomsTariffUpdate.pending.count
 
-    CustomsTariffImporter::Instrumentation.import_run_completed(
+    XiCnImporter::Instrumentation.import_run_completed(
       imported: imported_count,
       skipped: skipped_count,
       failed: failed_count,
@@ -30,7 +27,7 @@ class ImportCustomsTariffDocumentWorker
 
     notify_completed(imported_count:, skipped_count:, failed_count:, review_backlog:)
   rescue StandardError => e
-    CustomsTariffImporter::Instrumentation.import_run_failed(
+    XiCnImporter::Instrumentation.import_run_failed(
       error_class: e.class.name,
       error_message: e.message,
     )
@@ -46,23 +43,21 @@ class ImportCustomsTariffDocumentWorker
     status = failed_count.positive? ? 'completed with failures' : 'completed'
 
     notify_slack(
-      "Customs tariff document import #{status}. " \
+      "XI CN document import #{status}. " \
       "imported: #{imported_count}, skipped: #{skipped_count}, failed: #{failed_count}, " \
       "pending review: #{review_backlog}",
     )
   end
 
   def notify_failed(error)
-    notify_slack(
-      "Customs tariff document import failed. #{error.class}: #{error.message}",
-    )
+    notify_slack("XI CN document import failed. #{error.class}: #{error.message}")
   end
 
   def notify_slack(message)
     SlackNotifierService.call(message)
   rescue StandardError => e
     Rails.logger.error(
-      "Failed to send customs tariff document import Slack notification: #{e.class}: #{e.message}",
+      "Failed to send XI CN document import Slack notification: #{e.class}: #{e.message}",
     )
   end
 end

--- a/app/workers/xi_cn_reimport_worker.rb
+++ b/app/workers/xi_cn_reimport_worker.rb
@@ -1,0 +1,11 @@
+class XiCnReimportWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :sync, retry: false
+
+  def perform(version)
+    return unless TradeTariffBackend.xi?
+
+    XiCnImporter::Reimporter.new.call(version:)
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -91,6 +91,10 @@
       cron: "0 9 * * *"
       description: "Checks GOV.UK for a new Customs Tariff document version and imports it"
       enabled: <%= ENV.fetch('SERVICE', 'uk') == 'uk' %>
+    ImportXiCnDocumentWorker:
+      cron: "0 9 * * *"
+      description: "Checks EUR-Lex for new CN editions and imports section/chapter/GRI notes into the XI schema"
+      enabled: <%= ENV.fetch('SERVICE', 'uk') == 'xi' %>
     RefreshTariffKnowledgeCompressedNotesWorker:
       cron: "0 3 * * *"
       description: "Refreshes tariff knowledge graph and compressed notes for current declarable goods"

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -93,7 +93,7 @@
       enabled: <%= ENV.fetch('SERVICE', 'uk') == 'uk' %>
     ImportXiCnDocumentWorker:
       cron: "0 9 * * *"
-      description: "Checks EUR-Lex for new CN editions and imports section/chapter/GRI notes into the XI schema"
+      description: "Checks the EU Publications Office for new CN editions and imports section/chapter/GRI notes into the XI schema"
       enabled: <%= ENV.fetch('SERVICE', 'uk') == 'xi' %>
     RefreshTariffKnowledgeCompressedNotesWorker:
       cron: "0 3 * * *"

--- a/lib/tasks/xi_cn_importer.rake
+++ b/lib/tasks/xi_cn_importer.rake
@@ -1,0 +1,8 @@
+namespace :importer do
+  namespace :xi_cn do
+    desc 'Reimport XI CN notes for a specific version, or all non-failed versions if none given'
+    task :reimport, [:version] => :environment do |_, args|
+      XiCnImporter::Reimporter.new.call(version: args[:version].presence)
+    end
+  end
+end

--- a/spec/lib/customs_tariff_importer/importer_spec.rb
+++ b/spec/lib/customs_tariff_importer/importer_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe CustomsTariffImporter::Importer do
       it 'archives the document to S3' do
         results
         expect(TariffSynchronizer::FileService).to have_received(:write_file).with(
-          'data/customs_tariff_documents/UKGT_1.30.docx',
+          'data/customs_tariff_documents/uk/UKGT_1.30.docx',
           docx_content,
         )
       end

--- a/spec/lib/xi_cn_importer/document_fetcher_spec.rb
+++ b/spec/lib/xi_cn_importer/document_fetcher_spec.rb
@@ -26,11 +26,11 @@ RSpec.describe XiCnImporter::DocumentFetcher do
       .to_return(status: 200, body: sparql_response_body,
                  headers: { 'Content-Type' => 'application/sparql-results+json' })
 
-    stub_request(:get, 'http://publications.europa.eu/resource/cellar/abc123def456.0006.03/DOC_1')
+    stub_request(:get, 'https://publications.europa.eu/resource/cellar/abc123def456.0006.03/DOC_1')
       .with(headers: { 'Accept' => 'application/xhtml+xml' })
       .to_return(status: 200, body: html_body)
 
-    stub_request(:get, 'http://publications.europa.eu/resource/cellar/abc123def456.0006.01/DOC_1')
+    stub_request(:get, 'https://publications.europa.eu/resource/cellar/abc123def456.0006.01/DOC_1')
       .to_return(status: 200, body: pdf_body, headers: { 'Content-Type' => 'application/pdf' })
   end
 
@@ -51,7 +51,7 @@ RSpec.describe XiCnImporter::DocumentFetcher do
 
     it 'stores the Cellar URL as cellar_url' do
       result = fetcher.call.first
-      expect(result.cellar_url).to eq 'http://publications.europa.eu/resource/cellar/abc123def456.0006.03/DOC_1'
+      expect(result.cellar_url).to eq 'https://publications.europa.eu/resource/cellar/abc123def456.0006.03/DOC_1'
     end
 
     context 'when the version is already imported (not failed)' do

--- a/spec/lib/xi_cn_importer/document_fetcher_spec.rb
+++ b/spec/lib/xi_cn_importer/document_fetcher_spec.rb
@@ -1,0 +1,86 @@
+require 'rails_helper'
+
+RSpec.describe XiCnImporter::DocumentFetcher do
+  subject(:fetcher) { described_class.new }
+
+  let(:sparql_response_body) do
+    {
+      'results' => {
+        'bindings' => [
+          {
+            'work' => { 'value' => 'http://publications.europa.eu/resource/cellar/abc123def456' },
+            'celex' => { 'value' => '32025R1926' },
+            'force_date' => { 'value' => '2026-01-01' },
+            'pub_date' => { 'value' => '2025-10-31' },
+          },
+        ],
+      },
+    }.to_json
+  end
+
+  let(:html_body) { '<html><body><p>test</p></body></html>' }
+  let(:pdf_body)  { '%PDF-1.4 fake' }
+
+  before do
+    stub_request(:post, described_class::SPARQL_ENDPOINT)
+      .to_return(status: 200, body: sparql_response_body,
+                 headers: { 'Content-Type' => 'application/sparql-results+json' })
+
+    stub_request(:get, 'http://publications.europa.eu/resource/cellar/abc123def456.0006.03/DOC_1')
+      .with(headers: { 'Accept' => 'application/xhtml+xml' })
+      .to_return(status: 200, body: html_body)
+
+    stub_request(:get, 'http://publications.europa.eu/resource/cellar/abc123def456.0006.01/DOC_1')
+      .to_return(status: 200, body: pdf_body, headers: { 'Content-Type' => 'application/pdf' })
+  end
+
+  describe '#call' do
+    it 'returns a Result with the correct CELEX and dates' do
+      result = fetcher.call.first
+      expect(result.celex).to eq '32025R1926'
+      expect(result.force_date).to eq Date.new(2026, 1, 1)
+      expect(result.publication_date).to eq Date.new(2025, 10, 31)
+    end
+
+    it 'populates html_content, pdf_content, and pdf_checksum' do
+      result = fetcher.call.first
+      expect(result.html_content).to eq html_body
+      expect(result.pdf_content).to eq pdf_body
+      expect(result.pdf_checksum).to eq Digest::SHA256.hexdigest(pdf_body)
+    end
+
+    it 'stores the Cellar URL as cellar_url' do
+      result = fetcher.call.first
+      expect(result.cellar_url).to eq 'http://publications.europa.eu/resource/cellar/abc123def456.0006.03/DOC_1'
+    end
+
+    context 'when the version is already imported (not failed)' do
+      before { create(:customs_tariff_update, version: '32025R1926', status: CustomsTariffUpdate::PENDING) }
+
+      it 'skips the version and returns an empty array' do
+        expect(fetcher.call).to be_empty
+      end
+    end
+
+    context 'when the version previously failed' do
+      before { create(:customs_tariff_update, :failed, version: '32025R1926') }
+
+      it 'retries the version' do
+        expect(fetcher.call.length).to eq 1
+      end
+    end
+
+    context 'when the SPARQL endpoint returns no bindings' do
+      before do
+        stub_request(:post, described_class::SPARQL_ENDPOINT)
+          .to_return(status: 200,
+                     body: { 'results' => { 'bindings' => [] } }.to_json,
+                     headers: { 'Content-Type' => 'application/sparql-results+json' })
+      end
+
+      it 'returns an empty array' do
+        expect(fetcher.call).to be_empty
+      end
+    end
+  end
+end

--- a/spec/lib/xi_cn_importer/importer_spec.rb
+++ b/spec/lib/xi_cn_importer/importer_spec.rb
@@ -1,0 +1,112 @@
+require 'rails_helper'
+
+RSpec.describe XiCnImporter::Importer do
+  subject(:importer) { described_class.new }
+
+  let(:celex)        { '32025R1926' }
+  let(:force_date)   { Date.new(2026, 1, 1) }
+  let(:html_content) { '<html><body></body></html>' }
+  let(:pdf_content)  { '%PDF-1.4 stub' }
+  let(:pdf_checksum) { Digest::SHA256.hexdigest(pdf_content) }
+
+  let(:fetched_result) do
+    XiCnImporter::DocumentFetcher::Result.new(
+      celex:,
+      force_date:,
+      publication_date: Date.new(2025, 10, 31),
+      cellar_url: 'http://publications.europa.eu/resource/cellar/abc.0006.03/DOC_1',
+      html_content:,
+      pdf_content:,
+      pdf_checksum:,
+    )
+  end
+
+  let(:extracted_result) do
+    XiCnImporter::NotesExtractor::Result.new(
+      sections: { 1 => 'Section I note content.' },
+      chapters: { '01' => 'Chapter 1 note content.' },
+      general_rules: { '1' => 'GRI rule one.' },
+    )
+  end
+
+  before do
+    allow(XiCnImporter::DocumentFetcher).to receive(:new).and_return(
+      instance_double(XiCnImporter::DocumentFetcher, call: [fetched_result]),
+    )
+    allow(XiCnImporter::NotesExtractor).to receive(:new).and_return(
+      instance_double(XiCnImporter::NotesExtractor, call: extracted_result),
+    )
+    allow(TariffSynchronizer::FileService).to receive(:write_file)
+  end
+
+  describe '#call' do
+    it 'writes the PDF to S3 at the XI prefix path' do
+      importer.call
+      expect(TariffSynchronizer::FileService)
+        .to have_received(:write_file)
+        .with("data/customs_tariff_documents/xi/CN_#{celex}.pdf", pdf_content)
+    end
+
+    it 'creates a CustomsTariffUpdate with status pending' do
+      expect { importer.call }
+        .to change { CustomsTariffUpdate.where(version: celex).count }.by(1)
+
+      update = CustomsTariffUpdate.first(version: celex)
+      expect(update.status).to eq CustomsTariffUpdate::PENDING
+      expect(update.validity_start_date).to eq force_date
+    end
+
+    it 'creates chapter, section, and general rule notes' do
+      importer.call
+      expect(CustomsTariffChapterNote.where(customs_tariff_update_version: celex).count).to eq 1
+      expect(CustomsTariffSectionNote.where(customs_tariff_update_version: celex).count).to eq 1
+      expect(CustomsTariffGeneralRule.where(customs_tariff_update_version: celex).count).to eq 1
+    end
+
+    it 'returns :imported status' do
+      results = importer.call
+      expect(results.first.status).to eq :imported
+      expect(results.first.celex).to eq celex
+    end
+
+    context 'when extraction raises an error' do
+      before do
+        allow(XiCnImporter::NotesExtractor).to receive(:new).and_raise(RuntimeError, 'parse error')
+      end
+
+      it 'returns :failed status' do
+        results = importer.call
+        expect(results.first.status).to eq :failed
+        expect(results.first.error).to eq 'parse error'
+      end
+
+      it 'creates a failed CustomsTariffUpdate' do
+        importer.call
+        update = CustomsTariffUpdate.first(version: celex)
+        expect(update.status).to eq CustomsTariffUpdate::FAILED
+      end
+
+      context 'when a pre-existing FAILED record exists' do
+        it 'refreshes the error message and timestamp' do
+          old_error = 'previous import error'
+          old_timestamp = 2.days.ago
+          CustomsTariffUpdate.create(
+            version: celex,
+            validity_start_date: old_timestamp.to_date,
+            status: CustomsTariffUpdate::FAILED,
+            import_error: old_error,
+          )
+
+          travel_to 1.day.ago do
+            importer.call
+          end
+
+          update = CustomsTariffUpdate.first(version: celex)
+          expect(update.status).to eq CustomsTariffUpdate::FAILED
+          expect(update.import_error).to eq 'parse error'
+          expect(update.updated_at).to be > old_timestamp
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/xi_cn_importer/importer_spec.rb
+++ b/spec/lib/xi_cn_importer/importer_spec.rb
@@ -47,6 +47,13 @@ RSpec.describe XiCnImporter::Importer do
         .with("data/customs_tariff_documents/xi/CN_#{celex}.pdf", pdf_content)
     end
 
+    it 'writes the XHTML to S3 at the XI prefix path' do
+      importer.call
+      expect(TariffSynchronizer::FileService)
+        .to have_received(:write_file)
+        .with("data/customs_tariff_documents/xi/CN_#{celex}.xhtml", html_content)
+    end
+
     it 'creates a CustomsTariffUpdate with status pending' do
       expect { importer.call }
         .to change { CustomsTariffUpdate.where(version: celex).count }.by(1)

--- a/spec/lib/xi_cn_importer/importer_spec.rb
+++ b/spec/lib/xi_cn_importer/importer_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe XiCnImporter::Importer do
       celex:,
       force_date:,
       publication_date: Date.new(2025, 10, 31),
-      cellar_url: 'http://publications.europa.eu/resource/cellar/abc.0006.03/DOC_1',
+      cellar_url: 'https://publications.europa.eu/resource/cellar/abc.0006.03/DOC_1',
       html_content:,
       pdf_content:,
       pdf_checksum:,

--- a/spec/lib/xi_cn_importer/notes_extractor/formatter_spec.rb
+++ b/spec/lib/xi_cn_importer/notes_extractor/formatter_spec.rb
@@ -1,0 +1,1434 @@
+require 'rails_helper'
+
+RSpec.describe XiCnImporter::NotesExtractor::Formatter do
+  subject(:formatter) { described_class.new }
+
+  describe '#call' do
+    it 'returns blank content unchanged' do
+      expect(formatter.call('')).to eq('')
+      expect(formatter.call(nil)).to be_nil
+    end
+
+    # ══════════════════════════════════════════════════════════════════════════
+    # Chapter-notes section rules
+    # (content before "### Additional Notes")
+    # ══════════════════════════════════════════════════════════════════════════
+
+    # ── Rule: (a) → a) list marker normalisation ─────────────────────────────
+    # EU source uses (a)/(b)/(c) style; govspeak expects a)/b)/c) in chapter notes.
+    # First confirmed: Chapter 01
+
+    it 'converts indented (a)/(b)/(c) markers to a)/b)/c) style in chapter notes' do
+      input = <<~TEXT
+        1. This chapter covers all live animals, except:
+
+            (a) first item;
+
+            (b) second item; and
+
+            (c) third item.
+      TEXT
+
+      expected = <<~TEXT
+        1. This chapter covers all live animals, except:
+
+            a) first item;
+
+            b) second item; and
+
+            c) third item.
+      TEXT
+
+      expect(formatter.call(input.chomp)).to eq(expected.chomp)
+    end
+
+    it 'converts multi-character roman-numeral markers (i)/(ii)/(iii) to i)/ii)/iii) style' do
+      input = "    (i) first;\n\n    (ii) second;\n\n    (iii) third."
+      expected = "    i) first;\n\n    ii) second;\n\n    iii) third."
+      expect(formatter.call(input)).to eq(expected)
+    end
+
+    it 'does not convert (a) markers that appear mid-sentence' do
+      input = 'The provisions of paragraph (a) apply here.'
+      expect(formatter.call(input)).to eq(input)
+    end
+
+    # ── Rule: merge dangling note-number+marker lines with their content ──────
+    # EU XHTML can place the note number ("6.") in the label cell and "(a)" as
+    # the cell content, with the actual (a) text in the NEXT row (empty label).
+    # This produces "6. (a)" alone on a line followed by the text on the next.
+    # Govspeak needs them on the same line. Handled in chapter notes by
+    # merge_trailing_list_markers; in Additional Notes by an extended ISOLATED_MARKER_PATTERN.
+
+    it 'merges a note-number+marker line with the following content in chapter notes' do
+      # "6. (a)" is a dangling marker — its content is in the next extractor row.
+      # "(b)" already has its content on the same line (no merge needed).
+      input = [
+        '6. (a)',
+        '',
+        '   Uncooked seasoned meats fall in Chapter 16.',
+        '',
+        '   (b) Products falling in heading 0210.',
+      ].join("\n")
+
+      expected = [
+        '6. a) Uncooked seasoned meats fall in Chapter 16.',
+        '',
+        '   b) Products falling in heading 0210.',
+      ].join("\n")
+
+      expect(formatter.call(input)).to eq(expected)
+    end
+
+    it 'merges a bare isolated (a) marker with the following content in chapter notes' do
+      input = "Some lead-in:\n\n(a)\n\nfirst item;\n\n(b) second item."
+      expected = "Some lead-in:\n\na) first item;\n\nb) second item."
+      expect(formatter.call(input)).to eq(expected)
+    end
+
+    # ── Rule: align orphaned first list item to match sibling indent ──────────
+    # EU XHTML for some notes (e.g. Chapter 04 note 5) emits the first sub-list
+    # item at 0 indent while all subsequent siblings are at 4 spaces. After
+    # normalise_list_marker converts (a)→a), the 0-indent marker is detected and
+    # raised to match the indent of the next list item.
+    # First confirmed: Chapter 04 chapter notes, note 5 item (a).
+
+    it 'aligns a misindented first list item with the indent of subsequent sibling items' do
+      input = [
+        '5. This chapter does not cover:',
+        '',
+        '(a) non-living insects (heading 0511);',
+        '',
+        '    (b) products obtained from whey (heading 1702);',
+        '',
+        '    (c) products from milk (heading 1901);',
+        '',
+        '    (d) albumins (heading 3502).',
+      ].join("\n")
+
+      expected = [
+        '5. This chapter does not cover:',
+        '',
+        '    a) non-living insects (heading 0511);',
+        '',
+        '    b) products obtained from whey (heading 1702);',
+        '',
+        '    c) products from milk (heading 1901);',
+        '',
+        '    d) albumins (heading 3502).',
+      ].join("\n")
+
+      expect(formatter.call(input)).to eq(expected)
+    end
+
+    # ── Rule: merge continuation clauses at 0 indent with the preceding list item ─
+    # EU XHTML can split a list item's sentence across two table rows: the item text
+    # (ending with a comma) in one row and a continuation clause at 0 indent in the
+    # next row. Merge the continuation back onto the list item.
+    # First confirmed: Chapter 08 chapter notes note 3, item (b) — the clause
+    # "provided that they retain the character of dried fruit or dried nuts." was
+    # arriving at 0 indent after the b) item row.
+
+    it 'merges a continuation clause at 0 indent with the preceding comma-terminated list item' do
+      input = [
+        '3. Dried fruit may be treated for the following purposes:',
+        '',
+        '    (a) for additional preservation (for example, by sulphuring),',
+        '',
+        '    (b) to improve or maintain their appearance (for example, by the addition of vegetable oil),',
+        '',
+        'provided that they retain the character of dried fruit.',
+        '',
+        '4. Heading 0812 applies to fruit and nuts.',
+      ].join("\n")
+
+      expected = [
+        '3. Dried fruit may be treated for the following purposes:',
+        '',
+        '    a) for additional preservation (for example, by sulphuring),',
+        '',
+        '    b) to improve or maintain their appearance (for example, by the addition of vegetable oil), provided that they retain the character of dried fruit.',
+        '',
+        '4. Heading 0812 applies to fruit and nuts.',
+      ].join("\n")
+
+      expect(formatter.call(input)).to eq(expected)
+    end
+
+    # ── Rule: indent continuation paragraphs that follow a chapter-note list ──
+    # EU XHTML can emit a note's closing paragraph at 0 indent after the list it
+    # supplements. Govspeak needs it at the same indent as the list items so it
+    # reads as part of the numbered note. Unlike the comma-terminated case
+    # (merge_list_item_continuations), the last list item ends with a full stop and
+    # the continuation is a structurally separate paragraph.
+    # First confirmed: Chapter 09 chapter notes, note 1.
+
+    it 'indents a continuation paragraph at 0 indent to match the preceding list indent' do
+      input = [
+        '1. Mixtures are to be classified as follows:',
+        '',
+        '    (a) mixtures of two or more of the same heading;',
+        '',
+        '    (b) mixtures of different headings are classified in heading 0910.',
+        '',
+        'The addition of other substances shall not affect their classification.',
+        '',
+        '2. This chapter does not cover cubeb pepper.',
+      ].join("\n")
+
+      expected = [
+        '1. Mixtures are to be classified as follows:',
+        '',
+        '    a) mixtures of two or more of the same heading;',
+        '',
+        '    b) mixtures of different headings are classified in heading 0910.',
+        '',
+        '    The addition of other substances shall not affect their classification.',
+        '',
+        '2. This chapter does not cover cubeb pepper.',
+      ].join("\n")
+
+      expect(formatter.call(input)).to eq(expected)
+    end
+
+    it 'does not indent a numbered note that follows a list' do
+      input = [
+        '1. This chapter covers:',
+        '',
+        '    (a) item one;',
+        '',
+        '    (b) item two.',
+        '',
+        '2. This chapter does not cover.',
+      ].join("\n")
+
+      expected = [
+        '1. This chapter covers:',
+        '',
+        '    a) item one;',
+        '',
+        '    b) item two.',
+        '',
+        '2. This chapter does not cover.',
+      ].join("\n")
+
+      expect(formatter.call(input)).to eq(expected)
+    end
+
+    # ── Rule: raise pre-list continuation paragraphs to 3 spaces ─────────────────
+    # EU XHTML can emit a note's continuation sentence at 0 indent *before* the
+    # sub-list it introduces. list_indent is 0 at that point (no items seen yet),
+    # so the post-list raise doesn't fire. Govspeak needs the sentence at 3 spaces
+    # so the ordered-list counter is not reset and the sub-items don't render as a
+    # code block. First confirmed: Chapter 12 notes 3 and 4.
+
+    it 'raises a pre-list continuation paragraph to 3 spaces inside a numbered note' do
+      input = [
+        '3. For the purposes of heading 1209, beet seeds are seeds of a kind used for sowing.',
+        '',
+        'Heading 1209 does not, however, apply to the following, even if for sowing:',
+        '',
+        '    a) leguminous vegetables;',
+        '',
+        '    b) spices.',
+        '',
+        '4. Heading 1211 applies to basil.',
+        '',
+        'Heading 1211 does not, however, apply to:',
+        '',
+        '    a) medicaments.',
+        '',
+        '5. For the purposes of heading 1212.',
+      ].join("\n")
+
+      result = formatter.call(input)
+
+      expect(result).to include('   Heading 1209 does not, however, apply to the following, even if for sowing:')
+      expect(result).to include('   Heading 1211 does not, however, apply to:')
+      expect(result).to include('3. For the purposes of heading 1209')
+      expect(result).to include('5. For the purposes of heading 1212.')
+    end
+
+    # ── Rule: two-digit note continuation indent ─────────────────────────────
+    # Govspeak requires continuation paragraphs to be indented to the content-
+    # start column of the enclosing list item. For "10. text" that is 4 spaces
+    # (not 3). Without this, govspeak restarts the ordered-list counter at 11.
+    # EU XHTML sometimes emits these continuation paragraphs at 3 spaces which
+    # our pre-processing leaves untouched; we must raise them to 4.
+    # First confirmed: Chapter 84, Note 10 → Note 11.
+
+    it 'raises a continuation paragraph at 3 spaces to 4 spaces inside a two-digit note' do
+      input = [
+        '10. For the purposes of heading 8485, the expression means the formation of objects.',
+        '',
+        '   Subject to note 1 to Section XVI and note 1 to Chapter 84, machines are classified.',
+        '',
+        '11. Next note.',
+      ].join("\n")
+
+      result = formatter.call(input)
+
+      expect(result).to include("\n    Subject to note 1 to Section XVI")
+      expect(result).to include('11. Next note.')
+      expect(result).not_to include("\n   Subject to note 1")
+    end
+
+    it 'still raises 0-indent continuation to 3 spaces inside a single-digit note' do
+      input = [
+        '3. This heading covers products.',
+        '',
+        'However, it does not cover excluded items.',
+        '',
+        '4. Next note.',
+      ].join("\n")
+
+      result = formatter.call(input)
+
+      expect(result).to include('   However, it does not cover excluded items.')
+      expect(result).to include('4. Next note.')
+    end
+
+    it 'raises a letter sub-list at 3 spaces to 4 spaces inside a two-digit note' do
+      # Chapter 22 note 12: sub-list items (a)-(f) arrive at 3 spaces under a two-digit
+      # note, not indented enough for govspeak (which needs 4 to continue the ordered list).
+      # Without this, note 13 starts a new <ol> and the browser renders it as "1.".
+      input = [
+        '12. Subheading 2207 20 covers mixtures denatured with one or more of the following:',
+        '',
+        '   a) automotive petrol;',
+        '',
+        '   b) tert-butyl ethyl ether;',
+        '',
+        '   c) methyl tert-butylether.',
+        '',
+        '   The denaturants referred to in points (b) and (c) must be used in combination.',
+        '',
+        '13. For the purposes of subheadings 2202 99 11.',
+      ].join("\n")
+
+      result = formatter.call(input)
+
+      expect(result).to include('    a) automotive petrol;')
+      expect(result).to include('    b) tert-butyl ethyl ether;')
+      expect(result).to include('    c) methyl tert-butylether.')
+      expect(result).to include('    The denaturants referred to')
+      expect(result).to include('13. For the purposes of subheadings')
+      expect(result).not_to include("\n   a) automotive petrol")
+    end
+
+    it 'does not raise a list marker at 0 indent to 3 spaces when it is the pre-list item' do
+      input = [
+        '6. This note covers:',
+        '',
+        'a) item one;',
+        '',
+        'b) item two.',
+        '',
+        '7. Next note.',
+      ].join("\n")
+
+      result = formatter.call(input)
+
+      expect(result).not_to include('   a) item one;')
+      expect(result).to include('7. Next note.')
+    end
+
+    # ── Rule: normalise deep numeric sub-items to the enclosing letter-list indent ─
+    # EU XHTML nests (1)/(2) sub-items one table level deeper than the enclosing a)/b)
+    # letter-list, producing 8-space indentation when the letter-list is at 4 spaces.
+    # At 8 spaces they can render as a code block or deeply nested item in govspeak.
+    # Normalise them to list_indent (matching the enclosing letter-list).
+    # First confirmed: Chapter 19 note 2, sub-items under b).
+
+    it 'normalises numeric sub-items deeper than the letter-list to the letter-list indent' do
+      input = [
+        '2. For the purposes of heading 1901:',
+        '',
+        "    a) the term 'groats' means cereal groats of Chapter 11;",
+        '',
+        "    b) the terms 'flour' and 'meal' mean:",
+        '',
+        '        (1) cereal flour and meal of Chapter 11, and',
+        '',
+        '        (2) flour, meal and powder of vegetable origin.',
+        '',
+        '3. Heading 1904 does not cover.',
+      ].join("\n")
+
+      result = formatter.call(input)
+
+      expect(result).to include("    a) the term 'groats' means cereal groats of Chapter 11;")
+      expect(result).to include("    b) the terms 'flour' and 'meal' mean:")
+      expect(result).to include('    (1) cereal flour and meal of Chapter 11, and')
+      expect(result).to include('    (2) flour, meal and powder of vegetable origin.')
+      expect(result).to include('3. Heading 1904 does not cover.')
+    end
+
+    # ── Rule: em-dash sub-bullets under a letter-list item → hyphen at letter-list indent ─
+    # EU XHTML nests em-dash (—) sub-bullets in a two-column sub-table inside the letter-list
+    # item cell, producing "        — content" at 8 spaces (depth = 2) when the letter-list
+    # is at 4 spaces (depth = 1). convert_emdash_bullet (now also in format_main_part)
+    # converts — to - , and indent_note_continuations pulls the resulting "- " items
+    # back to list_indent (4 spaces), matching the letter-list level.
+    # First confirmed: Chapter 59 notes 5 and 8.
+
+    it 'converts em-dash sub-bullets under a letter-list item to hyphens at the letter-list indent' do
+      input = [
+        "5. For the purposes of heading 5906, the expression 'rubberised textile fabrics' means:",
+        '',
+        '    a) textile fabrics impregnated, coated, covered or laminated with rubber:',
+        '',
+        '        — weighing not more than 1 500 g/m2, or',
+        '',
+        '        — weighing more than 1 500 g/m2 and containing more than 50 % by weight of textile material;',
+        '',
+        '    b) fabrics made from yarn, strip or the like;',
+        '',
+        '6. Next note.',
+      ].join("\n")
+
+      result = formatter.call(input)
+
+      expect(result).to include('    a) textile fabrics impregnated')
+      expect(result).to include('    - weighing not more than 1 500 g/m2, or')
+      expect(result).to include('    - weighing more than 1 500 g/m2')
+      expect(result).to include('    b) fabrics made from yarn, strip or the like;')
+      expect(result).to include('6. Next note.')
+      expect(result).not_to include('—')
+    end
+
+    # ── Rule: (A)/(B)/(C) uppercase sub-markers in chapter notes with nested letter-lists ─
+    # EU XHTML nests (A)/(B)/(C) sub-markers at 4 spaces inside a numbered note, then places
+    # a)/b)/c) letter-list items 8 spaces deep (one extra XHTML table depth). The
+    # letter-list items must be pulled back to 4 spaces (same level as the uppercase marker),
+    # not left at 8 spaces which would make them appear as a deeper sub-list.
+    # First confirmed: Chapter 84, Note 2.
+
+    # ── Rule: govspeak table rows below list_indent raised to list_indent ──────────
+    # When a letter-list item is at 4 spaces, continuation content (including table rows)
+    # must also be at 4 spaces. TableFormatter emits rows at 3 spaces (INDENT); those 3-
+    # space rows would fall below the list item level. Raise them to list_indent so
+    # govspeak keeps the table inside the list item rather than breaking the list.
+    # First confirmed: Chapter 74, note 1 — oj-table inside letter-list item (a).
+
+    it 'raises table rows below list_indent to list_indent when inside a letter-list' do
+      input = [
+        '1. In this chapter, the expressions have the following meanings:',
+        '',
+        '    a) Refined copper: Metal containing at least 99,85 % by weight of copper.',
+        '',
+        '   | Element | Limiting content % by weight |',
+        '   | --- | --- |',
+        '   | Ag Silver | 0,25 |',
+        '   | Zn Zinc | 1 |',
+        '',
+        '    b) Copper alloys: Metallic substances in which copper predominates.',
+      ].join("\n")
+
+      result = formatter.call(input)
+
+      expect(result).to include('    | Element | Limiting content % by weight |')
+      expect(result).to include('    | --- | --- |')
+      expect(result).to include('    | Ag Silver | 0,25 |')
+      expect(result).to include('    b) Copper alloys')
+      expect(result).not_to include("\n   | Element")
+    end
+
+    # ── Rule: roman-numeral / continuation letter-list items deeper than list_indent ──
+    # EU XHTML can nest ii)/iii) sub-items one table level deeper than the enclosing
+    # a)/b) list when both should be at the same govspeak indent. Pull back to list_indent.
+    # Also: plain continuation paragraphs of those deeper items arrive at the same depth
+    # and must be pulled back too.
+    # First confirmed: Chapter 85, Note 12 — ii) at 8 spaces under a) at 4 spaces.
+
+    it 'pulls a roman-numeral list item deeper than list_indent back to list_indent' do
+      input = [
+        '12. For the purposes of headings 8541 and 8542:',
+        '',
+        "    a) (i) 'Semiconductor devices' are devices.",
+        '',
+        "        ii) 'Light-emitting diodes' are devices based on semiconductor materials.",
+        '',
+        '        LEDs of heading 8541 do not incorporate power supply elements.',
+        '',
+        "    b) 'Electronic integrated circuits' are circuits.",
+        '',
+        '    For the classification of the articles defined in this note, headings 8541 and 8542 shall take precedence.',
+      ].join("\n")
+
+      result = formatter.call(input)
+
+      expect(result).to include("    ii) 'Light-emitting diodes'")
+      expect(result).to include('    LEDs of heading 8541 do not')
+      expect(result).to include("    b) 'Electronic integrated circuits'")
+      expect(result).to include('    For the classification of the articles')
+      expect(result).not_to include('        ii)')
+      expect(result).not_to include('        LEDs')
+    end
+
+    # ── Rule: 0-indent letter-list items after list_indent > 0 raised to list_indent ──
+    # Sub-items that are sub-sub-items (e.g. b)/c)/d) under a MCO definition item) can
+    # arrive at 0 indent from the extractor due to XHTML depth artefacts. When list_indent
+    # is already set, they should be raised to list_indent, not left at 0 (which would
+    # break govspeak's rendering of the enclosing note and its final paragraph).
+    # First confirmed: Chapter 85, Note 12 b)/c)/d) under (3)(a).
+
+    it 'raises 0-indent letter-list continuation items to list_indent when list_indent > 0' do
+      input = [
+        '12. For the purposes of this note:',
+        '',
+        "    b) 'Electronic integrated circuits' are:",
+        '',
+        "    (3) (a) 'Silicon based sensors' consist of microelectronic structures.",
+        '',
+        "b) 'Silicon based actuators' consist of structures.",
+        '',
+        "c) 'Silicon based resonators' are components.",
+        '',
+        '    For the classification of the articles, headings 8541 and 8542 shall take precedence.',
+      ].join("\n")
+
+      result = formatter.call(input)
+
+      expect(result).to include("    b) 'Silicon based actuators'")
+      expect(result).to include("    c) 'Silicon based resonators'")
+      expect(result).to include('    For the classification of the articles')
+      expect(result).not_to include("\nb) 'Silicon based actuators'")
+      expect(result).not_to include("\nc) 'Silicon based resonators'")
+    end
+
+    # ── Rule: A./B. dot-sub-section with nested letter-list and (N) sub-items ──
+    # EU OJ XHTML for ch48 note 5 produces a three-level structure:
+    #   A./B. at 4 spaces → (a)/(b)/(c) at 8 spaces → (1)/(2) at 12 spaces
+    # After normalise_list_marker converts (a)→a), govspeak treats 8+ spaces inside a
+    # numbered list item as a code block (scrollable pre box). The formatter must:
+    #   • Clamp letter-list items to uppercase_dot_indent + 2 (6 spaces) to stay below
+    #     the govspeak code-block threshold.
+    #   • Clamp (N) items to the same level (6 spaces) rather than passing through at 12.
+    #   • Raise a 0-indent closing paragraph ("Heading 4802 does not...") to
+    #     uppercase_dot_indent (4) rather than all the way to list_indent (6).
+    # First confirmed: Chapter 48, Note 5 — A./B. sub-sections with (a)/(b)/(1)/(2).
+    it 'clamps letter-list and (N) sub-items to uppercase_dot_indent + 2 inside an A./B. dot-sub-section' do
+      input = [
+        '5. Text satisfying any of the following criteria:',
+        '',
+        '    A. For paper weighing not more than 150 g/m2:',
+        '',
+        '        a) containing 10 % or more of fibres, and',
+        '',
+        '            (1) weighing not more than 80 g/m2; or',
+        '',
+        '            (2) coloured throughout the mass; or',
+        '',
+        '        b) containing more than 8 % ash.',
+        '',
+        '    B. For paper weighing more than 150 g/m2:',
+        '',
+        '        a) coloured throughout the mass; or',
+        '',
+        '        b) having a brightness of 60 % or more, and',
+        '',
+        '            (1) a caliper of 225 micrometres or less; or',
+        '',
+        '            (2) a caliper of more than 225 micrometres.',
+        '',
+        '        c) having a brightness of less than 60 %.',
+        '',
+        '6. Next note.',
+      ].join("\n")
+
+      result = formatter.call(input)
+
+      expect(result).to include('      (1) weighing not more than 80 g/m2; or')
+      expect(result).to include('      (2) coloured throughout the mass; or')
+      expect(result).to include('      (1) a caliper of 225 micrometres or less; or')
+      expect(result).to include('      (2) a caliper of more than 225 micrometres.')
+      expect(result).to include('      a) containing 10 % or more of fibres, and')
+      expect(result).to include('      a) coloured throughout the mass; or')
+      expect(result).not_to include("\n        (1) weighing")
+      expect(result).not_to include("\n            (1) weighing")
+    end
+
+    it 'raises a 0-indent closing paragraph inside A./B. to uppercase_dot_indent (4), not list_indent (6)' do
+      input = [
+        '5. Text satisfying any of the following criteria:',
+        '',
+        '    A. For paper weighing not more than 150 g/m2:',
+        '',
+        '        a) coloured throughout the mass; or',
+        '',
+        '        b) having brightness of 60 % or more.',
+        '',
+        '    B. For paper weighing more than 150 g/m2:',
+        '',
+        '        a) coloured throughout the mass; or',
+        '',
+        '        b) having a brightness of 60 % or more.',
+        '',
+        '        c) having a brightness of less than 60 %.',
+        '',
+        'Heading 4802 does not, however, cover filter paper.',
+        '',
+        '6. Next note.',
+      ].join("\n")
+
+      result = formatter.call(input)
+
+      expect(result).to include('    Heading 4802 does not, however, cover filter paper.')
+      expect(result).not_to include('        Heading 4802')
+      expect(result).not_to include("\nHeading 4802")
+    end
+
+    it 'normalises letter-list items deeper than an uppercase sub-marker to the sub-marker indent' do
+      input = [
+        '2. In this chapter note 2 introduces some machinery:',
+        '',
+        '    (A) Heat exchangers of a kind used in various industries:',
+        '',
+        '        a) industrial cooling systems;',
+        '',
+        '        b) other heat transfer applications.',
+        '',
+        '    (B) Machinery for liquefying air or other gases.',
+        '',
+        '    (C) Centrifuges.',
+        '',
+        '3. Next note.',
+      ].join("\n")
+
+      result = formatter.call(input)
+
+      expect(result).to include('    (A) Heat exchangers')
+      expect(result).to include('    a) industrial cooling systems;')
+      expect(result).to include('    b) other heat transfer applications.')
+      expect(result).to include('    (B) Machinery for liquefying air')
+      expect(result).to include('    (C) Centrifuges.')
+      expect(result).not_to include('        a)')
+      expect(result).not_to include('        b)')
+    end
+
+    it 'does not merge when the next non-blank after a comma-terminated list item is another list item' do
+      input = [
+        '3. This chapter does not cover:',
+        '',
+        '    (a) item one,',
+        '',
+        '    (b) item two.',
+      ].join("\n")
+
+      expected = [
+        '3. This chapter does not cover:',
+        '',
+        '    a) item one,',
+        '',
+        '    b) item two.',
+      ].join("\n")
+
+      expect(formatter.call(input)).to eq(expected)
+    end
+
+    it 'does not alter list items when all siblings share the same indent' do
+      input = [
+        '3. For the purposes of heading 0405:',
+        '',
+        '    (a) the term butter means natural butter;',
+        '',
+        '    (b) the expression dairy spreads means a spreadable emulsion.',
+      ].join("\n")
+
+      expected = [
+        '3. For the purposes of heading 0405:',
+        '',
+        '    a) the term butter means natural butter;',
+        '',
+        '    b) the expression dairy spreads means a spreadable emulsion.',
+      ].join("\n")
+
+      expect(formatter.call(input)).to eq(expected)
+    end
+
+    # ── Rule: strip spaces before punctuation ────────────────────────────────
+    # EU publication leaves a trailing space after heading references before
+    # punctuation: "0301 ," "0308 ;" "9508 ."
+    # First confirmed: Chapter 01
+
+    it 'removes spaces before commas, semicolons and full stops' do
+      input = 'of heading 0301 , 0306 , 0307 or 0308 ;'
+      expect(formatter.call(input)).to eq('of heading 0301, 0306, 0307 or 0308;')
+    end
+
+    it 'removes a space before a trailing full stop' do
+      input = 'animals of heading 9508 .'
+      expect(formatter.call(input)).to eq('animals of heading 9508.')
+    end
+
+    it 'removes a space before a closing parenthesis' do
+      # EU XHTML heading references in parenthetical lists: "heading 0208 or 0210 );"
+      # First confirmed: Chapter 03 chapter notes items (b), (c), (d)
+      input = 'meat of mammals of heading 0106 (heading 0208 or 0210 );'
+      expect(formatter.call(input)).to eq('meat of mammals of heading 0106 (heading 0208 or 0210);')
+    end
+
+    it 'removes a space before a colon' do
+      input = "the term 'pellets' means products :"
+      expect(formatter.call(input)).to eq("the term 'pellets' means products:")
+    end
+
+    # ── Rule: collapse internal double spaces ─────────────────────────────────
+    # Double spaces arise when two trailing-space artefacts are adjacent.
+    # First confirmed: Chapter 01
+
+    it 'collapses double spaces within content while preserving leading indent' do
+      input = '    text with  double  spaces inside'
+      expect(formatter.call(input)).to eq('    text with double spaces inside')
+    end
+
+    # ══════════════════════════════════════════════════════════════════════════
+    # Additional Notes section rules
+    # (content after "### Additional Notes")
+    # ══════════════════════════════════════════════════════════════════════════
+
+    # ── Rule: (a) markers preserved in Additional Notes ───────────────────────
+    # Additional Notes use the parenthesised form (a)/(b) — govspeak convention
+    # for this section differs from chapter notes. Do NOT convert to a)/b).
+    # First confirmed: Chapter 02 Additional Notes
+
+    it 'preserves (a)/(b) markers in Additional Notes (does not strip parens)' do
+      input = "### Additional Notes\n\n   (a) first item;\n\n   (b) second item."
+      expect(formatter.call(input)).to eq("### Additional Notes\n\n   (a) first item;\n\n   (b) second item.")
+    end
+
+    # ── Rule: normalise all-whitespace lines to blank ─────────────────────────
+    # EU XHTML deeply nested tables produce lines that are only spaces.
+    # First confirmed: Chapter 02 Additional Notes
+
+    it 'treats lines containing only spaces in Additional Notes as blank lines' do
+      input = "### Additional Notes\n\nline one\n         \nline two"
+      expect(formatter.call(input)).to eq("### Additional Notes\n\nline one\n\nline two")
+    end
+
+    # ── Rule: normalise deep indentation ─────────────────────────────────────
+    # EU XHTML nests tables 12+ levels deep; depth tracking produces 48+ leading
+    # spaces as an artefact. Strip the common base indent to restore readable nesting.
+    # First confirmed: Chapter 02 Additional Notes
+
+    it 'strips the common base indent from deeply-indented Additional Notes blocks' do
+      # Line 1 at 48 spaces (becomes 0 relative), line 2 at 52 spaces (becomes 4 relative)
+      input = "### Additional Notes\n\n#{' ' * 48}top level\n\n#{' ' * 52}nested level"
+      expected = "### Additional Notes\n\ntop level\n\n    nested level"
+      expect(formatter.call(input)).to eq(expected)
+    end
+
+    it 'leaves lines with fewer than 13 leading spaces untouched when deep lines exist' do
+      input = "### Additional Notes\n\nnormal line\n\n#{' ' * 48}deep line"
+      expect(formatter.call(input)).to eq("### Additional Notes\n\nnormal line\n\ndeep line")
+    end
+
+    # ── Rule: merge isolated marker lines with content ────────────────────────
+    # EU two-column tables sometimes place the marker ((a), B., —, 1. A.) in
+    # one row and the content in the next, producing a label-only line in the
+    # extracted output.
+    # First confirmed: Chapter 02 Additional Notes
+
+    it 'merges an isolated (a) marker line with the following content line' do
+      input = "### Additional Notes\n\n(a)\n\nsome content text"
+      expect(formatter.call(input)).to eq("### Additional Notes\n\n   (a) some content text")
+    end
+
+    it 'merges an isolated uppercase-letter sub-section label (B.) with content and indents to 3 spaces' do
+      input = "### Additional Notes\n\nB.\n\nThe import of the following products is prohibited."
+      expect(formatter.call(input)).to eq("### Additional Notes\n\n   B. The import of the following products is prohibited.")
+    end
+
+    it 'merges an isolated numbered-plus-letter label (1. A.) with content' do
+      input = "### Additional Notes\n\n1. A.\n\nThe following expressions have the meanings hereby assigned to them:"
+      expected = "### Additional Notes\n\n1. A. The following expressions have the meanings hereby assigned to them:"
+      expect(formatter.call(input)).to eq(expected)
+    end
+
+    it 'merges an isolated standalone number (1.) with content and indents it' do
+      input = "### Additional Notes\n\n    1.\n\nfats of heading 1502; or"
+      expect(formatter.call(input)).to eq("### Additional Notes\n\n      1. fats of heading 1502; or")
+    end
+
+    it 'does not merge a line that has content after the marker' do
+      input = "### Additional Notes\n\n1. A. The following expressions:\n\n   (a) some text."
+      expect(formatter.call(input)).to eq("### Additional Notes\n\n1. A. The following expressions:\n\n   (a) some text.")
+    end
+
+    it 'merges a note-number+(a) isolated marker with the following content in Additional Notes' do
+      # EU XHTML for Additional Note 6 puts "6." in the label cell and "(a)" as the
+      # cell content, then "(a)"'s text in the next row. This is distinct from "1. A."
+      # (uppercase) — here the sub-marker is a lowercase parenthetical.
+      # First confirmed: Chapter 02 Additional Notes note 6.
+      input = [
+        '### Additional Notes',
+        '',
+        '6. (a)',
+        '',
+        'Uncooked seasoned meats fall in Chapter 16.',
+        '',
+        '(b) Products falling in heading 0210.',
+      ].join("\n")
+
+      expected = [
+        '### Additional Notes',
+        '',
+        '6. (a) Uncooked seasoned meats fall in Chapter 16.',
+        '',
+        '   (b) Products falling in heading 0210.',
+      ].join("\n")
+
+      expect(formatter.call(input)).to eq(expected)
+    end
+
+    it 'does not merge an isolated (x) marker when next non-empty line is also an isolated marker' do
+      # (h) followed by 1. — both are isolated markers, so (h) stays alone as a heading
+      # and 1. is independently merged with its own content.
+      input = [
+        '### Additional Notes',
+        '',
+        '(h)',
+        '',
+        '    1.',
+        '',
+        '        first sub-item;',
+        '',
+        '    2.',
+        '',
+        '        second sub-item.',
+      ].join("\n")
+
+      expected = [
+        '### Additional Notes',
+        '',
+        '   (h)',
+        '',
+        '      1. first sub-item;',
+        '',
+        '      2. second sub-item.',
+      ].join("\n")
+
+      expect(formatter.call(input)).to eq(expected)
+    end
+
+    it 'does not merge an isolated (x) marker when next non-empty line is an already-populated indented numbered sub-item' do
+      # Simulates extractor output: extractor emits "(h)" alone and "    1. 'crop'..." as
+      # a separate block (the sub-table rows were already merged with their labels by the
+      # extractor). Without this guard merge_isolated_markers would re-join them into
+      # "(h) 1. 'crop'..." — matching the regression seen in Ch02 Additional Notes 1.A.(h).
+      # First confirmed: Chapter 02 Additional Notes 1.A.(h).
+      input = [
+        '### Additional Notes',
+        '',
+        '(h)',
+        '',
+        "    1. 'crop' and 'chuck and blade' cuts: the dorsal part of the forequarter;",
+        '',
+        "    2. 'brisket' cut: the lower part of the forequarter.",
+      ].join("\n")
+
+      expected = [
+        '### Additional Notes',
+        '',
+        '   (h)',
+        '',
+        "      1. 'crop' and 'chuck and blade' cuts: the dorsal part of the forequarter;",
+        '',
+        "      2. 'brisket' cut: the lower part of the forequarter.",
+      ].join("\n")
+
+      expect(formatter.call(input)).to eq(expected)
+    end
+
+    # ── Rule: re-anchor (a)/(b) indentation to 3 spaces ──────────────────────
+    # After deep-indentation stripping, (a)/(b) markers may still have excess
+    # relative indent. Govspeak convention places them at 3 spaces so they sit
+    # visually under the sub-note letter (A., B., …) above them.
+    # First confirmed: Chapter 02 Additional Notes
+
+    it 'normalises (a)/(b) indentation to 3 spaces in Additional Notes' do
+      input = "### Additional Notes\n\n            (a) some definition text;"
+      expect(formatter.call(input)).to eq("### Additional Notes\n\n   (a) some definition text;")
+    end
+
+    # ── Rule: two-digit note uses 4-space continuation indent in Additional Notes ─
+    # Govspeak requires sub-item lines to be indented to the content-start column of
+    # the enclosing ordered-list item. For "12. text" that is 4 spaces (not 3), so
+    # (a)/(b) items and closing paragraphs inside a two-digit additional note must be
+    # at 4 spaces — otherwise govspeak starts a new <ol> for the next note.
+    # First confirmed: Chapter 22, Additional Note 12 → Note 13 numbering reset.
+
+    it 'uses 4 spaces for (a)/(b) sub-items inside a two-digit Additional Note' do
+      input = [
+        '### Additional Notes',
+        '',
+        '12. Subheading 2207 20 covers mixtures denatured with one or more of the following:',
+        '',
+        '   (a) automotive petrol;',
+        '',
+        '   (b) tert-butyl ethyl ether;',
+        '',
+        '   (c) methyl tert-butylether.',
+        '',
+        '   The denaturants referred to in (b) and (c) must be used in combination.',
+        '',
+        '13. For the purposes of subheadings 2202 99 11.',
+      ].join("\n")
+
+      result = formatter.call(input)
+
+      expect(result).to include('    (a) automotive petrol;')
+      expect(result).to include('    (b) tert-butyl ethyl ether;')
+      expect(result).to include('    (c) methyl tert-butylether.')
+      expect(result).to include('    The denaturants referred to')
+      expect(result).to include('13. For the purposes of subheadings')
+      expect(result).not_to include("\n   (a) automotive")
+    end
+
+    it 'still uses 3 spaces for (a)/(b) sub-items inside a single-digit Additional Note' do
+      input = [
+        '### Additional Notes',
+        '',
+        '9. Note nine with sub-items:',
+        '',
+        '   (a) first item;',
+        '',
+        '   (b) second item.',
+        '',
+        '10. Next note.',
+      ].join("\n")
+
+      result = formatter.call(input)
+
+      expect(result).to include('   (a) first item;')
+      expect(result).to include('   (b) second item.')
+      expect(result).to include('10. Next note.')
+    end
+
+    it 'normalises indented numeric sub-items to 6 spaces in Additional Notes' do
+      input = "### Additional Notes\n\n    1. fats of heading 1502; or"
+      expect(formatter.call(input)).to eq("### Additional Notes\n\n      1. fats of heading 1502; or")
+    end
+
+    # ── Rule: collapse consecutive blank lines ─────────────────────────────────
+    # Deep-indentation normalisation can leave multiple consecutive blank lines.
+    # First confirmed: Chapter 02 Additional Notes
+
+    it 'collapses multiple consecutive blank lines into one' do
+      input = "### Additional Notes\n\nline one\n\n\n\nline two"
+      expect(formatter.call(input)).to eq("### Additional Notes\n\nline one\n\nline two")
+    end
+
+    # ── Rule: em-dash bullet conversion ──────────────────────────────────────
+    # EU source uses — (em-dash) as a list bullet in Additional Notes.
+    # Govspeak expects markdown dash: "- "
+    # First confirmed: Chapter 02 Additional Notes
+
+    it 'converts an em-dash bullet marker to a markdown dash in Additional Notes' do
+      input = "### Additional Notes\n\n— prohibition of imports"
+      expect(formatter.call(input)).to eq("### Additional Notes\n\n- prohibition of imports")
+    end
+
+    it 'merges an isolated em-dash line with content then converts to dash' do
+      input = "### Additional Notes\n\n—\n\nprohibition of imports"
+      expect(formatter.call(input)).to eq("### Additional Notes\n\n- prohibition of imports")
+    end
+
+    # ── Rule: normalise indented bullet indentation to 6 spaces ──────────────
+    # Bullet points that sit inside an (a)/(b) item in Additional Notes are
+    # over-indented from XHTML nesting. Govspeak expects them at 6 spaces —
+    # one level (3 spaces) deeper than the (a)/(b) marker at 3 spaces.
+    # First confirmed: Chapter 02 Additional Notes item (c).
+
+    it 'normalises indented bullet points to 6 spaces in Additional Notes' do
+      input = "### Additional Notes\n\n   (c) portions composed of either:\n\n            - forequarters; and\n\n            - hindquarters."
+      expected = "### Additional Notes\n\n   (c) portions composed of either:\n\n      - forequarters; and\n\n      - hindquarters."
+      expect(formatter.call(input)).to eq(expected)
+    end
+
+    it 'converts an indented em-dash bullet to a markdown dash at 6 spaces' do
+      input = "### Additional Notes\n\n   (c) portions composed of either:\n\n            — forequarters; and"
+      expected = "### Additional Notes\n\n   (c) portions composed of either:\n\n      - forequarters; and"
+      expect(formatter.call(input)).to eq(expected)
+    end
+
+    it 'does not alter top-level bullet points that have no indentation' do
+      input = "### Additional Notes\n\n- top level bullet"
+      expect(formatter.call(input)).to eq("### Additional Notes\n\n- top level bullet")
+    end
+
+    # ── Rule: uppercase sub-section labels (B., C.) → 3-space indent ─────────
+    # B./C./D. are siblings of A. within the same numbered note (1. A./B./C.).
+    # Govspeak needs them at 3 spaces so it knows they're still inside the "1."
+    # item — without this indent, "2. A." is miscounted as "1. A.".
+    # First confirmed: Chapter 02 Additional Notes (note 1 sections B and C).
+
+    it 'normalises uppercase sub-section labels (B., C.) to 3-space indent' do
+      # B. and C. appear as isolated markers then get merged with their content
+      input = [
+        '### Additional Notes',
+        '',
+        'B.',
+        '',
+        'Products covered by this chapter.',
+        '',
+        'C.',
+        '',
+        'In determining the number of ribs.',
+        '',
+        '2. A. The following expressions apply:',
+      ].join("\n")
+
+      expected = [
+        '### Additional Notes',
+        '',
+        '   B. Products covered by this chapter.',
+        '',
+        '   C. In determining the number of ribs.',
+        '',
+        '2. A. The following expressions apply:',
+      ].join("\n")
+
+      expect(formatter.call(input)).to eq(expected)
+    end
+
+    it 'normalises a standalone uppercase sub-section label to 3 spaces when it has no content' do
+      input = "### Additional Notes\n\nB."
+      expect(formatter.call(input)).to eq("### Additional Notes\n\n   B.")
+    end
+
+    it 'does not re-indent a numbered note line that starts with a digit (2. A. …)' do
+      input = "### Additional Notes\n\n2. A. The following expressions apply:"
+      expect(formatter.call(input)).to eq("### Additional Notes\n\n2. A. The following expressions apply:")
+    end
+
+    # ── Rule: indent continuation paragraphs inside sub-sections to 3 spaces ─
+    # EU XHTML two-column tables can emit each sentence as a separate row with
+    # an empty label cell. These rows come through at 0-1 space indent but are
+    # semantically inside the preceding B./C./(a) sub-section.
+    # The formatter tracks context (inside_sub_section flag) to re-indent them
+    # to 3 spaces, preventing govspeak from miscounting numbered notes.
+    # First confirmed: Chapter 02 Additional Notes, sections C and D.
+    # Without this rule "3. A." renders as "1. A." because C.'s continuation
+    # paragraphs fall outside the indent scope of note 1.
+
+    it 'indents continuation paragraphs within uppercase sub-sections to 3 spaces' do
+      # C. and D. have secondary sentences in separate extractor rows (0-1 space indent).
+      # The cheeks/snouts paragraph and "These subheadings" line are continuation text.
+      # "3. A." at 0 indent must reset context and stay at 0.
+      input = [
+        '### Additional Notes',
+        '',
+        'C. Main sentence, includes parts thereof.',
+        ' The head is separated from the carcase as follows:',
+        '',
+        '      - by a straight cut; or',
+        '',
+        '      - by a parallel cut.',
+        '',
+        ' The cheeks and snouts are considered parts of heads.',
+        '',
+        'D. For the purposes of subheading 0209 10, fat has the following meaning.',
+        ' These subheadings also include fat without rind.',
+        '',
+        '3. A. For the purposes of heading 0204, the following expressions apply:',
+      ].join("\n")
+
+      expected = [
+        '### Additional Notes',
+        '',
+        '   C. Main sentence, includes parts thereof.',
+        '   The head is separated from the carcase as follows:',
+        '',
+        '      - by a straight cut; or',
+        '',
+        '      - by a parallel cut.',
+        '',
+        '   The cheeks and snouts are considered parts of heads.',
+        '',
+        '   D. For the purposes of subheading 0209 10, fat has the following meaning.',
+        '   These subheadings also include fat without rind.',
+        '',
+        '3. A. For the purposes of heading 0204, the following expressions apply:',
+      ].join("\n")
+
+      expect(formatter.call(input)).to eq(expected)
+    end
+
+    # ── Rule: cap over-indented continuation text at 6 spaces ────────────────
+    # The EU XHTML sometimes nests a continuation paragraph one level deeper
+    # than the bullet list it follows (12 spaces vs 6 for bullets). Govspeak
+    # needs it at the same 6-space level as the bullets.
+    # First confirmed: Chapter 02 Additional Notes 1.A.(c) — "The forequarters
+    # and hindquarters constituting 'compensated quarters' must be presented..."
+    # arriving at 12 spaces instead of 6.
+
+    it 'normalises over-indented continuation text after bullets to 6 spaces' do
+      input = [
+        '### Additional Notes',
+        '',
+        "(c) 'compensated quarters': portions composed of either:",
+        '',
+        '      - forequarters at the tenth rib; or',
+        '',
+        '      - forequarters at the fifth rib.',
+        '',
+        '            The forequarters and hindquarters must be presented at the same time.',
+      ].join("\n")
+
+      expected = [
+        '### Additional Notes',
+        '',
+        "   (c) 'compensated quarters': portions composed of either:",
+        '',
+        '      - forequarters at the tenth rib; or',
+        '',
+        '      - forequarters at the fifth rib.',
+        '',
+        '      The forequarters and hindquarters must be presented at the same time.',
+      ].join("\n")
+
+      expect(formatter.call(input)).to eq(expected)
+    end
+
+    # ── Rule: raise continuation content under standalone dash-bullets to 9 spaces ─
+    # EU XHTML chemical composition lists (e.g. ch72 'Tool steel') use — sub-bullets
+    # at 6 spaces with 'and'/'or' connectors at 3 spaces and composition values at
+    # 0 spaces. These are multi-line continuations of the bullet item above them.
+    # When not inside an (a)/(b) sub-section, they must be raised to 9 spaces so
+    # govspeak renders them as continuation of the 6-space bullet, not loose paragraphs.
+    # The guard !inside_sub_section preserves the existing behaviour for bullets that
+    # appear inside (a)/(b) sub-sections (e.g. ch02), where continuation text is
+    # already correctly handled by inside_sub_section → 3 spaces.
+    # First confirmed: Chapter 72 Additional Notes, 'Tool steel' composition list.
+
+    it 'raises continuation content under standalone dash-bullets to 9 spaces' do
+      input = [
+        '### Additional Notes',
+        '',
+        '1. Tool steel definitions:',
+        '',
+        '      - less than 0,6 % of carbon',
+        '',
+        '   and',
+        '',
+        '0,7 % or more of silicon, or',
+        '',
+        '   or',
+        '',
+        '4 % or more of tungsten,',
+        '',
+        '      - 0,8 % or more of carbon',
+        '',
+        '   and',
+        '',
+        '0,05 % or more of vanadium.',
+      ].join("\n")
+
+      result = formatter.call(input)
+
+      expect(result).to include('      - less than 0,6 % of carbon')
+      expect(result).to include('         and')
+      expect(result).to include('         0,7 % or more of silicon, or')
+      expect(result).to include('         or')
+      expect(result).to include('         4 % or more of tungsten,')
+      expect(result).to include('      - 0,8 % or more of carbon')
+      expect(result).to include('         0,05 % or more of vanadium.')
+    end
+
+    it 'does not raise continuation content after dash-bullets that are inside a sub-section' do
+      input = [
+        '### Additional Notes',
+        '',
+        'C. Heading text.',
+        ' continuation of C.',
+        '',
+        '      - bullet one',
+        '',
+        ' continuation after bullet',
+        '',
+        '3. A. Next note.',
+      ].join("\n")
+
+      result = formatter.call(input)
+
+      expect(result).to include('   continuation after bullet')
+      expect(result).not_to include('         continuation after bullet')
+    end
+
+    it 'indents continuation paragraphs inside (a)/(b) sub-items to 3 spaces' do
+      # An (a) item with a second sentence in a separate extractor row at 1 space indent.
+      input = [
+        '### Additional Notes',
+        '',
+        '(a) first sentence of item a.',
+        ' second sentence still inside item a.',
+        '',
+        '(b) item b text.',
+      ].join("\n")
+
+      expected = [
+        '### Additional Notes',
+        '',
+        '   (a) first sentence of item a.',
+        '   second sentence still inside item a.',
+        '',
+        '   (b) item b text.',
+      ].join("\n")
+
+      expect(formatter.call(input)).to eq(expected)
+    end
+
+    # ── Rule: indent continuation paragraphs under numbered notes to 3 spaces ──
+    # EU XHTML places each numbered note and its continuation paragraphs as
+    # separate rows. After extraction, continuation paragraphs arrive at 0 indent.
+    # Govspeak requires them at 3 spaces so they sit inside the numbered note item.
+    # Without this indent, subsequent numbered notes are miscounted.
+    # First confirmed: Chapter 03 Additional Notes (notes 1 and 2).
+
+    it 'indents continuation paragraphs under a numbered note to 3 spaces in Additional Notes' do
+      input = [
+        '### Additional Notes',
+        '',
+        '1. For the purposes of subheadings 0305 32 11, cod fillets are considered to be salted fish.',
+        '',
+        'However, frozen cod fillets which have a total salt content of less than 12 % are classified elsewhere.',
+        '',
+        "2. For the purposes of the subheadings referred to, the term 'fillets' includes 'loins'.",
+        '',
+        'The classification of such products as fillets is unaffected by cutting them into pieces.',
+        '',
+        'The provisions of the first two paragraphs apply to the following fish:',
+        '',
+        '   (a) tuna, of the genus Thunnus;',
+        '',
+        '   (b) swordfish (Xiphias gladius);',
+      ].join("\n")
+
+      expected = [
+        '### Additional Notes',
+        '',
+        '1. For the purposes of subheadings 0305 32 11, cod fillets are considered to be salted fish.',
+        '',
+        '   However, frozen cod fillets which have a total salt content of less than 12 % are classified elsewhere.',
+        '',
+        "2. For the purposes of the subheadings referred to, the term 'fillets' includes 'loins'.",
+        '',
+        '   The classification of such products as fillets is unaffected by cutting them into pieces.',
+        '',
+        '   The provisions of the first two paragraphs apply to the following fish:',
+        '',
+        '   (a) tuna, of the genus Thunnus;',
+        '',
+        '   (b) swordfish (Xiphias gladius);',
+      ].join("\n")
+
+      expect(formatter.call(input)).to eq(expected)
+    end
+
+    # ══════════════════════════════════════════════════════════════════════════
+    # Integration tests
+    # ══════════════════════════════════════════════════════════════════════════
+
+    it 'correctly formats Chapter 01 chapter note' do
+      input = <<~TEXT
+        1. This chapter covers all live animals, except:
+
+            (a) fish and crustaceans, molluscs and other aquatic invertebrates, of heading 0301 , 0306 , 0307  or 0308 ;
+
+            (b) cultures of micro-organisms and other products of heading 3002 ; and
+
+            (c) animals of heading 9508 .
+      TEXT
+
+      expected = <<~TEXT
+        1. This chapter covers all live animals, except:
+
+            a) fish and crustaceans, molluscs and other aquatic invertebrates, of heading 0301, 0306, 0307 or 0308;
+
+            b) cultures of micro-organisms and other products of heading 3002; and
+
+            c) animals of heading 9508.
+      TEXT
+
+      expect(formatter.call(input.chomp)).to eq(expected.chomp)
+    end
+
+    it 'correctly formats a Chapter 02 Additional Notes block' do
+      # Simulates extractor output: "1. A." in one row, content at deep indent;
+      # (a)/(b) markers isolated; B. sub-section isolated; (a)/(b) keep parens.
+      base = ' ' * 48
+      input = [
+        '1. A.',
+        '',
+        "#{base}The following expressions have the meanings hereby assigned to them:",
+        '',
+        "#{base}    (a)",
+        '',
+        "#{base}        'carcases of bovine animals' means the whole carcases;",
+        '',
+        "#{base}    (b)",
+        '',
+        "#{base}        'half-carcases' means the product obtained by splitting;",
+      ].join("\n")
+
+      # Wrap in Additional Notes section as the extractor would produce
+      full_input = "### Additional Notes\n\n#{input}"
+
+      expected = [
+        '### Additional Notes',
+        '',
+        '1. A. The following expressions have the meanings hereby assigned to them:',
+        '',
+        "   (a) 'carcases of bovine animals' means the whole carcases;",
+        '',
+        "   (b) 'half-carcases' means the product obtained by splitting;",
+      ].join("\n")
+
+      expect(formatter.call(full_input)).to eq(expected)
+    end
+
+    # ── Rule: uppercase (A)/(B) sub-markers in deeply-indented chapter notes ───
+    # EU XHTML can use uppercase (A)/(B) as sub-markers inside a numbered note, with
+    # both the marker and its content at ~48 spaces of indentation from the table depth.
+    # normalise_deep_indentation (now also in format_main_part) strips the base indent;
+    # merge_trailing_list_markers (extended to [a-zA-Z]+) merges the isolated marker with
+    # its content; indent_note_continuations re-indents sibling (B)/(C) etc. to 3
+    # spaces, matching the chapter-note govspeak convention.
+    # First confirmed: Chapter 10 note 1.
+
+    it 'merges uppercase (A)/(B) sub-markers from deeply-indented chapter notes and indents siblings to 3 spaces' do
+      indent     = ' ' * 48
+      whitespace = ' ' * 45
+      input = [
+        '1. (A)',
+        whitespace,
+        "#{indent}The products specified in the headings of this chapter.",
+        whitespace,
+        "#{indent}(B)",
+        whitespace,
+        "#{indent}The Chapter does not cover grains.",
+        '',
+        '2. Heading 1005 does not cover sweetcorn.',
+      ].join("\n")
+
+      result = formatter.call(input)
+
+      expect(result).to include('1. (A) The products specified in the headings of this chapter.')
+      expect(result).to include('   (B) The Chapter does not cover grains.')
+      expect(result).to include('2. Heading 1005 does not cover sweetcorn.')
+    end
+
+    it 'does not indent a numbered note that follows a note with uppercase (A)/(B) sub-markers' do
+      indent     = ' ' * 48
+      whitespace = ' ' * 45
+      input = [
+        '1. (A)',
+        whitespace,
+        "#{indent}First note content.",
+        '',
+        '2. Second note has no uppercase sub-markers.',
+      ].join("\n")
+
+      result = formatter.call(input)
+
+      expect(result).to include('1. (A) First note content.')
+      expect(result).to include('2. Second note has no uppercase sub-markers.')
+      expect(result).not_to match(/\A {3,}2\./)
+    end
+
+    # ── Rule: normalise sub-items inside N. (A) notes to 3-space indent ─────────
+    # When a note opens with "N. (A) text", the EU XHTML nests the sub-tables one
+    # level deeper than the enclosing note table. (a)/(b) items arrive at 8 spaces
+    # (depth=2) and (B)/(C) siblings at 4 spaces (depth=1). Govspeak needs them all
+    # at 3 spaces — the standard continuation indent for a numbered list item.
+    # normalise_uppercase_sub_note_indentation re-indents lines at ≥ 4 spaces to 3.
+    # indent_note_continuations then correctly raises "Otherwise…" paragraphs
+    # (arriving at 0 from the extractor) to list_indent=3.
+    # First confirmed: Chapter 11 note 2 (cereal milling classification).
+
+    it 'normalises sub-items and continuation paragraphs under N. (A) notes to 3-space indent' do
+      # Extractor output: (A)+(B) at depth=1 (4 spaces), (a)/(b) at depth=2 (8 spaces),
+      # "Otherwise…" paragraphs at 0 indent from the extractor.
+      input = [
+        '2.     (A) Products from the milling of the cereals if they have:',
+        '',
+        '        (a) a starch content exceeding column 2; and',
+        '',
+        '        (b) an ash content not exceeding column 3.',
+        '',
+        'Otherwise, they fall in heading 2302.',
+        '',
+        '    (B) Products falling in this chapter shall be classified in heading 1101.',
+        '',
+        'Otherwise, they fall in heading 1103.',
+        '',
+        '3. This note covers something else.',
+      ].join("\n")
+
+      result = formatter.call(input)
+
+      expect(result).to include('2. (A) Products from the milling')
+      expect(result).to include('   a) a starch content exceeding column 2; and')
+      expect(result).to include('   b) an ash content not exceeding column 3.')
+      expect(result).to include('   Otherwise, they fall in heading 2302.')
+      expect(result).to include('   (B) Products falling in this chapter')
+      expect(result).to include('   Otherwise, they fall in heading 1103.')
+      expect(result).to include('3. This note covers something else.')
+    end
+
+    it 'normalises (B)/(C) sub-markers at 4 spaces to 3 spaces when under a N. (A) note' do
+      # (B)/(C) arrive at 4 spaces from a depth=1 sub-table in the XHTML. The new
+      # normalise_uppercase_sub_note_indentation pass re-indents ≥ 4 space items to 3.
+      input = [
+        '1. (A) First sub-section content.',
+        '',
+        '    (B) Second sub-section content.',
+        '',
+        '    (C) Third sub-section content.',
+        '',
+        '2. Next note.',
+      ].join("\n")
+
+      result = formatter.call(input)
+
+      expect(result).to include('1. (A) First sub-section content.')
+      expect(result).to include('   (B) Second sub-section content.')
+      expect(result).to include('   (C) Third sub-section content.')
+      expect(result).to include('2. Next note.')
+    end
+
+    it 'applies chapter-note rules to chapter part and additional-note rules to additional part' do
+      input = [
+        '1. This chapter covers:',
+        '',
+        '    (a) fish of heading 0301 , 0306 ;',
+        '',
+        '### Additional Notes',
+        '',
+        '1. A.',
+        '',
+        'The following expressions apply:',
+        '',
+        '(a)',
+        '',
+        'definition text;',
+      ].join("\n")
+
+      expected = [
+        '1. This chapter covers:',
+        '',
+        '    a) fish of heading 0301, 0306;',
+        '',
+        '### Additional Notes',
+        '',
+        '1. A. The following expressions apply:',
+        '',
+        '   (a) definition text;',
+      ].join("\n")
+
+      expect(formatter.call(input)).to eq(expected)
+    end
+  end
+end

--- a/spec/lib/xi_cn_importer/notes_extractor_spec.rb
+++ b/spec/lib/xi_cn_importer/notes_extractor_spec.rb
@@ -1,0 +1,823 @@
+require 'rails_helper'
+
+RSpec.describe XiCnImporter::NotesExtractor do
+  def extract(html)
+    described_class.new('32025R1926', html).call
+  end
+
+  let(:gri_only_html) do
+    <<~HTML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <html xmlns="http://www.w3.org/1999/xhtml"><body>
+      <p class="oj-ti-grseq-1">PART ONE</p>
+      <p class="oj-ti-grseq-1"><span class="oj-italic">SECTION I</span></p>
+      <p class="oj-ti-grseq-1"><span class="oj-bold">A. General rules</span></p>
+      <table><tbody>
+        <tr>
+          <td><p class="oj-normal">1.</p></td>
+          <td><p class="oj-normal">Classification shall be determined according to the terms of the headings.</p></td>
+        </tr>
+        <tr>
+          <td><p class="oj-normal">2.</p></td>
+          <td><p class="oj-normal">Any reference in a heading to an article shall be taken to include a reference to that article.</p></td>
+        </tr>
+      </tbody></table>
+      </body></html>
+    HTML
+  end
+
+  let(:full_fixture_html) do
+    <<~HTML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <html xmlns="http://www.w3.org/1999/xhtml"><body>
+      <p class="oj-ti-grseq-1">PART ONE</p>
+      <table><tbody>
+        <tr><td><p class="oj-normal">1.</p></td><td><p class="oj-normal">GRI rule one.</p></td></tr>
+      </tbody></table>
+      <p class="oj-ti-grseq-1"><span class="oj-bold">SCHEDULE OF CUSTOMS DUTIES</span></p>
+      <p class="oj-ti-grseq-1"><span class="oj-italic">SECTION I</span></p>
+      <p class="oj-ti-annotation"><span class="oj-bold">Notes</span></p>
+      <table><tbody>
+        <tr>
+          <td><p class="normal">1.</p></td>
+          <td><p class="normal">This section does not cover goods of Chapter 1.</p></td>
+        </tr>
+        <tr>
+          <td><p class="normal">2.</p></td>
+          <td>
+            <p class="normal">In this section the following expressions apply:</p>
+            <table><tbody>
+              <tr><td><p class="oj-normal">(a)</p></td><td><p class="oj-normal">First sub-item text.</p></td></tr>
+              <tr><td><p class="oj-normal">(b)</p></td><td><p class="oj-normal">Second sub-item text.</p></td></tr>
+            </tbody></table>
+          </td>
+        </tr>
+      </tbody></table>
+      <p class="oj-ti-grseq-1"><span class="oj-italic">CHAPTER 1</span></p>
+      <p class="oj-ti-annotation"><span class="oj-bold">Note</span></p>
+      <table><tbody>
+        <tr><td><p class="normal">1.</p></td><td><p class="normal">This chapter covers all live animals.</p></td></tr>
+      </tbody></table>
+      <p class="oj-ti-annotation">Additional notes</p>
+      <table><tbody>
+        <tr><td><p class="normal">1.</p></td><td><p class="normal">For the purposes of subheading 0101 21 the following applies.</p></td></tr>
+      </tbody></table>
+      <table class="oj-table"><tbody>
+        <tr><td>0101000000</td><td>Live horses</td></tr>
+      </tbody></table>
+      </body></html>
+    HTML
+  end
+
+  describe 'footnote anchor stripping' do
+    it 'strips EU OJ footnote back-reference links (href="#ntr...") from cell text' do
+      # Actual EU OJ XHTML structure: the footnote number sits inside an <a href="#ntr...">
+      # with an oj-note-tag <span>. The surrounding ( and ) are also inside the <a>.
+      html = <<~HTML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <html xmlns="http://www.w3.org/1999/xhtml"><body>
+        <p class="oj-ti-grseq-1">PART ONE</p>
+        <p class="oj-ti-grseq-1"><span class="oj-bold">SCHEDULE OF CUSTOMS DUTIES</span></p>
+        <p class="oj-ti-grseq-1"><span class="oj-italic">SECTION I</span></p>
+        <p class="oj-ti-annotation"><span class="oj-bold">Notes</span></p>
+        <table><tbody>
+          <tr>
+            <td><p class="normal">1.</p></td>
+            <td><p class="normal">Commission Implementing Regulation (EU) 2018/150 <a id="ntc190-L_202501926EN.000302-E0190" href="#ntr190-L_202501926EN.000302-E0190">(<span class="oj-super oj-note-tag">190</span>)</a>.</p></td>
+          </tr>
+        </tbody></table>
+        </body></html>
+      HTML
+
+      result = extract(html)
+      expect(result.sections[1]).to include('Commission Implementing Regulation (EU) 2018/150.')
+      expect(result.sections[1]).not_to include('(190)')
+    end
+
+    it 'preserves plain parenthetical numbers in prose that are not inside <sup>' do
+      html = <<~HTML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <html xmlns="http://www.w3.org/1999/xhtml"><body>
+        <p class="oj-ti-grseq-1">PART ONE</p>
+        <p class="oj-ti-grseq-1"><span class="oj-bold">SCHEDULE OF CUSTOMS DUTIES</span></p>
+        <p class="oj-ti-grseq-1"><span class="oj-italic">SECTION I</span></p>
+        <p class="oj-ti-grseq-1"><span class="oj-italic">CHAPTER 10</span></p>
+        <p class="oj-ti-annotation"><span class="oj-bold">Subheading notes</span></p>
+        <table><tbody>
+          <tr>
+            <td><p class="normal">1.</p></td>
+            <td><p class="normal">Triticum durum which have the same number (28) of chromosomes as that species.</p></td>
+          </tr>
+        </tbody></table>
+        </body></html>
+      HTML
+
+      result = extract(html)
+      expect(result.chapters['10']).to include('the same number (28) of chromosomes')
+    end
+  end
+
+  describe 'content table extraction' do
+    let(:chapter_with_content_table_html) do
+      <<~HTML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <html xmlns="http://www.w3.org/1999/xhtml"><body>
+        <p class="oj-ti-grseq-1">PART ONE</p>
+        <p class="oj-ti-grseq-1"><span class="oj-bold">SCHEDULE OF CUSTOMS DUTIES</span></p>
+        <p class="oj-ti-grseq-1"><span class="oj-italic">SECTION II</span></p>
+        <p class="oj-ti-grseq-1"><span class="oj-italic">CHAPTER 11</span></p>
+        <p class="oj-ti-annotation"><span class="oj-bold">Notes</span></p>
+        <table><tbody>
+          <tr>
+            <td><p class="normal">2.</p></td>
+            <td>
+              <p class="oj-normal">(A) Products from the milling of the cereals listed in the table below fall in this chapter.</p>
+              <p class="oj-normal">(B) Products falling in this chapter shall be classified in heading 1101 or 1102.</p>
+              <table width="100%" border="0" class="oj-table"><tbody>
+                <tr class="oj-table">
+                  <td class="oj-table"><p class="oj-tbl-hdr">Cereal</p></td>
+                  <td class="oj-table"><p class="oj-tbl-hdr">Starch content</p></td>
+                  <td class="oj-table" colspan="2"><p class="oj-tbl-hdr">Rate of passage through a sieve with an aperture of</p></td>
+                </tr>
+                <tr class="oj-table">
+                  <td class="oj-table"><p class="oj-normal"> </p></td>
+                  <td class="oj-table"><p class="oj-normal"> </p></td>
+                  <td class="oj-table"><p class="oj-tbl-hdr">315 micrometres (microns)</p></td>
+                  <td class="oj-table"><p class="oj-tbl-hdr">500 micrometres (microns)</p></td>
+                </tr>
+                <tr class="oj-table">
+                  <td class="oj-table"><p class="oj-tbl-hdr">(1)</p></td>
+                  <td class="oj-table"><p class="oj-tbl-hdr">(2)</p></td>
+                  <td class="oj-table"><p class="oj-tbl-hdr">(3)</p></td>
+                  <td class="oj-table"><p class="oj-tbl-hdr">(4)</p></td>
+                </tr>
+                <tr class="oj-table">
+                  <td class="oj-table"><p class="oj-tbl-txt">Wheat and rye</p></td>
+                  <td class="oj-table"><p class="oj-tbl-txt">45 %</p></td>
+                  <td class="oj-table"><p class="oj-tbl-txt">80 %</p></td>
+                  <td class="oj-table"><p class="oj-tbl-txt">—</p></td>
+                </tr>
+                <tr class="oj-table">
+                  <td class="oj-table"><p class="oj-tbl-txt">Maize (corn) and grain sorghum</p></td>
+                  <td class="oj-table"><p class="oj-tbl-txt">45 %</p></td>
+                  <td class="oj-table"><p class="oj-tbl-txt">—</p></td>
+                  <td class="oj-table"><p class="oj-tbl-txt">90 %</p></td>
+                </tr>
+              </tbody></table>
+            </td>
+          </tr>
+        </tbody></table>
+        </body></html>
+      HTML
+    end
+
+    it 'renders an oj-tbl-hdr/oj-tbl-txt table embedded in a chapter note as an indented markdown table' do
+      result = extract(chapter_with_content_table_html)
+      chapter = result.chapters['11']
+
+      expect(chapter).to include('   | Cereal |')
+      expect(chapter).to include('   | Wheat and rye |')
+      expect(chapter).to include('   | Maize (corn) and grain sorghum |')
+    end
+
+    it 'merges a colspan header row with the sub-header row below it to form complete column labels' do
+      result = extract(chapter_with_content_table_html)
+      chapter = result.chapters['11']
+
+      expect(chapter).to include('Rate of passage through a sieve with an aperture of 315 micrometres (microns)')
+      expect(chapter).to include('Rate of passage through a sieve with an aperture of 500 micrometres (microns)')
+    end
+
+    it 'emits column-numbering rows like (1)(2)(3) as data rows below the markdown separator' do
+      result = extract(chapter_with_content_table_html)
+      chapter = result.chapters['11']
+
+      lines = chapter.split("\n")
+      separator_index = lines.index { |l| l.match?(/\A\s*\| ---/) }
+      numbering_index = lines.index { |l| l.include?('| (1) |') }
+
+      expect(separator_index).to be < numbering_index
+    end
+  end
+
+  describe 'letter-list with nested oj-table inside a note cell (Ch74/75/76/80 pattern)' do
+    # EU OJ XHTML for chapters like 74 wraps each letter-list item (a)/(b)/(c) in its own
+    # two-column structural sub-table inside the note cell. Item (a)'s content cell then
+    # contains an oj-table (oj-tbl-hdr/oj-tbl-txt) for the element composition table.
+    # The shallow content_table? check must NOT flag the outer structural sub-table as a
+    # content table (it would collapse everything into a single govspeak row). Instead:
+    # - outer note table → extract_table_content
+    # - each (a)/(b)/(c) structural sub-table → extract_table_content (not table_formatter)
+    # - the inner oj-table inside (a) → table_formatter (correct)
+    # First confirmed: Chapter 74, note 1 — refined copper composition table.
+
+    let(:ch74_note_html) do
+      <<~HTML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <html xmlns="http://www.w3.org/1999/xhtml"><body>
+        <p class="oj-ti-grseq-1">PART ONE</p>
+        <p class="oj-ti-grseq-1"><span class="oj-bold">SCHEDULE OF CUSTOMS DUTIES</span></p>
+        <p class="oj-ti-grseq-1"><span class="oj-italic">SECTION XV</span></p>
+        <p class="oj-ti-grseq-1"><span class="oj-italic">CHAPTER 74</span></p>
+        <p class="oj-ti-annotation"><span class="oj-bold">Notes</span></p>
+        <table><tbody>
+          <tr>
+            <td><p class="normal">1.</p></td>
+            <td>
+              <span>In this chapter, the following expressions have the meanings hereby assigned to them:</span>
+              <table><tbody>
+                <tr>
+                  <td><p class="oj-normal">(a)</p></td>
+                  <td>
+                    <p class="oj-normal">Refined copper: Metal containing at least 99,85 % by weight of copper; or</p>
+                    <p class="oj-ti-tbl">Other elements</p>
+                    <table class="oj-table"><tbody>
+                      <tr class="oj-table">
+                        <td class="oj-table" colspan="2"><p class="oj-tbl-hdr">Element</p></td>
+                        <td class="oj-table"><p class="oj-tbl-hdr">Limiting content % by weight</p></td>
+                      </tr>
+                      <tr class="oj-table">
+                        <td class="oj-table"><p class="oj-tbl-txt">Ag</p></td>
+                        <td class="oj-table"><p class="oj-tbl-txt">Silver</p></td>
+                        <td class="oj-table"><p class="oj-tbl-txt">0,25</p></td>
+                      </tr>
+                      <tr class="oj-table">
+                        <td class="oj-table"><p class="oj-tbl-txt">Zn</p></td>
+                        <td class="oj-table"><p class="oj-tbl-txt">Zinc</p></td>
+                        <td class="oj-table"><p class="oj-tbl-txt">1</p></td>
+                      </tr>
+                    </tbody></table>
+                  </td>
+                </tr>
+              </tbody></table>
+              <table><tbody>
+                <tr>
+                  <td><p class="oj-normal">(b)</p></td>
+                  <td><p class="oj-normal">Copper alloys: Metallic substances in which copper predominates.</p></td>
+                </tr>
+              </tbody></table>
+              <table><tbody>
+                <tr>
+                  <td><p class="oj-normal">(c)</p></td>
+                  <td><p class="oj-normal">Master alloys: Alloys containing more than 10 % by weight of copper.</p></td>
+                </tr>
+              </tbody></table>
+            </td>
+          </tr>
+        </tbody></table>
+        </body></html>
+      HTML
+    end
+
+    it 'extracts all letter-list items (a)/(b)/(c) — not just the one containing the oj-table' do
+      result = extract(ch74_note_html)
+      chapter = result.chapters['74']
+
+      expect(chapter).to include('b) Copper alloys')
+      expect(chapter).to include('c) Master alloys')
+    end
+
+    it 'renders the nested oj-table as a proper markdown table' do
+      result = extract(ch74_note_html)
+      chapter = result.chapters['74']
+
+      expect(chapter).to include('| Ag |')
+      expect(chapter).to include('| Zn |')
+      expect(chapter).to include('| Element |')
+      expect(chapter).not_to include('Ag Silver 0,25')
+    end
+
+    it 'renders letter-list label as a govspeak list marker, not a govspeak table cell' do
+      result = extract(ch74_note_html)
+      chapter = result.chapters['74']
+
+      expect(chapter).not_to include('| (a) |')
+      expect(chapter).not_to include('| a) |')
+      expect(chapter).to include('a) Refined copper')
+    end
+  end
+
+  describe 'Additional Notes parenthetical label with numeric sub-items only (no intro text)' do
+    # EU OJ XHTML: "(h)" row whose content cell contains ONLY a sub-table with rows
+    # "1." and "2." (no introductory <p> text). The extractor must emit "(h)" on its
+    # own line followed by "1." and "2." as indented numbered items at 6 spaces, not
+    # collapse them into "(h) 1. item text" on a single line.
+    # First confirmed: Chapter 02 Additional Notes 1.A.(h).
+
+    let(:parenthetical_with_numeric_sub_items_html) do
+      <<~HTML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <html xmlns="http://www.w3.org/1999/xhtml"><body>
+        <p class="oj-ti-grseq-1">PART ONE</p>
+        <p class="oj-ti-grseq-1"><span class="oj-bold">SCHEDULE OF CUSTOMS DUTIES</span></p>
+        <p class="oj-ti-grseq-1"><span class="oj-italic">SECTION I</span></p>
+        <p class="oj-ti-grseq-1"><span class="oj-italic">CHAPTER 2</span></p>
+        <p class="oj-ti-annotation"><span class="oj-bold">Note</span></p>
+        <table><tbody>
+          <tr><td><p class="oj-normal">1.</p></td><td><p class="oj-normal">This chapter does not cover insects.</p></td></tr>
+        </tbody></table>
+        <p class="oj-ti-annotation">Additional notes</p>
+        <table><tbody>
+          <tr>
+            <td><p class="oj-normal">(g)</p></td>
+            <td><p class="oj-normal">'separated hindquarters': the rear part of a half-carcase.</p></td>
+          </tr>
+          <tr>
+            <td><p class="oj-normal">(h)</p></td>
+            <td>
+              <table><tbody>
+                <tr>
+                  <td><p class="oj-normal">1.</p></td>
+                  <td><p class="oj-normal">'crop' and 'chuck and blade' cuts: the dorsal part of the forequarter.</p></td>
+                </tr>
+                <tr>
+                  <td><p class="oj-normal">2.</p></td>
+                  <td><p class="oj-normal">'brisket' cut: the lower part of the forequarter.</p></td>
+                </tr>
+              </tbody></table>
+            </td>
+          </tr>
+        </tbody></table>
+        </body></html>
+      HTML
+    end
+
+    it 'emits (h) on its own line, not merged with the first numeric sub-item' do
+      chapter = extract(parenthetical_with_numeric_sub_items_html).chapters['02']
+      lines = chapter.split("\n")
+      h_line = lines.find { |l| l.strip == '(h)' }
+      expect(h_line).to be_present
+    end
+
+    it 'places numeric sub-items at 6 spaces (inside (h), not inline with it)' do
+      chapter = extract(parenthetical_with_numeric_sub_items_html).chapters['02']
+      lines = chapter.split("\n")
+      item1 = lines.find { |l| l.include?("'crop' and 'chuck and blade' cuts") }
+      item2 = lines.find { |l| l.include?("'brisket' cut") }
+      expect(item1).to be_present
+      expect(item2).to be_present
+      expect(item1[/\A( *)/, 1].length).to eq(6)
+      expect(item2[/\A( *)/, 1].length).to eq(6)
+    end
+
+    it 'places (g) with its own content inline (parenthetical with text, not a sub-table)' do
+      chapter = extract(parenthetical_with_numeric_sub_items_html).chapters['02']
+      lines = chapter.split("\n")
+      g_line = lines.find { |l| l.include?("'separated hindquarters'") }
+      expect(g_line).to be_present
+      expect(g_line).to include('(g)')
+    end
+  end
+
+  describe '<span> with inline italic children as a text container (not structural wrapper)' do
+    # EU OJ XHTML wraps a paragraph in a top-level <span> where the only element children
+    # are inline formatting spans like <span class="oj-italic">. The structural-wrapper
+    # check must NOT fire here (no <table> children) — the entire span should be treated
+    # as a text container and all text (including species names in italics) extracted.
+    # First confirmed: Chapter 03 Additional Notes 1 — "cod fillets (Gadus morhua, Gadus
+    # ogac, Gadus macrocephalus) having a total salt content..." was losing its main
+    # sentence and returning only the three italic species names.
+
+    let(:italic_span_html) do
+      <<~HTML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <html xmlns="http://www.w3.org/1999/xhtml"><body>
+        <p class="oj-ti-grseq-1">PART ONE</p>
+        <p class="oj-ti-grseq-1"><span class="oj-bold">SCHEDULE OF CUSTOMS DUTIES</span></p>
+        <p class="oj-ti-grseq-1"><span class="oj-italic">SECTION I</span></p>
+        <p class="oj-ti-grseq-1"><span class="oj-italic">CHAPTER 3</span></p>
+        <p class="oj-ti-annotation"><span class="oj-bold">Note</span></p>
+        <table><tbody>
+          <tr><td><p class="oj-normal">1.</p></td><td><p class="oj-normal">This chapter does not cover insects.</p></td></tr>
+        </tbody></table>
+        <p class="oj-ti-annotation">Additional notes</p>
+        <table><tbody>
+          <tr>
+            <td><p class="oj-normal">1.</p></td>
+            <td>
+              <span>For the purposes of subheadings 0305 32 11 and 0305 32 19, cod fillets (<span class="oj-italic">Gadus morhua</span>, <span class="oj-italic">Gadus ogac</span>, <span class="oj-italic">Gadus macrocephalus</span>) having a total salt content by weight of 12 % or more are considered to be salted fish.</span>
+              <p class="oj-normal">However, frozen cod fillets which have a total salt content by weight of less than 12 % are to be classified under subheadings 0304 71 10 and 0304 71 90.</p>
+            </td>
+          </tr>
+        </tbody></table>
+        </body></html>
+      HTML
+    end
+
+    it 'extracts the full sentence from the outer span, including text around italic species names' do
+      chapter = extract(italic_span_html).chapters['03']
+      expect(chapter).to include('For the purposes of subheadings 0305 32 11')
+      expect(chapter).to include('Gadus morhua')
+      expect(chapter).to include('Gadus macrocephalus')
+      expect(chapter).to include('are considered to be salted fish')
+    end
+
+    it 'does not lose the However paragraph that follows the outer span' do
+      chapter = extract(italic_span_html).chapters['03']
+      expect(chapter).to include('However, frozen cod fillets')
+      expect(chapter).to include('0304 71 10')
+    end
+
+    it 'keeps the sentence and the species names on the same block, not as three separate lines' do
+      chapter = extract(italic_span_html).chapters['03']
+      lines = chapter.split("\n").reject(&:empty?)
+      morhua_line = lines.find { |l| l.include?('Gadus morhua') }
+      expect(morhua_line).to include('For the purposes of subheadings')
+    end
+  end
+
+  describe 'text-only <span> as intro sentence before sub-item tables' do
+    # EU OJ XHTML wraps intro text in a plain <span> (no element children) followed
+    # by sibling <table> elements for each sub-item. The extractor must treat the
+    # text-only span as a paragraph (extract its text) and the sibling tables as
+    # indented sub-items — not collapse everything or drop the intro.
+    # First confirmed: Chapter 11 note 3, Additional Notes 1 and 2.
+
+    let(:intro_span_html) do
+      <<~HTML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <html xmlns="http://www.w3.org/1999/xhtml"><body>
+        <p class="oj-ti-grseq-1">PART ONE</p>
+        <p class="oj-ti-grseq-1"><span class="oj-bold">SCHEDULE OF CUSTOMS DUTIES</span></p>
+        <p class="oj-ti-grseq-1"><span class="oj-italic">SECTION II</span></p>
+        <p class="oj-ti-grseq-1"><span class="oj-italic">CHAPTER 11</span></p>
+        <p class="oj-ti-annotation"><span class="oj-bold">Notes</span></p>
+        <table><tbody>
+          <tr>
+            <td><p class="normal">3.</p></td>
+            <td>
+              <span>For the purposes of heading 1103, the terms mean products obtained by the fragmentation of cereal grains, of which:</span>
+              <table><tbody>
+                <tr>
+                  <td><p class="oj-normal">(a)</p></td>
+                  <td><p class="oj-normal">in the case of maize products, at least 95 % by weight passes through a sieve.</p></td>
+                </tr>
+              </tbody></table>
+              <table><tbody>
+                <tr>
+                  <td><p class="oj-normal">(b)</p></td>
+                  <td><p class="oj-normal">in the case of other cereal products, at least 95 % by weight passes through a sieve.</p></td>
+                </tr>
+              </tbody></table>
+            </td>
+          </tr>
+        </tbody></table>
+        <p class="oj-ti-annotation">Additional notes</p>
+        <table><tbody>
+          <tr>
+            <td><p class="normal">1.</p></td>
+            <td>
+              <span>The duty-rate applicable to mixtures of this chapter shall be as follows:</span>
+              <table><tbody>
+                <tr>
+                  <td><p class="oj-normal">(a)</p></td>
+                  <td><p class="oj-normal">in mixtures where one component is at least 90 %, that rate applies;</p></td>
+                </tr>
+              </tbody></table>
+              <table><tbody>
+                <tr>
+                  <td><p class="oj-normal">(b)</p></td>
+                  <td><p class="oj-normal">in other mixtures, the highest rate applies.</p></td>
+                </tr>
+              </tbody></table>
+            </td>
+          </tr>
+        </tbody></table>
+        </body></html>
+      HTML
+    end
+
+    it 'preserves the intro sentence from a text-only <span> before chapter-note sub-item tables' do
+      chapter = extract(intro_span_html).chapters['11']
+      expect(chapter).to include('For the purposes of heading 1103')
+      expect(chapter).to include('in the case of maize products')
+      expect(chapter).to include('in the case of other cereal products')
+    end
+
+    it 'does not lose the intro sentence from a text-only <span> in Additional Notes' do
+      sections = extract(intro_span_html)
+      chapter = sections.chapters['11']
+      expect(chapter).to include('The duty-rate applicable to mixtures')
+      expect(chapter).to include('in mixtures where one component')
+      expect(chapter).to include('in other mixtures')
+    end
+
+    it 'places the intro sentence before the (a)/(b) sub-items in chapter notes' do
+      chapter = extract(intro_span_html).chapters['11']
+      intro_idx = chapter.index('For the purposes of heading 1103')
+      a_idx     = chapter.index('in the case of maize products')
+      expect(intro_idx).to be < a_idx
+    end
+
+    it 'places the intro sentence before the (a)/(b) sub-items in Additional Notes' do
+      chapter = extract(intro_span_html).chapters['11']
+      intro_idx = chapter.index('The duty-rate applicable to mixtures')
+      a_idx     = chapter.index('in mixtures where one component')
+      expect(intro_idx).to be < a_idx
+    end
+  end
+
+  describe 'nested (A)/(B) chapter note with (a)/(b) sub-items inside a <span> wrapper' do
+    let(:nested_ab_html) do
+      <<~HTML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <html xmlns="http://www.w3.org/1999/xhtml"><body>
+        <p class="oj-ti-grseq-1">PART ONE</p>
+        <p class="oj-ti-grseq-1"><span class="oj-bold">SCHEDULE OF CUSTOMS DUTIES</span></p>
+        <p class="oj-ti-grseq-1"><span class="oj-italic">SECTION II</span></p>
+        <p class="oj-ti-grseq-1"><span class="oj-italic">CHAPTER 11</span></p>
+        <p class="oj-ti-annotation"><span class="oj-bold">Notes</span></p>
+        <table><tbody>
+          <tr>
+            <td><p class="normal">2.</p></td>
+            <td>
+              <span>
+                <table><tbody>
+                  <tr>
+                    <td><p class="oj-normal">(A)</p></td>
+                    <td>
+                      <p class="oj-normal">Products from the milling of the cereals listed in the table below fall in this chapter if they have:</p>
+                      <table><tbody>
+                        <tr>
+                          <td><p class="oj-normal">(a)</p></td>
+                          <td><p class="oj-normal">a starch content exceeding that indicated in column 2; and</p></td>
+                        </tr>
+                      </tbody></table>
+                      <table><tbody>
+                        <tr>
+                          <td><p class="oj-normal">(b)</p></td>
+                          <td><p class="oj-normal">an ash content not exceeding that indicated in column 3.</p></td>
+                        </tr>
+                      </tbody></table>
+                      <p class="oj-normal">Otherwise, they fall in heading 2302.</p>
+                    </td>
+                  </tr>
+                </tbody></table>
+                <table><tbody>
+                  <tr>
+                    <td><p class="oj-normal">(B)</p></td>
+                    <td>
+                      <p class="oj-normal">Products falling in this chapter shall be classified in heading 1101.</p>
+                      <p class="oj-normal">Otherwise, they fall in heading 1103.</p>
+                    </td>
+                  </tr>
+                </tbody></table>
+              </span>
+            </td>
+          </tr>
+        </tbody></table>
+        </body></html>
+      HTML
+    end
+
+    it 'extracts (A) and (B) as separate blocks, not as a single collapsed paragraph' do
+      chapter = extract(nested_ab_html).chapters['11']
+      expect(chapter).to include('(A) Products from the milling')
+      expect(chapter).to include('(B) Products falling in this chapter')
+      # Both markers must be present — if they were collapsed into one paragraph
+      # the (B) marker would appear inline without a preceding blank line.
+      ab_index = chapter.index('(A)')
+      bb_index = chapter.index('(B)')
+      expect(bb_index).to be > ab_index
+      expect(chapter[ab_index...bb_index]).to include("\n\n")
+    end
+
+    it 'places (a) and (b) sub-items as indented list items under (A)' do
+      chapter = extract(nested_ab_html).chapters['11']
+      lines = chapter.split("\n")
+      a_line = lines.find { |l| l.include?('a starch content exceeding') }
+      b_line = lines.find { |l| l.include?('an ash content not exceeding') }
+      expect(a_line).to be_present
+      expect(b_line).to be_present
+      expect(a_line[/\A( *)/, 1].length).to be > 0
+      expect(b_line[/\A( *)/, 1].length).to be > 0
+    end
+
+    it 'places "Otherwise" continuation paragraphs as their own indented lines (not collapsed into the sub-list)' do
+      chapter = extract(nested_ab_html).chapters['11']
+      lines = chapter.split("\n")
+      otherwise_lines = lines.select { |l| l.include?('Otherwise') }
+      expect(otherwise_lines).not_to be_empty
+      otherwise_lines.each do |line|
+        expect(line[/\A( *)/, 1].length).to be > 0
+      end
+    end
+
+    it 'places (B) as a separate indented block after (A) (not collapsed into (A))' do
+      chapter = extract(nested_ab_html).chapters['11']
+      lines = chapter.split("\n")
+      b_line = lines.find { |l| l.match?(/\A\s+\(B\)/) }
+      expect(b_line).to be_present
+      expect(b_line[/\A( *)/, 1].length).to be > 0
+    end
+  end
+
+  describe 'GRI extraction' do
+    it 'extracts numbered rules keyed by rule number string' do
+      result = extract(gri_only_html)
+      expect(result.general_rules['1']).to eq 'Classification shall be determined according to the terms of the headings.'
+      expect(result.general_rules['2']).to eq 'Any reference in a heading to an article shall be taken to include a reference to that article.'
+    end
+
+    it 'returns empty sections and chapters when there is no Part Two' do
+      result = extract(gri_only_html)
+      expect(result.sections).to be_empty
+      expect(result.chapters).to be_empty
+    end
+  end
+
+  describe 'section note extraction' do
+    it 'extracts section notes with integer keys' do
+      result = extract(full_fixture_html)
+      expect(result.sections[1]).to include('This section does not cover goods of Chapter 1.')
+    end
+
+    it 'includes the second note with its intro text' do
+      result = extract(full_fixture_html)
+      expect(result.sections[1]).to include('In this section the following expressions apply:')
+    end
+
+    it 'indents sub-items with 4 spaces and converts (a)/(b) to a)/b) form' do
+      # Section notes go through format_chapter_part which applies normalise_list_marker,
+      # converting (a)→a) consistent with chapter notes govspeak convention.
+      result = extract(full_fixture_html)
+      expect(result.sections[1]).to include('    a) First sub-item text.')
+      expect(result.sections[1]).to include('    b) Second sub-item text.')
+    end
+
+    it 'emits a ### Additional Notes heading when Additional Notes appears after the main section notes' do
+      # Sections 16 and 17 have Additional Notes following the main numbered notes.
+      # handle_collecting_section must inject the heading when it encounters the annotation header.
+      html = <<~HTML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <html xmlns="http://www.w3.org/1999/xhtml"><body>
+        <p class="oj-ti-grseq-1">PART ONE</p>
+        <p class="oj-ti-grseq-1"><span class="oj-bold">SCHEDULE OF CUSTOMS DUTIES</span></p>
+        <p class="oj-ti-grseq-1"><span class="oj-italic">SECTION XVI</span></p>
+        <p class="oj-ti-annotation"><span class="oj-bold">Notes</span></p>
+        <table><tbody>
+          <tr><td><p class="oj-normal">1.</p></td><td><p class="oj-normal">This section does not cover transmission belts.</p></td></tr>
+        </tbody></table>
+        <p class="oj-ti-annotation">Additional Notes</p>
+        <table><tbody>
+          <tr><td><p class="oj-normal">1.</p></td><td><p class="oj-normal">Tools necessary for maintenance are to be classified with those machines.</p></td></tr>
+          <tr><td><p class="oj-normal">2.</p></td><td><p class="oj-normal">The declarant shall produce an illustrated document.</p></td></tr>
+        </tbody></table>
+        </body></html>
+      HTML
+
+      result = extract(html)
+      section = result.sections[16]
+      expect(section).to include('### Additional Notes')
+      expect(section).to include('Tools necessary for maintenance')
+      expect(section).to include('The declarant shall produce')
+      expect(section.index('### Additional Notes')).to be > section.index('This section does not cover')
+    end
+
+    it 'emits a ### Subheading notes heading when Subheading Notes appears after the main section notes' do
+      # Section 11 has Subheading Notes following the main numbered notes.
+      # handle_collecting_section must inject the heading when it encounters the annotation header.
+      html = <<~HTML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <html xmlns="http://www.w3.org/1999/xhtml"><body>
+        <p class="oj-ti-grseq-1">PART ONE</p>
+        <p class="oj-ti-grseq-1"><span class="oj-bold">SCHEDULE OF CUSTOMS DUTIES</span></p>
+        <p class="oj-ti-grseq-1"><span class="oj-italic">SECTION XI</span></p>
+        <p class="oj-ti-annotation"><span class="oj-bold">Notes</span></p>
+        <table><tbody>
+          <tr><td><p class="oj-normal">1.</p></td><td><p class="oj-normal">This section does not cover animal brush-making bristles.</p></td></tr>
+        </tbody></table>
+        <p class="oj-ti-annotation">Subheading Notes</p>
+        <table><tbody>
+          <tr><td><p class="oj-normal">1.</p></td><td><p class="oj-normal">In this section the expression 'unbleached yarn' means yarn which has the natural colour of its constituent fibres.</p></td></tr>
+          <tr><td><p class="oj-normal">2.</p></td><td><p class="oj-normal">Products of Chapters 56 to 63 containing two or more textile materials are to be regarded as consisting wholly of that textile material.</p></td></tr>
+        </tbody></table>
+        </body></html>
+      HTML
+
+      result = extract(html)
+      section = result.sections[11]
+      expect(section).to include('### Subheading notes')
+      expect(section).to include('unbleached yarn')
+      expect(section).to include('Products of Chapters 56 to 63')
+      expect(section.index('### Subheading notes')).to be > section.index('This section does not cover')
+    end
+  end
+
+  describe 'chapter note extraction' do
+    it 'extracts chapter notes with zero-padded two-character string keys' do
+      result = extract(full_fixture_html)
+      expect(result.chapters['01']).to include('This chapter covers all live animals.')
+    end
+
+    it 'includes additional notes under the ### Additional Notes heading' do
+      result = extract(full_fixture_html)
+      expect(result.chapters['01']).to include('### Additional Notes')
+      expect(result.chapters['01']).to include('For the purposes of subheading 0101 21')
+    end
+
+    it 'does not include the commodity table content' do
+      result = extract(full_fixture_html)
+      expect(result.chapters['01']).not_to include('0101000000')
+      expect(result.chapters['01']).not_to include('Live horses')
+    end
+
+    it 'recognises an "Additional notes" heading that carries a footnote superscript as the additional notes separator' do
+      # EU OJ XHTML appends footnote references (<a href="#ntr97-...">(<span>97</span>)</a>)
+      # followed by a non-breaking space (&nbsp;, U+00A0) directly inside the annotation <p>.
+      # node.text.strip returns "Additional notes (97)" — doesn't match ADDITIONAL_NOTES_PATTERN.
+      # paragraph_text_without_footnotes strips the <a href="#ntr..."> nodes AND normalises
+      #   (which Ruby's \s does not match) so the heading text matches correctly.
+      # First confirmed: Chapter 27 "Additional notes" heading with footnote (97).
+      html = <<~HTML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <html xmlns="http://www.w3.org/1999/xhtml"><body>
+        <p class="oj-ti-grseq-1">PART ONE</p>
+        <p class="oj-ti-grseq-1"><span class="oj-bold">SCHEDULE OF CUSTOMS DUTIES</span></p>
+        <p class="oj-ti-grseq-1"><span class="oj-italic">SECTION V</span></p>
+        <p class="oj-ti-grseq-1"><span class="oj-italic">CHAPTER 27</span></p>
+        <p class="oj-ti-annotation"><span class="oj-bold">Notes</span></p>
+        <table><tbody>
+          <tr><td><p class="normal">1.</p></td><td><p class="normal">This chapter does not cover separate chemically defined compounds.</p></td></tr>
+        </tbody></table>
+        <p class="oj-ti-annotation">Subheading notes</p>
+        <table><tbody>
+          <tr><td><p class="normal">1.</p></td><td><p class="normal">For the purposes of subheading 2701 11.</p></td></tr>
+        </tbody></table>
+        <p class="oj-ti-annotation" id="d1e60582-3-1"><span class="oj-bold">Additional notes</span><a id="ntc97-L_202501926EN.000302-E0097" href="#ntr97-L_202501926EN.000302-E0097">(<span class="oj-super oj-note-tag">97</span>)</a>&#160;</p>
+        <table><tbody>
+          <tr><td><p class="normal">1.</p></td><td><p class="normal">For the purposes of subheading 2707 99 80.</p></td></tr>
+        </tbody></table>
+        </body></html>
+      HTML
+
+      result = extract(html)
+      chapter = result.chapters['27']
+
+      expect(chapter).to include('### Additional Notes')
+      expect(chapter).to include('For the purposes of subheading 2707 99 80.')
+      expect(chapter.index('### Subheading notes')).to be < chapter.index('### Additional Notes')
+    end
+
+    it 'emits a ### Subheading notes heading when the annotation header is Subheading notes' do
+      html = <<~HTML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <html xmlns="http://www.w3.org/1999/xhtml"><body>
+        <p class="oj-ti-grseq-1">PART ONE</p>
+        <p class="oj-ti-grseq-1"><span class="oj-bold">SCHEDULE OF CUSTOMS DUTIES</span></p>
+        <p class="oj-ti-grseq-1"><span class="oj-italic">SECTION I</span></p>
+        <p class="oj-ti-grseq-1"><span class="oj-italic">CHAPTER 4</span></p>
+        <p class="oj-ti-annotation"><span class="oj-bold">Notes</span></p>
+        <table><tbody>
+          <tr><td><p class="normal">6.</p></td><td><p class="normal">For the purposes of heading 0410.</p></td></tr>
+        </tbody></table>
+        <p class="oj-ti-annotation">Subheading notes</p>
+        <table><tbody>
+          <tr><td><p class="normal">1.</p></td><td><p class="normal">For the purposes of subheading 0404 10.</p></td></tr>
+          <tr><td><p class="normal">2.</p></td><td><p class="normal">For the purposes of subheading 0405 10.</p></td></tr>
+        </tbody></table>
+        <p class="oj-ti-annotation">Additional notes</p>
+        <table><tbody>
+          <tr><td><p class="normal">1.</p></td><td><p class="normal">The duty rate applicable to mixtures.</p></td></tr>
+        </tbody></table>
+        </body></html>
+      HTML
+
+      result = extract(html)
+      chapter = result.chapters['04']
+      expect(chapter).to include('### Subheading notes')
+      expect(chapter).to include('For the purposes of subheading 0404 10.')
+      expect(chapter).to include('For the purposes of subheading 0405 10.')
+      expect(chapter.index('### Subheading notes')).to be < chapter.index('### Additional Notes')
+    end
+
+    it 'emits a ### Subheading notes heading when Subheading notes is the first annotation for a chapter' do
+      # Chapters 75-80 have no regular Notes section — Subheading notes is the first
+      # annotation header encountered. The fix ensures handle_in_chapter injects the
+      # heading when it transitions to :collecting_chapter, not only handle_collecting_chapter.
+      html = <<~HTML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <html xmlns="http://www.w3.org/1999/xhtml"><body>
+        <p class="oj-ti-grseq-1">PART ONE</p>
+        <p class="oj-ti-grseq-1"><span class="oj-bold">SCHEDULE OF CUSTOMS DUTIES</span></p>
+        <p class="oj-ti-grseq-1"><span class="oj-italic">SECTION XV</span></p>
+        <p class="oj-ti-grseq-1"><span class="oj-italic">CHAPTER 75</span></p>
+        <p class="oj-ti-annotation">Subheading notes</p>
+        <table><tbody>
+          <tr><td><p class="normal">1.</p></td><td><p class="normal">For the purposes of subheading 7501 10.</p></td></tr>
+        </tbody></table>
+        <p class="oj-ti-annotation">Additional notes</p>
+        <table><tbody>
+          <tr><td><p class="normal">1.</p></td><td><p class="normal">The duty rate applicable to nickel mattes.</p></td></tr>
+        </tbody></table>
+        </body></html>
+      HTML
+
+      result = extract(html)
+      chapter = result.chapters['75']
+      expect(chapter).to include('### Subheading notes')
+      expect(chapter).to include('For the purposes of subheading 7501 10.')
+      expect(chapter.index('### Subheading notes')).to be < chapter.index('### Additional Notes')
+    end
+  end
+end

--- a/spec/lib/xi_cn_importer/reimporter_spec.rb
+++ b/spec/lib/xi_cn_importer/reimporter_spec.rb
@@ -4,8 +4,13 @@ RSpec.describe XiCnImporter::Reimporter do
   subject(:reimporter) { described_class.new }
 
   let(:celex)  { '32025R1926' }
-  let(:update) { create(:customs_tariff_update, version: celex, source_url: 'http://cellar.example.com/doc') }
-  let(:html)   { '<html><body></body></html>' }
+  let(:update) do
+    create(:customs_tariff_update,
+           version: celex,
+           source_url: 'http://cellar.example.com/doc',
+           s3_path: "data/customs_tariff_documents/xi/CN_#{celex}.pdf")
+  end
+  let(:html) { '<html><body></body></html>' }
 
   let(:extracted) do
     XiCnImporter::NotesExtractor::Result.new(
@@ -49,13 +54,36 @@ RSpec.describe XiCnImporter::Reimporter do
       it 'is a no-op when the version does not exist' do
         expect { reimporter.call(version: 'nonexistent') }.not_to raise_error
       end
+
+      context 'when the extractor returns an empty result' do
+        before do
+          allow(XiCnImporter::NotesExtractor).to receive(:new).and_return(
+            instance_double(XiCnImporter::NotesExtractor,
+                            call: XiCnImporter::NotesExtractor::Result.new(
+                              sections: {}, chapters: {}, general_rules: {},
+                            )),
+          )
+          create(:customs_tariff_section_note, customs_tariff_update: update, section_id: 1, content: 'existing')
+        end
+
+        it 'raises rather than wiping notes' do
+          expect { reimporter.call(version: celex) }.to raise_error(/Empty extract/)
+        end
+
+        it 'leaves existing notes intact' do
+          reimporter.call(version: celex)
+        rescue RuntimeError
+          expect(CustomsTariffSectionNote.where(customs_tariff_update_version: celex).count).to eq 1
+        end
+      end
     end
 
     context 'without a version (reimport all)' do
       let(:second_update) do
         create(:customs_tariff_update,
                version: '32024R1234',
-               source_url: 'http://cellar.example.com/doc2')
+               source_url: 'http://cellar.example.com/doc2',
+               s3_path: 'data/customs_tariff_documents/xi/CN_32024R1234.pdf')
       end
 
       before do

--- a/spec/lib/xi_cn_importer/reimporter_spec.rb
+++ b/spec/lib/xi_cn_importer/reimporter_spec.rb
@@ -1,0 +1,92 @@
+require 'rails_helper'
+
+RSpec.describe XiCnImporter::Reimporter do
+  subject(:reimporter) { described_class.new }
+
+  let(:celex)  { '32025R1926' }
+  let(:update) { create(:customs_tariff_update, version: celex, source_url: 'http://cellar.example.com/doc') }
+  let(:html)   { '<html><body></body></html>' }
+
+  let(:extracted) do
+    XiCnImporter::NotesExtractor::Result.new(
+      sections: { 1 => 'Section content.' },
+      chapters: { '01' => 'Chapter content.' },
+      general_rules: { '1' => 'GRI content.' },
+    )
+  end
+
+  before do
+    update
+    stub_request(:get, 'http://cellar.example.com/doc')
+      .with(headers: { 'Accept' => 'application/xhtml+xml' })
+      .to_return(status: 200, body: html)
+
+    allow(XiCnImporter::NotesExtractor).to receive(:new).and_return(
+      instance_double(XiCnImporter::NotesExtractor, call: extracted),
+    )
+  end
+
+  describe '#call' do
+    context 'with a specific version' do
+      it 'deletes existing notes and recreates them' do
+        create(:customs_tariff_section_note,
+               customs_tariff_update: update,
+               section_id: 1,
+               content: 'old content')
+
+        reimporter.call(version: celex)
+
+        notes = CustomsTariffSectionNote.where(customs_tariff_update_version: celex).all
+        expect(notes.length).to eq 1
+        expect(notes.first.content).to eq 'Section content.'
+      end
+
+      it 'fetches HTML from the stored source_url' do
+        reimporter.call(version: celex)
+        expect(WebMock).to have_requested(:get, 'http://cellar.example.com/doc')
+      end
+
+      it 'is a no-op when the version does not exist' do
+        expect { reimporter.call(version: 'nonexistent') }.not_to raise_error
+      end
+    end
+
+    context 'without a version (reimport all)' do
+      let(:second_update) do
+        create(:customs_tariff_update,
+               version: '32024R1234',
+               source_url: 'http://cellar.example.com/doc2')
+      end
+
+      before do
+        second_update
+        stub_request(:get, 'http://cellar.example.com/doc2')
+          .to_return(status: 200, body: html)
+      end
+
+      it 'reimports all non-failed updates' do
+        reimporter.call
+        expect(XiCnImporter::NotesExtractor).to have_received(:new).twice
+      end
+
+      context 'when one update fails during reimport-all' do
+        before do
+          call_count = 0
+          allow(XiCnImporter::NotesExtractor).to receive(:new) do
+            call_count += 1
+            if call_count == 1
+              instance_double(XiCnImporter::NotesExtractor, call: extracted)
+            else
+              instance_double(XiCnImporter::NotesExtractor).tap { |d| allow(d).to receive(:call).and_raise(RuntimeError, 'parse error') }
+            end
+          end
+        end
+
+        it 'continues to the next update after a failure' do
+          expect { reimporter.call }.not_to raise_error
+          expect(XiCnImporter::NotesExtractor).to have_received(:new).twice
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/xi_cn_importer/reimporter_spec.rb
+++ b/spec/lib/xi_cn_importer/reimporter_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe XiCnImporter::Reimporter do
   let(:update) do
     create(:customs_tariff_update,
            version: celex,
-           source_url: 'http://cellar.example.com/doc',
            s3_path: "data/customs_tariff_documents/xi/CN_#{celex}.pdf")
   end
   let(:html) { '<html><body></body></html>' }
+  let(:html_io) { StringIO.new(html) }
 
   let(:extracted) do
     XiCnImporter::NotesExtractor::Result.new(
@@ -22,9 +22,9 @@ RSpec.describe XiCnImporter::Reimporter do
 
   before do
     update
-    stub_request(:get, 'http://cellar.example.com/doc')
-      .with(headers: { 'Accept' => 'application/xhtml+xml' })
-      .to_return(status: 200, body: html)
+    allow(TariffSynchronizer::FileService).to receive(:get)
+      .with("data/customs_tariff_documents/xi/CN_#{celex}.xhtml")
+      .and_return(html_io)
 
     allow(XiCnImporter::NotesExtractor).to receive(:new).and_return(
       instance_double(XiCnImporter::NotesExtractor, call: extracted),
@@ -46,9 +46,11 @@ RSpec.describe XiCnImporter::Reimporter do
         expect(notes.first.content).to eq 'Section content.'
       end
 
-      it 'fetches HTML from the stored source_url' do
+      it 'reads XHTML from S3 rather than fetching from Cellar' do
         reimporter.call(version: celex)
-        expect(WebMock).to have_requested(:get, 'http://cellar.example.com/doc')
+        expect(TariffSynchronizer::FileService)
+          .to have_received(:get)
+          .with("data/customs_tariff_documents/xi/CN_#{celex}.xhtml")
       end
 
       it 'is a no-op when the version does not exist' do
@@ -79,17 +81,18 @@ RSpec.describe XiCnImporter::Reimporter do
     end
 
     context 'without a version (reimport all)' do
+      let(:second_celex) { '32024R1234' }
       let(:second_update) do
         create(:customs_tariff_update,
-               version: '32024R1234',
-               source_url: 'http://cellar.example.com/doc2',
-               s3_path: 'data/customs_tariff_documents/xi/CN_32024R1234.pdf')
+               version: second_celex,
+               s3_path: "data/customs_tariff_documents/xi/CN_#{second_celex}.pdf")
       end
 
       before do
         second_update
-        stub_request(:get, 'http://cellar.example.com/doc2')
-          .to_return(status: 200, body: html)
+        allow(TariffSynchronizer::FileService).to receive(:get)
+          .with("data/customs_tariff_documents/xi/CN_#{second_celex}.xhtml")
+          .and_return(StringIO.new(html))
       end
 
       it 'reimports all non-failed updates' do

--- a/spec/lib/xi_cn_importer/reimporter_spec.rb
+++ b/spec/lib/xi_cn_importer/reimporter_spec.rb
@@ -73,8 +73,7 @@ RSpec.describe XiCnImporter::Reimporter do
         end
 
         it 'leaves existing notes intact' do
-          reimporter.call(version: celex)
-        rescue RuntimeError
+          expect { reimporter.call(version: celex) }.to raise_error(/Empty extract/)
           expect(CustomsTariffSectionNote.where(customs_tariff_update_version: celex).count).to eq 1
         end
       end

--- a/spec/requests/api/admin/customs_tariff_updates/reimport_controller_spec.rb
+++ b/spec/requests/api/admin/customs_tariff_updates/reimport_controller_spec.rb
@@ -4,14 +4,33 @@ RSpec.describe Api::Admin::CustomsTariffUpdates::ReimportController do
 
     before do
       allow(CustomsTariffReimportWorker).to receive(:perform_async)
+      allow(XiCnReimportWorker).to receive(:perform_async)
     end
 
-    it 'returns 202 and enqueues the worker' do
-      post "/uk/admin/customs_tariff_updates/#{update.version}/reimport.json",
-           headers: request_headers(format: :json)
+    context 'when SERVICE is uk' do
+      before { allow(TradeTariffBackend).to receive(:xi?).and_return(false) }
 
-      expect(response.status).to eq(202)
-      expect(CustomsTariffReimportWorker).to have_received(:perform_async).with(update.version)
+      it 'returns 202 and enqueues CustomsTariffReimportWorker' do
+        post "/uk/admin/customs_tariff_updates/#{update.version}/reimport.json",
+             headers: request_headers(format: :json)
+
+        expect(response.status).to eq(202)
+        expect(CustomsTariffReimportWorker).to have_received(:perform_async).with(update.version)
+        expect(XiCnReimportWorker).not_to have_received(:perform_async)
+      end
+    end
+
+    context 'when SERVICE is xi' do
+      before { allow(TradeTariffBackend).to receive(:xi?).and_return(true) }
+
+      it 'returns 202 and enqueues XiCnReimportWorker' do
+        post "/uk/admin/customs_tariff_updates/#{update.version}/reimport.json",
+             headers: request_headers(format: :json)
+
+        expect(response.status).to eq(202)
+        expect(XiCnReimportWorker).to have_received(:perform_async).with(update.version)
+        expect(CustomsTariffReimportWorker).not_to have_received(:perform_async)
+      end
     end
 
     it 'returns 404 for an unknown version' do

--- a/spec/requests/api/admin/customs_tariff_updates/sections_summary_controller_spec.rb
+++ b/spec/requests/api/admin/customs_tariff_updates/sections_summary_controller_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe Api::Admin::CustomsTariffUpdates::SectionsSummaryController do
   around { |example| TimeMachine.now { example.run } }
 
@@ -50,6 +52,8 @@ RSpec.describe Api::Admin::CustomsTariffUpdates::SectionsSummaryController do
     end
 
     context 'when chapter notes exist in the update' do
+      let!(:chapter) { create(:chapter, :chapter01, :with_section) }
+
       before do
         create(:customs_tariff_chapter_note, customs_tariff_update: approved_update, chapter_id: '01',
                                              content: 'Old chapter 1 content long enough for comparison')
@@ -58,13 +62,10 @@ RSpec.describe Api::Admin::CustomsTariffUpdates::SectionsSummaryController do
       end
 
       it 'returns chapter_notes_total and chapter_notes_changed for the section containing chapter 01' do
-        pending 'chapter_to_section_map relies on chapters_sections join table populated with real tariff data; ' \
-                'may be empty in test environment causing counts to be 0'
-
         get "/uk/admin/customs_tariff_updates/#{pending_update.version}/sections_summary.json",
             headers: request_headers(format: :json)
 
-        row = JSON.parse(response.body)['data'].find { |r| r.dig('attributes', 'section_id') == sections.first.id }
+        row = JSON.parse(response.body)['data'].find { |r| r.dig('attributes', 'section_id') == chapter.sections.first.id }
         expect(row.dig('attributes', 'chapter_notes_total')).to eq(1)
         expect(row.dig('attributes', 'chapter_notes_changed')).to eq(1)
       end

--- a/spec/requests/api/admin/customs_tariff_updates_controller_spec.rb
+++ b/spec/requests/api/admin/customs_tariff_updates_controller_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe Api::Admin::CustomsTariffUpdatesController do
   describe 'GET #index' do
     before { create(:customs_tariff_update) }
@@ -25,7 +27,7 @@ RSpec.describe Api::Admin::CustomsTariffUpdatesController do
     let!(:update) { create(:customs_tariff_update) }
 
     it 'returns the update' do
-      get "/uk/admin/customs_tariff_updates/#{update.version}.json", headers: request_headers(format: :json)
+      get "/uk/admin/customs_tariff_updates/#{update.version}", headers: request_headers(format: :json)
 
       expect(response.status).to eq(200)
       data = JSON.parse(response.body)['data']

--- a/spec/workers/import_customs_tariff_document_worker_spec.rb
+++ b/spec/workers/import_customs_tariff_document_worker_spec.rb
@@ -1,11 +1,24 @@
 RSpec.describe ImportCustomsTariffDocumentWorker, type: :worker do
   subject(:perform) { described_class.new.perform }
 
+  let(:importer_double) { instance_double(CustomsTariffImporter::Importer) }
+
   before do
+    allow(TradeTariffBackend).to receive(:uk?).and_return(true)
+    allow(CustomsTariffImporter::Importer).to receive(:new).and_return(importer_double)
     allow(SlackNotifierService).to receive(:call)
     allow(CustomsTariffImporter::Instrumentation).to receive(:import_run_started)
     allow(CustomsTariffImporter::Instrumentation).to receive(:import_run_completed)
     allow(CustomsTariffImporter::Instrumentation).to receive(:import_run_failed)
+  end
+
+  context 'when SERVICE is not uk' do
+    before { allow(TradeTariffBackend).to receive(:uk?).and_return(false) }
+
+    it 'is a no-op' do
+      perform
+      expect(CustomsTariffImporter::Importer).not_to have_received(:new)
+    end
   end
 
   def result(status:, version: nil, error: nil)

--- a/spec/workers/import_xi_cn_document_worker_spec.rb
+++ b/spec/workers/import_xi_cn_document_worker_spec.rb
@@ -35,11 +35,9 @@ RSpec.describe ImportXiCnDocumentWorker do
       end
     end
 
-    context 'when all documents are skipped' do
+    context 'when no new documents are found' do
       before do
-        allow(importer_double).to receive(:call).and_return([
-          XiCnImporter::Importer::Result.new(status: :skipped, celex: '32025R1926'),
-        ])
+        allow(importer_double).to receive(:call).and_return([])
       end
 
       it 'does not send a Slack notification' do

--- a/spec/workers/import_xi_cn_document_worker_spec.rb
+++ b/spec/workers/import_xi_cn_document_worker_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe ImportXiCnDocumentWorker do
+  subject(:worker) { described_class.new }
+
+  let(:importer_double) { instance_double(XiCnImporter::Importer) }
+
+  before do
+    allow(TradeTariffBackend).to receive(:xi?).and_return(true)
+    allow(XiCnImporter::Importer).to receive(:new).and_return(importer_double)
+    allow(SlackNotifierService).to receive(:call)
+  end
+
+  describe '#perform' do
+    context 'when SERVICE is not xi' do
+      before { allow(TradeTariffBackend).to receive(:xi?).and_return(false) }
+
+      it 'does nothing' do
+        worker.perform
+        expect(XiCnImporter::Importer).not_to have_received(:new)
+      end
+    end
+
+    context 'when documents are imported' do
+      before do
+        allow(importer_double).to receive(:call).and_return([
+          XiCnImporter::Importer::Result.new(status: :imported, celex: '32025R1926'),
+        ])
+      end
+
+      it 'sends a Slack notification with import counts' do
+        worker.perform
+        expect(SlackNotifierService).to have_received(:call)
+          .with(a_string_including('imported: 1'))
+      end
+    end
+
+    context 'when all documents are skipped' do
+      before do
+        allow(importer_double).to receive(:call).and_return([
+          XiCnImporter::Importer::Result.new(status: :skipped, celex: '32025R1926'),
+        ])
+      end
+
+      it 'does not send a Slack notification' do
+        worker.perform
+        expect(SlackNotifierService).not_to have_received(:call)
+      end
+    end
+
+    context 'when the importer raises an error' do
+      before do
+        allow(importer_double).to receive(:call).and_raise(RuntimeError, 'network timeout')
+      end
+
+      it 'sends a failure Slack notification' do
+        expect { worker.perform }.to raise_error(RuntimeError)
+        expect(SlackNotifierService).to have_received(:call)
+          .with(a_string_including('failed'))
+      end
+    end
+  end
+end

--- a/spec/workers/xi_cn_reimport_worker_spec.rb
+++ b/spec/workers/xi_cn_reimport_worker_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe XiCnReimportWorker do
+  subject(:worker) { described_class.new }
+
+  let(:reimporter_double) { instance_double(XiCnImporter::Reimporter, call: nil) }
+
+  before do
+    allow(TradeTariffBackend).to receive(:xi?).and_return(true)
+    allow(XiCnImporter::Reimporter).to receive(:new).and_return(reimporter_double)
+  end
+
+  it 'calls the Reimporter with the given version' do
+    worker.perform('32025R1926')
+    expect(reimporter_double).to have_received(:call).with(version: '32025R1926')
+  end
+
+  context 'when SERVICE is not xi' do
+    before { allow(TradeTariffBackend).to receive(:xi?).and_return(false) }
+
+    it 'does nothing' do
+      worker.perform('32025R1926')
+      expect(reimporter_double).not_to have_received(:call)
+    end
+  end
+end


### PR DESCRIPTION
## What:

This PR adds a brand new ETL pipeline for the XI (Northern Ireland) tariff — the **XI Combined Nomenclature (CN) importer**. It also tidies up a few things on the UK side.

Here's what's been added or changed:

**New XI CN pipeline:**
- **`XiCnImporter::DocumentFetcher`** — queries the EU Publications Office SPARQL endpoint to discover new annual CN regulations, then fetches both the XHTML and PDF from the EU Cellar CDN
- **`XiCnImporter::NotesExtractor`** — state machine that walks the EU OJ XHTML body and extracts section notes, chapter notes, and General Rules of Interpretation (GRIs)
- **`XiCnImporter::NotesExtractor::Formatter`** — converts raw extracted lines into govspeak-compatible markdown, handling EU-specific formatting quirks (parenthetical list markers, em-dash bullets, deep table indentation)
- **`XiCnImporter::Importer`** — orchestrates fetch → extract → persist, saving the PDF to S3 and all notes to the database as `pending`
- **`XiCnImporter::Reimporter`** — re-fetches the stored Cellar HTML URL and re-extracts notes for one or all versions; used by the rake task and admin UI
- **`ImportXiCnDocumentWorker`** — Sidekiq worker (default queue) scheduled daily at 9am with Slack notifications
- **`XiCnReimportWorker`** — background worker for on-demand reimport triggered from the admin UI
- **`XiCnImporter::Instrumentation`** and **`XiCnImporter::Logger`** — structured logging and StatsD metrics throughout
- **`lib/tasks/xi_cn_importer.rake`** — rake task `importer:xi_cn:reimport[<version>]` for manual reimport

**UK side fixes:**
- **`ImportCustomsTariffDocumentWorker`** — added `return unless TradeTariffBackend.uk?` guard (mirrors the XI worker) so it's a no-op if accidentally enqueued on an XI instance
- **`Api::Admin::CustomsTariffUpdates::ReimportController`** — now dispatches to the correct reimporter based on `SERVICE` (UK → `CustomsTariffImporter::Reimporter`, XI → `XiCnImporter::Reimporter`)

**Spec fixes:**
- `sections_summary_controller_spec.rb` — unpended the chapter counts test by creating a proper `chapter :with_section` in the test rather than relying on real tariff data

## Why:

Northern Ireland uses EU tariff classification under the Windsor Framework, so the XI service needs its own source of section and chapter notes — the EU Combined Nomenclature — rather than the UK GOV.UK document. Without this pipeline, XI notes would need to be maintained manually, which isn't sustainable as the CN updates annually.

The EU Cellar CDN serves structured XHTML (unlike the UK's Word `.docx`), so the XI extractor is a separate implementation — a state machine walking XML nodes rather than using a MarkerTrie for indentation inference.

A couple of things worth noting for reviewers:
- The XI importer stores the Cellar HTML URL on `CustomsTariffUpdate.source_url` at import time so the reimporter can re-fetch without re-running the SPARQL query
- The UK importer already had S3 storage and a service guard on the reimport controller, but was missing a service guard on the worker itself — that's been added

## Ticket:

[AI-895](https://transformuk.atlassian.net/browse/AI-895)

## Risk:

**Risk level:** 🟢

**Reason for rating:** Entirely additive — new tables, new workers, new rake task. Nothing existing is removed or modified in a breaking way. The UK reimport controller change is covered by request specs. The new XI workers are guarded by `TradeTariffBackend.xi?` so they're a no-op on UK instances.

> ⚠️ **Follow-up ticket needed:** Existing UK customs tariff documents in the dev/staging/production S3 buckets may need migrating to the new `data/customs_tariff_documents/uk/` prefix path. This has been scoped as a separate ticket and does not block this PR.

## Have you?

- [ ] Added documentation for new APIs
- [ ] Added new environment variables with correct values to all apps in all spaces