### PR TITLE
AI-1019: Migrate UK customs tariff document S3 paths to include uk/ prefix

### DIFF
--- a/app/lib/xi_cn_importer/document_fetcher.rb
+++ b/app/lib/xi_cn_importer/document_fetcher.rb
@@ -82,7 +82,7 @@ module XiCnImporter
       raise
     end
 
-    private
+  private
 
     def sparql_results
       uri = URI(SPARQL_ENDPOINT)

--- a/app/lib/xi_cn_importer/importer.rb
+++ b/app/lib/xi_cn_importer/importer.rb
@@ -15,7 +15,7 @@ module XiCnImporter
       documents.map { |doc| import_document(doc) }
     end
 
-    private
+  private
 
     def import_document(fetched)
       s3_path      = "#{S3_KEY_PREFIX}/CN_#{fetched.celex}.pdf"

--- a/app/lib/xi_cn_importer/instrumentation.rb
+++ b/app/lib/xi_cn_importer/instrumentation.rb
@@ -36,7 +36,7 @@ module XiCnImporter
       instrument('reimport_failed', version:, error_class:, error_message:)
     end
 
-    private
+  private
 
     def instrument(event, payload = {})
       ActiveSupport::Notifications.instrument("#{event}.#{NAMESPACE}", payload)

--- a/app/lib/xi_cn_importer/logger.rb
+++ b/app/lib/xi_cn_importer/logger.rb
@@ -67,7 +67,7 @@ module XiCnImporter
       )
     end
 
-    private
+  private
 
     def log_entry(data)
       data.merge(service: 'xi_cn_importer', timestamp: Time.current.iso8601).to_json

--- a/app/lib/xi_cn_importer/notes_extractor.rb
+++ b/app/lib/xi_cn_importer/notes_extractor.rb
@@ -36,7 +36,7 @@ module XiCnImporter
       Result.new(chapters: @chapters, sections: @sections, general_rules: @general_rules)
     end
 
-    private
+  private
 
     # --- Node dispatch ---
 

--- a/app/lib/xi_cn_importer/notes_extractor/formatter.rb
+++ b/app/lib/xi_cn_importer/notes_extractor/formatter.rb
@@ -21,7 +21,7 @@ module XiCnImporter
         ].compact.join("\n\n")
       end
 
-      private
+    private
 
       # ── Chapter notes (before "### Additional Notes") ───────────────────────
       # Standard EU formatting artefacts: (a)→a) marker style, punctuation spacing,

--- a/app/lib/xi_cn_importer/notes_extractor/formatter/table_formatter.rb
+++ b/app/lib/xi_cn_importer/notes_extractor/formatter/table_formatter.rb
@@ -64,7 +64,7 @@ module XiCnImporter
           end
         end
 
-        private
+      private
 
         def header_row?(cells)
           cells.any? do |cell|

--- a/app/lib/xi_cn_importer/reimporter.rb
+++ b/app/lib/xi_cn_importer/reimporter.rb
@@ -21,7 +21,7 @@ module XiCnImporter
       end
     end
 
-    private
+  private
 
     def reimport(update)
       html_s3_path = "#{S3_KEY_PREFIX}/CN_#{update.version}.xhtml"

--- a/app/workers/import_xi_cn_document_worker.rb
+++ b/app/workers/import_xi_cn_document_worker.rb
@@ -33,7 +33,7 @@ class ImportXiCnDocumentWorker
     raise
   end
 
-  private
+private
 
   def notify_completed(imported_count:, failed_count:, review_backlog:)
     return unless imported_count.positive? || failed_count.positive?

--- a/db/data_migrations/20260714120000_migrate_uk_customs_tariff_document_s3_paths.rb
+++ b/db/data_migrations/20260714120000_migrate_uk_customs_tariff_document_s3_paths.rb
@@ -1,0 +1,22 @@
+# Idempotent: WHERE clause only matches the old path pattern without the uk/ prefix.
+Sequel.migration do
+  up do
+    run <<~SQL
+      UPDATE customs_tariff_updates
+      SET s3_path = REPLACE(s3_path,
+                            'data/customs_tariff_documents/UKGT_',
+                            'data/customs_tariff_documents/uk/UKGT_')
+      WHERE s3_path LIKE 'data/customs_tariff_documents/UKGT_%.docx'
+    SQL
+  end
+
+  down do
+    run <<~SQL
+      UPDATE customs_tariff_updates
+      SET s3_path = REPLACE(s3_path,
+                            'data/customs_tariff_documents/uk/UKGT_',
+                            'data/customs_tariff_documents/UKGT_')
+      WHERE s3_path LIKE 'data/customs_tariff_documents/uk/UKGT_%.docx'
+    SQL
+  end
+end

--- a/spec/factories/customs_tariff_update_factory.rb
+++ b/spec/factories/customs_tariff_update_factory.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     validity_start_date { Time.zone.today }
     status { CustomsTariffUpdate::PENDING }
     source_url { 'https://assets.publishing.service.gov.uk/media/abc123/UKGT_1.30.docx' }
-    s3_path { "data/customs_tariff_documents/UKGT_#{version}.docx" }
+    s3_path { "data/customs_tariff_documents/uk/UKGT_#{version}.docx" }
     file_checksum { SecureRandom.hex(32) }
     document_created_on { Time.zone.today }
 

--- a/spec/requests/api/admin/customs_tariff_updates/sections_summary_controller_spec.rb
+++ b/spec/requests/api/admin/customs_tariff_updates/sections_summary_controller_spec.rb
@@ -52,8 +52,6 @@ RSpec.describe Api::Admin::CustomsTariffUpdates::SectionsSummaryController do
     end
 
     context 'when chapter notes exist in the update' do
-      let!(:chapter) { create(:chapter, :chapter01, :with_section) }
-
       before do
         create(:chapter, :chapter01).tap do |chapter|
           chapter.add_section(sections.first)
@@ -69,7 +67,7 @@ RSpec.describe Api::Admin::CustomsTariffUpdates::SectionsSummaryController do
         get "/uk/admin/customs_tariff_updates/#{pending_update.version}/sections_summary.json",
             headers: request_headers(format: :json)
 
-        row = JSON.parse(response.body)['data'].find { |r| r.dig('attributes', 'section_id') == chapter.sections.first.id }
+        row = JSON.parse(response.body)['data'].find { |r| r.dig('attributes', 'section_id') == sections.first.id }
         expect(row.dig('attributes', 'chapter_notes_total')).to eq(1)
         expect(row.dig('attributes', 'chapter_notes_changed')).to eq(1)
       end


### PR DESCRIPTION
### Jira link

[AI-1019](https://transformuk.atlassian.net/browse/AI-1019)

### What?

This PR migrates the S3 path references stored in `customs_tariff_updates` to include a `uk/` prefix, aligning the database with the path convention the importer has already been writing for new records. It also fixes a regression in the sections summary spec introduced in AI-895.

- **`db/data_migrations/20260714120000_migrate_uk_customs_tariff_document_s3_paths.rb`** — idempotent data migration that updates any existing `s3_path` values from `data/customs_tariff_documents/UKGT_<version>.docx` to `data/customs_tariff_documents/uk/UKGT_<version>.docx`. The `WHERE` clause only matches the old pattern so re-running is safe.
- **`spec/factories/customs_tariff_update_factory.rb`** — factory default `s3_path` updated to reflect the new `uk/` prefix so factory-created records match what the importer now writes.
- **Rubocop fixes** — `Layout/AccessModifierIndentation` corrected across all `xi_cn_importer` files and the worker (outdented `private` to match house style).
- **`spec/requests/api/admin/customs_tariff_updates/sections_summary_controller_spec.rb`** — reverts a bad change introduced in AI-895 that created a duplicate chapter record and looked up the wrong section ID, causing `chapter_notes_total` to read 0 instead of 1.

### Why?

When the UK importer was updated to write documents under `data/customs_tariff_documents/uk/`, existing rows in `customs_tariff_updates` still held the old path without the `uk/` subdirectory. This PR closes that gap so the database is consistent — old records and new records all point to the same path convention.

A couple of things worth noting:

- **Deployment order matters.** The S3 files must be copied to their new keys before the data migration runs, otherwise there is a window where the DB points to `uk/` but the files aren't there yet. The AWS commands below should be run first in each environment, then `bundle exec rake data:migrate` to update the DB, and only once both are confirmed working should the old S3 keys be deleted.
- The migration is fully reversible — the `down` block restores the original paths.

### AWS S3 operations (required before deploying)

Run these in order: copy first, verify, then delete after the migration is confirmed working.

**Dev** (`s3://trade-tariff-persistence-844815912454`):
```bash
# Copy old keys to new uk/ prefix
aws s3 cp s3://trade-tariff-persistence-844815912454/data/customs_tariff_documents/ \
          s3://trade-tariff-persistence-844815912454/data/customs_tariff_documents/uk/ \
          --recursive \
          --exclude "*" \
          --include "UKGT_*.docx"

# Once migration is verified, delete old keys
aws s3 rm s3://trade-tariff-persistence-844815912454/data/customs_tariff_documents/ \
          --recursive \
          --exclude "*" \
          --include "UKGT_*.docx"
```

**Staging** (`s3://trade-tariff-persistence-451934005581`): same commands, different bucket.

**Prod** (`s3://trade-tariff-persistence-382373577178`): same commands — requires production AWS access (Admin required to run).

### Have you?

- [ ] Added documentation for new APIs
- [ ] Added new environment variables with correct values to all apps in all spaces

### Deployment risks

- Includes a data migration (`customs_tariff_updates.s3_path`) that must be co-ordinated with S3 file copy operations — see AWS commands above. The migration itself is non-destructive and reversible, but the S3 copy step must happen first.
- Production S3 operations require someone with production AWS access.

### Risk

**Risk level:** 🟠

**Reason for rating:** Involves a data migration on `customs_tariff_updates` and co-ordinated S3 file operations that must happen in the correct order across three environments. The migration is non-destructive and reversible, but the deployment sequence (S3 copy → DB migrate → S3 delete) requires care.