### PR TITLE
refactor(xi-cn): extract section note creation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -63,7 +63,6 @@ Metrics/BlockLength:
     - 'app/engines/v2_api.rb'
     - 'app/lib/xi_cn_importer/importer.rb'
     - 'app/lib/xi_cn_importer/notes_extractor/formatter.rb'
-    - 'app/lib/xi_cn_importer/reimporter.rb'
     - 'app/models/goods_nomenclatures/nested_set/ancestor_associations.rb'
     - 'app/models/goods_nomenclatures/nested_set/descendant_associations.rb'
     - 'app/models/goods_nomenclatures/nested_set/measure_associations.rb'

--- a/app/lib/xi_cn_importer/reimporter.rb
+++ b/app/lib/xi_cn_importer/reimporter.rb
@@ -37,15 +37,7 @@ module XiCnImporter
         CustomsTariffChapterNote.where(customs_tariff_update_version: update.version).delete
         CustomsTariffGeneralRule.where(customs_tariff_update_version: update.version).delete
 
-        extracted.sections.each do |section_id, note_content|
-          CustomsTariffSectionNote.create(
-            customs_tariff_update_version: update.version,
-            section_id:,
-            content: note_content,
-            validity_start_date: update.validity_start_date,
-            status: CustomsTariffSectionNote::PENDING,
-          )
-        end
+        create_section_notes(update, extracted.sections)
 
         extracted.chapters.each do |chapter_id, note_content|
           CustomsTariffChapterNote.create(
@@ -66,6 +58,18 @@ module XiCnImporter
             status: CustomsTariffGeneralRule::PENDING,
           )
         end
+      end
+    end
+
+    def create_section_notes(update, sections)
+      sections.each do |section_id, note_content|
+        CustomsTariffSectionNote.create(
+          customs_tariff_update_version: update.version,
+          section_id:,
+          content: note_content,
+          validity_start_date: update.validity_start_date,
+          status: CustomsTariffSectionNote::PENDING,
+        )
       end
     end
   end


### PR DESCRIPTION
## Summary

- extract section-note creation from the XI CN reimport transaction into a private `create_section_notes` method
- keep the call at the same point inside the same database transaction
- reduce the offending transaction block from 30 lines to below the default 25-line limit
- remove the exact `Metrics/BlockLength` exclusion for `app/lib/xi_cn_importer/reimporter.rb`

## Risk

🟢 Low risk

**Reason for rating:** This moves a directly covered persistence loop verbatim within the same class and transaction. Iteration order, attributes, exception propagation, and rollback semantics are unchanged.

## Verification

- `bundle exec rspec spec/lib/xi_cn_importer/reimporter_spec.rb` — 7 examples, 0 failures
- scoped RuboCop — 2 files inspected, no offenses
- tracked Ruby/Rake RuboCop — 2,358 files inspected, no offenses
- `Metrics/BlockLength` passes with the exact exclusion removed
- two independent read-only reviews found no actionable concerns