### PR TITLE
refactor(green-lanes): extract category assessment importer

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -75,7 +75,6 @@ Metrics/ModuleLength:
   Exclude:
     - 'app/lib/tariff_synchronizer.rb'
     - 'app/models/measure.rb'
-    - 'lib/tasks/green_lanes.rake'
     - 'lib/tasks/labels.rake'
     - 'lib/tasks/self_texts.rake'
     - 'lib/tasks/tariff_knowledge.rake'

--- a/app/services/green_lanes/category_assessment_importer.rb
+++ b/app/services/green_lanes/category_assessment_importer.rb
@@ -1,0 +1,69 @@
+module GreenLanes
+  class CategoryAssessmentImporter
+    class << self
+      def call(&missing_theme_handler)
+        raise 'Only supported on XI service' unless TradeTariffBackend.xi?
+
+        themes = GreenLanes::Theme.all.index_by { |theme| [theme.section, theme.subsection] }
+        assessments = GreenLanes::CategoryAssessment.all.index_by { |assessment| category_assessment_key(assessment) }
+
+        GreenLanes::CategoryAssessment.db.transaction do
+          GreenLanes::CategoryAssessmentJson.all.each do |json_ca|
+            import_category_assessment(json_ca, themes, assessments, missing_theme_handler)
+          end
+        end
+      end
+
+    private
+
+      def category_assessment_key(assessment)
+        [assessment.measure_type_id, assessment.regulation_id]
+      end
+
+      def import_category_assessment(json_ca, themes, assessments, missing_theme_handler)
+        return if json_ca.category.to_s == '3'
+        return missing_theme_handler&.call(json_ca) if json_ca.theme.blank?
+
+        key = [json_ca.measure_type_id, json_ca.regulation_id]
+        assessment = assessments[key] || build_category_assessment(json_ca)
+        theme = category_assessment_theme(json_ca, themes)
+
+        if assessment.id.nil?
+          assessment.theme = theme
+          assessment.save(validate: true)
+        elsif assessment.theme != theme
+          raise 'Inconsistent theme'
+        end
+
+        assessments[key] = assessment
+      end
+
+      def build_category_assessment(json_ca)
+        assessment = GreenLanes::CategoryAssessment.new
+        assessment.measure_type_id = json_ca.measure_type_id
+        assessment.regulation_id = json_ca.regulation_id
+        regulation = ModificationRegulation.actual.where(modification_regulation_id: json_ca.regulation_id).all.last
+        regulation ||= BaseRegulation.actual.where(base_regulation_id: json_ca.regulation_id).all.last
+        assessment.regulation_role = regulation&.role || 1
+        assessment
+      end
+
+      def category_assessment_theme(json_ca, themes)
+        section, subsection, theme_name = json_ca.theme.split('.', 3)
+        theme_key = [section.to_i, subsection.to_i]
+        themes[theme_key] ||= build_theme(section, subsection, json_ca.category, theme_name)
+      end
+
+      def build_theme(section, subsection, category, theme_name)
+        GreenLanes::Theme.new.tap do |theme|
+          theme.section = section
+          theme.subsection = subsection
+          theme.category = category
+          theme.theme = theme_name
+          theme.description = theme_name
+          theme.save(validate: true)
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/green_lanes.rake
+++ b/lib/tasks/green_lanes.rake
@@ -1,68 +1,6 @@
 module GreenLanesTasks
 module_function
 
-  def import_category_assessments
-    raise 'Only supported on XI service' unless TradeTariffBackend.xi?
-
-    themes = GreenLanes::Theme.all.index_by { |theme| [theme.section, theme.subsection] }
-    assessments = GreenLanes::CategoryAssessment.all.index_by { |assessment| category_assessment_key(assessment) }
-
-    GreenLanes::CategoryAssessment.db.transaction do
-      GreenLanes::CategoryAssessmentJson.all.each do |json_ca|
-        import_category_assessment(json_ca, themes, assessments)
-      end
-    end
-  end
-
-  def category_assessment_key(assessment)
-    [assessment.measure_type_id, assessment.regulation_id]
-  end
-
-  def import_category_assessment(json_ca, themes, assessments)
-    return if json_ca.category.to_s == '3'
-    return puts "MISSING THEME, SKIPPING: #{json_ca.inspect}" if json_ca.theme.blank?
-
-    key = [json_ca.measure_type_id, json_ca.regulation_id]
-    assessment = assessments[key] || build_category_assessment(json_ca)
-    theme = category_assessment_theme(json_ca, themes)
-
-    if assessment.id.nil?
-      assessment.theme = theme
-      assessment.save(validate: true)
-    elsif assessment.theme != theme
-      raise 'Inconsistent theme'
-    end
-
-    assessments[key] = assessment
-  end
-
-  def build_category_assessment(json_ca)
-    assessment = GreenLanes::CategoryAssessment.new
-    assessment.measure_type_id = json_ca.measure_type_id
-    assessment.regulation_id = json_ca.regulation_id
-    regulation = ModificationRegulation.actual.where(modification_regulation_id: json_ca.regulation_id).all.last
-    regulation ||= BaseRegulation.actual.where(base_regulation_id: json_ca.regulation_id).all.last
-    assessment.regulation_role = regulation&.role || 1
-    assessment
-  end
-
-  def category_assessment_theme(json_ca, themes)
-    section, subsection, theme_name = json_ca.theme.split('.', 3)
-    theme_key = [section.to_i, subsection.to_i]
-    themes[theme_key] ||= build_theme(section, subsection, json_ca.category, theme_name)
-  end
-
-  def build_theme(section, subsection, category, theme_name)
-    GreenLanes::Theme.new.tap do |theme|
-      theme.section = section
-      theme.subsection = subsection
-      theme.category = category
-      theme.theme = theme_name
-      theme.description = theme_name
-      theme.save(validate: true)
-    end
-  end
-
   def import_tr_category_assessments
     raise 'Only supported on XI service' unless TradeTariffBackend.xi?
 
@@ -143,11 +81,9 @@ module_function
   end
 
   def csv_category_assessment_data
-    if Rails.application.config.persistence_bucket.present?
-      s3_csv('data/categorisation/category_assessment.csv')
-    else
-      local_category_assessment_csv
-    end
+    return s3_csv('data/categorisation/category_assessment.csv') if Rails.application.config.persistence_bucket.present?
+
+    local_category_assessment_csv
   end
 
   def local_category_assessment_csv
@@ -206,7 +142,7 @@ namespace :green_lanes do
 
   desc 'Import CategoryAssessments data'
   task import_category_assessments: :environment do
-    GreenLanesTasks.import_category_assessments
+    GreenLanes::CategoryAssessmentImporter.call { |json_ca| puts "MISSING THEME, SKIPPING: #{json_ca.inspect}" }
   end
 
   desc 'Import Trade Remedies CategoryAssessments data'


### PR DESCRIPTION
## Summary

- move category-assessment import behavior from `GreenLanesTasks` into `GreenLanes::CategoryAssessmentImporter`
- preserve missing-theme stdout at the rake boundary via a callback, keeping raw output out of the application service
- retain the existing transaction, theme/assessment indexes, duplicate handling, regulation-role resolution, and conflict behavior
- use the existing guard-clause pattern for CSV source selection to bring `GreenLanesTasks` to the default 100-line module limit
- remove the exact `Metrics/ModuleLength` exclusion for `lib/tasks/green_lanes.rake`

## Risk

🟢 Low risk

**Reason for rating:** This is a behavior-preserving extraction backed by the characterization coverage merged in #3489. The public rake task contract is unchanged, and the only adjacent rewrite is an equivalent guard clause.

## Verification

- `bundle exec rspec spec/lib/tasks/green_lanes_rake_spec.rb` — 14 examples, 0 failures
- `bundle exec rails zeitwerk:check` — All is good
- scoped RuboCop — 3 files inspected, no offenses
- tracked/new Ruby and Rake RuboCop — 2,358 files inspected, no offenses
- `GreenLanesTasks` passes `Metrics/ModuleLength` with its exclusion removed
- two independent read-only reviews found no actionable concerns