### PR TITLE
AI-1052: Expand CN abbreviation in XI Slack notifications

### DIFF
--- a/app/lib/xi_cn_importer/document_fetcher.rb
+++ b/app/lib/xi_cn_importer/document_fetcher.rb
@@ -82,7 +82,7 @@ module XiCnImporter
       raise
     end
 
-    private
+  private
 
     def sparql_results
       uri = URI(SPARQL_ENDPOINT)

--- a/app/lib/xi_cn_importer/importer.rb
+++ b/app/lib/xi_cn_importer/importer.rb
@@ -15,7 +15,7 @@ module XiCnImporter
       documents.map { |doc| import_document(doc) }
     end
 
-    private
+  private
 
     def import_document(fetched)
       s3_path      = "#{S3_KEY_PREFIX}/CN_#{fetched.celex}.pdf"

--- a/app/lib/xi_cn_importer/instrumentation.rb
+++ b/app/lib/xi_cn_importer/instrumentation.rb
@@ -36,7 +36,7 @@ module XiCnImporter
       instrument('reimport_failed', version:, error_class:, error_message:)
     end
 
-    private
+  private
 
     def instrument(event, payload = {})
       ActiveSupport::Notifications.instrument("#{event}.#{NAMESPACE}", payload)

--- a/app/lib/xi_cn_importer/logger.rb
+++ b/app/lib/xi_cn_importer/logger.rb
@@ -67,7 +67,7 @@ module XiCnImporter
       )
     end
 
-    private
+  private
 
     def log_entry(data)
       data.merge(service: 'xi_cn_importer', timestamp: Time.current.iso8601).to_json

--- a/app/lib/xi_cn_importer/notes_extractor.rb
+++ b/app/lib/xi_cn_importer/notes_extractor.rb
@@ -36,7 +36,7 @@ module XiCnImporter
       Result.new(chapters: @chapters, sections: @sections, general_rules: @general_rules)
     end
 
-    private
+  private
 
     # --- Node dispatch ---
 

--- a/app/lib/xi_cn_importer/notes_extractor/formatter.rb
+++ b/app/lib/xi_cn_importer/notes_extractor/formatter.rb
@@ -21,7 +21,7 @@ module XiCnImporter
         ].compact.join("\n\n")
       end
 
-      private
+    private
 
       # ── Chapter notes (before "### Additional Notes") ───────────────────────
       # Standard EU formatting artefacts: (a)→a) marker style, punctuation spacing,

--- a/app/lib/xi_cn_importer/notes_extractor/formatter/table_formatter.rb
+++ b/app/lib/xi_cn_importer/notes_extractor/formatter/table_formatter.rb
@@ -64,7 +64,7 @@ module XiCnImporter
           end
         end
 
-        private
+      private
 
         def header_row?(cells)
           cells.any? do |cell|

--- a/app/lib/xi_cn_importer/reimporter.rb
+++ b/app/lib/xi_cn_importer/reimporter.rb
@@ -21,7 +21,7 @@ module XiCnImporter
       end
     end
 
-    private
+  private
 
     def reimport(update)
       html_s3_path = "#{S3_KEY_PREFIX}/CN_#{update.version}.xhtml"

--- a/app/workers/import_xi_cn_document_worker.rb
+++ b/app/workers/import_xi_cn_document_worker.rb
@@ -33,7 +33,7 @@ class ImportXiCnDocumentWorker
     raise
   end
 
-  private
+private
 
   def notify_completed(imported_count:, failed_count:, review_backlog:)
     return unless imported_count.positive? || failed_count.positive?
@@ -41,14 +41,14 @@ class ImportXiCnDocumentWorker
     status = failed_count.positive? ? 'completed with failures' : 'completed'
 
     notify_slack(
-      "XI CN document import #{status}. " \
+      "XI Combined Nomenclature document import #{status}. " \
       "imported: #{imported_count}, failed: #{failed_count}, " \
       "pending review: #{review_backlog}",
     )
   end
 
   def notify_failed(error)
-    notify_slack("XI CN document import failed. #{error.class}: #{error.message}")
+    notify_slack("XI Combined Nomenclature document import failed. #{error.class}: #{error.message}")
   end
 
   def notify_slack(message)

--- a/spec/requests/api/admin/customs_tariff_updates/sections_summary_controller_spec.rb
+++ b/spec/requests/api/admin/customs_tariff_updates/sections_summary_controller_spec.rb
@@ -52,8 +52,6 @@ RSpec.describe Api::Admin::CustomsTariffUpdates::SectionsSummaryController do
     end
 
     context 'when chapter notes exist in the update' do
-      let!(:chapter) { create(:chapter, :chapter01, :with_section) }
-
       before do
         create(:chapter, :chapter01).tap do |chapter|
           chapter.add_section(sections.first)
@@ -69,7 +67,7 @@ RSpec.describe Api::Admin::CustomsTariffUpdates::SectionsSummaryController do
         get "/uk/admin/customs_tariff_updates/#{pending_update.version}/sections_summary.json",
             headers: request_headers(format: :json)
 
-        row = JSON.parse(response.body)['data'].find { |r| r.dig('attributes', 'section_id') == chapter.sections.first.id }
+        row = JSON.parse(response.body)['data'].find { |r| r.dig('attributes', 'section_id') == sections.first.id }
         expect(row.dig('attributes', 'chapter_notes_total')).to eq(1)
         expect(row.dig('attributes', 'chapter_notes_changed')).to eq(1)
       end


### PR DESCRIPTION
### Jira link

[AI-1052](https://transformuk.atlassian.net/browse/AI-1052)

### What?

Expands the "CN" abbreviation in the `ImportXiCnDocumentWorker` Slack notification messages so it reads "Combined Nomenclature" rather than the ambiguous "CN" (which could be read as Chapter Notes).

- **`app/workers/import_xi_cn_document_worker.rb`** — both the completion and failure notification messages updated from "XI CN document import..." to "XI Combined Nomenclature document import..."

- Also fixed a spec and rubocop offenses.

### Why?

A reviewer flagged that "CN" in the Slack message was unclear — it wasn't obvious whether it referred to Combined Nomenclature or Chapter Notes. Since the worker imports EU Combined Nomenclature documents, spelling it out removes that ambiguity for anyone reading the channel.

### Risk

**Risk level:** 🟢

**Reason for rating:** Copy-only change to Slack notification strings. No logic, no API changes, no data affected.