### PR TITLE
refactor(sequel): extract optimized SQL helpers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -73,7 +73,6 @@ Metrics/BlockLength:
 Metrics/ModuleLength:
   Enabled: true
   Exclude:
-    - 'app/lib/sequel/plugins/optimized_many_to_many.rb'
     - 'app/lib/tariff_synchronizer.rb'
     - 'app/models/measure.rb'
     - 'lib/tasks/green_lanes.rake'

--- a/app/lib/sequel/plugins/optimized_many_to_many.rb
+++ b/app/lib/sequel/plugins/optimized_many_to_many.rb
@@ -1,63 +1,13 @@
 # lib/sequel/plugins/optimized_many_to_many.rb
+require_relative 'optimized_many_to_many/sql_helpers'
+
 module Sequel
   module Plugins
     module OptimizedManyToMany
       EagerLoadQuery = Data.define(:sql, :bind_args, :left_keys, :left_pks)
+      extend SqlHelpers
 
     module_function
-
-      def join_conditions(right_key, right_pk, join_table, target_table, db = Sequel::Model.db)
-        join_table_name = extract_table_name(join_table)
-
-        Array(right_key).zip(Array(right_pk)).map { |join_key, pk|
-          left = db.literal(Sequel.qualify(join_table_name, join_key))
-          right = db.literal(Sequel.qualify(target_table, pk))
-          "#{left} = #{right}"
-        }.join(' AND ')
-      end
-
-      def where_conditions(join_table, left_keys, db = Sequel::Model.db)
-        join_table_name = extract_table_name(join_table)
-        keys = Array(left_keys).map { |lk| Sequel.qualify(join_table_name, lk) }
-
-        if keys.size == 1
-          db.literal(keys.first)
-        else
-          "(#{keys.map { |k| db.literal(k) }.join(', ')})"
-        end
-      end
-
-      def qualify_order(order, target_table, associated_class)
-        return nil unless order
-
-        qualified_order = Array(order).map do |o|
-          if o.is_a?(Sequel::SQL::OrderedExpression)
-            Sequel::SQL::OrderedExpression.new(
-              Sequel.qualify(target_table, o.expression),
-              o.descending,
-            )
-          else
-            Sequel.qualify(target_table, o)
-          end
-        end
-
-        qualified_order.map { |o| associated_class.dataset.literal(o) }.join(', ')
-      end
-
-      def table_ref(table, db = Sequel::Model.db)
-        # Handles Symbol, AliasedExpression, QualifiedIdentifier, etc.
-        db.literal(table)
-      end
-
-      def extract_table_name(table)
-        if table.is_a?(Sequel::SQL::AliasedExpression)
-          table.alias
-        elsif table.is_a?(Sequel::SQL::QualifiedIdentifier)
-          table.table
-        else
-          table
-        end
-      end
 
       def eager_loader_query(reflection, ids)
         associated_class = reflection.associated_class

--- a/app/lib/sequel/plugins/optimized_many_to_many/sql_helpers.rb
+++ b/app/lib/sequel/plugins/optimized_many_to_many/sql_helpers.rb
@@ -1,0 +1,60 @@
+module Sequel
+  module Plugins
+    module OptimizedManyToMany
+      module SqlHelpers
+        def join_conditions(right_key, right_pk, join_table, target_table, db = Sequel::Model.db)
+          join_table_name = extract_table_name(join_table)
+
+          Array(right_key).zip(Array(right_pk)).map { |join_key, pk|
+            left = db.literal(Sequel.qualify(join_table_name, join_key))
+            right = db.literal(Sequel.qualify(target_table, pk))
+            "#{left} = #{right}"
+          }.join(' AND ')
+        end
+
+        def where_conditions(join_table, left_keys, db = Sequel::Model.db)
+          join_table_name = extract_table_name(join_table)
+          keys = Array(left_keys).map { |lk| Sequel.qualify(join_table_name, lk) }
+
+          if keys.size == 1
+            db.literal(keys.first)
+          else
+            "(#{keys.map { |k| db.literal(k) }.join(', ')})"
+          end
+        end
+
+        def qualify_order(order, target_table, associated_class)
+          return nil unless order
+
+          qualified_order = Array(order).map do |o|
+            if o.is_a?(Sequel::SQL::OrderedExpression)
+              Sequel::SQL::OrderedExpression.new(
+                Sequel.qualify(target_table, o.expression),
+                o.descending,
+              )
+            else
+              Sequel.qualify(target_table, o)
+            end
+          end
+
+          qualified_order.map { |o| associated_class.dataset.literal(o) }.join(', ')
+        end
+
+        def table_ref(table, db = Sequel::Model.db)
+          # Handles Symbol, AliasedExpression, QualifiedIdentifier, etc.
+          db.literal(table)
+        end
+
+        def extract_table_name(table)
+          if table.is_a?(Sequel::SQL::AliasedExpression)
+            table.alias
+          elsif table.is_a?(Sequel::SQL::QualifiedIdentifier)
+            table.table
+          else
+            table
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What:

- Extract the existing optimized many-to-many SQL literal helpers into `OptimizedManyToMany::SqlHelpers`.
- Remove `app/lib/sequel/plugins/optimized_many_to_many.rb` from the `Metrics/ModuleLength` exclusion list.

## Why:

This is the next independently mergeable slice in the RuboCop cleanup programme. The plugin was only three lines over the default module-length limit; extracting its cohesive SQL helper concern enables the cop without changing SQL construction or association behavior.

## Ticket:

N/A

## Risk:

**Risk level:** 🟢 Green

**Reason for rating:**

This is a structure-only refactor with the helper bodies moved unchanged. The existing focused integration spec covers ordinary and optimized datasets, eager and nested loading, ordering, and simple/composite key paths; focused coverage was 105/108 relevant lines before the extraction.

## Verification:

- `bundle exec rspec spec/lib/sequel/plugins/optimized_many_to_many_spec.rb` — 14 examples, 0 failures.
- `bundle exec rubocop --config .rubocop.yml .` — 2,375 files, 0 offenses.
- Independent programme/spec review — approved with no findings.
- Independent behavior-risk review — approved with no blocking findings.
- Staged diff — 63 additions, 54 deletions; under the PR line limit.

## Manual evidence:

Not applicable. No user-facing output changes.

## Accessibility impact:

None.

## Backend, API, environment and deployment impact:

- No API, database, environment, or deployment-order changes.
- No SQL or association behavior changes intended.
- The custom Sidekiq cop and all unrelated RuboCop configuration remain unchanged.