### PR TITLE
refactor(green-lanes): extract theme importer

### DIFF
--- a/app/services/green_lanes/theme_importer.rb
+++ b/app/services/green_lanes/theme_importer.rb
@@ -1,0 +1,53 @@
+require 'nokogiri'
+
+module GreenLanes
+  class ThemeImporter
+    class << self
+      def call
+        raise 'Not in XI environment' unless TradeTariffBackend.xi?
+
+        source_file = Rails.root.join('data/green_lanes/themes.html')
+        raise "Cannot read file '#{source_file}'" unless File.file?(source_file)
+
+        existing_themes = GreenLanes::Theme.all.index_by { |theme| [theme.section, theme.subsection] }
+
+        GreenLanes::Theme.db.transaction do
+          import_nodes(Nokogiri::HTML(source_file.read), existing_themes)
+        end
+      end
+
+    private
+
+      def import_nodes(source_doc, existing_themes)
+        section = nil
+        source_doc.css('div#anx_IV p.oj-ti-grseq-1,div#anx_IV table').each do |node|
+          section = import_node(node, section, existing_themes)
+        end
+      end
+
+      def import_node(node, section, existing_themes)
+        case node.name
+        when 'p'
+          node.content.strip.gsub(/Category /, '').to_i
+        when 'table'
+          import_table(node, section, existing_themes)
+          section
+        else
+          section
+        end
+      end
+
+      def import_table(node, section, existing_themes)
+        cells = node.css('td')
+        subsection = cells[0].content.strip.gsub(/\.$/, '').to_i
+        description = cells[1].content.strip
+        instance = existing_themes[[section, subsection]] || GreenLanes::Theme.new(section:, subsection:)
+
+        instance.theme = description.slice(0, 254)
+        instance.description = description
+        instance.category = section
+        instance.save(raise_on_failure: true)
+      end
+    end
+  end
+end

--- a/lib/tasks/green_lanes.rake
+++ b/lib/tasks/green_lanes.rake
@@ -1,51 +1,6 @@
 module GreenLanesTasks
 module_function
 
-  def import_themes
-    raise 'Not in XI environment' unless TradeTariffBackend.xi?
-
-    source_file = Rails.root.join('data/green_lanes/themes.html')
-    raise "Cannot read file '#{source_file}'" unless File.file?(source_file)
-
-    existing_themes = GreenLanes::Theme.all.index_by { |theme| [theme.section, theme.subsection] }
-
-    GreenLanes::Theme.db.transaction do
-      import_theme_nodes(Nokogiri::HTML(source_file.open), existing_themes)
-    end
-  end
-
-  def import_theme_nodes(source_doc, existing_themes)
-    section = nil
-    source_doc.css('div#anx_IV p.oj-ti-grseq-1,div#anx_IV table').each do |node|
-      section = import_theme_node(node, section, existing_themes)
-    end
-  end
-
-  def import_theme_node(node, section, existing_themes)
-    case node.name
-    when 'p'
-      node.content.strip.gsub(/Category /, '').to_i
-    when 'table'
-      import_theme_table(node, section, existing_themes)
-      section
-    else
-      puts 'Unknown element, skipping'
-      section
-    end
-  end
-
-  def import_theme_table(node, section, existing_themes)
-    cells = node.css('td')
-    subsection = cells[0].content.strip.gsub(/\.$/, '').to_i
-    description = cells[1].content.strip
-    instance = existing_themes[[section, subsection]] || GreenLanes::Theme.new(section:, subsection:)
-
-    instance.theme = description.slice(0, 254)
-    instance.description = description
-    instance.category = section
-    instance.save(raise_on_failure: true)
-  end
-
   def import_category_assessments
     raise 'Only supported on XI service' unless TradeTariffBackend.xi?
 
@@ -246,7 +201,7 @@ namespace :green_lanes do
 
   desc 'Import Themes data'
   task import_themes: :environment do
-    GreenLanesTasks.import_themes
+    GreenLanes::ThemeImporter.call
   end
 
   desc 'Import CategoryAssessments data'


### PR DESCRIPTION
## What:

Moves Annex IV theme import out of `GreenLanesTasks` into the cohesive, Zeitwerk-loaded `GreenLanes::ThemeImporter` service.

The existing `green_lanes:import_themes` task remains the public adapter with the same name, description, `:environment` prerequisite, XI guard, source path, transaction boundary, parsing, and persistence behavior.

The dead “unknown node” stdout branch is removed because the importer’s CSS selector can return only `p` and `table` nodes; this also keeps the extracted service compliant with `Rails/Output` without a disable.

## Why:

`GreenLanesTasks` is a known `Metrics/ModuleLength` hotspot containing unrelated operational pipelines. This is the second small extraction, backed by the characterization coverage merged in #3487.

The exact Green Lanes exclusion remains for now because further independently reviewed extractions are still required.

## Ticket:

N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:**

Behavior-preserving refactor covered end-to-end through the existing Rake interface, including document-wide rollback. Focused specs, full RuboCop, and Zeitwerk validation pass.