### PR TITLE
refactor(nested-set): extract measure association registration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -64,7 +64,6 @@ Metrics/BlockLength:
     - 'app/lib/xi_cn_importer/importer.rb'
     - 'app/lib/xi_cn_importer/notes_extractor/formatter.rb'
     - 'app/models/goods_nomenclatures/nested_set/ancestor_associations.rb'
-    - 'app/models/goods_nomenclatures/nested_set/measure_associations.rb'
 
 # The listed files are known hotspots; this cop is enforced everywhere else.
 # Remove each entry as its hotspot is refactored.

--- a/app/models/goods_nomenclatures/nested_set/measure_associations.rb
+++ b/app/models/goods_nomenclatures/nested_set/measure_associations.rb
@@ -4,28 +4,7 @@ module GoodsNomenclatures
       extend ActiveSupport::Concern
 
       included do
-        one_to_many :measures,
-                    primary_key: :goods_nomenclature_sid,
-                    key: :goods_nomenclature_sid,
-                    class_name: '::Measure',
-                    read_only: true do |ds|
-          ds.with_actual(Measure)
-            .dedupe_similar
-            .with_regulation_dates_query
-            .without_excluded_types
-        end
-
-        one_to_many :overview_measures,
-                    primary_key: :goods_nomenclature_sid,
-                    key: :goods_nomenclature_sid,
-                    class_name: '::Measure',
-                    read_only: true do |ds|
-          ds.with_actual(Measure)
-            .dedupe_similar
-            .with_regulation_dates_query
-            .without_excluded_types
-            .overview
-        end
+        MeasureAssociations.register_measure_associations(self)
 
         def_column_accessor :leaf
 
@@ -43,6 +22,31 @@ module GoodsNomenclatures
               .non_grouping
               .where(tree_node__child_sid: nil)
           end
+        end
+      end
+
+      def self.register_measure_associations(model)
+        model.one_to_many :measures,
+                          primary_key: :goods_nomenclature_sid,
+                          key: :goods_nomenclature_sid,
+                          class_name: '::Measure',
+                          read_only: true do |ds|
+          ds.with_actual(Measure)
+            .dedupe_similar
+            .with_regulation_dates_query
+            .without_excluded_types
+        end
+
+        model.one_to_many :overview_measures,
+                          primary_key: :goods_nomenclature_sid,
+                          key: :goods_nomenclature_sid,
+                          class_name: '::Measure',
+                          read_only: true do |ds|
+          ds.with_actual(Measure)
+            .dedupe_similar
+            .with_regulation_dates_query
+            .without_excluded_types
+            .overview
         end
       end
     end


### PR DESCRIPTION
## Summary

- move `measures` and `overview_measures` registration behind one narrowly scoped concern method
- preserve association order, Sequel options, dataset chains, leaf projection, and declarable filtering
- remove only the exact `Metrics/BlockLength` exclusion for `measure_associations.rb`

## Cop and hotspot

- Cop: `Metrics/BlockLength`
- Hotspot before: `app/models/goods_nomenclatures/nested_set/measure_associations.rb` included block at 36/25
- After: no target-cop offense; the exact file exclusion is removed

## Coverage relied upon

The existing nested-set integration spec directly exercises both associations, excluded and overview measure filtering, eager loading, leaf projection, and declarable filtering. No new tests were needed.

## Verification

- focused nested-set spec — 115 examples, 0 failures
- full tracked RuboCop with configured exclusions — 2,356 files, 0 offenses
- explicit default-config `Metrics/BlockLength` audit — 1 file, 0 offenses
- `rails zeitwerk:check` — All is good
- `git diff --check` — clean
- commit and pre-push hooks — passed
- independent specification and code-quality reviews — no findings

## Risk

🟢 Low risk

**Reason for rating:** This is a mechanical class-registration extraction. Association names, order, options, dataset transformations, and runtime APIs are unchanged, with direct focused integration coverage and runtime metadata verification.