### PR TITLE
refactor(nested-set): extract descendant association registration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -64,7 +64,6 @@ Metrics/BlockLength:
     - 'app/lib/xi_cn_importer/importer.rb'
     - 'app/lib/xi_cn_importer/notes_extractor/formatter.rb'
     - 'app/models/goods_nomenclatures/nested_set/ancestor_associations.rb'
-    - 'app/models/goods_nomenclatures/nested_set/descendant_associations.rb'
     - 'app/models/goods_nomenclatures/nested_set/measure_associations.rb'
 
 # The listed files are known hotspots; this cop is enforced everywhere else.

--- a/app/models/goods_nomenclatures/nested_set/descendant_associations.rb
+++ b/app/models/goods_nomenclatures/nested_set/descendant_associations.rb
@@ -4,15 +4,21 @@ module GoodsNomenclatures
       extend ActiveSupport::Concern
 
       included do
-        many_to_many :descendants,
-                     left_primary_key: :goods_nomenclature_sid,
-                     left_key: Sequel.qualify(:origin_nodes, :goods_nomenclature_sid),
-                     right_primary_key: :goods_nomenclature_sid,
-                     right_key: :goods_nomenclature_sid,
-                     class_name: '::GoodsNomenclature',
-                     join_table: Sequel.as(:goods_nomenclature_tree_nodes, :descendant_nodes),
-                     after_load: :recursive_descendant_populator,
-                     read_only: true do |ds|
+        DescendantAssociations.register_descendants(self)
+        DescendantAssociations.register_children(self)
+        DescendantAssociations.register_historical_children(self)
+      end
+
+      def self.register_descendants(model)
+        model.many_to_many :descendants,
+                           left_primary_key: :goods_nomenclature_sid,
+                           left_key: Sequel.qualify(:origin_nodes, :goods_nomenclature_sid),
+                           right_primary_key: :goods_nomenclature_sid,
+                           right_key: :goods_nomenclature_sid,
+                           class_name: '::GoodsNomenclature',
+                           join_table: Sequel.as(:goods_nomenclature_tree_nodes, :descendant_nodes),
+                           after_load: :recursive_descendant_populator,
+                           read_only: true do |ds|
           raise DateNotSet unless TimeMachine.date_is_set?
 
           ds.non_hidden
@@ -28,15 +34,17 @@ module GoodsNomenclatures
                 TreeNode.descendant_node_constraints(origin, descendants)
             end
         end
+      end
 
-        many_to_many :children,
-                     left_primary_key: :goods_nomenclature_sid,
-                     left_key: Sequel.qualify(:origin_nodes, :goods_nomenclature_sid),
-                     right_primary_key: :goods_nomenclature_sid,
-                     right_key: :goods_nomenclature_sid,
-                     class_name: '::GoodsNomenclature',
-                     join_table: Sequel.as(:goods_nomenclature_tree_nodes, :child_nodes),
-                     read_only: true do |ds|
+      def self.register_children(model)
+        model.many_to_many :children,
+                           left_primary_key: :goods_nomenclature_sid,
+                           left_key: Sequel.qualify(:origin_nodes, :goods_nomenclature_sid),
+                           right_primary_key: :goods_nomenclature_sid,
+                           right_key: :goods_nomenclature_sid,
+                           class_name: '::GoodsNomenclature',
+                           join_table: Sequel.as(:goods_nomenclature_tree_nodes, :child_nodes),
+                           read_only: true do |ds|
           raise DateNotSet unless TimeMachine.date_is_set?
 
           ds.non_hidden
@@ -52,15 +60,17 @@ module GoodsNomenclatures
                 TreeNode.descendant_node_constraints(origin, children)
             end
         end
+      end
 
-        many_to_many :historical_children,
-                     left_primary_key: :goods_nomenclature_sid,
-                     left_key: Sequel.qualify(:origin_nodes, :goods_nomenclature_sid),
-                     right_primary_key: :goods_nomenclature_sid,
-                     right_key: :goods_nomenclature_sid,
-                     class_name: '::GoodsNomenclature',
-                     join_table: Sequel.as(:goods_nomenclature_tree_nodes, :child_nodes),
-                     read_only: true do |ds|
+      def self.register_historical_children(model)
+        model.many_to_many :historical_children,
+                           left_primary_key: :goods_nomenclature_sid,
+                           left_key: Sequel.qualify(:origin_nodes, :goods_nomenclature_sid),
+                           right_primary_key: :goods_nomenclature_sid,
+                           right_key: :goods_nomenclature_sid,
+                           class_name: '::GoodsNomenclature',
+                           join_table: Sequel.as(:goods_nomenclature_tree_nodes, :child_nodes),
+                           read_only: true do |ds|
           ds.non_hidden
             .order(:child_nodes__position)
             .select_append(:child_nodes__depth, :child_nodes__number_indents)


### PR DESCRIPTION
## Summary

- move descendant, child, and historical-child association registration into narrowly scoped concern methods
- preserve each Sequel association definition and its declaration order
- remove the exact `Metrics/BlockLength` exclusion for `descendant_associations.rb`

## Verification

- `bundle exec rspec spec/models/goods_nomenclatures/nested_set_spec.rb` — 115 examples, 0 failures
- focused SimpleCov — 28/28 executable lines covered in the changed model
- full tracked RuboCop with configured exclusions — 2,356 files, 0 offenses
- commit and pre-push hooks passed
- two independent reviews found no issues

## Risk

🟢 Low risk

**Reason for rating:** This is a mechanical registration extraction. Association names, options, dataset blocks, callbacks, and declaration order are unchanged, and the focused integration spec exercises all three associations.