### PR TITLE
chore(rubocop): enable length cops outside known hotspots

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -53,15 +53,30 @@ Layout/LineLength:
 Metrics/AbcSize:
   Max: 20
 
-# Legacy codebase-wide policy cop with many existing offenses; left disabled
-# until it can be split into focused refactors.
 Metrics/BlockLength:
-  Enabled: false
+  Enabled: true
+  Exclude:
+    - 'app/engines/admin_api.rb'
+    - 'app/engines/v1_api.rb'
+    - 'app/engines/v2_api.rb'
+    - 'app/lib/xi_cn_importer/importer.rb'
+    - 'app/lib/xi_cn_importer/notes_extractor/formatter.rb'
+    - 'app/lib/xi_cn_importer/reimporter.rb'
+    - 'app/models/goods_nomenclatures/nested_set/ancestor_associations.rb'
+    - 'app/models/goods_nomenclatures/nested_set/descendant_associations.rb'
+    - 'app/models/goods_nomenclatures/nested_set/measure_associations.rb'
 
-# Legacy codebase-wide policy cop with many existing offenses; left disabled
-# until it can be split into focused refactors.
 Metrics/ModuleLength:
-  Enabled: false
+  Enabled: true
+  Exclude:
+    - 'app/lib/sequel/plugins/optimized_many_to_many.rb'
+    - 'app/lib/tariff_synchronizer.rb'
+    - 'app/models/measure.rb'
+    - 'lib/tasks/green_lanes.rake'
+    - 'lib/tasks/labels.rake'
+    - 'lib/tasks/self_texts.rake'
+    - 'lib/tasks/tariff_knowledge.rake'
+    - 'lib/tasks/tariff_sync_tooling.rake'
 
 RSpec/SpecFilePathFormat:
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -53,6 +53,8 @@ Layout/LineLength:
 Metrics/AbcSize:
   Max: 20
 
+# The listed files are known hotspots; this cop is enforced everywhere else.
+# Remove each entry as its hotspot is refactored.
 Metrics/BlockLength:
   Enabled: true
   Exclude:
@@ -66,6 +68,8 @@ Metrics/BlockLength:
     - 'app/models/goods_nomenclatures/nested_set/descendant_associations.rb'
     - 'app/models/goods_nomenclatures/nested_set/measure_associations.rb'
 
+# The listed files are known hotspots; this cop is enforced everywhere else.
+# Remove each entry as its hotspot is refactored.
 Metrics/ModuleLength:
   Enabled: true
   Exclude:


### PR DESCRIPTION
## What:
Enable `Metrics/BlockLength` and `Metrics/ModuleLength` across the repository while excluding only the exact files that currently offend.

- `BlockLength`: 17 existing offenses across 9 explicitly listed files
- `ModuleLength`: 8 existing offenses across 8 explicitly listed files
- All other files are now protected from accumulating new length-cop debt

## Why:
The previous global disables allowed new offenses to accumulate while the existing hotspots were being split into bounded follow-up work. File-level exclusions make the remaining backlog explicit and immediately enforce both cops everywhere else.

## Ticket:
N/A

## Verification:
- RED audit before exclusions: 2,374 files, 25 offenses
- Scoped length-cop audit after exclusions: 2,374 files, 0 offenses
- Full RuboCop: 2,374 files, 0 offenses
- `git diff --check`: passed
- Pre-push `debride` hook: passed
- Independent spec-compliance review: approved
- Independent code-quality review: approved

No RSpec changes were needed because this PR changes lint configuration only and does not alter application behaviour.

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Configuration-only enforcement change. It does not change application runtime behaviour, APIs, data processing, dependencies, or deployment configuration. Existing hotspots remain excluded for separate covered follow-up PRs.