### PR TITLE
fix: wrap logger in ActiveSupport::TaggedLogging instance

### DIFF
--- a/config/environments/production_environment_config.rb
+++ b/config/environments/production_environment_config.rb
@@ -26,7 +26,7 @@ module ProductionEnvironmentConfig
     end
 
     def configure_logging(config)
-      config.logger = ActiveSupport::Logger.new($stdout)
+      config.logger = ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new($stdout))
       config.lograge.enabled = true
       config.lograge.formatter = Lograge::Formatters::Logstash.new
       config.lograge.custom_options = lograge_custom_options


### PR DESCRIPTION
## What:
Fixes a bug where `Rails.logger.tagged` was not available despite being in use

## Why:
PR #3469 added tagged log output but the production config doesn't use TaggedLogging

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**

Adds support for tagged logging, no other change to production logging other than supporting code that is already in `main`.

