### PR TITLE
AI-1040: Allow HNSW index use in vector retrieval

### DIFF
--- a/app/models/goods_nomenclature_self_text.rb
+++ b/app/models/goods_nomenclature_self_text.rb
@@ -60,7 +60,11 @@ class GoodsNomenclatureSelfText < Sequel::Model
       distance_expr = Sequel.lit("goods_nomenclature_self_texts.search_embedding <=> #{vector_literal}")
 
       exclude(search_embedding: nil)
-        .association_join(:goods_nomenclature)
+        .join(
+          :goods_nomenclatures,
+          { Sequel[:goods_nomenclature][:goods_nomenclature_sid] => Sequel[:goods_nomenclature_self_texts][:goods_nomenclature_sid] },
+          table_alias: :goods_nomenclature,
+        )
         .where(goods_nomenclature__producline_suffix: GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX)
         .where { GoodsNomenclature.validity_dates_filter(:goods_nomenclature) }
         .exclude(goods_nomenclature__goods_nomenclature_item_id: HiddenGoodsNomenclature.codes)

--- a/spec/models/goods_nomenclature_self_text_spec.rb
+++ b/spec/models/goods_nomenclature_self_text_spec.rb
@@ -80,6 +80,17 @@ RSpec.describe GoodsNomenclatureSelfText do
     end
   end
 
+  describe '.vector_search' do
+    it 'joins goods nomenclatures directly so vector ordering can use the HNSW index' do
+      vector_literal = "'[#{Array.new(1536, 0).join(',')}]'::vector"
+
+      sql = described_class.vector_search(vector_literal, limit: 10).sql
+
+      expect(sql).to include('INNER JOIN "goods_nomenclatures" AS "goods_nomenclature"')
+      expect(sql).not_to include('INNER JOIN (SELECT * FROM "goods_nomenclatures" ORDER BY')
+    end
+  end
+
   describe '.admin_listing' do
     let(:commodity) { create(:goods_nomenclature, producline_suffix: GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX) }
 


### PR DESCRIPTION
## What:

- [x] Replace the ordered goods nomenclature association subquery with a qualified direct join
- [x] Preserve vector score ordering and all existing eligibility filters
- [x] Add a regression spec for the HNSW-compatible SQL shape

## Why:

`GoodsNomenclature` has a default item ID/product-line ordering. Sequel carried that ordering into `association_join` as an ordered subquery, which made PostgreSQL choose a sequential scan, hash join and top-N sort instead of the populated HNSW index.

The direct join removes the unrelated inner ordering while leaving the vector distance ordering unchanged. Against the populated development database, the plan changed from a sequential scan at roughly 240 ms to an HNSW index scan below 1 ms on warm runs.

## Ticket:

[AI-1040](https://transformuk.atlassian.net/browse/AI-1040)

## Risk:

**Risk level:** 🟢

**Reason for rating:** The guided classification search feature is not live. The change only alters query construction, with no schema, index, API or response-order changes.