### PR TITLE
feat: tag log output with client_id from JWT or API Gateway key

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,6 +13,7 @@ class ApplicationController < ActionController::API
 
   before_action :set_trade_tariff_request_id
   before_action :maintenance_mode_if_active
+  around_action :tag_logs_with_client_id
   around_action :configure_time_machine
   around_action :apply_jsonapi_query_options
   after_action  :check_query_count, if: -> { TradeTariffBackend.check_query_count? }
@@ -51,7 +52,7 @@ protected
     payload[:request_id] = logged_request_id
     payload[:user_agent] = request_user_agent
     payload[:request_source] = TradeTariffRequest.request_source
-    payload[:client_id] = request.headers['HTTP_X_CLIENT_ID']
+    payload[:client_id] = TradeTariffRequest.client_id
   end
 
 private
@@ -125,9 +126,29 @@ private
     self.class.name.start_with?('Api::V2::')
   end
 
+  def tag_logs_with_client_id(&block)
+    Rails.logger.tagged(TradeTariffRequest.client_id || 'anonymous', &block)
+  end
+
   def set_trade_tariff_request_id
     TradeTariffRequest.request_id = params[:request_id].presence || request.request_id
     TradeTariffRequest.request_source = TradeTariffRequest.request_source_for_user_agent(request_user_agent)
+    TradeTariffRequest.client_id =
+      extract_client_id_from_jwt(request.headers['Authorization']) ||
+      request.headers['X-Client-Id']
+  end
+
+  def extract_client_id_from_jwt(authorization_header)
+    return nil unless authorization_header&.start_with?('Bearer ')
+
+    token = authorization_header.delete_prefix('Bearer ')
+    segments = token.split('.')
+    return nil unless segments.length == 3
+
+    payload = JSON.parse(Base64.urlsafe_decode64(segments[1]))
+    payload['client_id'] || payload['sub']
+  rescue ArgumentError, JSON::ParserError
+    nil
   end
 
   def set_api_docs_link_header

--- a/app/lib/trade_tariff_request.rb
+++ b/app/lib/trade_tariff_request.rb
@@ -6,6 +6,7 @@ class TradeTariffRequest < ActiveSupport::CurrentAttributes
   attribute :whodunnit,
             :request_id,
             :request_source,
+            :client_id,
             :green_lanes,
             :time_machine_now,
             # Controls how TimeMachine filters associated records in queries.

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -87,6 +87,11 @@ RSpec.describe ApplicationController, type: :request do
     end
 
     context 'with request logging payload' do
+      def jwt_with_claims(claims)
+        payload = Base64.urlsafe_encode64(claims.to_json, padding: false)
+        "header.#{payload}.signature"
+      end
+
       def process_action_payload_for(params:, headers: {})
         events = []
         subscriber = ActiveSupport::Notifications.subscribe('process_action.action_controller') do |*args|
@@ -161,6 +166,97 @@ RSpec.describe ApplicationController, type: :request do
         )
 
         expect(payload[:request_source]).to eq('backend_only')
+      end
+
+      it 'extracts client_id from a Bearer JWT with a client_id claim' do
+        token = jwt_with_claims('client_id' => 'my-client', 'sub' => 'my-subject')
+        payload = process_action_payload_for(
+          params: {},
+          headers: { 'Authorization' => "Bearer #{token}" },
+        )
+
+        expect(payload[:client_id]).to eq('my-client')
+      end
+
+      it 'falls back to sub when the JWT has no client_id claim' do
+        token = jwt_with_claims('sub' => 'my-subject')
+        payload = process_action_payload_for(
+          params: {},
+          headers: { 'Authorization' => "Bearer #{token}" },
+        )
+
+        expect(payload[:client_id]).to eq('my-subject')
+      end
+
+      it 'sets client_id to nil when the Authorization header is absent' do
+        payload = process_action_payload_for(params: {}, headers: {})
+
+        expect(payload[:client_id]).to be_nil
+      end
+
+      it 'sets client_id to nil for a non-JWT bearer token with no X-Client-Id header' do
+        payload = process_action_payload_for(
+          params: {},
+          headers: { 'Authorization' => 'Bearer not-a-jwt' },
+        )
+
+        expect(payload[:client_id]).to be_nil
+      end
+
+      it 'falls back to X-Client-Id header when no JWT is present' do
+        payload = process_action_payload_for(
+          params: {},
+          headers: { 'X-Client-Id' => 'apigw-key-id-abc123' },
+        )
+
+        expect(payload[:client_id]).to eq('apigw-key-id-abc123')
+      end
+
+      it 'prefers JWT client_id over X-Client-Id header' do
+        token = jwt_with_claims('client_id' => 'jwt-client')
+        payload = process_action_payload_for(
+          params: {},
+          headers: {
+            'Authorization' => "Bearer #{token}",
+            'X-Client-Id' => 'apigw-key-id-abc123',
+          },
+        )
+
+        expect(payload[:client_id]).to eq('jwt-client')
+      end
+    end
+
+    context 'with logger tagging' do
+      def jwt_with_claims(claims)
+        payload = Base64.urlsafe_encode64(claims.to_json, padding: false)
+        "header.#{payload}.signature"
+      end
+
+      it 'tags log output with client_id from the Bearer JWT' do
+        token = jwt_with_claims('client_id' => 'tagged-client')
+        tagged_with = nil
+
+        allow(Rails.logger).to receive(:tagged) do |tag, &block|
+          tagged_with = tag
+          block.call
+        end
+
+        api_get('/uk/api/healthcheck', headers: { 'Authorization' => "Bearer #{token}" })
+
+        expect(tagged_with).to eq('tagged-client')
+      end
+
+      it 'tags log output with "anonymous" when no token is present' do
+        tagged_with = nil
+
+        allow(Rails.logger).to receive(:tagged) do |tag, &block|
+          tagged_with = tag
+          block.call
+        end
+
+        api_get('/uk/api/healthcheck')
+
+        expect(tagged_with).to eq('anonymous')
       end
     end
   end


### PR DESCRIPTION
## What:
Tag every log line with a client identifier extracted from the incoming request, and expose it in the structured action controller payload.

Two sources are tried in order:
1. **Bearer JWT** — decodes the payload (without re-verifying the signature, which is already trusted) and prefers the `client_id` claim over `sub`. Covers Cognito-authenticated user API requests.
2. **`X-Client-Id` header** — falls back to this when no JWT is present. This header is injected by the API Gateway integration using `context.identity.apiKeyId`, covering API-key-authenticated requests. (The API Gateway Terraform change to inject this header is a separate PR in the terraform-modules repo.)

All log lines for a request are tagged via `Rails.logger.tagged` with the resolved client ID (or `'anonymous'` if none). The structured `process_action.action_controller` payload (`payload[:client_id]`) now reads from `TradeTariffRequest.client_id` rather than the old `HTTP_X_CLIENT_ID` header.

## Why:
We have no visibility into which API client is responsible for a given request in the logs, making it difficult to diagnose per-client issues or attribute traffic.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:** Additive only — new `TradeTariffRequest` attribute, new `around_action`, and a logging tag. No change to routing, auth logic, response payloads, or database access. The structured log payload field changes source (from the `HTTP_X_CLIENT_ID` header to `TradeTariffRequest.client_id`) but the value is equivalent for any request that previously set that header.