### PR TITLE
refactor(nested-set): extract ancestor association registration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -63,7 +63,6 @@ Metrics/BlockLength:
     - 'app/engines/v2_api.rb'
     - 'app/lib/xi_cn_importer/importer.rb'
     - 'app/lib/xi_cn_importer/notes_extractor/formatter.rb'
-    - 'app/models/goods_nomenclatures/nested_set/ancestor_associations.rb'
 
 # The listed files are known hotspots; this cop is enforced everywhere else.
 # Remove each entry as its hotspot is refactored.

--- a/app/models/goods_nomenclatures/nested_set/ancestor_associations.rb
+++ b/app/models/goods_nomenclatures/nested_set/ancestor_associations.rb
@@ -4,23 +4,31 @@ module GoodsNomenclatures
       extend ActiveSupport::Concern
 
       included do
-        one_to_one :tree_node, key: :goods_nomenclature_sid,
-                               class_name: 'GoodsNomenclatures::TreeNode',
-                               reciprocal: :goods_nomenclature,
-                               graph_use_association_block: true,
-                               read_only: true do |ds|
+        AncestorAssociations.register_tree_node(self)
+        AncestorAssociations.register_ancestors(self)
+        AncestorAssociations.register_parent(self)
+      end
+
+      def self.register_tree_node(model)
+        model.one_to_one :tree_node, key: :goods_nomenclature_sid,
+                                     class_name: 'GoodsNomenclatures::TreeNode',
+                                     reciprocal: :goods_nomenclature,
+                                     graph_use_association_block: true,
+                                     read_only: true do |ds|
           ds.with_actual(GoodsNomenclatures::TreeNode)
         end
+      end
 
-        many_to_many :ancestors,
-                     left_primary_key: :goods_nomenclature_sid,
-                     left_key: Sequel.qualify(:origin_nodes, :goods_nomenclature_sid),
-                     right_primary_key: :goods_nomenclature_sid,
-                     right_key: :goods_nomenclature_sid,
-                     class_name: '::GoodsNomenclature',
-                     join_table: Sequel.as(:goods_nomenclature_tree_nodes, :ancestor_nodes),
-                     after_load: :recursive_ancestor_populator,
-                     read_only: true do |ds|
+      def self.register_ancestors(model)
+        model.many_to_many :ancestors,
+                           left_primary_key: :goods_nomenclature_sid,
+                           left_key: Sequel.qualify(:origin_nodes, :goods_nomenclature_sid),
+                           right_primary_key: :goods_nomenclature_sid,
+                           right_key: :goods_nomenclature_sid,
+                           class_name: '::GoodsNomenclature',
+                           join_table: Sequel.as(:goods_nomenclature_tree_nodes, :ancestor_nodes),
+                           after_load: :recursive_ancestor_populator,
+                           read_only: true do |ds|
           raise DateNotSet unless TimeMachine.date_is_set?
 
           ds.order(:ancestor_nodes__position)
@@ -36,15 +44,17 @@ module GoodsNomenclatures
                 TreeNode.ancestor_node_constraints(origin, ancestors)
             end
         end
+      end
 
-        one_through_one :parent,
-                        left_primary_key: :goods_nomenclature_sid,
-                        left_key: Sequel.qualify(:origin_nodes, :goods_nomenclature_sid),
-                        right_primary_key: :goods_nomenclature_sid,
-                        right_key: :goods_nomenclature_sid,
-                        class_name: '::GoodsNomenclature',
-                        join_table: Sequel.as(:goods_nomenclature_tree_nodes, :parent_nodes),
-                        read_only: true do |ds|
+      def self.register_parent(model)
+        model.one_through_one :parent,
+                              left_primary_key: :goods_nomenclature_sid,
+                              left_key: Sequel.qualify(:origin_nodes, :goods_nomenclature_sid),
+                              right_primary_key: :goods_nomenclature_sid,
+                              right_key: :goods_nomenclature_sid,
+                              class_name: '::GoodsNomenclature',
+                              join_table: Sequel.as(:goods_nomenclature_tree_nodes, :parent_nodes),
+                              read_only: true do |ds|
           raise DateNotSet unless TimeMachine.date_is_set?
 
           ds.order(:parent_nodes__position)


### PR DESCRIPTION
## Summary

- move `tree_node`, `ancestors`, and `parent` registration behind narrowly scoped concern methods
- preserve association order, Sequel metadata, dataset SQL, callbacks, and temporal guards
- remove only the exact `Metrics/BlockLength` exclusion for `ancestor_associations.rb`

## Cop and hotspot

- Cop: `Metrics/BlockLength`
- Hotspot before: the `included` block at 50/25
- After: no target-cop offense; the exact exclusion is removed

## Coverage relied upon

Existing nested-set and tree-node integration specs cover direct and eager association loading, recursive population, ordering and selected metadata, validity boundaries, reciprocal caching, and missing-TimeMachine errors. No new tests were needed.

## Verification

- nested-set/tree-node focused group — 140 examples, 0 failures
- full tracked RuboCop with configured exclusions — 2,356 files, 0 offenses
- explicit default-config `Metrics/BlockLength` audit — 1 file, 0 offenses
- `rails zeitwerk:check` — All is good
- `git diff --check` — clean
- commit and pre-push hooks — passed
- independent specification and code-quality reviews — no findings

## Risk

🟢 Low risk

**Reason for rating:** This is a mechanical class-registration extraction. Association names, declaration order, options, callbacks, dataset blocks, and model APIs are unchanged, with direct focused integration and runtime metadata verification.