### PR TITLE
fix(logging): keep CloudWatch JSON fields queryable

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,7 +13,6 @@ class ApplicationController < ActionController::API
 
   before_action :set_trade_tariff_request_id
   before_action :maintenance_mode_if_active
-  around_action :tag_logs_with_client_id
   around_action :configure_time_machine
   around_action :apply_jsonapi_query_options
   after_action  :check_query_count, if: -> { TradeTariffBackend.check_query_count? }
@@ -124,10 +123,6 @@ private
 
   def v2_api_controller?
     self.class.name.start_with?('Api::V2::')
-  end
-
-  def tag_logs_with_client_id(&block)
-    Rails.logger.tagged(TradeTariffRequest.client_id || 'anonymous', &block)
   end
 
   def set_trade_tariff_request_id

--- a/app/lib/search/logger.rb
+++ b/app/lib/search/logger.rb
@@ -297,6 +297,8 @@ module Search
         timestamp: Time.current.iso8601,
       )
       entry[:request_source] = event.payload[:request_source] if event.payload[:request_source].present?
+      client_id = event.payload[:client_id].presence || TradeTariffRequest.client_id.presence
+      entry[:client_id] = client_id if client_id
       entry.to_json
     end
 

--- a/config/environments/production_environment_config.rb
+++ b/config/environments/production_environment_config.rb
@@ -26,7 +26,7 @@ module ProductionEnvironmentConfig
     end
 
     def configure_logging(config)
-      config.logger = ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new($stdout))
+      config.logger = ActiveSupport::Logger.new($stdout)
       config.lograge.enabled = true
       config.lograge.formatter = Lograge::Formatters::Logstash.new
       config.lograge.custom_options = lograge_custom_options
@@ -35,7 +35,6 @@ module ProductionEnvironmentConfig
         HealthcheckController#checkz
       ]
       config.silence_healthcheck_path = '/healthcheckz'
-      config.log_tags = [:request_id]
       config.log_level = ENV.fetch('RAILS_LOG_LEVEL', 'info')
       config.active_support.deprecation = :notify
     end

--- a/spec/config/environments/production_environment_config_spec.rb
+++ b/spec/config/environments/production_environment_config_spec.rb
@@ -71,6 +71,16 @@ RSpec.describe ProductionEnvironmentConfig do
     end
   end
 
+  describe '.configure_logging' do
+    it 'configures an untagged logger so JSON fields remain queryable' do
+      described_class.configure_logging(config)
+
+      expect(config.logger).to be_a(ActiveSupport::Logger)
+      expect(config.logger).not_to be_a(ActiveSupport::TaggedLogging)
+      expect(config.log_tags).to be_nil
+    end
+  end
+
   describe '.truncate_lograge_exception_message' do
     subject(:truncate) { described_class.truncate_lograge_exception_message }
 

--- a/spec/lib/search/logger_spec.rb
+++ b/spec/lib/search/logger_spec.rb
@@ -42,6 +42,15 @@ RSpec.describe Search::Logger do
     ensure
       TradeTariffRequest.request_source = nil
     end
+
+    it 'includes client ID as a structured field' do
+      TradeTariffRequest.client_id = 'api-client'
+      logger_instance.public_send(method_name, build_event(event_name, payload))
+      json = parsed_log_output
+      expect(json['client_id']).to eq('api-client')
+    ensure
+      TradeTariffRequest.client_id = nil
+    end
   end
 
   describe '#search_started' do

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -225,39 +225,5 @@ RSpec.describe ApplicationController, type: :request do
         expect(payload[:client_id]).to eq('jwt-client')
       end
     end
-
-    context 'with logger tagging' do
-      def jwt_with_claims(claims)
-        payload = Base64.urlsafe_encode64(claims.to_json, padding: false)
-        "header.#{payload}.signature"
-      end
-
-      it 'tags log output with client_id from the Bearer JWT' do
-        token = jwt_with_claims('client_id' => 'tagged-client')
-        tagged_with = nil
-
-        allow(Rails.logger).to receive(:tagged) do |tag, &block|
-          tagged_with = tag
-          block.call
-        end
-
-        api_get('/uk/api/healthcheck', headers: { 'Authorization' => "Bearer #{token}" })
-
-        expect(tagged_with).to eq('tagged-client')
-      end
-
-      it 'tags log output with "anonymous" when no token is present' do
-        tagged_with = nil
-
-        allow(Rails.logger).to receive(:tagged) do |tag, &block|
-          tagged_with = tag
-          block.call
-        end
-
-        api_get('/uk/api/healthcheck')
-
-        expect(tagged_with).to eq('anonymous')
-      end
-    end
   end
 end


### PR DESCRIPTION
## What:
- remove Rails request/client tag prefixes from production log output
- keep `request_id` and `client_id` in structured Lograge request records
- add `client_id` to structured search diagnostic records

## Why:
Tagged logging prefixes JSON with opaque text such as `[request-id] [client-id]`. CloudWatch Logs Insights therefore cannot discover or query the JSON `request_id`, `service`, or event fields, which breaks the search diagnostics endpoint.

Client attribution remains available as a queryable structured field in both HTTP request logs and search logs.

Verification:
- 1,396 request specs, 0 failures
- 95 focused logging/search specs, 0 failures
- RuboCop on changed files, no offences

## Ticket:
[AI-1061](https://transformuk.atlassian.net/browse/AI-1061)

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Low risk. This repairs currently unusable CloudWatch field discovery and only changes log formatting/metadata; it does not alter API responses or search behaviour.