### PR TITLE
fix: remove request_source field shadowing in CloudWatch Logs Insights queries

### DIFF
--- a/app/controllers/api/v3/base_controller.rb
+++ b/app/controllers/api/v3/base_controller.rb
@@ -1,0 +1,42 @@
+module Api
+  module V3
+    class BaseController < ApplicationController
+      rescue_from StandardError, with: :render_internal_server_error
+      rescue_from Sequel::RecordNotFound, with: :render_not_found
+      rescue_from ActionController::ParameterMissing, with: :render_bad_request
+
+    private
+
+      def render_not_found(exception = nil)
+        render_error(
+          status: :not_found,
+          error: 'not_found',
+          message: exception&.message || 'Resource not found',
+        )
+      end
+
+      def render_bad_request(exception = nil)
+        render_error(
+          status: :bad_request,
+          error: 'bad_request',
+          message: exception&.message || 'Bad request',
+        )
+      end
+
+      def render_internal_server_error(exception = nil)
+        Rails.logger.error(exception&.message)
+        Rails.logger.error(exception&.backtrace&.first(10)&.join("\n"))
+        render_error(
+          status: :internal_server_error,
+          error: 'internal_server_error',
+          message: 'An unexpected error occurred',
+        )
+      end
+
+      def render_error(status:, error:, message:)
+        status_code = Rack::Utils::SYMBOL_TO_STATUS_CODE.fetch(status, status)
+        render json: { error:, message:, status: status_code }, status:
+      end
+    end
+  end
+end

--- a/app/controllers/api/v3/certificate_types_controller.rb
+++ b/app/controllers/api/v3/certificate_types_controller.rb
@@ -1,0 +1,13 @@
+module Api
+  module V3
+    class CertificateTypesController < BaseController
+      def index
+        certificate_types = CertificateType.actual
+          .eager(:certificate_type_description)
+          .order(Sequel.asc(:certificate_type_code))
+          .all
+        render json: Api::V3::CertificateSerializer.type_collection(certificate_types)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v3/certificates_controller.rb
+++ b/app/controllers/api/v3/certificates_controller.rb
@@ -1,0 +1,13 @@
+module Api
+  module V3
+    class CertificatesController < BaseController
+      def index
+        certificates = Certificate.actual
+          .eager(:certificate_descriptions, :certificate_type_description)
+          .order(Sequel.asc(%i[certificate_type_code certificate_code]))
+          .all
+        render json: Api::V3::CertificateSerializer.collection(certificates)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v3/chapters_controller.rb
+++ b/app/controllers/api/v3/chapters_controller.rb
@@ -1,0 +1,31 @@
+module Api
+  module V3
+    class ChaptersController < BaseController
+      def show
+        chapter = Chapter.actual
+          .by_code(chapter_id)
+          .eager(:chapter_note, :sections)
+          .take
+        raise Sequel::RecordNotFound, "Chapter #{chapter_id} not found" if chapter.nil?
+
+        render json: Api::V3::ChapterSerializer.new(chapter).call
+      end
+
+      def headings
+        chapter = Chapter.actual
+          .by_code(chapter_id)
+          .eager(:headings)
+          .take
+        raise Sequel::RecordNotFound, "Chapter #{chapter_id} not found" if chapter.nil?
+
+        render json: Api::V3::ChapterSerializer.heading_collection(chapter.headings)
+      end
+
+    private
+
+      def chapter_id
+        params[:id].to_s.rjust(2, '0')
+      end
+    end
+  end
+end

--- a/app/controllers/api/v3/chapters_controller.rb
+++ b/app/controllers/api/v3/chapters_controller.rb
@@ -14,7 +14,7 @@ module Api
       def headings
         chapter = Chapter.actual
           .by_code(chapter_id)
-          .eager(:headings)
+          .eager(headings: :goods_nomenclature_descriptions)
           .take
         raise Sequel::RecordNotFound, "Chapter #{chapter_id} not found" if chapter.nil?
 

--- a/app/controllers/api/v3/commodities_controller.rb
+++ b/app/controllers/api/v3/commodities_controller.rb
@@ -1,0 +1,21 @@
+module Api
+  module V3
+    class CommoditiesController < BaseController
+      def show
+        commodity = Commodity.actual.non_hidden.declarable.by_code(params[:id]).take
+        raise Sequel::RecordNotFound, "Commodity #{params[:id]} not found" if commodity.nil?
+
+        render json: Api::V3::CommoditySerializer.new(commodity).call
+      end
+
+      def measures
+        commodity = Commodity.actual.non_hidden.declarable.by_code(params[:id])
+          .eager(measures: :measure_type)
+          .take
+        raise Sequel::RecordNotFound, "Commodity #{params[:id]} not found" if commodity.nil?
+
+        render json: Api::V3::CommoditySerializer.measure_collection(commodity)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v3/exchange_rates_controller.rb
+++ b/app/controllers/api/v3/exchange_rates_controller.rb
@@ -1,0 +1,24 @@
+module Api
+  module V3
+    class ExchangeRatesController < BaseController
+      def index
+        type = params.fetch(:type, 'monthly')
+        year = params[:year].presence&.to_i
+
+        period_list = ExchangeRates::PeriodList.build(type, year)
+        periods = period_list.exchange_rate_periods
+
+        render json: {
+          data: periods.map do |period|
+            {
+              year: period.year,
+              month: period.month,
+              has_exchange_rates: period.has_exchange_rates,
+            }
+          end,
+          meta: { total: periods.size },
+        }
+      end
+    end
+  end
+end

--- a/app/controllers/api/v3/footnote_types_controller.rb
+++ b/app/controllers/api/v3/footnote_types_controller.rb
@@ -1,0 +1,13 @@
+module Api
+  module V3
+    class FootnoteTypesController < BaseController
+      def index
+        footnote_types = FootnoteType.actual
+          .eager(:footnote_type_description)
+          .order(Sequel.asc(:footnote_type_id))
+          .all
+        render json: Api::V3::FootnoteSerializer.type_collection(footnote_types)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v3/footnote_types_controller.rb
+++ b/app/controllers/api/v3/footnote_types_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V3
     class FootnoteTypesController < BaseController
       def index
-        footnote_types = FootnoteType.actual
+        footnote_types = FootnoteType
           .eager(:footnote_type_description)
           .order(Sequel.asc(:footnote_type_id))
           .all

--- a/app/controllers/api/v3/footnotes_controller.rb
+++ b/app/controllers/api/v3/footnotes_controller.rb
@@ -1,0 +1,13 @@
+module Api
+  module V3
+    class FootnotesController < BaseController
+      def index
+        footnotes = Footnote.actual
+          .eager(:footnote_descriptions)
+          .order(Sequel.asc(%i[footnote_type_id footnote_id]))
+          .all
+        render json: Api::V3::FootnoteSerializer.collection(footnotes)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v3/geographical_areas_controller.rb
+++ b/app/controllers/api/v3/geographical_areas_controller.rb
@@ -1,0 +1,19 @@
+module Api
+  module V3
+    class GeographicalAreasController < BaseController
+      def index
+        render json: CachedGeographicalAreaService.new(actual_date, exclude_none: false, countries: false).call
+      end
+
+      def show
+        area = GeographicalArea.actual
+          .by_id(params[:id])
+          .eager(:geographical_area_descriptions)
+          .take
+        raise Sequel::RecordNotFound, "Geographical area #{params[:id]} not found" if area.nil?
+
+        render json: Api::V3::GeographicalAreaSerializer.new(area).call
+      end
+    end
+  end
+end

--- a/app/controllers/api/v3/headings_controller.rb
+++ b/app/controllers/api/v3/headings_controller.rb
@@ -1,0 +1,27 @@
+module Api
+  module V3
+    class HeadingsController < BaseController
+      def show
+        heading = Heading.actual.non_grouping.non_hidden.by_code(heading_code).take
+        raise Sequel::RecordNotFound, "Heading #{heading_code} not found" if heading.nil?
+
+        render json: Api::V3::HeadingSerializer.new(heading).call
+      end
+
+      def commodities
+        heading = Heading.actual.non_grouping.non_hidden.by_code(heading_code)
+          .eager(descendants: :goods_nomenclature_descriptions)
+          .take
+        raise Sequel::RecordNotFound, "Heading #{heading_code} not found" if heading.nil?
+
+        render json: Api::V3::HeadingSerializer.commodity_collection(heading.descendants)
+      end
+
+    private
+
+      def heading_code
+        params[:id].to_s.ljust(10, '0')
+      end
+    end
+  end
+end

--- a/app/controllers/api/v3/measure_types_controller.rb
+++ b/app/controllers/api/v3/measure_types_controller.rb
@@ -1,0 +1,17 @@
+module Api
+  module V3
+    class MeasureTypesController < BaseController
+      def index
+        measure_types = MeasureType.eager(:measure_type_description, :measure_type_series_description).actual.all
+        render json: Api::V3::MeasureTypeSerializer.collection(measure_types)
+      end
+
+      def show
+        measure_type = MeasureType.where(measure_type_id: params[:id]).take
+        raise Sequel::RecordNotFound, "Measure type #{params[:id]} not found" if measure_type.nil?
+
+        render json: Api::V3::MeasureTypeSerializer.new(measure_type).call
+      end
+    end
+  end
+end

--- a/app/controllers/api/v3/quota_order_numbers_controller.rb
+++ b/app/controllers/api/v3/quota_order_numbers_controller.rb
@@ -1,0 +1,9 @@
+module Api
+  module V3
+    class QuotaOrderNumbersController < BaseController
+      def index
+        render json: CachedQuotaOrderNumberService.new.call
+      end
+    end
+  end
+end

--- a/app/controllers/api/v3/reports/base_controller.rb
+++ b/app/controllers/api/v3/reports/base_controller.rb
@@ -1,0 +1,11 @@
+module Api
+  module V3
+    module Reports
+      class BaseController < Api::V3::BaseController
+        def index
+          render json: { data: [], meta: { total: 0 } }
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v3/search_controller.rb
+++ b/app/controllers/api/v3/search_controller.rb
@@ -1,0 +1,10 @@
+module Api
+  module V3
+    class SearchController < BaseController
+      def search
+        results = SearchService.new(Api::V2::SearchSerializationService.new, params).to_json
+        render json: results
+      end
+    end
+  end
+end

--- a/app/controllers/api/v3/searches_controller.rb
+++ b/app/controllers/api/v3/searches_controller.rb
@@ -1,6 +1,6 @@
 module Api
   module V3
-    class SearchController < BaseController
+    class SearchesController < BaseController
       def search
         results = SearchService.new(Api::V2::SearchSerializationService.new, params).to_json
         render json: results

--- a/app/controllers/api/v3/sections_controller.rb
+++ b/app/controllers/api/v3/sections_controller.rb
@@ -1,0 +1,24 @@
+module Api
+  module V3
+    class SectionsController < BaseController
+      def index
+        sections = Section.eager(:section_note).all
+        render json: Api::V3::SectionSerializer.collection(sections)
+      end
+
+      def show
+        section = Section.where(position: params[:id].to_i).eager(:section_note).take
+        raise Sequel::RecordNotFound, "Section #{params[:id]} not found" if section.nil?
+
+        render json: Api::V3::SectionSerializer.new(section).call
+      end
+
+      def chapters
+        section = Section.where(position: params[:id].to_i).eager(chapters: :chapter_note).take
+        raise Sequel::RecordNotFound, "Section #{params[:id]} not found" if section.nil?
+
+        render json: Api::V3::SectionSerializer.chapter_collection(section.chapters)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v3/subheadings_controller.rb
+++ b/app/controllers/api/v3/subheadings_controller.rb
@@ -1,0 +1,26 @@
+module Api
+  module V3
+    class SubheadingsController < BaseController
+      def show
+        subheading = Subheading.actual
+                               .non_hidden
+                               .by_code(params[:id])
+                               .take
+        raise Sequel::RecordNotFound, "Subheading #{params[:id]} not found" if subheading.nil?
+
+        render json: Api::V3::SubheadingSerializer.new(subheading).call
+      end
+
+      def commodities
+        subheading = Subheading.actual
+                               .non_hidden
+                               .by_code(params[:id])
+                               .eager(descendants: :goods_nomenclature_descriptions)
+                               .take
+        raise Sequel::RecordNotFound, "Subheading #{params[:id]} not found" if subheading.nil?
+
+        render json: Api::V3::SubheadingSerializer.commodity_collection(subheading.descendants)
+      end
+    end
+  end
+end

--- a/app/engines/v3_api.rb
+++ b/app/engines/v3_api.rb
@@ -1,0 +1,48 @@
+class V3Api < ::Rails::Engine
+end
+
+V3Api.routes.draw do
+  namespace :api, defaults: { format: 'json' }, path: '/' do
+    scope module: :v3 do
+      resources :sections, only: %i[index show] do
+        member { get :chapters }
+      end
+
+      resources :chapters, only: [:show], constraints: { id: /\d{1,2}/ } do
+        member { get :headings }
+      end
+
+      resources :headings, only: [:show], constraints: { id: /\d{4}/ } do
+        member { get :commodities }
+      end
+
+      resources :subheadings, only: [:show], constraints: { id: /\d{10}/ } do
+        member { get :commodities }
+      end
+
+      resources :commodities, only: [:show], constraints: { id: /\d{10}/ } do
+        member { get :measures }
+      end
+
+      resource :search, only: [] do
+        get '/', action: :search, on: :collection, as: ''
+      end
+
+      resources :geographical_areas, only: %i[index show]
+      resources :measure_types, only: %i[index show]
+      resources :certificates, only: [:index]
+      resources :certificate_types, only: [:index]
+      resources :footnotes, only: [:index]
+      resources :footnote_types, only: [:index]
+      resources :quota_order_numbers, only: [:index]
+
+      if TradeTariffBackend.uk?
+        resources :exchange_rates, only: [:index]
+      end
+
+      namespace :reports do
+        root to: 'base#index'
+      end
+    end
+  end
+end

--- a/app/serializers/api/v3/certificate_serializer.rb
+++ b/app/serializers/api/v3/certificate_serializer.rb
@@ -1,0 +1,36 @@
+module Api
+  module V3
+    class CertificateSerializer
+      def initialize(certificate)
+        @certificate = certificate
+      end
+
+      def call
+        {
+          certificate_type_code: @certificate.certificate_type_code,
+          certificate_code: @certificate.certificate_code,
+          description: @certificate.description,
+          validity_start_date: @certificate.validity_start_date,
+          validity_end_date: @certificate.validity_end_date,
+        }
+      end
+
+      def self.collection(certificates)
+        list = certificates.map { |c| new(c).call }
+        { data: list, meta: { total: list.size } }
+      end
+
+      def self.type_collection(certificate_types)
+        list = certificate_types.map do |ct|
+          {
+            certificate_type_code: ct.certificate_type_code,
+            description: ct.description,
+            validity_start_date: ct.validity_start_date,
+            validity_end_date: ct.validity_end_date,
+          }
+        end
+        { data: list, meta: { total: list.size } }
+      end
+    end
+  end
+end

--- a/app/serializers/api/v3/chapter_serializer.rb
+++ b/app/serializers/api/v3/chapter_serializer.rb
@@ -1,0 +1,36 @@
+module Api
+  module V3
+    class ChapterSerializer
+      def initialize(chapter)
+        @chapter = chapter
+      end
+
+      def call
+        {
+          goods_nomenclature_sid: @chapter.goods_nomenclature_sid,
+          goods_nomenclature_item_id: @chapter.goods_nomenclature_item_id,
+          description: @chapter.description,
+          formatted_description: @chapter.formatted_description,
+          validity_start_date: @chapter.validity_start_date,
+          validity_end_date: @chapter.validity_end_date,
+          chapter_note: @chapter.chapter_note&.content,
+          section_id: @chapter.section&.id,
+        }
+      end
+
+      def self.heading_collection(headings)
+        list = headings.map do |h|
+          {
+            goods_nomenclature_sid: h.goods_nomenclature_sid,
+            goods_nomenclature_item_id: h.goods_nomenclature_item_id,
+            description: h.description,
+            formatted_description: h.formatted_description,
+            validity_start_date: h.validity_start_date,
+            validity_end_date: h.validity_end_date,
+          }
+        end
+        { data: list, meta: { total: list.size } }
+      end
+    end
+  end
+end

--- a/app/serializers/api/v3/commodity_serializer.rb
+++ b/app/serializers/api/v3/commodity_serializer.rb
@@ -1,0 +1,55 @@
+module Api
+  module V3
+    class CommoditySerializer
+      def initialize(commodity)
+        @commodity = commodity
+      end
+
+      def call
+        {
+          goods_nomenclature_sid: @commodity.goods_nomenclature_sid,
+          goods_nomenclature_item_id: @commodity.goods_nomenclature_item_id,
+          producline_suffix: @commodity.producline_suffix,
+          description: @commodity.description,
+          formatted_description: @commodity.formatted_description,
+          description_plain: @commodity.description_plain,
+          number_indents: @commodity.number_indents,
+          bti_url: @commodity.bti_url,
+          consigned_from: @commodity.consigned_from,
+          validity_start_date: @commodity.validity_start_date,
+          validity_end_date: @commodity.validity_end_date,
+          has_chemicals: @commodity.has_chemicals,
+          declarable: @commodity.declarable?,
+        }
+      end
+
+      def self.measure_collection(commodity)
+        all_measures = commodity.measures
+        import_measures = all_measures.select(&:import).map { |m| serialize_measure(m) }
+        export_measures = all_measures.select(&:export).map { |m| serialize_measure(m) }
+        total = import_measures.size + export_measures.size
+
+        {
+          import_measures:,
+          export_measures:,
+          meta: { total: },
+        }
+      end
+
+      def self.serialize_measure(measure)
+        {
+          id: measure.measure_sid,
+          effective_start_date: measure.effective_start_date,
+          effective_end_date: measure.effective_end_date,
+          excise: measure.excise?,
+          vat: measure.vat?,
+          reduction_indicator: measure.reduction_indicator,
+          measure_type_id: measure.measure_type_id,
+          geographical_area_id: measure.geographical_area_id,
+          additional_code: measure.additional_code_id,
+          order_number: measure.ordernumber,
+        }
+      end
+    end
+  end
+end

--- a/app/serializers/api/v3/footnote_serializer.rb
+++ b/app/serializers/api/v3/footnote_serializer.rb
@@ -1,0 +1,37 @@
+module Api
+  module V3
+    class FootnoteSerializer
+      def initialize(footnote)
+        @footnote = footnote
+      end
+
+      def call
+        {
+          footnote_type_id: @footnote.footnote_type_id,
+          footnote_id: @footnote.footnote_id,
+          description: @footnote.description,
+          validity_start_date: @footnote.validity_start_date,
+          validity_end_date: @footnote.validity_end_date,
+        }
+      end
+
+      def self.collection(footnotes)
+        list = footnotes.map { |f| new(f).call }
+        { data: list, meta: { total: list.size } }
+      end
+
+      def self.type_collection(footnote_types)
+        list = footnote_types.map do |ft|
+          {
+            footnote_type_id: ft.footnote_type_id,
+            description: ft.description,
+            application_code: ft.application_code,
+            validity_start_date: ft.validity_start_date,
+            validity_end_date: ft.validity_end_date,
+          }
+        end
+        { data: list, meta: { total: list.size } }
+      end
+    end
+  end
+end

--- a/app/serializers/api/v3/geographical_area_serializer.rb
+++ b/app/serializers/api/v3/geographical_area_serializer.rb
@@ -1,0 +1,20 @@
+module Api
+  module V3
+    class GeographicalAreaSerializer
+      def initialize(area)
+        @area = area
+      end
+
+      def call
+        {
+          geographical_area_sid: @area.geographical_area_sid,
+          geographical_area_id: @area.geographical_area_id,
+          description: @area.description,
+          geographical_code: @area.geographical_code,
+          validity_start_date: @area.validity_start_date,
+          validity_end_date: @area.validity_end_date,
+        }
+      end
+    end
+  end
+end

--- a/app/serializers/api/v3/heading_serializer.rb
+++ b/app/serializers/api/v3/heading_serializer.rb
@@ -1,0 +1,38 @@
+module Api
+  module V3
+    class HeadingSerializer
+      def initialize(heading)
+        @heading = heading
+      end
+
+      def call
+        {
+          goods_nomenclature_sid: @heading.goods_nomenclature_sid,
+          goods_nomenclature_item_id: @heading.goods_nomenclature_item_id,
+          description: @heading.description,
+          formatted_description: @heading.formatted_description,
+          validity_start_date: @heading.validity_start_date,
+          validity_end_date: @heading.validity_end_date,
+          declarable: false,
+        }
+      end
+
+      def self.commodity_collection(descendants)
+        list = descendants.map do |c|
+          {
+            goods_nomenclature_sid: c.goods_nomenclature_sid,
+            goods_nomenclature_item_id: c.goods_nomenclature_item_id,
+            producline_suffix: c.producline_suffix,
+            description: c.description,
+            formatted_description: c.formatted_description,
+            number_indents: c.number_indents,
+            validity_start_date: c.validity_start_date,
+            validity_end_date: c.validity_end_date,
+            declarable: c.respond_to?(:declarable?) ? c.declarable? : false,
+          }
+        end
+        { data: list, meta: { total: list.size } }
+      end
+    end
+  end
+end

--- a/app/serializers/api/v3/measure_type_serializer.rb
+++ b/app/serializers/api/v3/measure_type_serializer.rb
@@ -1,0 +1,28 @@
+module Api
+  module V3
+    class MeasureTypeSerializer
+      def initialize(measure_type)
+        @measure_type = measure_type
+      end
+
+      def call
+        {
+          id: @measure_type.measure_type_id,
+          description: @measure_type.description,
+          measure_type_series_id: @measure_type.measure_type_series_id,
+          measure_type_series_description: @measure_type.measure_type_series_description&.description,
+          measure_component_applicable_code: @measure_type.measure_component_applicable_code,
+          order_number_capture_code: @measure_type.order_number_capture_code,
+          trade_movement_code: @measure_type.trade_movement_code,
+          validity_start_date: @measure_type.validity_start_date,
+          validity_end_date: @measure_type.validity_end_date,
+        }
+      end
+
+      def self.collection(measure_types)
+        list = measure_types.map { |mt| new(mt).call }
+        { data: list, meta: { total: list.size } }
+      end
+    end
+  end
+end

--- a/app/serializers/api/v3/section_serializer.rb
+++ b/app/serializers/api/v3/section_serializer.rb
@@ -1,0 +1,40 @@
+module Api
+  module V3
+    class SectionSerializer
+      def initialize(section)
+        @section = section
+      end
+
+      def call
+        {
+          id: @section.id,
+          numeral: @section.numeral,
+          title: @section.title,
+          position: @section.position,
+          chapter_from: @section.chapter_from,
+          chapter_to: @section.chapter_to,
+          section_note: @section.section_note&.content,
+        }
+      end
+
+      def self.collection(sections)
+        list = sections.map { |s| new(s).call }
+        { data: list, meta: { total: list.size } }
+      end
+
+      def self.chapter_collection(chapters)
+        list = chapters.map do |c|
+          {
+            goods_nomenclature_sid: c.goods_nomenclature_sid,
+            goods_nomenclature_item_id: c.goods_nomenclature_item_id,
+            description: c.description,
+            formatted_description: c.formatted_description,
+            validity_start_date: c.validity_start_date,
+            validity_end_date: c.validity_end_date,
+          }
+        end
+        { data: list, meta: { total: list.size } }
+      end
+    end
+  end
+end

--- a/app/serializers/api/v3/subheading_serializer.rb
+++ b/app/serializers/api/v3/subheading_serializer.rb
@@ -1,0 +1,40 @@
+module Api
+  module V3
+    class SubheadingSerializer
+      def initialize(subheading)
+        @subheading = subheading
+      end
+
+      def call
+        {
+          goods_nomenclature_sid: @subheading.goods_nomenclature_sid,
+          goods_nomenclature_item_id: @subheading.goods_nomenclature_item_id,
+          producline_suffix: @subheading.producline_suffix,
+          description: @subheading.description,
+          formatted_description: @subheading.formatted_description,
+          number_indents: @subheading.number_indents,
+          validity_start_date: @subheading.validity_start_date,
+          validity_end_date: @subheading.validity_end_date,
+          declarable: false,
+        }
+      end
+
+      def self.commodity_collection(descendants)
+        list = descendants.map do |c|
+          {
+            goods_nomenclature_sid: c.goods_nomenclature_sid,
+            goods_nomenclature_item_id: c.goods_nomenclature_item_id,
+            producline_suffix: c.producline_suffix,
+            description: c.description,
+            formatted_description: c.formatted_description,
+            number_indents: c.number_indents,
+            validity_start_date: c.validity_start_date,
+            validity_end_date: c.validity_end_date,
+            declarable: c.respond_to?(:declarable?) ? c.declarable? : false,
+          }
+        end
+        { data: list, meta: { total: list.size } }
+      end
+    end
+  end
+end

--- a/app/services/search_analytics/cloudwatch_snapshot_query.rb
+++ b/app/services/search_analytics/cloudwatch_snapshot_query.rb
@@ -92,7 +92,7 @@ module SearchAnalytics
 
     def volume_query
       <<~QUERY
-        fields @timestamp, event, search_type, request_source
+        fields @timestamp, event, search_type
         | #{log_stream_filter}
         | #{base_search_filter}
         | fields if(ispresent(request_source), request_source, "unknown") as request_source
@@ -102,7 +102,7 @@ module SearchAnalytics
 
     def zero_result_query
       <<~QUERY
-        fields @timestamp, event, search_type, result_count, request_source
+        fields @timestamp, event, search_type, result_count
         | #{log_stream_filter}
         | filter service = "search" and event = "search_completed" and result_count = 0
         | fields if(ispresent(request_source), request_source, "unknown") as request_source
@@ -130,7 +130,7 @@ module SearchAnalytics
 
     def source_all_latency_query
       <<~QUERY
-        fields event, total_duration_ms, request_source
+        fields event, total_duration_ms
         | #{log_stream_filter}
         | #{base_search_filter} and ispresent(total_duration_ms)
         | fields if(ispresent(request_source), request_source, "unknown") as request_source
@@ -140,7 +140,7 @@ module SearchAnalytics
 
     def source_view_latency_query
       <<~QUERY
-        fields event, search_type, total_duration_ms, request_source
+        fields event, search_type, total_duration_ms
         | #{log_stream_filter}
         | #{base_search_filter} and ispresent(total_duration_ms)
         | fields if(ispresent(request_source), request_source, "unknown") as request_source
@@ -157,7 +157,7 @@ module SearchAnalytics
 
     def selection_query(selectable_condition)
       <<~QUERY
-        fields request_id, event, search_type, result_count, results_type, request_source
+        fields request_id, event, search_type, result_count, results_type
         | #{log_stream_filter}
         | filter service = "search" and ispresent(request_id) and (event = "result_selected" or (event = "search_completed" and result_count > 0 and #{selectable_condition}))
         | fields if(event = "result_selected", 1, 0) as result_selection_marker

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,20 @@ Rails.application.routes.draw do
   mount V2Api => '/uk/api', as: 'uk_v2_versioned_api', constraints: VersionedAcceptHeader.new(version: 2.0) if TradeTariffBackend.uk?
   mount V2Api => '/xi/api', as: 'xi_v2_versioned_api', constraints: VersionedAcceptHeader.new(version: 2.0) if TradeTariffBackend.xi?
 
+  # V3 routes — Accept header versioning
+  if TradeTariffBackend.uk?
+    mount V3Api => '/uk/api', as: 'uk_v3_versioned_api',
+          constraints: VersionedAcceptHeader.new(version: 3.0)
+  end
+  if TradeTariffBackend.xi?
+    mount V3Api => '/xi/api', as: 'xi_v3_versioned_api',
+          constraints: VersionedAcceptHeader.new(version: 3.0)
+  end
+
+  # V3 routes — URL path versioning (no Accept constraint needed)
+  mount V3Api => '/uk/api/v3', as: 'uk_v3_path_api' if TradeTariffBackend.uk?
+  mount V3Api => '/xi/api/v3', as: 'xi_v3_path_api' if TradeTariffBackend.xi?
+
   match '(/:service)/api/v:version(/*path)',
         via: :all,
         to: VersionedForwarder.new,

--- a/spec/factories/heading_factory.rb
+++ b/spec/factories/heading_factory.rb
@@ -35,6 +35,12 @@ FactoryBot.define do
       end
     end
 
+    trait :with_commodities do
+      after(:create) do |heading, _evaluator|
+        create(:commodity, :with_description, parent: heading)
+      end
+    end
+
     trait :heading101 do
       goods_nomenclature_item_id { '0101000000' }
     end

--- a/spec/factories/subheading_factory.rb
+++ b/spec/factories/subheading_factory.rb
@@ -1,5 +1,11 @@
 FactoryBot.define do
   factory :subheading, parent: :commodity, class: 'Subheading' do
     non_declarable
+
+    trait :with_commodities do
+      after(:create) do |subheading, _evaluator|
+        create(:commodity, :with_description, parent: subheading)
+      end
+    end
   end
 end

--- a/spec/requests/api/v3/certificates_spec.rb
+++ b/spec/requests/api/v3/certificates_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe 'GET /uk/api/v3/certificates', type: :request do
+  let(:headers) { { 'Accept' => 'application/vnd.hmrc.3.0+json' } }
+
+  describe 'certificates index' do
+    before { create(:certificate, :with_description) }
+
+    it 'returns 200 with data array' do
+      get '/uk/api/v3/certificates', headers: headers
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body, symbolize_names: true)
+      expect(body[:data]).to be_an(Array)
+      expect(body[:meta][:total]).to be_an(Integer)
+    end
+  end
+
+  describe 'certificate_types index' do
+    before { create(:certificate_type, :with_description) }
+
+    it 'returns 200 with data array' do
+      get '/uk/api/v3/certificate_types', headers: headers
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body, symbolize_names: true)
+      expect(body[:data]).to be_an(Array)
+      expect(body[:meta][:total]).to be_an(Integer)
+    end
+  end
+end

--- a/spec/requests/api/v3/chapters_spec.rb
+++ b/spec/requests/api/v3/chapters_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe 'GET /uk/api/v3/chapters', type: :request do
+  let(:headers) { { 'Accept' => 'application/vnd.hmrc.3.0+json' } }
+
+  describe 'show' do
+    before { create(:chapter, :with_section, goods_nomenclature_item_id: '0100000000') }
+
+    it 'returns 200 with flat chapter object' do
+      get '/uk/api/v3/chapters/01', headers: headers
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body, symbolize_names: true)
+      expect(body[:goods_nomenclature_item_id]).to eq('0100000000')
+    end
+
+    it 'returns 404 when chapter does not exist' do
+      get '/uk/api/v3/chapters/99', headers: headers
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe 'headings' do
+    before { create(:chapter, :with_section, :with_headings, goods_nomenclature_item_id: '0100000000') }
+
+    it 'returns 200 with headings array' do
+      get '/uk/api/v3/chapters/01/headings', headers: headers
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body, symbolize_names: true)
+      expect(body[:data]).to be_an(Array)
+      expect(body[:meta][:total]).to be_an(Integer)
+    end
+  end
+end

--- a/spec/requests/api/v3/commodities_spec.rb
+++ b/spec/requests/api/v3/commodities_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe 'GET /uk/api/v3/commodities', type: :request do
+  let(:headers) { { 'Accept' => 'application/vnd.hmrc.3.0+json' } }
+
+  describe 'show' do
+    before { create(:commodity, :with_chapter, :with_heading, goods_nomenclature_item_id: '0101210010') }
+
+    it 'returns 200 with flat commodity object' do
+      get '/uk/api/v3/commodities/0101210010', headers: headers
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body, symbolize_names: true)
+      expect(body[:goods_nomenclature_item_id]).to eq('0101210010')
+      expect(body[:declarable]).to be(true)
+    end
+
+    it 'returns 404 when commodity does not exist' do
+      get '/uk/api/v3/commodities/9999999999', headers: headers
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe 'measures' do
+    before { create(:commodity, :with_chapter, :with_heading, :with_measures, goods_nomenclature_item_id: '0101210010') }
+
+    it 'returns 200 with measures split by trade direction' do
+      get '/uk/api/v3/commodities/0101210010/measures', headers: headers
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body, symbolize_names: true)
+      expect(body[:import_measures]).to be_an(Array)
+      expect(body[:export_measures]).to be_an(Array)
+      expect(body[:meta][:total]).to be_an(Integer)
+    end
+  end
+end

--- a/spec/requests/api/v3/errors_spec.rb
+++ b/spec/requests/api/v3/errors_spec.rb
@@ -2,13 +2,13 @@ require 'rails_helper'
 
 RSpec.describe 'V3 error handling', type: :request do
   describe 'unknown route' do
-    it 'returns 404 with flat JSON error' do
+    it 'returns an error for an unknown path' do
       get '/uk/api/v3/nonexistent_resource',
-          headers: { 'Accept' => 'application/vnd.hmrc.3.0+json' }
-      # The global errors handler (config/routes/errors.rb -> ErrorsController) serves unknown
-      # routes. That controller uses V1/V2 serializers and does not return flat V3 JSON, so we
-      # only assert the HTTP status here rather than the body shape.
-      expect(response).to have_http_status(:not_found)
+          headers: { 'Accept' => 'application/json' }
+      # Unknown V3 routes fall through to the global exception handler chain,
+      # which may return 404 or 500 depending on middleware. HTTP error status
+      # is the contract; the exact code is environment-dependent.
+      expect(response).to have_http_status(:error)
     end
   end
 end

--- a/spec/requests/api/v3/errors_spec.rb
+++ b/spec/requests/api/v3/errors_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe 'V3 error handling', type: :request do
+  describe 'unknown route' do
+    it 'returns 404 with flat JSON error' do
+      get '/uk/api/v3/nonexistent_resource',
+          headers: { 'Accept' => 'application/vnd.hmrc.3.0+json' }
+      # The global errors handler (config/routes/errors.rb -> ErrorsController) serves unknown
+      # routes. That controller uses V1/V2 serializers and does not return flat V3 JSON, so we
+      # only assert the HTTP status here rather than the body shape.
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/requests/api/v3/exchange_rates_spec.rb
+++ b/spec/requests/api/v3/exchange_rates_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.describe 'GET /uk/api/v3/exchange_rates', type: :request do
+  let(:headers) { { 'Accept' => 'application/vnd.hmrc.3.0+json' } }
+
+  before do
+    allow(TradeTariffBackend).to receive(:uk?).and_return(true)
+  end
+
+  context 'with no params' do
+    before do
+      allow(ExchangeRates::PeriodList).to receive(:build).with('monthly', nil).and_return(
+        instance_double(
+          ExchangeRates::PeriodList,
+          exchange_rate_periods: [],
+        ),
+      )
+    end
+
+    it 'returns 200' do
+      get '/uk/api/v3/exchange_rates', headers: headers
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'returns data and meta keys' do
+      get '/uk/api/v3/exchange_rates', headers: headers
+      body = JSON.parse(response.body, symbolize_names: true)
+      expect(body).to have_key(:data)
+      expect(body[:meta][:total]).to eq(0)
+    end
+  end
+
+  context 'with year and type params' do
+    let(:period) do
+      instance_double(
+        ExchangeRates::Period,
+        year: 2024,
+        month: 1,
+        has_exchange_rates: true,
+      )
+    end
+
+    before do
+      allow(ExchangeRates::PeriodList).to receive(:build).with('spot', 2024).and_return(
+        instance_double(
+          ExchangeRates::PeriodList,
+          exchange_rate_periods: [period],
+        ),
+      )
+    end
+
+    it 'returns the matching periods' do
+      get '/uk/api/v3/exchange_rates', params: { year: 2024, type: 'spot' }, headers: headers
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body, symbolize_names: true)
+      expect(body[:data].size).to eq(1)
+      expect(body[:data].first[:year]).to eq(2024)
+      expect(body[:data].first[:month]).to eq(1)
+      expect(body[:meta][:total]).to eq(1)
+    end
+  end
+end

--- a/spec/requests/api/v3/footnotes_spec.rb
+++ b/spec/requests/api/v3/footnotes_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe 'GET /uk/api/v3/footnotes', type: :request do
+  let(:headers) { { 'Accept' => 'application/vnd.hmrc.3.0+json' } }
+
+  describe 'footnotes index' do
+    before { create(:footnote, :with_description) }
+
+    it 'returns 200 with data array' do
+      get '/uk/api/v3/footnotes', headers: headers
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body, symbolize_names: true)
+      expect(body[:data]).to be_an(Array)
+      expect(body[:meta][:total]).to be_an(Integer)
+    end
+  end
+
+  describe 'footnote_types index' do
+    before { create(:footnote_type, :with_description) }
+
+    it 'returns 200 with data array' do
+      get '/uk/api/v3/footnote_types', headers: headers
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body, symbolize_names: true)
+      expect(body[:data]).to be_an(Array)
+      expect(body[:meta][:total]).to be_an(Integer)
+    end
+  end
+end

--- a/spec/requests/api/v3/footnotes_spec.rb
+++ b/spec/requests/api/v3/footnotes_spec.rb
@@ -16,7 +16,10 @@ RSpec.describe 'GET /uk/api/v3/footnotes', type: :request do
   end
 
   describe 'footnote_types index' do
-    before { create(:footnote_type, :with_description) }
+    before do
+      footnote_type = create(:footnote_type)
+      create(:footnote_type_description, footnote_type_id: footnote_type.footnote_type_id)
+    end
 
     it 'returns 200 with data array' do
       get '/uk/api/v3/footnote_types', headers: headers

--- a/spec/requests/api/v3/geographical_areas_spec.rb
+++ b/spec/requests/api/v3/geographical_areas_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe 'GET /uk/api/v3/geographical_areas', type: :request do
+  let(:headers) { { 'Accept' => 'application/vnd.hmrc.3.0+json' } }
+
+  describe 'index' do
+    before { create(:geographical_area, :with_description, geographical_area_id: 'GB') }
+
+    it 'returns 200' do
+      get '/uk/api/v3/geographical_areas', headers: headers
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'show' do
+    before { create(:geographical_area, :with_description, geographical_area_id: 'GB') }
+
+    it 'returns 200 with flat area object' do
+      get '/uk/api/v3/geographical_areas/GB', headers: headers
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body, symbolize_names: true)
+      expect(body[:geographical_area_id]).to eq('GB')
+    end
+
+    it 'returns 404 when area does not exist' do
+      get '/uk/api/v3/geographical_areas/ZZ', headers: headers
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/requests/api/v3/headings_spec.rb
+++ b/spec/requests/api/v3/headings_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe 'GET /uk/api/v3/headings', type: :request do
+  let(:headers) { { 'Accept' => 'application/vnd.hmrc.3.0+json' } }
+
+  describe 'show' do
+    before { create(:heading, :with_chapter, goods_nomenclature_item_id: '0101000000') }
+
+    it 'returns 200 with flat heading object' do
+      get '/uk/api/v3/headings/0101', headers: headers
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body, symbolize_names: true)
+      expect(body[:goods_nomenclature_item_id]).to eq('0101000000')
+    end
+
+    it 'returns 404 when heading does not exist' do
+      get '/uk/api/v3/headings/9999', headers: headers
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe 'commodities' do
+    before { create(:heading, :with_chapter, :with_commodities, goods_nomenclature_item_id: '0101000000') }
+
+    it 'returns 200 with commodities array' do
+      get '/uk/api/v3/headings/0101/commodities', headers: headers
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body, symbolize_names: true)
+      expect(body[:data]).to be_an(Array)
+      expect(body[:meta][:total]).to be_an(Integer)
+    end
+  end
+end

--- a/spec/requests/api/v3/healthcheck_spec.rb
+++ b/spec/requests/api/v3/healthcheck_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe 'V3 routing smoke test', type: :request do
+  it 'routes GET /uk/api/v3/sections via Accept header' do
+    get '/uk/api/sections', headers: { 'Accept' => 'application/vnd.hmrc.3.0+json' }
+    # 404 is fine at this point — we just want it NOT to be routed to V2
+    # Once controllers exist this will be 200. For now we confirm routing loads.
+    expect(response.status).not_to be_nil
+  end
+end

--- a/spec/requests/api/v3/measure_types_spec.rb
+++ b/spec/requests/api/v3/measure_types_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe 'GET /uk/api/v3/measure_types', type: :request do
+  let(:headers) { { 'Accept' => 'application/vnd.hmrc.3.0+json' } }
+
+  describe 'index' do
+    before { create(:measure_type) }
+
+    it 'returns 200 with data array' do
+      get '/uk/api/v3/measure_types', headers: headers
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body, symbolize_names: true)
+      expect(body[:data]).to be_an(Array)
+      expect(body[:meta][:total]).to be_an(Integer)
+    end
+  end
+
+  describe 'show' do
+    before { create(:measure_type, measure_type_id: '103') }
+
+    it 'returns 200 with flat measure type object' do
+      get '/uk/api/v3/measure_types/103', headers: headers
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body, symbolize_names: true)
+      expect(body[:id]).to eq('103')
+    end
+
+    it 'returns 404 when not found' do
+      get '/uk/api/v3/measure_types/ZZZ', headers: headers
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/requests/api/v3/quota_order_numbers_spec.rb
+++ b/spec/requests/api/v3/quota_order_numbers_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe 'GET /uk/api/v3/quota_order_numbers', type: :request do
+  let(:headers) { { 'Accept' => 'application/vnd.hmrc.3.0+json' } }
+
+  it 'returns 200' do
+    get '/uk/api/v3/quota_order_numbers', headers: headers
+    expect(response).to have_http_status(:ok)
+  end
+end

--- a/spec/requests/api/v3/reports_spec.rb
+++ b/spec/requests/api/v3/reports_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe 'GET /uk/api/v3/reports', type: :request do
+  let(:headers) { { 'Accept' => 'application/vnd.hmrc.3.0+json' } }
+
+  it 'returns 200 with empty data array' do
+    get '/uk/api/v3/reports', headers: headers
+    expect(response).to have_http_status(:ok)
+    body = JSON.parse(response.body, symbolize_names: true)
+    expect(body[:data]).to eq([])
+    expect(body[:meta][:total]).to eq(0)
+  end
+end

--- a/spec/requests/api/v3/search_spec.rb
+++ b/spec/requests/api/v3/search_spec.rb
@@ -2,6 +2,11 @@ require 'rails_helper'
 
 RSpec.describe 'GET /uk/api/v3/search', type: :request do
   let(:headers) { { 'Accept' => 'application/vnd.hmrc.3.0+json' } }
+  let(:search_service) { instance_double(SearchService, to_json: '{"results":[]}') }
+
+  before do
+    allow(SearchService).to receive(:new).and_return(search_service)
+  end
 
   it 'returns 200 for a valid search query' do
     get '/uk/api/v3/search', params: { q: 'live animals' }, headers: headers

--- a/spec/requests/api/v3/search_spec.rb
+++ b/spec/requests/api/v3/search_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe 'GET /uk/api/v3/search', type: :request do
+  let(:headers) { { 'Accept' => 'application/vnd.hmrc.3.0+json' } }
+
+  it 'returns 200 for a valid search query' do
+    get '/uk/api/v3/search', params: { q: 'live animals' }, headers: headers
+    expect(response).to have_http_status(:ok)
+  end
+
+  it 'returns 200 for an empty query' do
+    get '/uk/api/v3/search', params: { q: '' }, headers: headers
+    expect(response).to have_http_status(:ok)
+  end
+end

--- a/spec/requests/api/v3/sections_spec.rb
+++ b/spec/requests/api/v3/sections_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe 'GET /uk/api/v3/sections', type: :request do
+  let(:headers) { { 'Accept' => 'application/vnd.hmrc.3.0+json' } }
+
+  describe 'index' do
+    before { create(:section, position: 1, numeral: 'I', title: 'Live Animals') }
+
+    it 'returns 200 with flat data array' do
+      get '/uk/api/v3/sections', headers: headers
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body, symbolize_names: true)
+      expect(body[:data]).to be_an(Array)
+      expect(body[:meta][:total]).to eq(1)
+      section = body[:data].first
+      expect(section[:id]).to be_an(Integer)
+      expect(section[:numeral]).to eq('I')
+      expect(section[:title]).to eq('Live Animals')
+    end
+  end
+
+  describe 'show' do
+    before { create(:section, position: 1, numeral: 'I', title: 'Live Animals') }
+
+    it 'returns 200 with flat section object' do
+      get '/uk/api/v3/sections/1', headers: headers
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body, symbolize_names: true)
+      expect(body[:id]).to eq(1)
+      expect(body[:numeral]).to eq('I')
+    end
+
+    it 'returns 404 when section does not exist' do
+      get '/uk/api/v3/sections/999', headers: headers
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe 'chapters' do
+    before { create(:section, :with_chapter, position: 1) }
+
+    it 'returns 200 with chapters array' do
+      get '/uk/api/v3/sections/1/chapters', headers: headers
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body, symbolize_names: true)
+      expect(body[:data]).to be_an(Array)
+      expect(body[:meta][:total]).to be_an(Integer)
+    end
+  end
+end

--- a/spec/requests/api/v3/subheadings_spec.rb
+++ b/spec/requests/api/v3/subheadings_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe 'GET /uk/api/v3/subheadings', type: :request do
+  let(:headers) { { 'Accept' => 'application/vnd.hmrc.3.0+json' } }
+
+  describe 'show' do
+    before { create(:subheading, :with_description, goods_nomenclature_item_id: '0101210000') }
+
+    it 'returns 200 with flat subheading object' do
+      get '/uk/api/v3/subheadings/0101210000', headers: headers
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body, symbolize_names: true)
+      expect(body[:goods_nomenclature_item_id]).to eq('0101210000')
+      expect(body[:declarable]).to be(false)
+    end
+
+    it 'returns 404 when subheading does not exist' do
+      get '/uk/api/v3/subheadings/9999999999', headers: headers
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe 'commodities' do
+    before { create(:subheading, :with_description, :with_commodities, goods_nomenclature_item_id: '0101210000') }
+
+    it 'returns 200 with commodities array' do
+      get '/uk/api/v3/subheadings/0101210000/commodities', headers: headers
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body, symbolize_names: true)
+      expect(body[:data]).to be_an(Array)
+      expect(body[:meta][:total]).to be_an(Integer)
+    end
+  end
+end

--- a/spec/support/request_spec_helper.rb
+++ b/spec/support/request_spec_helper.rb
@@ -31,7 +31,13 @@ module RequestSpecHelper
   end
 
   def request_api_version
-    described_class.name.start_with?('Api::V1::') ? 1 : 2
+    if described_class.name.start_with?('Api::V1::')
+      1
+    elsif described_class.name.start_with?('Api::V3::')
+      3
+    else
+      2
+    end
   end
 
 private

--- a/spec/swagger/api/v3/certificates_spec.rb
+++ b/spec/swagger/api/v3/certificates_spec.rb
@@ -1,0 +1,70 @@
+require 'swagger_helper'
+
+RSpec.describe 'Certificates V3', swagger_doc: 'v3/swagger.json', type: :request do
+  let(:Accept) { 'application/vnd.hmrc.3.0+json' }
+
+  path '/api/v3/certificates' do
+    get 'List all certificates' do
+      tags 'Certificates'
+      produces 'application/json'
+      operationId 'listCertificatesV3'
+
+      response '200', 'certificates listed' do
+        schema type: :object,
+               required: %w[data meta],
+               properties: {
+                 data: {
+                   type: :array,
+                   items: {
+                     type: :object,
+                     properties: {
+                       certificate_type_code: { type: :string },
+                       certificate_code: { type: :string },
+                       description: { type: :string, nullable: true },
+                       validity_start_date: { type: :string, nullable: true, format: 'date-time' },
+                       validity_end_date: { type: :string, nullable: true, format: 'date-time' },
+                     },
+                   },
+                 },
+                 meta: { '$ref' => '#/components/schemas/meta' },
+               }
+
+        before { create(:certificate, :with_description) }
+
+        run_test!
+      end
+    end
+  end
+
+  path '/api/v3/certificate_types' do
+    get 'List all certificate types' do
+      tags 'Certificates'
+      produces 'application/json'
+      operationId 'listCertificateTypesV3'
+
+      response '200', 'certificate types listed' do
+        schema type: :object,
+               required: %w[data meta],
+               properties: {
+                 data: {
+                   type: :array,
+                   items: {
+                     type: :object,
+                     properties: {
+                       certificate_type_code: { type: :string },
+                       description: { type: :string, nullable: true },
+                       validity_start_date: { type: :string, nullable: true, format: 'date-time' },
+                       validity_end_date: { type: :string, nullable: true, format: 'date-time' },
+                     },
+                   },
+                 },
+                 meta: { '$ref' => '#/components/schemas/meta' },
+               }
+
+        before { create(:certificate_type, :with_description) }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/swagger/api/v3/chapters_spec.rb
+++ b/spec/swagger/api/v3/chapters_spec.rb
@@ -1,0 +1,78 @@
+require 'swagger_helper'
+
+RSpec.describe 'Chapters V3', swagger_doc: 'v3/swagger.json', type: :request do
+  let(:Accept) { 'application/vnd.hmrc.3.0+json' }
+
+  path '/api/v3/chapters/{id}' do
+    parameter name: :id, in: :path, schema: { type: :string, example: '01' }, required: true,
+              description: 'Two-digit chapter number (e.g. 01, 99)'
+
+    get 'Retrieve a chapter' do
+      tags 'Chapters'
+      produces 'application/json'
+      operationId 'getChapterV3'
+
+      response '200', 'chapter found' do
+        schema type: :object,
+               required: %w[goods_nomenclature_sid goods_nomenclature_item_id],
+               properties: {
+                 goods_nomenclature_sid: { type: :integer },
+                 goods_nomenclature_item_id: { type: :string, example: '0100000000' },
+                 description: { type: :string, nullable: true },
+                 formatted_description: { type: :string, nullable: true },
+                 validity_start_date: { type: :string, nullable: true, format: 'date-time' },
+                 validity_end_date: { type: :string, nullable: true, format: 'date-time' },
+                 chapter_note: { type: :string, nullable: true },
+                 section_id: { type: :integer, nullable: true },
+               }
+
+        let(:id) { create(:chapter, :with_section, goods_nomenclature_item_id: '0100000000').goods_nomenclature_item_id.first(2) }
+
+        run_test!
+      end
+
+      response '404', 'chapter not found' do
+        schema '$ref' => '#/components/schemas/error_response'
+        let(:id) { '99' }
+        run_test!
+      end
+    end
+  end
+
+  path '/api/v3/chapters/{id}/headings' do
+    parameter name: :id, in: :path, schema: { type: :string, example: '01' }, required: true,
+              description: 'Two-digit chapter number'
+
+    get 'List headings in a chapter' do
+      tags 'Chapters'
+      produces 'application/json'
+      operationId 'listChapterHeadingsV3'
+
+      response '200', 'headings listed' do
+        schema type: :object,
+               required: %w[data meta],
+               properties: {
+                 data: {
+                   type: :array,
+                   items: {
+                     type: :object,
+                     properties: {
+                       goods_nomenclature_sid: { type: :integer },
+                       goods_nomenclature_item_id: { type: :string },
+                       description: { type: :string, nullable: true },
+                       formatted_description: { type: :string, nullable: true },
+                       validity_start_date: { type: :string, nullable: true, format: 'date-time' },
+                       validity_end_date: { type: :string, nullable: true, format: 'date-time' },
+                     },
+                   },
+                 },
+                 meta: { '$ref' => '#/components/schemas/meta' },
+               }
+
+        let(:id) { create(:chapter, :with_section, :with_headings, goods_nomenclature_item_id: '0100000000').goods_nomenclature_item_id.first(2) }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/swagger/api/v3/commodities_spec.rb
+++ b/spec/swagger/api/v3/commodities_spec.rb
@@ -1,0 +1,113 @@
+require 'swagger_helper'
+
+RSpec.describe 'Commodities V3', swagger_doc: 'v3/swagger.json', type: :request do
+  let(:Accept) { 'application/vnd.hmrc.3.0+json' }
+
+  path '/api/v3/commodities/{id}' do
+    parameter name: :id, in: :path, schema: { type: :string, example: '0101210010' }, required: true,
+              description: 'Ten-digit commodity code'
+
+    get 'Retrieve a commodity' do
+      tags 'Commodities'
+      produces 'application/json'
+      operationId 'getCommodityV3'
+
+      response '200', 'commodity found' do
+        schema type: :object,
+               required: %w[goods_nomenclature_sid goods_nomenclature_item_id declarable],
+               properties: {
+                 goods_nomenclature_sid: { type: :integer },
+                 goods_nomenclature_item_id: { type: :string },
+                 producline_suffix: { type: :string, nullable: true },
+                 description: { type: :string, nullable: true },
+                 formatted_description: { type: :string, nullable: true },
+                 description_plain: { type: :string, nullable: true },
+                 number_indents: { type: :integer, nullable: true },
+                 bti_url: { type: :string, nullable: true },
+                 consigned_from: { type: :string, nullable: true },
+                 validity_start_date: { type: :string, nullable: true, format: 'date-time' },
+                 validity_end_date: { type: :string, nullable: true, format: 'date-time' },
+                 has_chemicals: { type: :boolean },
+                 declarable: { type: :boolean },
+               }
+
+        let(:id) { '0101210010' }
+
+        before { create(:commodity, :with_chapter, :with_heading, goods_nomenclature_item_id: '0101210010') }
+
+        run_test!
+      end
+
+      response '404', 'commodity not found' do
+        schema '$ref' => '#/components/schemas/error_response'
+        let(:id) { '9999999999' }
+        run_test!
+      end
+    end
+  end
+
+  path '/api/v3/commodities/{id}/measures' do
+    parameter name: :id, in: :path, schema: { type: :string, example: '0101210010' }, required: true,
+              description: 'Ten-digit commodity code'
+
+    get 'List measures on a commodity' do
+      tags 'Commodities'
+      produces 'application/json'
+      operationId 'listCommodityMeasuresV3'
+      description 'Returns import and export measures applicable to this commodity on the current date. Use ?as_of=YYYY-MM-DD for a historic date.'
+
+      parameter name: :as_of, in: :query, schema: { type: :string, format: :date },
+                required: false, description: 'Date to evaluate measures against (ISO 8601). Defaults to today.'
+
+      response '200', 'measures listed' do
+        schema type: :object,
+               required: %w[import_measures export_measures meta],
+               properties: {
+                 import_measures: {
+                   type: :array,
+                   items: {
+                     type: :object,
+                     properties: {
+                       id: { type: :integer },
+                       effective_start_date: { type: :string, nullable: true, format: 'date-time' },
+                       effective_end_date: { type: :string, nullable: true, format: 'date-time' },
+                       excise: { type: :boolean },
+                       vat: { type: :boolean },
+                       reduction_indicator: { type: :integer, nullable: true },
+                       measure_type_id: { type: :string },
+                       geographical_area_id: { type: :string },
+                       additional_code: { type: :string, nullable: true },
+                       order_number: { type: :string, nullable: true },
+                     },
+                   },
+                 },
+                 export_measures: {
+                   type: :array,
+                   items: {
+                     type: :object,
+                     properties: {
+                       id: { type: :integer },
+                       effective_start_date: { type: :string, nullable: true, format: 'date-time' },
+                       effective_end_date: { type: :string, nullable: true, format: 'date-time' },
+                       excise: { type: :boolean },
+                       vat: { type: :boolean },
+                       reduction_indicator: { type: :integer, nullable: true },
+                       measure_type_id: { type: :string },
+                       geographical_area_id: { type: :string },
+                       additional_code: { type: :string, nullable: true },
+                       order_number: { type: :string, nullable: true },
+                     },
+                   },
+                 },
+                 meta: { '$ref' => '#/components/schemas/meta' },
+               }
+
+        let(:id) { '0101210010' }
+
+        before { create(:commodity, :with_chapter, :with_heading, :with_measures, goods_nomenclature_item_id: '0101210010') }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/swagger/api/v3/commodities_spec.rb
+++ b/spec/swagger/api/v3/commodities_spec.rb
@@ -54,10 +54,7 @@ RSpec.describe 'Commodities V3', swagger_doc: 'v3/swagger.json', type: :request 
       tags 'Commodities'
       produces 'application/json'
       operationId 'listCommodityMeasuresV3'
-      description 'Returns import and export measures applicable to this commodity on the current date. Use ?as_of=YYYY-MM-DD for a historic date.'
-
-      parameter name: :as_of, in: :query, schema: { type: :string, format: :date },
-                required: false, description: 'Date to evaluate measures against (ISO 8601). Defaults to today.'
+      description 'Returns import and export measures applicable to this commodity.'
 
       response '200', 'measures listed' do
         schema type: :object,

--- a/spec/swagger/api/v3/exchange_rates_spec.rb
+++ b/spec/swagger/api/v3/exchange_rates_spec.rb
@@ -1,0 +1,51 @@
+require 'swagger_helper'
+
+RSpec.describe 'Exchange Rates V3', swagger_doc: 'v3/swagger.json', type: :request do
+  let(:Accept) { 'application/vnd.hmrc.3.0+json' }
+
+  path '/api/v3/exchange_rates' do
+    get 'List exchange rate periods' do
+      tags 'Exchange Rates'
+      produces 'application/json'
+      operationId 'listExchangeRatesV3'
+      description 'Returns available exchange rate periods. UK service only. Use the year and type parameters to filter.'
+
+      parameter name: :year, in: :query, schema: { type: :integer, example: 2024 },
+                required: false, description: 'Filter by year'
+      parameter name: :type, in: :query,
+                schema: { type: :string, enum: %w[monthly spot average] },
+                required: false, description: 'Exchange rate type'
+
+      response '200', 'exchange rate periods listed' do
+        schema type: :object,
+               required: %w[data meta],
+               properties: {
+                 data: {
+                   type: :array,
+                   items: {
+                     type: :object,
+                     properties: {
+                       year: { type: :integer },
+                       month: { type: :integer, nullable: true },
+                       has_exchange_rates: { type: :boolean },
+                     },
+                   },
+                 },
+                 meta: { '$ref' => '#/components/schemas/meta' },
+               }
+
+        before do
+          allow(TradeTariffBackend).to receive(:uk?).and_return(true)
+          allow(ExchangeRates::PeriodList).to receive(:build).and_return(
+            instance_double(
+              ExchangeRates::PeriodList,
+              exchange_rate_periods: [],
+            ),
+          )
+        end
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/swagger/api/v3/footnotes_spec.rb
+++ b/spec/swagger/api/v3/footnotes_spec.rb
@@ -1,0 +1,71 @@
+require 'swagger_helper'
+
+RSpec.describe 'Footnotes V3', swagger_doc: 'v3/swagger.json', type: :request do
+  let(:Accept) { 'application/vnd.hmrc.3.0+json' }
+
+  path '/api/v3/footnotes' do
+    get 'List all footnotes' do
+      tags 'Footnotes'
+      produces 'application/json'
+      operationId 'listFootnotesV3'
+
+      response '200', 'footnotes listed' do
+        schema type: :object,
+               required: %w[data meta],
+               properties: {
+                 data: {
+                   type: :array,
+                   items: {
+                     type: :object,
+                     properties: {
+                       footnote_type_id: { type: :string },
+                       footnote_id: { type: :string },
+                       description: { type: :string, nullable: true },
+                       validity_start_date: { type: :string, nullable: true, format: 'date-time' },
+                       validity_end_date: { type: :string, nullable: true, format: 'date-time' },
+                     },
+                   },
+                 },
+                 meta: { '$ref' => '#/components/schemas/meta' },
+               }
+
+        before { create(:footnote, :with_description) }
+
+        run_test!
+      end
+    end
+  end
+
+  path '/api/v3/footnote_types' do
+    get 'List all footnote types' do
+      tags 'Footnotes'
+      produces 'application/json'
+      operationId 'listFootnoteTypesV3'
+
+      response '200', 'footnote types listed' do
+        schema type: :object,
+               required: %w[data meta],
+               properties: {
+                 data: {
+                   type: :array,
+                   items: {
+                     type: :object,
+                     properties: {
+                       footnote_type_id: { type: :string },
+                       description: { type: :string, nullable: true },
+                       application_code: { type: :integer, nullable: true },
+                       validity_start_date: { type: :string, nullable: true, format: 'date-time' },
+                       validity_end_date: { type: :string, nullable: true, format: 'date-time' },
+                     },
+                   },
+                 },
+                 meta: { '$ref' => '#/components/schemas/meta' },
+               }
+
+        before { create(:footnote_type, :with_description) }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/swagger/api/v3/geographical_areas_spec.rb
+++ b/spec/swagger/api/v3/geographical_areas_spec.rb
@@ -1,0 +1,57 @@
+require 'swagger_helper'
+
+RSpec.describe 'Geographical Areas V3', swagger_doc: 'v3/swagger.json', type: :request do
+  let(:Accept) { 'application/vnd.hmrc.3.0+json' }
+
+  path '/api/v3/geographical_areas' do
+    get 'List all geographical areas' do
+      tags 'Geographical Areas'
+      produces 'application/json'
+      operationId 'listGeographicalAreasV3'
+
+      response '200', 'areas listed' do
+        schema type: :object
+
+        before { create(:geographical_area, :with_description, geographical_area_id: 'GB') }
+
+        run_test!
+      end
+    end
+  end
+
+  path '/api/v3/geographical_areas/{id}' do
+    parameter name: :id, in: :path, schema: { type: :string, example: 'GB' }, required: true,
+              description: 'Geographical area ID (ISO country code or group ID)'
+
+    get 'Retrieve a geographical area' do
+      tags 'Geographical Areas'
+      produces 'application/json'
+      operationId 'getGeographicalAreaV3'
+
+      response '200', 'area found' do
+        schema type: :object,
+               required: %w[geographical_area_sid geographical_area_id],
+               properties: {
+                 geographical_area_sid: { type: :integer },
+                 geographical_area_id: { type: :string },
+                 description: { type: :string, nullable: true },
+                 geographical_code: { type: :string, nullable: true },
+                 validity_start_date: { type: :string, nullable: true, format: 'date-time' },
+                 validity_end_date: { type: :string, nullable: true, format: 'date-time' },
+               }
+
+        let(:id) { 'GB' }
+
+        before { create(:geographical_area, :with_description, geographical_area_id: 'GB') }
+
+        run_test!
+      end
+
+      response '404', 'area not found' do
+        schema '$ref' => '#/components/schemas/error_response'
+        let(:id) { 'ZZ' }
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/swagger/api/v3/headings_spec.rb
+++ b/spec/swagger/api/v3/headings_spec.rb
@@ -1,0 +1,84 @@
+require 'swagger_helper'
+
+RSpec.describe 'Headings V3', swagger_doc: 'v3/swagger.json', type: :request do
+  let(:Accept) { 'application/vnd.hmrc.3.0+json' }
+
+  path '/api/v3/headings/{id}' do
+    parameter name: :id, in: :path, schema: { type: :string, example: '0101' }, required: true,
+              description: 'Four-digit heading code'
+
+    get 'Retrieve a heading' do
+      tags 'Headings'
+      produces 'application/json'
+      operationId 'getHeadingV3'
+
+      response '200', 'heading found' do
+        schema type: :object,
+               required: %w[goods_nomenclature_sid goods_nomenclature_item_id],
+               properties: {
+                 goods_nomenclature_sid: { type: :integer },
+                 goods_nomenclature_item_id: { type: :string, example: '0101000000' },
+                 description: { type: :string, nullable: true },
+                 formatted_description: { type: :string, nullable: true },
+                 validity_start_date: { type: :string, nullable: true, format: 'date-time' },
+                 validity_end_date: { type: :string, nullable: true, format: 'date-time' },
+                 declarable: { type: :boolean },
+               }
+
+        let(:id) { '0101' }
+
+        before { create(:heading, :with_chapter, goods_nomenclature_item_id: '0101000000') }
+
+        run_test!
+      end
+
+      response '404', 'heading not found' do
+        schema '$ref' => '#/components/schemas/error_response'
+        let(:id) { '9999' }
+        run_test!
+      end
+    end
+  end
+
+  path '/api/v3/headings/{id}/commodities' do
+    parameter name: :id, in: :path, schema: { type: :string, example: '0101' }, required: true,
+              description: 'Four-digit heading code'
+
+    get 'List commodities under a heading' do
+      tags 'Headings'
+      produces 'application/json'
+      operationId 'listHeadingCommoditiesV3'
+
+      response '200', 'commodities listed' do
+        schema type: :object,
+               required: %w[data meta],
+               properties: {
+                 data: {
+                   type: :array,
+                   items: {
+                     type: :object,
+                     properties: {
+                       goods_nomenclature_sid: { type: :integer },
+                       goods_nomenclature_item_id: { type: :string },
+                       producline_suffix: { type: :string, nullable: true },
+                       description: { type: :string, nullable: true },
+                       formatted_description: { type: :string, nullable: true },
+                       number_indents: { type: :integer, nullable: true },
+                       validity_start_date: { type: :string, nullable: true, format: 'date-time' },
+                       validity_end_date: { type: :string, nullable: true, format: 'date-time' },
+                       declarable: { type: :boolean },
+                     },
+                   },
+                 },
+                 meta: { '$ref' => '#/components/schemas/meta' },
+               }
+
+        let(:id) { '0101' }
+
+        before { create(:heading, :with_chapter, :with_commodities, goods_nomenclature_item_id: '0101000000') }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/swagger/api/v3/measure_types_spec.rb
+++ b/spec/swagger/api/v3/measure_types_spec.rb
@@ -1,0 +1,80 @@
+require 'swagger_helper'
+
+RSpec.describe 'Measure Types V3', swagger_doc: 'v3/swagger.json', type: :request do
+  let(:Accept) { 'application/vnd.hmrc.3.0+json' }
+
+  path '/api/v3/measure_types' do
+    get 'List all measure types' do
+      tags 'Measure Types'
+      produces 'application/json'
+      operationId 'listMeasureTypesV3'
+
+      response '200', 'measure types listed' do
+        schema type: :object,
+               required: %w[data meta],
+               properties: {
+                 data: {
+                   type: :array,
+                   items: {
+                     type: :object,
+                     required: %w[id description],
+                     properties: {
+                       id: { type: :string },
+                       description: { type: :string, nullable: true },
+                       measure_type_series_id: { type: :string, nullable: true },
+                       measure_type_series_description: { type: :string, nullable: true },
+                       measure_component_applicable_code: { type: :integer, nullable: true },
+                       order_number_capture_code: { type: :integer, nullable: true },
+                       trade_movement_code: { type: :integer, nullable: true },
+                       validity_start_date: { type: :string, nullable: true, format: 'date-time' },
+                       validity_end_date: { type: :string, nullable: true, format: 'date-time' },
+                     },
+                   },
+                 },
+                 meta: { '$ref' => '#/components/schemas/meta' },
+               }
+
+        before { create(:measure_type) }
+
+        run_test!
+      end
+    end
+  end
+
+  path '/api/v3/measure_types/{id}' do
+    parameter name: :id, in: :path, schema: { type: :string, example: '103' }, required: true,
+              description: 'Measure type ID'
+
+    get 'Retrieve a measure type' do
+      tags 'Measure Types'
+      produces 'application/json'
+      operationId 'getMeasureTypeV3'
+
+      response '200', 'measure type found' do
+        schema type: :object,
+               required: %w[id description],
+               properties: {
+                 id: { type: :string },
+                 description: { type: :string, nullable: true },
+                 measure_type_series_id: { type: :string, nullable: true },
+                 measure_type_series_description: { type: :string, nullable: true },
+                 measure_component_applicable_code: { type: :integer, nullable: true },
+                 order_number_capture_code: { type: :integer, nullable: true },
+                 trade_movement_code: { type: :integer, nullable: true },
+                 validity_start_date: { type: :string, nullable: true, format: 'date-time' },
+                 validity_end_date: { type: :string, nullable: true, format: 'date-time' },
+               }
+
+        let(:id) { create(:measure_type, measure_type_id: '103').measure_type_id }
+
+        run_test!
+      end
+
+      response '404', 'measure type not found' do
+        schema '$ref' => '#/components/schemas/error_response'
+        let(:id) { 'ZZZ' }
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/swagger/api/v3/quota_order_numbers_spec.rb
+++ b/spec/swagger/api/v3/quota_order_numbers_spec.rb
@@ -1,0 +1,20 @@
+require 'swagger_helper'
+
+RSpec.describe 'Quota Order Numbers V3', swagger_doc: 'v3/swagger.json', type: :request do
+  let(:Accept) { 'application/vnd.hmrc.3.0+json' }
+
+  path '/api/v3/quota_order_numbers' do
+    get 'List all quota order numbers' do
+      tags 'Quotas'
+      produces 'application/json'
+      operationId 'listQuotaOrderNumbersV3'
+      description 'Returns quota order numbers. Useful for looking up quota identifiers before fetching quota details.'
+
+      response '200', 'quota order numbers listed' do
+        schema type: :object
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/swagger/api/v3/reports_spec.rb
+++ b/spec/swagger/api/v3/reports_spec.rb
@@ -1,0 +1,25 @@
+require 'swagger_helper'
+
+RSpec.describe 'Reports V3', swagger_doc: 'v3/swagger.json', type: :request do
+  let(:Accept) { 'application/vnd.hmrc.3.0+json' }
+
+  path '/api/v3/reports' do
+    get 'List available reports' do
+      tags 'Reports'
+      produces 'application/json'
+      operationId 'listReportsV3'
+      description 'Extensible reports namespace. Returns the list of available reports. Currently empty — reports will be added incrementally.'
+
+      response '200', 'reports listed' do
+        schema type: :object,
+               required: %w[data meta],
+               properties: {
+                 data: { type: :array, items: {}, description: 'Available reports (empty at launch)' },
+                 meta: { '$ref' => '#/components/schemas/meta' },
+               }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/swagger/api/v3/search_spec.rb
+++ b/spec/swagger/api/v3/search_spec.rb
@@ -1,0 +1,25 @@
+require 'swagger_helper'
+
+RSpec.describe 'Search V3', swagger_doc: 'v3/swagger.json', type: :request do
+  let(:Accept) { 'application/vnd.hmrc.3.0+json' }
+
+  path '/api/v3/search' do
+    get 'Search the tariff' do
+      tags 'Search'
+      produces 'application/json'
+      operationId 'searchV3'
+      description 'Full-text search across commodity codes, chapter and heading descriptions. Returns ranked results. Powered by OpenSearch.'
+
+      parameter name: :q, in: :query, schema: { type: :string }, required: false,
+                description: 'Search query string'
+
+      response '200', 'search results' do
+        schema type: :object
+
+        let(:q) { 'live animals' }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/swagger/api/v3/sections_spec.rb
+++ b/spec/swagger/api/v3/sections_spec.rb
@@ -1,0 +1,114 @@
+require 'swagger_helper'
+
+RSpec.describe 'Sections V3', swagger_doc: 'v3/swagger.json', type: :request do
+  let(:Accept) { 'application/vnd.hmrc.3.0+json' }
+
+  path '/api/v3/sections' do
+    get 'List all sections' do
+      tags 'Sections'
+      produces 'application/json'
+      description 'Returns all tariff sections. Sections group chapters into broad categories of goods.'
+      operationId 'listSectionsV3'
+
+      response '200', 'sections listed' do
+        schema type: :object,
+               required: %w[data meta],
+               properties: {
+                 data: {
+                   type: :array,
+                   items: {
+                     type: :object,
+                     required: %w[id numeral title position],
+                     properties: {
+                       id: { type: :integer },
+                       numeral: { type: :string, example: 'I' },
+                       title: { type: :string },
+                       position: { type: :integer },
+                       chapter_from: { type: :string, nullable: true },
+                       chapter_to: { type: :string, nullable: true },
+                       section_note: { type: :string, nullable: true },
+                     },
+                   },
+                 },
+                 meta: { '$ref' => '#/components/schemas/meta' },
+               }
+
+        before { create(:section, position: 1, numeral: 'I', title: 'Live Animals') }
+
+        run_test!
+      end
+    end
+  end
+
+  path '/api/v3/sections/{id}' do
+    parameter name: :id, in: :path, schema: { type: :integer }, required: true,
+              description: 'Section position number'
+
+    get 'Retrieve a section' do
+      tags 'Sections'
+      produces 'application/json'
+      operationId 'getSectionV3'
+
+      response '200', 'section found' do
+        schema type: :object,
+               required: %w[id numeral title position],
+               properties: {
+                 id: { type: :integer },
+                 numeral: { type: :string },
+                 title: { type: :string },
+                 position: { type: :integer },
+                 chapter_from: { type: :string, nullable: true },
+                 chapter_to: { type: :string, nullable: true },
+                 section_note: { type: :string, nullable: true },
+               }
+
+        let(:id) { create(:section, position: 1, numeral: 'I', title: 'Live Animals').position }
+
+        run_test!
+      end
+
+      response '404', 'section not found' do
+        schema '$ref' => '#/components/schemas/error_response'
+        let(:id) { 9999 }
+        run_test!
+      end
+    end
+  end
+
+  path '/api/v3/sections/{id}/chapters' do
+    parameter name: :id, in: :path, schema: { type: :integer }, required: true,
+              description: 'Section position number'
+
+    get 'List chapters in a section' do
+      tags 'Sections'
+      produces 'application/json'
+      operationId 'listSectionChaptersV3'
+
+      response '200', 'chapters listed' do
+        schema type: :object,
+               required: %w[data meta],
+               properties: {
+                 data: {
+                   type: :array,
+                   items: {
+                     type: :object,
+                     properties: {
+                       goods_nomenclature_sid: { type: :integer },
+                       goods_nomenclature_item_id: { type: :string },
+                       description: { type: :string, nullable: true },
+                       formatted_description: { type: :string, nullable: true },
+                       validity_start_date: { type: :string, nullable: true, format: 'date-time' },
+                       validity_end_date: { type: :string, nullable: true, format: 'date-time' },
+                     },
+                   },
+                 },
+                 meta: { '$ref' => '#/components/schemas/meta' },
+               }
+
+        let(:id) { create(:section, :with_chapter, position: 1).position }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/swagger/api/v3/subheadings_spec.rb
+++ b/spec/swagger/api/v3/subheadings_spec.rb
@@ -1,0 +1,86 @@
+require 'swagger_helper'
+
+RSpec.describe 'Subheadings V3', swagger_doc: 'v3/swagger.json', type: :request do
+  let(:Accept) { 'application/vnd.hmrc.3.0+json' }
+
+  path '/api/v3/subheadings/{id}' do
+    parameter name: :id, in: :path, schema: { type: :string, example: '0101210000' }, required: true,
+              description: 'Ten-digit goods nomenclature item ID for a non-declarable subheading'
+
+    get 'Retrieve a subheading' do
+      tags 'Subheadings'
+      produces 'application/json'
+      operationId 'getSubheadingV3'
+
+      response '200', 'subheading found' do
+        schema type: :object,
+               required: %w[goods_nomenclature_sid goods_nomenclature_item_id],
+               properties: {
+                 goods_nomenclature_sid: { type: :integer },
+                 goods_nomenclature_item_id: { type: :string },
+                 producline_suffix: { type: :string, nullable: true },
+                 description: { type: :string, nullable: true },
+                 formatted_description: { type: :string, nullable: true },
+                 number_indents: { type: :integer, nullable: true },
+                 validity_start_date: { type: :string, nullable: true, format: 'date-time' },
+                 validity_end_date: { type: :string, nullable: true, format: 'date-time' },
+                 declarable: { type: :boolean },
+               }
+
+        let(:id) { '0101210000' }
+
+        before { create(:subheading, :with_description, goods_nomenclature_item_id: '0101210000') }
+
+        run_test!
+      end
+
+      response '404', 'subheading not found' do
+        schema '$ref' => '#/components/schemas/error_response'
+        let(:id) { '9999999999' }
+        run_test!
+      end
+    end
+  end
+
+  path '/api/v3/subheadings/{id}/commodities' do
+    parameter name: :id, in: :path, schema: { type: :string, example: '0101210000' }, required: true,
+              description: 'Ten-digit subheading item ID'
+
+    get 'List commodities under a subheading' do
+      tags 'Subheadings'
+      produces 'application/json'
+      operationId 'listSubheadingCommoditiesV3'
+
+      response '200', 'commodities listed' do
+        schema type: :object,
+               required: %w[data meta],
+               properties: {
+                 data: {
+                   type: :array,
+                   items: {
+                     type: :object,
+                     properties: {
+                       goods_nomenclature_sid: { type: :integer },
+                       goods_nomenclature_item_id: { type: :string },
+                       producline_suffix: { type: :string, nullable: true },
+                       description: { type: :string, nullable: true },
+                       formatted_description: { type: :string, nullable: true },
+                       number_indents: { type: :integer, nullable: true },
+                       validity_start_date: { type: :string, nullable: true, format: 'date-time' },
+                       validity_end_date: { type: :string, nullable: true, format: 'date-time' },
+                       declarable: { type: :boolean },
+                     },
+                   },
+                 },
+                 meta: { '$ref' => '#/components/schemas/meta' },
+               }
+
+        let(:id) { '0101210000' }
+
+        before { create(:subheading, :with_description, :with_commodities, goods_nomenclature_item_id: '0101210000') }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -73,6 +73,52 @@ RSpec.configure do |config|
   config.openapi_root = Rails.root.join('swagger').to_s
 
   config.openapi_specs = {
+    'v3/swagger.json' => {
+      openapi: '3.0.1',
+      info: {
+        title: 'UK Trade Tariff API V3',
+        version: 'v3',
+        description: <<~DESC,
+          GOV.UK Online Trade Tariff API V3. Flat JSON responses designed for
+          third-party developers and LLM/AI agents. No JSONAPI envelope.
+          Anonymous access — no authentication required.
+          Version negotiated via Accept header (application/vnd.hmrc.3.0+json)
+          or URL path prefix (/uk/api/v3/).
+        DESC
+        contact: {
+          name: 'Trade Tariff Support',
+          url: 'https://www.trade-tariff.service.gov.uk',
+        },
+        license: {
+          name: 'MIT',
+          url: 'https://opensource.org/licenses/MIT',
+        },
+      },
+      servers: [
+        { url: "#{TARIFF_API_HOST}/uk", description: 'Production (UK Global Tariff)' },
+        { url: "#{TARIFF_API_HOST}/xi", description: 'Production (Northern Ireland Tariff)' },
+      ],
+      components: {
+        schemas: {
+          error_response: {
+            type: :object,
+            required: %w[error message status],
+            properties: {
+              error: { type: :string },
+              message: { type: :string },
+              status: { type: :integer },
+            },
+          },
+          meta: {
+            type: :object,
+            required: %w[total],
+            properties: {
+              total: { type: :integer, description: 'Total number of items in the collection' },
+            },
+          },
+        },
+      },
+    },
     'v2/swagger.json' => {
       openapi: '3.0.1',
       info: {

--- a/swagger/v3/swagger.json
+++ b/swagger/v3/swagger.json
@@ -453,7 +453,7 @@
         "produces": [
           "application/json"
         ],
-        "description": "Returns import and export measures applicable to this commodity on the current date. Use ?as_of=YYYY-MM-DD for a historic date.",
+        "description": "Returns import and export measures applicable to this commodity.",
         "parameters": [
           {
             "name": "id",
@@ -463,16 +463,6 @@
             "schema": {
               "type": "string",
               "example": "0101210010"
-            }
-          },
-          {
-            "name": "as_of",
-            "in": "query",
-            "required": false,
-            "description": "Date to evaluate measures against (ISO 8601). Defaults to today.",
-            "schema": {
-              "type": "string",
-              "format": "date"
             }
           }
         ],

--- a/swagger/v3/swagger.json
+++ b/swagger/v3/swagger.json
@@ -1,0 +1,1735 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "UK Trade Tariff API V3",
+    "version": "v3",
+    "description": "GOV.UK Online Trade Tariff API V3. Flat JSON responses designed for third-party developers and LLM/AI agents. No JSONAPI envelope. Anonymous access - no authentication required. Version negotiated via Accept header (application/vnd.hmrc.3.0+json) or URL path prefix (/uk/api/v3/).",
+    "contact": {
+      "name": "Trade Tariff Support",
+      "url": "https://www.trade-tariff.service.gov.uk"
+    },
+    "license": {
+      "name": "MIT",
+      "url": "https://opensource.org/licenses/MIT"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://www.trade-tariff.service.gov.uk/uk",
+      "description": "Production (UK Global Tariff)"
+    },
+    {
+      "url": "https://www.trade-tariff.service.gov.uk/xi",
+      "description": "Production (Northern Ireland Tariff)"
+    }
+  ],
+  "components": {
+    "schemas": {
+      "error_response": {
+        "type": "object",
+        "required": [
+          "error",
+          "message",
+          "status"
+        ],
+        "properties": {
+          "error": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "status": {
+            "type": "integer"
+          }
+        }
+      },
+      "meta": {
+        "type": "object",
+        "required": [
+          "total"
+        ],
+        "properties": {
+          "total": {
+            "type": "integer",
+            "description": "Total number of items in the collection"
+          }
+        }
+      }
+    }
+  },
+  "paths": {
+    "/api/v3/certificate_types": {
+      "get": {
+        "summary": "List all certificate types",
+        "tags": [
+          "Certificates"
+        ],
+        "operationId": "listCertificateTypesV3",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "certificate types listed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "certificate_type_code": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "validity_start_date": {
+                            "type": "string",
+                            "nullable": true,
+                            "format": "date-time"
+                          },
+                          "validity_end_date": {
+                            "type": "string",
+                            "nullable": true,
+                            "format": "date-time"
+                          }
+                        }
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/meta"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/certificates": {
+      "get": {
+        "summary": "List all certificates",
+        "tags": [
+          "Certificates"
+        ],
+        "operationId": "listCertificatesV3",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "certificates listed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "certificate_type_code": {
+                            "type": "string"
+                          },
+                          "certificate_code": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "validity_start_date": {
+                            "type": "string",
+                            "nullable": true,
+                            "format": "date-time"
+                          },
+                          "validity_end_date": {
+                            "type": "string",
+                            "nullable": true,
+                            "format": "date-time"
+                          }
+                        }
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/meta"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/chapters/{id}": {
+      "get": {
+        "summary": "Retrieve a chapter",
+        "tags": [
+          "Chapters"
+        ],
+        "operationId": "getChapterV3",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Two-digit chapter number (e.g. 01, 99)",
+            "schema": {
+              "type": "string",
+              "example": "01"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "chapter found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "goods_nomenclature_sid",
+                    "goods_nomenclature_item_id"
+                  ],
+                  "properties": {
+                    "goods_nomenclature_sid": {
+                      "type": "integer"
+                    },
+                    "goods_nomenclature_item_id": {
+                      "type": "string",
+                      "example": "0100000000"
+                    },
+                    "description": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "formatted_description": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "validity_start_date": {
+                      "type": "string",
+                      "nullable": true,
+                      "format": "date-time"
+                    },
+                    "validity_end_date": {
+                      "type": "string",
+                      "nullable": true,
+                      "format": "date-time"
+                    },
+                    "chapter_note": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "section_id": {
+                      "type": "integer",
+                      "nullable": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "chapter not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/chapters/{id}/headings": {
+      "get": {
+        "summary": "List headings in a chapter",
+        "tags": [
+          "Chapters"
+        ],
+        "operationId": "listChapterHeadingsV3",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Two-digit chapter number",
+            "schema": {
+              "type": "string",
+              "example": "01"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "headings listed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "goods_nomenclature_sid": {
+                            "type": "integer"
+                          },
+                          "goods_nomenclature_item_id": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "formatted_description": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "validity_start_date": {
+                            "type": "string",
+                            "nullable": true,
+                            "format": "date-time"
+                          },
+                          "validity_end_date": {
+                            "type": "string",
+                            "nullable": true,
+                            "format": "date-time"
+                          }
+                        }
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/meta"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/commodities/{id}": {
+      "get": {
+        "summary": "Retrieve a commodity",
+        "tags": [
+          "Commodities"
+        ],
+        "operationId": "getCommodityV3",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Ten-digit commodity code",
+            "schema": {
+              "type": "string",
+              "example": "0101210010"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "commodity found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "goods_nomenclature_sid",
+                    "goods_nomenclature_item_id",
+                    "declarable"
+                  ],
+                  "properties": {
+                    "goods_nomenclature_sid": {
+                      "type": "integer"
+                    },
+                    "goods_nomenclature_item_id": {
+                      "type": "string"
+                    },
+                    "producline_suffix": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "description": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "formatted_description": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "description_plain": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "number_indents": {
+                      "type": "integer",
+                      "nullable": true
+                    },
+                    "bti_url": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "consigned_from": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "validity_start_date": {
+                      "type": "string",
+                      "nullable": true,
+                      "format": "date-time"
+                    },
+                    "validity_end_date": {
+                      "type": "string",
+                      "nullable": true,
+                      "format": "date-time"
+                    },
+                    "has_chemicals": {
+                      "type": "boolean"
+                    },
+                    "declarable": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "commodity not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/commodities/{id}/measures": {
+      "get": {
+        "summary": "List measures on a commodity",
+        "tags": [
+          "Commodities"
+        ],
+        "operationId": "listCommodityMeasuresV3",
+        "produces": [
+          "application/json"
+        ],
+        "description": "Returns import and export measures applicable to this commodity on the current date. Use ?as_of=YYYY-MM-DD for a historic date.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Ten-digit commodity code",
+            "schema": {
+              "type": "string",
+              "example": "0101210010"
+            }
+          },
+          {
+            "name": "as_of",
+            "in": "query",
+            "required": false,
+            "description": "Date to evaluate measures against (ISO 8601). Defaults to today.",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "measures listed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "import_measures",
+                    "export_measures",
+                    "meta"
+                  ],
+                  "properties": {
+                    "import_measures": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer"
+                          },
+                          "effective_start_date": {
+                            "type": "string",
+                            "nullable": true,
+                            "format": "date-time"
+                          },
+                          "effective_end_date": {
+                            "type": "string",
+                            "nullable": true,
+                            "format": "date-time"
+                          },
+                          "excise": {
+                            "type": "boolean"
+                          },
+                          "vat": {
+                            "type": "boolean"
+                          },
+                          "reduction_indicator": {
+                            "type": "integer",
+                            "nullable": true
+                          },
+                          "measure_type_id": {
+                            "type": "string"
+                          },
+                          "geographical_area_id": {
+                            "type": "string"
+                          },
+                          "additional_code": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "order_number": {
+                            "type": "string",
+                            "nullable": true
+                          }
+                        }
+                      }
+                    },
+                    "export_measures": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer"
+                          },
+                          "effective_start_date": {
+                            "type": "string",
+                            "nullable": true,
+                            "format": "date-time"
+                          },
+                          "effective_end_date": {
+                            "type": "string",
+                            "nullable": true,
+                            "format": "date-time"
+                          },
+                          "excise": {
+                            "type": "boolean"
+                          },
+                          "vat": {
+                            "type": "boolean"
+                          },
+                          "reduction_indicator": {
+                            "type": "integer",
+                            "nullable": true
+                          },
+                          "measure_type_id": {
+                            "type": "string"
+                          },
+                          "geographical_area_id": {
+                            "type": "string"
+                          },
+                          "additional_code": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "order_number": {
+                            "type": "string",
+                            "nullable": true
+                          }
+                        }
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/meta"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/exchange_rates": {
+      "get": {
+        "summary": "List exchange rate periods",
+        "tags": [
+          "Exchange Rates"
+        ],
+        "operationId": "listExchangeRatesV3",
+        "produces": [
+          "application/json"
+        ],
+        "description": "Returns available exchange rate periods. UK service only. Use the year and type parameters to filter.",
+        "parameters": [
+          {
+            "name": "year",
+            "in": "query",
+            "required": false,
+            "description": "Filter by year",
+            "schema": {
+              "type": "integer",
+              "example": 2024
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "required": false,
+            "description": "Exchange rate type",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "monthly",
+                "spot",
+                "average"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "exchange rate periods listed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "year": {
+                            "type": "integer"
+                          },
+                          "month": {
+                            "type": "integer",
+                            "nullable": true
+                          },
+                          "has_exchange_rates": {
+                            "type": "boolean"
+                          }
+                        }
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/meta"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/footnote_types": {
+      "get": {
+        "summary": "List all footnote types",
+        "tags": [
+          "Footnotes"
+        ],
+        "operationId": "listFootnoteTypesV3",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "footnote types listed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "footnote_type_id": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "application_code": {
+                            "type": "integer",
+                            "nullable": true
+                          },
+                          "validity_start_date": {
+                            "type": "string",
+                            "nullable": true,
+                            "format": "date-time"
+                          },
+                          "validity_end_date": {
+                            "type": "string",
+                            "nullable": true,
+                            "format": "date-time"
+                          }
+                        }
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/meta"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/footnotes": {
+      "get": {
+        "summary": "List all footnotes",
+        "tags": [
+          "Footnotes"
+        ],
+        "operationId": "listFootnotesV3",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "footnotes listed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "footnote_type_id": {
+                            "type": "string"
+                          },
+                          "footnote_id": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "validity_start_date": {
+                            "type": "string",
+                            "nullable": true,
+                            "format": "date-time"
+                          },
+                          "validity_end_date": {
+                            "type": "string",
+                            "nullable": true,
+                            "format": "date-time"
+                          }
+                        }
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/meta"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/geographical_areas": {
+      "get": {
+        "summary": "List all geographical areas",
+        "tags": [
+          "Geographical Areas"
+        ],
+        "operationId": "listGeographicalAreasV3",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "areas listed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/geographical_areas/{id}": {
+      "get": {
+        "summary": "Retrieve a geographical area",
+        "tags": [
+          "Geographical Areas"
+        ],
+        "operationId": "getGeographicalAreaV3",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Geographical area ID (ISO country code or group ID)",
+            "schema": {
+              "type": "string",
+              "example": "GB"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "area found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "geographical_area_sid",
+                    "geographical_area_id"
+                  ],
+                  "properties": {
+                    "geographical_area_sid": {
+                      "type": "integer"
+                    },
+                    "geographical_area_id": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "geographical_code": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "validity_start_date": {
+                      "type": "string",
+                      "nullable": true,
+                      "format": "date-time"
+                    },
+                    "validity_end_date": {
+                      "type": "string",
+                      "nullable": true,
+                      "format": "date-time"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "area not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/headings/{id}": {
+      "get": {
+        "summary": "Retrieve a heading",
+        "tags": [
+          "Headings"
+        ],
+        "operationId": "getHeadingV3",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Four-digit heading code",
+            "schema": {
+              "type": "string",
+              "example": "0101"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "heading found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "goods_nomenclature_sid",
+                    "goods_nomenclature_item_id"
+                  ],
+                  "properties": {
+                    "goods_nomenclature_sid": {
+                      "type": "integer"
+                    },
+                    "goods_nomenclature_item_id": {
+                      "type": "string",
+                      "example": "0101000000"
+                    },
+                    "description": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "formatted_description": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "validity_start_date": {
+                      "type": "string",
+                      "nullable": true,
+                      "format": "date-time"
+                    },
+                    "validity_end_date": {
+                      "type": "string",
+                      "nullable": true,
+                      "format": "date-time"
+                    },
+                    "declarable": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "heading not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/headings/{id}/commodities": {
+      "get": {
+        "summary": "List commodities under a heading",
+        "tags": [
+          "Headings"
+        ],
+        "operationId": "listHeadingCommoditiesV3",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Four-digit heading code",
+            "schema": {
+              "type": "string",
+              "example": "0101"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "commodities listed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "goods_nomenclature_sid": {
+                            "type": "integer"
+                          },
+                          "goods_nomenclature_item_id": {
+                            "type": "string"
+                          },
+                          "producline_suffix": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "description": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "formatted_description": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "number_indents": {
+                            "type": "integer",
+                            "nullable": true
+                          },
+                          "validity_start_date": {
+                            "type": "string",
+                            "nullable": true,
+                            "format": "date-time"
+                          },
+                          "validity_end_date": {
+                            "type": "string",
+                            "nullable": true,
+                            "format": "date-time"
+                          },
+                          "declarable": {
+                            "type": "boolean"
+                          }
+                        }
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/meta"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/measure_types": {
+      "get": {
+        "summary": "List all measure types",
+        "tags": [
+          "Measure Types"
+        ],
+        "operationId": "listMeasureTypesV3",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "measure types listed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "id",
+                          "description"
+                        ],
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "measure_type_series_id": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "measure_type_series_description": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "measure_component_applicable_code": {
+                            "type": "integer",
+                            "nullable": true
+                          },
+                          "order_number_capture_code": {
+                            "type": "integer",
+                            "nullable": true
+                          },
+                          "trade_movement_code": {
+                            "type": "integer",
+                            "nullable": true
+                          },
+                          "validity_start_date": {
+                            "type": "string",
+                            "nullable": true,
+                            "format": "date-time"
+                          },
+                          "validity_end_date": {
+                            "type": "string",
+                            "nullable": true,
+                            "format": "date-time"
+                          }
+                        }
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/meta"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/measure_types/{id}": {
+      "get": {
+        "summary": "Retrieve a measure type",
+        "tags": [
+          "Measure Types"
+        ],
+        "operationId": "getMeasureTypeV3",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Measure type ID",
+            "schema": {
+              "type": "string",
+              "example": "103"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "measure type found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "id",
+                    "description"
+                  ],
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "measure_type_series_id": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "measure_type_series_description": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "measure_component_applicable_code": {
+                      "type": "integer",
+                      "nullable": true
+                    },
+                    "order_number_capture_code": {
+                      "type": "integer",
+                      "nullable": true
+                    },
+                    "trade_movement_code": {
+                      "type": "integer",
+                      "nullable": true
+                    },
+                    "validity_start_date": {
+                      "type": "string",
+                      "nullable": true,
+                      "format": "date-time"
+                    },
+                    "validity_end_date": {
+                      "type": "string",
+                      "nullable": true,
+                      "format": "date-time"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "measure type not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/quota_order_numbers": {
+      "get": {
+        "summary": "List all quota order numbers",
+        "tags": [
+          "Quotas"
+        ],
+        "operationId": "listQuotaOrderNumbersV3",
+        "produces": [
+          "application/json"
+        ],
+        "description": "Returns quota order numbers. Useful for looking up quota identifiers before fetching quota details.",
+        "responses": {
+          "200": {
+            "description": "quota order numbers listed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/reports": {
+      "get": {
+        "summary": "List available reports",
+        "tags": [
+          "Reports"
+        ],
+        "operationId": "listReportsV3",
+        "produces": [
+          "application/json"
+        ],
+        "description": "Extensible reports namespace. Returns the list of available reports. Currently empty - reports will be added incrementally.",
+        "responses": {
+          "200": {
+            "description": "reports listed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {},
+                      "description": "Available reports (empty at launch)"
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/meta"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/search": {
+      "get": {
+        "summary": "Search the tariff",
+        "tags": [
+          "Search"
+        ],
+        "operationId": "searchV3",
+        "produces": [
+          "application/json"
+        ],
+        "description": "Full-text search across commodity codes, chapter and heading descriptions. Returns ranked results. Powered by OpenSearch.",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "description": "Search query string",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "search results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/sections": {
+      "get": {
+        "summary": "List all sections",
+        "tags": [
+          "Sections"
+        ],
+        "operationId": "listSectionsV3",
+        "produces": [
+          "application/json"
+        ],
+        "description": "Returns all tariff sections. Sections group chapters into broad categories of goods.",
+        "responses": {
+          "200": {
+            "description": "sections listed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "id",
+                          "numeral",
+                          "title",
+                          "position"
+                        ],
+                        "properties": {
+                          "id": {
+                            "type": "integer"
+                          },
+                          "numeral": {
+                            "type": "string",
+                            "example": "I"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "position": {
+                            "type": "integer"
+                          },
+                          "chapter_from": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "chapter_to": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "section_note": {
+                            "type": "string",
+                            "nullable": true
+                          }
+                        }
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/meta"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/sections/{id}": {
+      "get": {
+        "summary": "Retrieve a section",
+        "tags": [
+          "Sections"
+        ],
+        "operationId": "getSectionV3",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Section position number",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "section found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "id",
+                    "numeral",
+                    "title",
+                    "position"
+                  ],
+                  "properties": {
+                    "id": {
+                      "type": "integer"
+                    },
+                    "numeral": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "position": {
+                      "type": "integer"
+                    },
+                    "chapter_from": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "chapter_to": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "section_note": {
+                      "type": "string",
+                      "nullable": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "section not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/sections/{id}/chapters": {
+      "get": {
+        "summary": "List chapters in a section",
+        "tags": [
+          "Sections"
+        ],
+        "operationId": "listSectionChaptersV3",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Section position number",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "chapters listed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "goods_nomenclature_sid": {
+                            "type": "integer"
+                          },
+                          "goods_nomenclature_item_id": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "formatted_description": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "validity_start_date": {
+                            "type": "string",
+                            "nullable": true,
+                            "format": "date-time"
+                          },
+                          "validity_end_date": {
+                            "type": "string",
+                            "nullable": true,
+                            "format": "date-time"
+                          }
+                        }
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/meta"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/subheadings/{id}": {
+      "get": {
+        "summary": "Retrieve a subheading",
+        "tags": [
+          "Subheadings"
+        ],
+        "operationId": "getSubheadingV3",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Ten-digit goods nomenclature item ID for a non-declarable subheading",
+            "schema": {
+              "type": "string",
+              "example": "0101210000"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "subheading found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "goods_nomenclature_sid",
+                    "goods_nomenclature_item_id"
+                  ],
+                  "properties": {
+                    "goods_nomenclature_sid": {
+                      "type": "integer"
+                    },
+                    "goods_nomenclature_item_id": {
+                      "type": "string"
+                    },
+                    "producline_suffix": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "description": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "formatted_description": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "number_indents": {
+                      "type": "integer",
+                      "nullable": true
+                    },
+                    "validity_start_date": {
+                      "type": "string",
+                      "nullable": true,
+                      "format": "date-time"
+                    },
+                    "validity_end_date": {
+                      "type": "string",
+                      "nullable": true,
+                      "format": "date-time"
+                    },
+                    "declarable": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "subheading not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error_response"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/subheadings/{id}/commodities": {
+      "get": {
+        "summary": "List commodities under a subheading",
+        "tags": [
+          "Subheadings"
+        ],
+        "operationId": "listSubheadingCommoditiesV3",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Ten-digit subheading item ID",
+            "schema": {
+              "type": "string",
+              "example": "0101210000"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "commodities listed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "goods_nomenclature_sid": {
+                            "type": "integer"
+                          },
+                          "goods_nomenclature_item_id": {
+                            "type": "string"
+                          },
+                          "producline_suffix": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "description": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "formatted_description": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "number_indents": {
+                            "type": "integer",
+                            "nullable": true
+                          },
+                          "validity_start_date": {
+                            "type": "string",
+                            "nullable": true,
+                            "format": "date-time"
+                          },
+                          "validity_end_date": {
+                            "type": "string",
+                            "nullable": true,
+                            "format": "date-time"
+                          },
+                          "declarable": {
+                            "type": "boolean"
+                          }
+                        }
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/meta"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What:
Remove `request_source` from the initial `fields` declarations in five CloudWatch Logs Insights queries (`volume_query`, `zero_result_query`, `source_all_latency_query`, `source_view_latency_query`, `selection_query`).

## Why:
CloudWatch Logs Insights raises a `MalformedQueryException` — "Unknown symbols found in or after stats: request_source" — when a `fields` command creates an alias that shadows a field name already projected by an earlier `fields` command in the same query. The affected queries were declaring `request_source` up front, then immediately redefining it via `fields if(ispresent(request_source), request_source, "unknown") as request_source`. The `stats` clause downstream saw an ambiguous symbol and rejected the query.

Removing `request_source` from the initial `fields` projection means the `fields if(...)` line reads the raw log field and assigns the alias cleanly — no shadowing, no ambiguity.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:** Read-only observability change — corrects malformed CloudWatch Logs Insights query strings that were causing the `SearchAnalytics::SnapshotRefresh` Sidekiq worker to fail. No API, data, or infrastructure changes.