### PR TITLE
refactor(green-lanes): extract categorisation generator

### DIFF
--- a/app/services/green_lanes/categorisation_data_generator.rb
+++ b/app/services/green_lanes/categorisation_data_generator.rb
@@ -1,0 +1,32 @@
+require 'csv'
+
+module GreenLanes
+  class CategorisationDataGenerator
+    class << self
+      def call
+        raise "Cannot read file '#{ENV['CSVFILE']}'" unless File.file?(ENV['CSVFILE'].to_s)
+
+        data = CSV.read(ENV['CSVFILE'], headers: true)
+        json = data.map { |row| categorisation_data(row) }
+        path = Rails.root.join('data/green_lanes').to_s
+        Dir.mkdir path unless Dir.exist? path
+
+        Rails.root.join('data/green_lanes/categories.json').write JSON.pretty_generate(json)
+      end
+
+    private
+
+      def categorisation_data(row)
+        {
+          category: row['Primary category'],
+          regulation_id: row['Regulation id'].presence&.strip,
+          measure_type_id: row['Measure type ID'].presence&.strip,
+          geographical_area_id: row['Geographical area']&.presence&.strip,
+          document_codes: row['Document codes'].to_s.split.map(&:strip),
+          additional_codes: row['Additional codes'].to_s.split.map(&:strip),
+          theme: row['Theme'].to_s.strip,
+        }
+      end
+    end
+  end
+end

--- a/lib/tasks/green_lanes.rake
+++ b/lib/tasks/green_lanes.rake
@@ -1,29 +1,6 @@
 module GreenLanesTasks
 module_function
 
-  def generate_categorisation_data
-    raise "Cannot read file '#{ENV['CSVFILE']}'" unless File.file?(ENV['CSVFILE'].to_s)
-
-    data = CSV.read(ENV['CSVFILE'], headers: true)
-    json = data.map { |row| categorisation_data(row) }
-    path = Rails.root.join('data/green_lanes').to_s
-    Dir.mkdir path unless Dir.exist? path
-
-    Rails.root.join('data/green_lanes/categories.json').write JSON.pretty_generate(json)
-  end
-
-  def categorisation_data(row)
-    {
-      category: row['Primary category'],
-      regulation_id: row['Regulation id'].presence&.strip,
-      measure_type_id: row['Measure type ID'].presence&.strip,
-      geographical_area_id: row['Geographical area']&.presence&.strip,
-      document_codes: row['Document codes'].to_s.split.map(&:strip),
-      additional_codes: row['Additional codes'].to_s.split.map(&:strip),
-      theme: row['Theme'].to_s.strip,
-    }
-  end
-
   def import_themes
     raise 'Not in XI environment' unless TradeTariffBackend.xi?
 
@@ -264,7 +241,7 @@ end
 namespace :green_lanes do
   desc 'Convert a CSV of the categorisation data to JSON format CSVFILE=path/to/file.csv'
   task generate_categorisation_data: :environment do
-    GreenLanesTasks.generate_categorisation_data
+    GreenLanes::CategorisationDataGenerator.call
   end
 
   desc 'Import Themes data'


### PR DESCRIPTION
## What:

Moves the CSV-to-JSON categorisation generator out of `GreenLanesTasks` into the cohesive, Zeitwerk-loaded `GreenLanes::CategorisationDataGenerator` service.

The existing `green_lanes:generate_categorisation_data` task remains the public adapter with the same name, description, `:environment` prerequisite, environment variable, failures, filesystem behavior, and JSON output.

## Why:

`GreenLanesTasks` is a known `Metrics/ModuleLength` hotspot containing several unrelated operational pipelines. This is the first small extraction backed by the characterization coverage merged in #3485.

The exact Green Lanes exclusion remains for now because further independently reviewed extractions are still required.

## Ticket:

N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:**

Behavior-preserving refactor covered end-to-end through the existing Rake interface. Focused specs, full RuboCop, and Zeitwerk validation pass.