### PR TITLE
AI-1061: Explain compressed note prompt selection

### DIFF
--- a/app/lib/search/instrumentation.rb
+++ b/app/lib/search/instrumentation.rb
@@ -6,6 +6,7 @@ module Search
     extend QueryEvents
     extend ApiEvents
     extend ResultEvents
+    extend NoteEvidenceEvents
     extend EvaluationEvents
     extend PayloadHelpers
     extend ClassicResultSummaries

--- a/app/lib/search/instrumentation/note_evidence_events.rb
+++ b/app/lib/search/instrumentation/note_evidence_events.rb
@@ -1,0 +1,28 @@
+module Search
+  module Instrumentation
+    module NoteEvidenceEvents
+      def note_evidence_evaluated(request_id:, query:, effective_query:, iteration:, attempt_number:, operation:, enabled:, diagnostics:)
+        instrument(
+          'note_evidence_evaluated',
+          request_id:,
+          search_type: 'interactive',
+          query:,
+          effective_query:,
+          iteration:,
+          attempt_number:,
+          operation:,
+          note_evidence_enabled: enabled,
+          note_evidence_status: diagnostics[:status],
+          considered_note_count: diagnostics[:considered_note_count],
+          considered_evidence_count: diagnostics[:considered_evidence_count],
+          selected_note_count: diagnostics[:selected_note_count],
+          selected_evidence_count: diagnostics[:selected_evidence_count],
+          omitted_evidence_count: diagnostics[:omitted_evidence_count],
+          logged_omitted_evidence_count: diagnostics[:logged_omitted_evidence_count],
+          omitted_evidence_truncated: diagnostics[:omitted_evidence_truncated],
+          details: diagnostics,
+        )
+      end
+    end
+  end
+end

--- a/app/lib/search/logger.rb
+++ b/app/lib/search/logger.rb
@@ -108,6 +108,29 @@ module Search
       }, event)
     end
 
+    def note_evidence_evaluated(event)
+      info log_entry({
+        event: 'note_evidence_evaluated',
+        request_id: event.payload[:request_id],
+        search_type: event.payload[:search_type],
+        query: event.payload[:query],
+        effective_query: event.payload[:effective_query],
+        iteration: event.payload[:iteration],
+        attempt_number: event.payload[:attempt_number],
+        operation: event.payload[:operation],
+        note_evidence_enabled: event.payload[:note_evidence_enabled],
+        note_evidence_status: event.payload[:note_evidence_status],
+        considered_note_count: event.payload[:considered_note_count],
+        considered_evidence_count: event.payload[:considered_evidence_count],
+        selected_note_count: event.payload[:selected_note_count],
+        selected_evidence_count: event.payload[:selected_evidence_count],
+        omitted_evidence_count: event.payload[:omitted_evidence_count],
+        logged_omitted_evidence_count: event.payload[:logged_omitted_evidence_count],
+        omitted_evidence_truncated: event.payload[:omitted_evidence_truncated],
+        details: event.payload[:details],
+      }, event)
+    end
+
     def retrieval_results_returned(event)
       info log_entry({
         event: 'retrieval_results_returned',

--- a/app/services/interactive_search_service.rb
+++ b/app/services/interactive_search_service.rb
@@ -141,7 +141,7 @@ private
   def format_compressed_notes = compressed_note_contexts.to_json
 
   def compressed_notes_by_item_id
-    return {} unless AdminConfiguration.enabled?('search_compressed_notes_enabled')
+    return {} unless compressed_notes_enabled?
 
     @compressed_notes_by_item_id ||= begin
       item_ids = opensearch_results.map(&:goods_nomenclature_item_id).compact_blank.uniq
@@ -153,6 +153,8 @@ private
       end
     end
   end
+
+  def compressed_notes_enabled? = AdminConfiguration.enabled?('search_compressed_notes_enabled')
 
   def compressed_note_contexts
     return @compressed_note_contexts if defined?(@compressed_note_contexts)
@@ -172,7 +174,24 @@ private
     end
   end
 
-  def selected_compressed_note_contexts = @selected_compressed_note_contexts ||= TariffKnowledge::RelevantNoteFragmentSelector.call(query:, search_results: opensearch_results, notes_by_item_id: compressed_notes_by_item_id)
+  def selected_compressed_note_contexts = compressed_note_selection.contexts
+
+  def compressed_note_selection
+    @compressed_note_selection ||= TariffKnowledge::RelevantNoteFragmentSelector.call_with_diagnostics(
+      query:,
+      search_results: opensearch_results,
+      notes_by_item_id: compressed_notes_by_item_id,
+    )
+  end
+
+  def note_evidence_diagnostics
+    diagnostics = compressed_note_selection.diagnostics.deep_dup
+    diagnostics[:status] = 'disabled' unless compressed_notes_enabled?
+    diagnostics[:selected_contexts] = diagnostics[:selected_contexts].map do |context|
+      context.merge(note_ref: compressed_note_ref(context[:context_hash]))
+    end
+    diagnostics
+  end
 
   def compressed_note_ref(compressed_note_key)
     @compressed_note_refs ||= {}
@@ -244,6 +263,16 @@ private
   end
 
   def parse_model_response(context, operation:)
+    Search::Instrumentation.note_evidence_evaluated(
+      request_id:,
+      query:,
+      effective_query: expanded_query,
+      iteration: attempt,
+      attempt_number: attempt,
+      operation:,
+      enabled: compressed_notes_enabled?,
+      diagnostics: note_evidence_diagnostics,
+    )
     response = Search::Instrumentation.api_call(
       request_id: request_id,
       model: configured_model,

--- a/app/services/search_diagnostics/request_log_lookup.rb
+++ b/app/services/search_diagnostics/request_log_lookup.rb
@@ -82,9 +82,11 @@ module SearchDiagnostics
     def event_from(row)
       raw_fields = row.to_h { |field| [field.field, field.value] }
       message = raw_fields['@message']
-      fields = parsed_message_fields(message)
+      message_fields = parsed_message_fields(message)
+      fields = message_fields
         .merge(raw_fields.except('@message', '@timestamp', '@ptr'))
         .compact_blank
+      fields['details'] = message_fields['details'] if message_fields['details'].is_a?(Hash) || message_fields['details'].is_a?(Array)
 
       Event.new(
         timestamp: raw_fields['@timestamp'] || fields['timestamp'],
@@ -113,7 +115,7 @@ module SearchDiagnostics
 
     def cloudwatch_query
       <<~QUERY
-        fields @timestamp, @message, event, request_id, search_type, trace_version, query, base_query, effective_query, original_query, expanded_query, refined_query, added_answers, reason, result_count, max_score, total_duration_ms, duration_ms, leg, status, retrieval_method, stage, iteration, match_source, matched_value, target_type, target_id, target_endpoint, goods_nomenclature_item_id, goods_nomenclature_sid, goods_nomenclature_class, model, response_type, attempt_number, question_count, logged_question_count, questions_truncated, answer_count, candidate_count, logged_candidate_count, candidates_truncated, ranked_answer_count, logged_ranked_answer_count, ranked_answers_truncated, confidence_levels, ranking_source, final_result_type, results_type, total_attempts, total_questions, result_limit, error_type, error_message, error_message_truncated, details, description_intercept_matched, description_intercept_term, description_intercept_excluded, description_intercept_filtering, description_intercept_filter_prefix_count, description_intercept_guidance_level, description_intercept_guidance_location, description_intercept_escalate_to_webchat, matched, term, excluded, filtering, filter_prefix_count, guidance_level, guidance_location, escalate_to_webchat
+        fields @timestamp, @message, event, request_id, search_type, trace_version, query, base_query, effective_query, original_query, expanded_query, refined_query, added_answers, reason, result_count, max_score, total_duration_ms, duration_ms, leg, status, retrieval_method, stage, iteration, match_source, matched_value, target_type, target_id, target_endpoint, goods_nomenclature_item_id, goods_nomenclature_sid, goods_nomenclature_class, model, response_type, attempt_number, question_count, logged_question_count, questions_truncated, answer_count, candidate_count, logged_candidate_count, candidates_truncated, ranked_answer_count, logged_ranked_answer_count, ranked_answers_truncated, confidence_levels, ranking_source, note_evidence_enabled, note_evidence_status, considered_note_count, considered_evidence_count, selected_note_count, selected_evidence_count, omitted_evidence_count, logged_omitted_evidence_count, omitted_evidence_truncated, final_result_type, results_type, total_attempts, total_questions, result_limit, error_type, error_message, error_message_truncated, details, description_intercept_matched, description_intercept_term, description_intercept_excluded, description_intercept_filtering, description_intercept_filter_prefix_count, description_intercept_guidance_level, description_intercept_guidance_location, description_intercept_escalate_to_webchat, matched, term, excluded, filtering, filter_prefix_count, guidance_level, guidance_location, escalate_to_webchat
         | filter service = "search" and request_id = #{request_id.to_json}
         | sort @timestamp asc
         | limit #{limit}

--- a/app/services/tariff_knowledge/relevant_note_fragment_selector.rb
+++ b/app/services/tariff_knowledge/relevant_note_fragment_selector.rb
@@ -77,7 +77,7 @@ module TariffKnowledge
       def logged
         ordered_reasons = reason_order.select { |reason| @samples.key?(reason) } + (@samples.keys - reason_order)
         queues = ordered_reasons.index_with { |reason| @samples[reason].dup }
-        entries = ordered_reasons.filter_map { |reason| queues[reason].shift }
+        entries = ordered_reasons.first(limit).filter_map { |reason| queues[reason].shift }
 
         ordered_reasons.cycle do |reason|
           break if entries.size >= limit || queues.values.all?(&:empty?)

--- a/app/services/tariff_knowledge/relevant_note_fragment_selector.rb
+++ b/app/services/tariff_knowledge/relevant_note_fragment_selector.rb
@@ -1,11 +1,17 @@
 module TariffKnowledge
   class RelevantNoteFragmentSelector
+    Selection = Data.define(:contexts, :diagnostics)
+
     # The classifier prompt needs source evidence, not complete compressed notes.
     # These caps keep one broad chapter/section note from dominating the prompt:
     # at most two fragments may come from one compressed note, and at most eight
     # fragments are emitted for the whole candidate set.
     MAX_FRAGMENTS_PER_NOTE = 2
     MAX_TOTAL_FRAGMENTS = 8
+    MAX_LOGGED_OMITTED_EVIDENCE = 20
+    MAX_LOGGED_FRAGMENT_NODE_KEYS = 20
+    DUPLICATE_OMISSION_REASONS = %w[duplicate_same_score duplicate_lower_score].freeze
+    OMISSION_REASON_ORDER = %w[below_minimum_score per_note_limit total_evidence_limit duplicate_same_score duplicate_lower_score].freeze
 
     # A fragment must show more than generic relevance before it is emitted.
     # For example, an exclusion fragment starts at 3 points, so it still needs
@@ -43,7 +49,50 @@ module TariffKnowledge
     ].freeze
     STOP_WORDS = %w[above an and are article articles as at be by chapter chapters code codes for from goods has have heading headings in into is it its kind made nomenclature of on or other purposes than that the this to use used with without].to_set.freeze
 
-    def self.call(...) = new(...).call
+    class << self
+      def call(...) = new(...).call.contexts
+
+      def call_with_diagnostics(...) = new(...).call
+    end
+
+    class OmissionCollector
+      attr_reader :count
+
+      def initialize(limit:, reason_order:)
+        @limit = limit
+        @reason_order = reason_order
+        @count = 0
+        @counts = Hash.new(0)
+        @samples = Hash.new { |hash, reason| hash[reason] = [] }
+      end
+
+      def add(reason)
+        @count += 1
+        @counts[reason] += 1
+        @samples[reason] << yield if @samples[reason].size < limit
+      end
+
+      def count_for(*reasons) = reasons.sum { |reason| @counts[reason] }
+
+      def logged
+        ordered_reasons = reason_order.select { |reason| @samples.key?(reason) } + (@samples.keys - reason_order)
+        queues = ordered_reasons.index_with { |reason| @samples[reason].dup }
+        entries = ordered_reasons.filter_map { |reason| queues[reason].shift }
+
+        ordered_reasons.cycle do |reason|
+          break if entries.size >= limit || queues.values.all?(&:empty?)
+
+          entry = queues[reason].shift
+          entries << entry if entry
+        end
+
+        entries
+      end
+
+    private
+
+      attr_reader :limit, :reason_order
+    end
 
     def initialize(query:, search_results:, notes_by_item_id:)
       @query = query.to_s
@@ -52,38 +101,127 @@ module TariffKnowledge
     end
 
     def call
+      @omissions = OmissionCollector.new(limit: MAX_LOGGED_OMITTED_EVIDENCE, reason_order: OMISSION_REASON_ORDER)
       contexts = notes_by_item_id.each_with_object({}) do |(item_id, note), grouped|
         group = grouped[note.context_hash] ||= { key: note.context_hash, commodity_codes: [], fragments: {} }
         group[:commodity_codes] << item_id
         scored_fragments(note).each do |fragment|
           current = group[:fragments][fragment[:key]]
-          group[:fragments][fragment[:key]] = fragment if current.nil? || fragment[:score] > current[:score]
+          if current.nil?
+            group[:fragments][fragment[:key]] = fragment
+          elsif fragment[:score] > current[:score]
+            record_omission(current, note.context_hash, 'duplicate_lower_score')
+            group[:fragments][fragment[:key]] = fragment
+          else
+            reason = fragment[:score] == current[:score] ? 'duplicate_same_score' : 'duplicate_lower_score'
+            record_omission(fragment, note.context_hash, reason)
+          end
         end
       end
 
-      cap_total_fragments(contexts.values.filter_map { |context| selected_context(context) })
+      build_selection(contexts.values)
     end
 
   private
 
-    attr_reader :query, :search_results, :notes_by_item_id
+    attr_reader :query, :search_results, :notes_by_item_id, :omissions
 
-    def selected_context(context)
-      fragments = context[:fragments].values.select { |fragment| fragment[:score] >= MIN_SCORE }
-        .sort_by { |fragment| [-fragment[:score], fragment[:source].to_s, fragment[:key].to_s] }.first(MAX_FRAGMENTS_PER_NOTE)
-        .map { |fragment| fragment.except(:key) }
-      { key: context[:key], commodity_codes: context[:commodity_codes].uniq, fragments: } if fragments.any?
+    def build_selection(grouped_contexts)
+      eligible_contexts = []
+
+      grouped_contexts.each do |context|
+        ranked = context[:fragments].values.sort_by { |fragment| [-fragment[:score], fragment[:source].to_s, fragment[:key].to_s] }
+        below_minimum, eligible = ranked.partition { |fragment| fragment[:score] < MIN_SCORE }
+        selected_for_note = eligible.first(MAX_FRAGMENTS_PER_NOTE)
+
+        below_minimum.each { |fragment| record_omission(fragment, context[:key], 'below_minimum_score') }
+        eligible.drop(MAX_FRAGMENTS_PER_NOTE).each { |fragment| record_omission(fragment, context[:key], 'per_note_limit') }
+        eligible_contexts << context.merge(selected: selected_for_note) if selected_for_note.any?
+      end
+
+      contexts, selected_diagnostics = apply_total_limit(eligible_contexts)
+      logged_omitted = omissions.logged
+
+      Selection.new(
+        contexts:,
+        diagnostics: {
+          status: selection_status(grouped_contexts, contexts),
+          considered_note_count: grouped_contexts.size,
+          considered_evidence_count: grouped_contexts.sum { |context| context[:fragments].size } + omissions.count_for(*DUPLICATE_OMISSION_REASONS),
+          selected_note_count: contexts.size,
+          selected_evidence_count: contexts.sum { |context| context[:fragments].size },
+          omitted_evidence_count: omissions.count,
+          logged_omitted_evidence_count: logged_omitted.size,
+          omitted_evidence_truncated: logged_omitted.size < omissions.count,
+          limits: {
+            minimum_score: MIN_SCORE,
+            per_note: MAX_FRAGMENTS_PER_NOTE,
+            total: MAX_TOTAL_FRAGMENTS,
+          },
+          selected_contexts: selected_diagnostics,
+          omitted_evidence: logged_omitted,
+        },
+      )
     end
 
-    def cap_total_fragments(contexts)
+    def apply_total_limit(contexts)
       remaining = MAX_TOTAL_FRAGMENTS
+      prompt_contexts = []
+      diagnostic_contexts = []
+
       contexts
-        .sort_by { |context| [-context[:fragments].first[:score], context[:key].to_s] }
-        .filter_map do |context|
-          fragments = context[:fragments].first(remaining)
-          remaining -= fragments.size
-          context.merge(fragments:) if fragments.any?
+        .sort_by { |context| [-context[:selected].first[:score], context[:key].to_s] }
+        .each do |context|
+          selected = context[:selected].first(remaining)
+          context[:selected].drop(remaining).each { |fragment| record_omission(fragment, context[:key], 'total_evidence_limit') }
+          remaining -= selected.size
+          next if selected.empty?
+
+          commodity_codes = context[:commodity_codes].uniq
+          prompt_contexts << {
+            key: context[:key],
+            commodity_codes:,
+            fragments: selected.map { |fragment| prompt_fragment(fragment) },
+          }
+          diagnostic_contexts << {
+            context_hash: context[:key],
+            commodity_codes:,
+            evidence: selected.map { |fragment| selected_evidence(fragment, context[:key]) },
+          }
         end
+
+      [prompt_contexts, diagnostic_contexts]
+    end
+
+    def selection_status(grouped_contexts, contexts)
+      return 'no_compressed_notes' if grouped_contexts.empty?
+      return 'selected' if contexts.any?
+
+      'no_eligible_evidence'
+    end
+
+    def record_omission(fragment, context_hash, reason)
+      omissions.add(reason) { omitted_evidence(fragment, context_hash, reason) }
+    end
+
+    def prompt_fragment(fragment)
+      fragment.slice(:source, :source_ref, :type, :text, :score, :why_relevant)
+    end
+
+    def selected_evidence(fragment, context_hash)
+      diagnostic_evidence(fragment, context_hash).merge(decision: 'selected')
+    end
+
+    def omitted_evidence(fragment, context_hash, reason)
+      diagnostic_evidence(fragment, context_hash).merge(decision: 'omitted', omission_reason: reason)
+    end
+
+    def diagnostic_evidence(fragment, context_hash)
+      fragment.except(:key, :why_relevant).merge(
+        context_hash:,
+        source_node_key: fragment[:key],
+        score_reasons: fragment[:score_reasons],
+      )
     end
 
     def scored_fragments(note)
@@ -98,11 +236,19 @@ module TariffKnowledge
         score, reasons = score_block(evidence_block, source_text)
         {
           key: evidence_block['source_node_key'],
+          evidence_kind: 'note_block',
           source: evidence_block['source_title'],
           source_ref: source_reference(evidence_block),
+          source_type: evidence_block['source_type'],
+          source_id: evidence_block['source_id'],
+          source_version: evidence_block['source_version'],
           type: evidence_block['block_type'],
+          fragment_node_keys: Array(evidence_block['fragment_node_keys']).first(MAX_LOGGED_FRAGMENT_NODE_KEYS),
+          fragment_node_keys_truncated: Array(evidence_block['fragment_node_keys']).size > MAX_LOGGED_FRAGMENT_NODE_KEYS,
+          graph_paths: [%w[contains contains applies_to]],
           text: source_text.truncate(MAX_FRAGMENT_CHARS, omission: '...'),
           score:,
+          score_reasons: reasons,
           why_relevant: reasons.join('; '),
         }
       end
@@ -119,14 +265,33 @@ module TariffKnowledge
         score, reasons = score_fragment(evidence_record, text)
         {
           key: evidence_record['source_node_key'],
+          evidence_kind: 'note_fragment',
           source: evidence_record['source_title'] || fragment_node&.title,
           source_ref: source_reference(evidence_record),
+          source_type: evidence_record['source_type'],
+          source_id: evidence_record['source_id'],
+          source_version: evidence_record['source_version'],
+          parent_source_node_key: evidence_record['parent_source_node_key'],
+          parent_source_title: evidence_record['parent_source_title'],
           type: evidence_record['context_type'],
+          range_node_key: evidence_record['range_node_key'],
+          range_type: evidence_record['range_type'],
+          range_code: evidence_record['range_code'],
+          graph_paths: fragment_graph_paths(evidence_record),
           text: text.truncate(MAX_FRAGMENT_CHARS, omission: '...'),
           score:,
+          score_reasons: reasons,
           why_relevant: reasons.join('; '),
         }
       end
+    end
+
+    def fragment_graph_paths(evidence_record)
+      paths = []
+      relationships = Array(evidence_record['relationships'])
+      paths << %w[contains applies_to] if relationships.include?(Edge::APPLIES_TO)
+      paths << %w[contains references expands_to] if evidence_record['range_node_key'].present? || evidence_record['range_type'].present?
+      paths.presence || [%w[contains applies_to]]
     end
 
     def fragment_node_for(evidence_record)

--- a/spec/lib/search/instrumentation_spec.rb
+++ b/spec/lib/search/instrumentation_spec.rb
@@ -959,6 +959,54 @@ RSpec.describe Search::Instrumentation do
     end
   end
 
+  describe '.note_evidence_evaluated' do
+    it 'instruments bounded note evidence diagnostics' do
+      allow(ActiveSupport::Notifications).to receive(:instrument)
+      diagnostics = {
+        status: 'selected',
+        considered_note_count: 2,
+        considered_evidence_count: 5,
+        selected_note_count: 1,
+        selected_evidence_count: 2,
+        omitted_evidence_count: 3,
+        logged_omitted_evidence_count: 3,
+        omitted_evidence_truncated: false,
+        selected_contexts: [{ context_hash: 'hash-1' }],
+      }
+
+      described_class.note_evidence_evaluated(
+        request_id: 'req-1',
+        query: 'pig iron',
+        effective_query: 'pig iron primary forms',
+        iteration: 2,
+        attempt_number: 2,
+        operation: 'duplicate_question_retry',
+        enabled: true,
+        diagnostics:,
+      )
+
+      expect(ActiveSupport::Notifications).to have_received(:instrument).with(
+        'note_evidence_evaluated.search',
+        hash_including(
+          request_id: 'req-1',
+          search_type: 'interactive',
+          attempt_number: 2,
+          operation: 'duplicate_question_retry',
+          note_evidence_enabled: true,
+          note_evidence_status: 'selected',
+          considered_note_count: 2,
+          considered_evidence_count: 5,
+          selected_note_count: 1,
+          selected_evidence_count: 2,
+          omitted_evidence_count: 3,
+          logged_omitted_evidence_count: 3,
+          omitted_evidence_truncated: false,
+          details: diagnostics,
+        ),
+      )
+    end
+  end
+
   describe '.search_failed' do
     it 'instruments the search_failed event' do
       allow(ActiveSupport::Notifications).to receive(:instrument)

--- a/spec/lib/search/logger_spec.rb
+++ b/spec/lib/search/logger_spec.rb
@@ -286,6 +286,55 @@ RSpec.describe Search::Logger do
     end
   end
 
+  describe '#note_evidence_evaluated' do
+    let(:payload) do
+      {
+        request_id: 'req-1',
+        search_type: 'interactive',
+        query: 'pig iron',
+        effective_query: 'pig iron primary forms',
+        iteration: 2,
+        attempt_number: 2,
+        operation: 'duplicate_question_retry',
+        note_evidence_enabled: true,
+        note_evidence_status: 'selected',
+        considered_note_count: 2,
+        considered_evidence_count: 5,
+        selected_note_count: 1,
+        selected_evidence_count: 2,
+        omitted_evidence_count: 3,
+        logged_omitted_evidence_count: 3,
+        omitted_evidence_truncated: false,
+        details: { selected_contexts: [{ context_hash: 'hash-1' }] },
+      }
+    end
+
+    it_behaves_like 'a search log entry', :note_evidence_evaluated, 'note_evidence_evaluated',
+                    { request_id: 'req-1', note_evidence_status: 'selected' }
+
+    it 'logs the selection counts and nested evidence' do
+      logger_instance.note_evidence_evaluated(build_event('note_evidence_evaluated', payload))
+      json = parsed_log_output
+
+      expect(json).to include(
+        'event' => 'note_evidence_evaluated',
+        'request_id' => 'req-1',
+        'attempt_number' => 2,
+        'operation' => 'duplicate_question_retry',
+        'note_evidence_enabled' => true,
+        'note_evidence_status' => 'selected',
+        'considered_note_count' => 2,
+        'considered_evidence_count' => 5,
+        'selected_note_count' => 1,
+        'selected_evidence_count' => 2,
+        'omitted_evidence_count' => 3,
+        'logged_omitted_evidence_count' => 3,
+        'omitted_evidence_truncated' => false,
+      )
+      expect(json.dig('details', 'selected_contexts')).to eq([{ 'context_hash' => 'hash-1' }])
+    end
+  end
+
   describe '#duplicate_question_guard_checked' do
     let(:payload) do
       {

--- a/spec/requests/api/admin/search_diagnostics_controller_spec.rb
+++ b/spec/requests/api/admin/search_diagnostics_controller_spec.rb
@@ -19,12 +19,53 @@ RSpec.describe Api::Admin::SearchDiagnosticsController do
               'query' => 'horse',
             },
           ),
+          SearchDiagnostics::RequestLogLookup::Event.new(
+            timestamp: '2026-06-05 09:59:01.000',
+            event: 'note_evidence_evaluated',
+            search_type: 'interactive',
+            message: '{"event":"note_evidence_evaluated"}',
+            fields: {
+              'event' => 'note_evidence_evaluated',
+              'request_id' => 'request-123',
+              'search_type' => 'interactive',
+              'note_evidence_status' => 'selected',
+              'details' => {
+                'selected_contexts' => [
+                  {
+                    'context_hash' => 'hash-1',
+                    'note_ref' => 'compressed_note_1',
+                    'evidence' => [{ 'source_node_key' => 'note_block:chapter:72:1:a' }],
+                  },
+                ],
+              },
+            },
+          ),
         ],
       )
     end
 
     before do
       allow(SearchDiagnostics::RequestLogLookup).to receive(:call).and_return(diagnostic)
+    end
+
+    it 'returns nested note evidence diagnostics unchanged' do
+      get '/uk/admin/search_diagnostics/request-123.json', headers: request_headers(format: :json)
+
+      note_event = response.parsed_body.dig('data', 'attributes', 'events').find do |event|
+        event['event'] == 'note_evidence_evaluated'
+      end
+      expect(note_event['fields']).to include(
+        'note_evidence_status' => 'selected',
+        'details' => {
+          'selected_contexts' => [
+            {
+              'context_hash' => 'hash-1',
+              'note_ref' => 'compressed_note_1',
+              'evidence' => [{ 'source_node_key' => 'note_block:chapter:72:1:a' }],
+            },
+          ],
+        },
+      )
     end
 
     it 'returns search diagnostics for the request id' do

--- a/spec/services/interactive_search_service_spec.rb
+++ b/spec/services/interactive_search_service_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe InteractiveSearchService do
     allow(Search::Instrumentation).to receive(:question_returned)
     allow(Search::Instrumentation).to receive(:answer_returned)
     allow(Search::Instrumentation).to receive(:duplicate_question_guard_checked)
+    allow(Search::Instrumentation).to receive(:note_evidence_evaluated)
     allow(Search::Instrumentation).to receive(:search_failed)
     create(:admin_configuration, :boolean, name: 'interactive_search_enabled', value: true, area: 'classification')
     create(:admin_configuration, :integer, name: 'interactive_search_max_questions', value: 3, area: 'classification')
@@ -291,6 +292,14 @@ RSpec.describe InteractiveSearchService do
           iteration: 4,
           effective_query: expanded_query,
           operation: 'duplicate_question_retry',
+        )
+        expect(Search::Instrumentation).to have_received(:note_evidence_evaluated).with(
+          hash_including(
+            request_id: request_id,
+            iteration: 4,
+            attempt_number: 4,
+            operation: 'duplicate_question_retry',
+          ),
         )
       end
 
@@ -548,6 +557,26 @@ RSpec.describe InteractiveSearchService do
       expect(context_arg).to include('OpenSearch results:')
     end
 
+    it 'records that note evidence was disabled for the prompt' do
+      result
+
+      expect(Search::Instrumentation).to have_received(:note_evidence_evaluated).with(
+        request_id: 'test-request-123',
+        query: 'leather handbag',
+        effective_query: 'leather handbag travel bag accessory',
+        iteration: 1,
+        attempt_number: 1,
+        operation: 'interactive_search',
+        enabled: false,
+        diagnostics: include(
+          status: 'disabled',
+          considered_note_count: 0,
+          selected_note_count: 0,
+          selected_contexts: [],
+        ),
+      )
+    end
+
     context 'when the configured prompt wraps compressed notes in marker lines' do
       let(:default_search_context) do
         <<~CONTEXT
@@ -787,6 +816,40 @@ RSpec.describe InteractiveSearchService do
         expect(context_arg).not_to include('Historic heading 4202 evidence should not be used.')
         expect(context_arg).not_to include('Rejected notes should not be consumed.')
         expect(context_arg.scan('Heading 4202 includes handbags with outer surface of leather.').size).to eq(1)
+      end
+
+      it 'records the exact selected prompt evidence for the request iteration' do
+        result
+
+        expect(Search::Instrumentation).to have_received(:note_evidence_evaluated).with(
+          request_id: 'test-request-123',
+          query: 'leather handbag',
+          effective_query: 'leather handbag travel bag accessory',
+          iteration: 1,
+          attempt_number: 1,
+          operation: 'interactive_search',
+          enabled: true,
+          diagnostics: include(
+            status: 'selected',
+            selected_note_count: 1,
+            selected_evidence_count: 1,
+            selected_contexts: contain_exactly(
+              include(
+                context_hash: Digest::SHA256.hexdigest('Includes handbags with outer surface of leather. Excludes plastic sheeting.'),
+                note_ref: 'compressed_note_1',
+                commodity_codes: contain_exactly('4202210000', '4202290000'),
+                evidence: contain_exactly(
+                  include(
+                    evidence_kind: 'note_fragment',
+                    source_node_key: 'note_fragment:customs_tariff_chapter_note:1.31:42:0001',
+                    text: 'Heading 4202 includes handbags with outer surface of leather.',
+                    decision: 'selected',
+                  ),
+                ),
+              ),
+            ),
+          ),
+        )
       end
 
       context 'when the configured prompt has no compressed notes placeholder' do

--- a/spec/services/search_diagnostics/request_log_lookup_spec.rb
+++ b/spec/services/search_diagnostics/request_log_lookup_spec.rb
@@ -50,6 +50,32 @@ RSpec.describe SearchDiagnostics::RequestLogLookup do
           result_field('search_type', 'interactive'),
           result_field('result_count', '1'),
         ],
+        [
+          result_field('@timestamp', '2026-06-05 09:59:01.500'),
+          result_field('@message', {
+            service: 'search',
+            event: 'note_evidence_evaluated',
+            request_id:,
+            search_type: 'interactive',
+            query: 'pig iron',
+            iteration: 1,
+            note_evidence_status: 'selected',
+            details: {
+              selected_contexts: [
+                {
+                  context_hash: 'hash-1',
+                  note_ref: 'compressed_note_1',
+                  evidence: [{ source_node_key: 'note_block:chapter:72:1:a', score: 35 }],
+                },
+              ],
+            },
+          }.to_json),
+          result_field('event', 'note_evidence_evaluated'),
+          result_field('request_id', request_id),
+          result_field('search_type', 'interactive'),
+          result_field('note_evidence_status', 'selected'),
+          result_field('details', '{"selected_contexts":"projected-string-must-not-win"}'),
+        ],
       ],
     )
   end
@@ -82,6 +108,15 @@ RSpec.describe SearchDiagnostics::RequestLogLookup do
             'logged_ranked_answer_count',
             'ranked_answers_truncated',
             'ranking_source',
+            'note_evidence_enabled',
+            'note_evidence_status',
+            'considered_note_count',
+            'considered_evidence_count',
+            'selected_note_count',
+            'selected_evidence_count',
+            'omitted_evidence_count',
+            'logged_omitted_evidence_count',
+            'omitted_evidence_truncated',
             'filter service = "search"',
             'request_id = "request-123"',
             "limit #{described_class::DEFAULT_LIMIT}",
@@ -109,8 +144,25 @@ RSpec.describe SearchDiagnostics::RequestLogLookup do
     it 'returns classic and internal search events scoped by the same request id key' do
       events = lookup.call.events
 
-      expect(events.map(&:search_type)).to eq(%w[classic interactive])
+      expect(events.map(&:search_type)).to eq(%w[classic interactive interactive])
       expect(events.map { |event| event.fields['request_id'] }).to all(eq(request_id))
+    end
+
+    it 'preserves nested note evidence from the structured log message' do
+      event = lookup.call.events.find { |candidate| candidate.event == 'note_evidence_evaluated' }
+
+      expect(event.fields).to include(
+        'note_evidence_status' => 'selected',
+        'details' => {
+          'selected_contexts' => [
+            {
+              'context_hash' => 'hash-1',
+              'note_ref' => 'compressed_note_1',
+              'evidence' => [{ 'source_node_key' => 'note_block:chapter:72:1:a', 'score' => 35 }],
+            },
+          ],
+        },
+      )
     end
 
     context 'when CloudWatch is still running the query' do

--- a/spec/services/tariff_knowledge/relevant_note_fragment_selector_spec.rb
+++ b/spec/services/tariff_knowledge/relevant_note_fragment_selector_spec.rb
@@ -259,6 +259,22 @@ RSpec.describe TariffKnowledge::RelevantNoteFragmentSelector do
     )
   end
 
+  it 'bounds omitted evidence when distinct omission reasons exceed the limit' do
+    collector = described_class::OmissionCollector.new(
+      limit: 2,
+      reason_order: %w[first second third],
+    )
+
+    %w[first second third].each do |reason|
+      collector.add(reason) { { omission_reason: reason } }
+    end
+
+    expect(collector.logged).to eq([
+      { omission_reason: 'first' },
+      { omission_reason: 'second' },
+    ])
+  end
+
   it 'prefers exact query definition blocks over generic chapter exclusions' do
     pig_iron_note = create(
       :tariff_knowledge_compressed_note,

--- a/spec/services/tariff_knowledge/relevant_note_fragment_selector_spec.rb
+++ b/spec/services/tariff_knowledge/relevant_note_fragment_selector_spec.rb
@@ -77,6 +77,188 @@ RSpec.describe TariffKnowledge::RelevantNoteFragmentSelector do
     expect(fragment_texts).not_to include(a_string_including('candles'))
   end
 
+  it 'explains selected and omitted evidence without changing the prompt contexts' do
+    selection = described_class.call_with_diagnostics(
+      query:,
+      search_results:,
+      notes_by_item_id: { '9506911000' => note },
+    )
+
+    expect(selection.contexts).to eq(
+      described_class.call(
+        query:,
+        search_results:,
+        notes_by_item_id: { '9506911000' => note },
+      ),
+    )
+    expect(selection.diagnostics).to include(
+      status: 'selected',
+      considered_note_count: 1,
+      considered_evidence_count: 3,
+      selected_note_count: 1,
+      selected_evidence_count: 2,
+      omitted_evidence_count: 1,
+      omitted_evidence_truncated: false,
+      limits: {
+        minimum_score: described_class::MIN_SCORE,
+        per_note: described_class::MAX_FRAGMENTS_PER_NOTE,
+        total: described_class::MAX_TOTAL_FRAGMENTS,
+      },
+    )
+
+    selected = selection.diagnostics[:selected_contexts].first
+    expect(selected).to include(
+      context_hash: context_hash,
+      commodity_codes: %w[9506911000],
+    )
+    expect(selected[:evidence]).to all(include(
+                                         :source_node_key,
+                                         :source_type,
+                                         :source_id,
+                                         :source_version,
+                                         :score,
+                                         :score_reasons,
+                                         :graph_paths,
+                                         decision: 'selected',
+                                       ))
+    expect(selected[:evidence].pluck(:text)).to contain_exactly(
+      a_string_including('sports footwear'),
+      a_string_including('general physical exercise'),
+    )
+
+    omitted = selection.diagnostics[:omitted_evidence].sole
+    expect(omitted).to include(
+      context_hash: context_hash,
+      source_node_key: 'note_fragment:customs_tariff_chapter_note:1.31:95:0002',
+      decision: 'omitted',
+      omission_reason: 'below_minimum_score',
+    )
+  end
+
+  it 'distinguishes absent compressed notes from ineligible evidence' do
+    absent = described_class.call_with_diagnostics(
+      query:,
+      search_results:,
+      notes_by_item_id: {},
+    )
+    ineligible = described_class.call_with_diagnostics(
+      query:,
+      search_results:,
+      notes_by_item_id: { '9506911000' => create_note_with_evidence('9506911000', evidence_for('note_fragment:customs_tariff_chapter_note:1.31:95:0999', 'Candles only.', 'reference')) },
+    )
+
+    expect(absent.diagnostics[:status]).to eq('no_compressed_notes')
+    expect(ineligible.diagnostics[:status]).to eq('no_eligible_evidence')
+  end
+
+  it 'reports equal-score context duplicates accurately' do
+    shared_evidence = evidence_for(
+      'note_fragment:customs_tariff_chapter_note:1.31:95:0032',
+      'Heading 9506 includes articles and equipment for general physical exercise',
+      'inclusion',
+      range_type: 'heading',
+      range_code: '9506',
+    )
+    first_note = create_note_with_evidence('9506911000', shared_evidence)
+    second_note = create_note_with_evidence('6403999110', shared_evidence).tap do |duplicate|
+      duplicate.update(context_hash: first_note.context_hash)
+    end
+
+    selection = described_class.call_with_diagnostics(
+      query:,
+      search_results:,
+      notes_by_item_id: { '9506911000' => first_note, '6403999110' => second_note },
+    )
+
+    expect(selection.diagnostics[:omitted_evidence]).to include(
+      include(
+        source_node_key: shared_evidence['source_node_key'],
+        omission_reason: 'duplicate_same_score',
+      ),
+    )
+  end
+
+  it 'bounds block fragment keys in diagnostics' do
+    block_note = create(
+      :tariff_knowledge_compressed_note,
+      goods_nomenclature_item_id: '7201200000',
+      content: 'compressed note bounded block keys',
+      metadata: Sequel.pg_jsonb_wrap(
+        'evidence_blocks' => [
+          {
+            'source_node_key' => 'note_block:customs_tariff_chapter_note:1.31:72:1:a',
+            'source_title' => 'pig iron',
+            'source_context' => 'pig iron means iron-carbon alloys containing more than 2% carbon.',
+            'block_type' => 'definition',
+            'term' => 'pig iron',
+            'source_type' => 'customs_tariff_chapter_note',
+            'source_id' => '72',
+            'source_version' => '1.31',
+            'fragment_node_keys' => Array.new(25) { |index| "fragment-#{index}" },
+          },
+        ],
+      ),
+    )
+
+    selection = described_class.call_with_diagnostics(
+      query: 'pig iron',
+      search_results: [
+        search_result_class.new(
+          goods_nomenclature_item_id: '7201200000',
+          description: 'Non-alloy pig iron',
+          full_description: nil,
+          score: 10,
+        ),
+      ],
+      notes_by_item_id: { '7201200000' => block_note },
+    )
+    evidence = selection.diagnostics.dig(:selected_contexts, 0, :evidence, 0)
+
+    expect(evidence[:fragment_node_keys].size).to eq(described_class::MAX_LOGGED_FRAGMENT_NODE_KEYS)
+    expect(evidence[:fragment_node_keys_truncated]).to be(true)
+  end
+
+  it 'bounds omitted evidence while retaining samples from each omission reason' do
+    below_minimum = Array.new(25) do |index|
+      evidence_for(
+        "note_fragment:customs_tariff_chapter_note:1.31:95:low#{index}",
+        "Candles only #{index}.",
+        'reference',
+      )
+    end
+    eligible = Array.new(3) do |index|
+      evidence_for(
+        "note_fragment:customs_tariff_chapter_note:1.31:95:eligible#{index}",
+        "Heading 9506 includes exercise articles #{index}.",
+        'inclusion',
+        range_type: 'heading',
+        range_code: '9506',
+      )
+    end
+    note = create(
+      :tariff_knowledge_compressed_note,
+      goods_nomenclature_item_id: '9506911000',
+      content: 'compressed note with many omissions',
+      metadata: Sequel.pg_jsonb_wrap('evidence' => below_minimum + eligible),
+    )
+
+    selection = described_class.call_with_diagnostics(
+      query:,
+      search_results:,
+      notes_by_item_id: { '9506911000' => note },
+    )
+
+    expect(selection.diagnostics).to include(
+      omitted_evidence_count: 26,
+      logged_omitted_evidence_count: described_class::MAX_LOGGED_OMITTED_EVIDENCE,
+      omitted_evidence_truncated: true,
+    )
+    expect(selection.diagnostics[:omitted_evidence].pluck(:omission_reason)).to include(
+      'below_minimum_score',
+      'per_note_limit',
+    )
+  end
+
   it 'prefers exact query definition blocks over generic chapter exclusions' do
     pig_iron_note = create(
       :tariff_knowledge_compressed_note,
@@ -556,8 +738,8 @@ RSpec.describe TariffKnowledge::RelevantNoteFragmentSelector do
     expect(contexts.first[:fragments].first[:source_ref]).to eq('chapter 95 note')
   end
 
-  it 'caps total emitted fragments across all selected notes' do
-    contexts = described_class.call(
+  it 'caps total emitted fragments across all selected notes and explains the omissions' do
+    selection = described_class.call_with_diagnostics(
       query: 'plastic exercise article',
       search_results: Array.new(5) do |index|
         search_result_class.new(
@@ -573,7 +755,8 @@ RSpec.describe TariffKnowledge::RelevantNoteFragmentSelector do
       end,
     )
 
-    expect(contexts.sum { |context| context[:fragments].size }).to eq(described_class::MAX_TOTAL_FRAGMENTS)
+    expect(selection.contexts.sum { |context| context[:fragments].size }).to eq(described_class::MAX_TOTAL_FRAGMENTS)
+    expect(selection.diagnostics[:omitted_evidence]).to include(include(omission_reason: 'total_evidence_limit'))
   end
 
   it 'applies the global fragment cap to the highest scoring notes first' do


### PR DESCRIPTION
## What:

- add bounded, explainable diagnostics for compressed note block and fragment selection before each classifier prompt
- preserve nested evidence through the request-ID CloudWatch query endpoint
- correlate evidence with iteration, attempt number and model-call operation
- distinguish disabled, absent, ineligible and selected evidence states

```mermaid
flowchart LR
  A[Retrieved commodity candidates] --> B[Compressed note selector]
  B --> C[Classifier prompt]
  B --> D[note_evidence_evaluated]
  D --> E[Structured search log]
  E --> F[Request ID diagnostics endpoint]
```

### Verification

- [x] Full RSpec suite: 9,060 examples, 0 failures, 2 expected pending
- [x] Targeted RuboCop: 12 files, no offences
- [x] Zeitwerk check: All is good
- [x] Independent review: no remaining Critical, Important or Minor findings

## Why:

Operators can currently see the search journey but cannot prove which chapter/section note block or fragment reached a particular LLM prompt, why it scored, or why competing evidence was omitted. This adds bounded observability without changing the selected prompt content.

## Ticket:

[AI-1061](https://transformuk.atlassian.net/browse/AI-1061)

## Risk:
**Risk level:** 🟢

**Reason for rating:**
This is additive, currently unused diagnostic functionality. It does not change search retrieval, note selection, classifier prompt content, or an active production user journey. Payloads are bounded and the consuming admin UI is introduced separately.

───────────────────────────────────────────────────

Rate the overall risk of deploying this change:

🟢 Green  – Low risk. Good to go, standard review applies.

🟠 Amber  – Medium risk. Socialise with the team before merging.

🔴 Red    – High risk. Requires explicit approval from Thor or Neil before merging.
