### PR TITLE
Trigger auto-merge when PRs leave draft

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -3,6 +3,7 @@ name: Auto-merge low-risk PRs
 on:
   pull_request:
     types:
+      - ready_for_review
       - labeled
       - unlabeled
   pull_request_review:
@@ -22,8 +23,14 @@ permissions:
 jobs:
   auto-merge:
     if: >-
-      github.event_name != 'pull_request_review' ||
-      github.event.review.user.login == 'copilot-pull-request-reviewer[bot]'
+      (
+        github.event_name != 'pull_request' ||
+        !github.event.pull_request.draft
+      ) &&
+      (
+        github.event_name != 'pull_request_review' ||
+        github.event.review.user.login == 'copilot-pull-request-reviewer[bot]'
+      )
     uses: trade-tariff/trade-tariff-tools/.github/workflows/auto-merge-low-risk.yml@main
     with:
       label: low-risk

--- a/app/lib/xi_cn_importer/document_fetcher.rb
+++ b/app/lib/xi_cn_importer/document_fetcher.rb
@@ -82,7 +82,7 @@ module XiCnImporter
       raise
     end
 
-    private
+  private
 
     def sparql_results
       uri = URI(SPARQL_ENDPOINT)

--- a/app/lib/xi_cn_importer/importer.rb
+++ b/app/lib/xi_cn_importer/importer.rb
@@ -15,7 +15,7 @@ module XiCnImporter
       documents.map { |doc| import_document(doc) }
     end
 
-    private
+  private
 
     def import_document(fetched)
       s3_path      = "#{S3_KEY_PREFIX}/CN_#{fetched.celex}.pdf"

--- a/app/lib/xi_cn_importer/instrumentation.rb
+++ b/app/lib/xi_cn_importer/instrumentation.rb
@@ -36,7 +36,7 @@ module XiCnImporter
       instrument('reimport_failed', version:, error_class:, error_message:)
     end
 
-    private
+  private
 
     def instrument(event, payload = {})
       ActiveSupport::Notifications.instrument("#{event}.#{NAMESPACE}", payload)

--- a/app/lib/xi_cn_importer/logger.rb
+++ b/app/lib/xi_cn_importer/logger.rb
@@ -67,7 +67,7 @@ module XiCnImporter
       )
     end
 
-    private
+  private
 
     def log_entry(data)
       data.merge(service: 'xi_cn_importer', timestamp: Time.current.iso8601).to_json

--- a/app/lib/xi_cn_importer/notes_extractor.rb
+++ b/app/lib/xi_cn_importer/notes_extractor.rb
@@ -36,7 +36,7 @@ module XiCnImporter
       Result.new(chapters: @chapters, sections: @sections, general_rules: @general_rules)
     end
 
-    private
+  private
 
     # --- Node dispatch ---
 

--- a/app/lib/xi_cn_importer/notes_extractor/formatter.rb
+++ b/app/lib/xi_cn_importer/notes_extractor/formatter.rb
@@ -21,7 +21,7 @@ module XiCnImporter
         ].compact.join("\n\n")
       end
 
-      private
+    private
 
       # ── Chapter notes (before "### Additional Notes") ───────────────────────
       # Standard EU formatting artefacts: (a)→a) marker style, punctuation spacing,

--- a/app/lib/xi_cn_importer/notes_extractor/formatter/table_formatter.rb
+++ b/app/lib/xi_cn_importer/notes_extractor/formatter/table_formatter.rb
@@ -64,7 +64,7 @@ module XiCnImporter
           end
         end
 
-        private
+      private
 
         def header_row?(cells)
           cells.any? do |cell|

--- a/app/lib/xi_cn_importer/reimporter.rb
+++ b/app/lib/xi_cn_importer/reimporter.rb
@@ -21,7 +21,7 @@ module XiCnImporter
       end
     end
 
-    private
+  private
 
     def reimport(update)
       html_s3_path = "#{S3_KEY_PREFIX}/CN_#{update.version}.xhtml"

--- a/app/workers/import_xi_cn_document_worker.rb
+++ b/app/workers/import_xi_cn_document_worker.rb
@@ -33,7 +33,7 @@ class ImportXiCnDocumentWorker
     raise
   end
 
-  private
+private
 
   def notify_completed(imported_count:, failed_count:, review_backlog:)
     return unless imported_count.positive? || failed_count.positive?


### PR DESCRIPTION
## What

- Add `ready_for_review` to the low-risk auto-merge workflow pull request triggers.
- Add a caller-side draft guard so draft `pull_request` events do not invoke the reusable auto-merge workflow.
- Fix existing RuboCop `Layout/AccessModifierIndentation` offenses surfaced by this repo's all-files lint job.

## Why

Promoting a draft PR to ready for review should give the existing low-risk auto-merge workflow another chance to run. Draft PRs should not call into the reusable auto-merge workflow from pull request events.

## Ticket

N/A

## Tested

- Verified `.github/workflows/auto-merge.yml` contains `ready_for_review` and the draft guard on this branch.
- Ran `actionlint` against the updated workflow content.
- Ran `bundle exec rubocop` against the corrected XI CN importer files: 9 files inspected, no offenses detected.
- Local pre-commit hooks passed for the lint cleanup commit.

## Risk

**Risk level:** 🟢

**Reason for rating:** Low-risk workflow trigger change. This does not alter the reusable auto-merge workflow implementation, permissions, secrets, or application behavior; it only triggers the existing workflow when a PR is marked ready for review, while keeping draft pull request events guarded. The Ruby changes are RuboCop-only indentation corrections.