### PR TITLE
fix: remove request_source field shadowing in CloudWatch Logs Insights queries

### DIFF
--- a/app/services/search_analytics/cloudwatch_snapshot_query.rb
+++ b/app/services/search_analytics/cloudwatch_snapshot_query.rb
@@ -92,7 +92,7 @@ module SearchAnalytics
 
     def volume_query
       <<~QUERY
-        fields @timestamp, event, search_type, request_source
+        fields @timestamp, event, search_type
         | #{log_stream_filter}
         | #{base_search_filter}
         | fields if(ispresent(request_source), request_source, "unknown") as request_source
@@ -102,7 +102,7 @@ module SearchAnalytics
 
     def zero_result_query
       <<~QUERY
-        fields @timestamp, event, search_type, result_count, request_source
+        fields @timestamp, event, search_type, result_count
         | #{log_stream_filter}
         | filter service = "search" and event = "search_completed" and result_count = 0
         | fields if(ispresent(request_source), request_source, "unknown") as request_source
@@ -130,7 +130,7 @@ module SearchAnalytics
 
     def source_all_latency_query
       <<~QUERY
-        fields event, total_duration_ms, request_source
+        fields event, total_duration_ms
         | #{log_stream_filter}
         | #{base_search_filter} and ispresent(total_duration_ms)
         | fields if(ispresent(request_source), request_source, "unknown") as request_source
@@ -140,7 +140,7 @@ module SearchAnalytics
 
     def source_view_latency_query
       <<~QUERY
-        fields event, search_type, total_duration_ms, request_source
+        fields event, search_type, total_duration_ms
         | #{log_stream_filter}
         | #{base_search_filter} and ispresent(total_duration_ms)
         | fields if(ispresent(request_source), request_source, "unknown") as request_source
@@ -157,7 +157,7 @@ module SearchAnalytics
 
     def selection_query(selectable_condition)
       <<~QUERY
-        fields request_id, event, search_type, result_count, results_type, request_source
+        fields request_id, event, search_type, result_count, results_type
         | #{log_stream_filter}
         | filter service = "search" and ispresent(request_id) and (event = "result_selected" or (event = "search_completed" and result_count > 0 and #{selectable_condition}))
         | fields if(event = "result_selected", 1, 0) as result_selection_marker


### PR DESCRIPTION
## What:
Remove `request_source` from the initial `fields` declarations in five CloudWatch Logs Insights queries (`volume_query`, `zero_result_query`, `source_all_latency_query`, `source_view_latency_query`, `selection_query`).

## Why:
CloudWatch Logs Insights raises a `MalformedQueryException` — "Unknown symbols found in or after stats: request_source" — when a `fields` command creates an alias that shadows a field name already projected by an earlier `fields` command in the same query. The affected queries were declaring `request_source` up front, then immediately redefining it via `fields if(ispresent(request_source), request_source, "unknown") as request_source`. The `stats` clause downstream saw an ambiguous symbol and rejected the query.

Removing `request_source` from the initial `fields` projection means the `fields if(...)` line reads the raw log field and assigns the alias cleanly — no shadowing, no ambiguity.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:** Read-only observability change — corrects malformed CloudWatch Logs Insights query strings that were causing the `SearchAnalytics::SnapshotRefresh` Sidekiq worker to fail. No API, data, or infrastructure changes.