### PR TITLE
test(self-texts): characterize EU reference import

### DIFF
--- a/spec/lib/tasks/self_texts_rake_spec.rb
+++ b/spec/lib/tasks/self_texts_rake_spec.rb
@@ -7,11 +7,16 @@ RSpec.describe 'self_texts rake tasks' do
       suppress_output { Rake::Task['self_texts:populate_eu_references'].invoke }
     end
 
-    after { Rake::Task['self_texts:populate_eu_references'].reenable }
+    after do
+      Rake::Task['self_texts:populate_eu_references'].reenable
+      FileUtils.rm_f(csv_path)
+    end
 
     let(:csv_path) { Rails.root.join('tmp/test_self_texts.csv') }
+    let(:stored_embedding) { Sequel.lit("'[#{Array.new(1536, 0.1).join(',')}]'::vector") }
 
     before do
+      FileUtils.rm_f(csv_path)
       stub_const('SelfTextLookupService::DEFAULT_CSV_PATH', csv_path)
       # Override the hardcoded CSV path in the rake task by stubbing Rails.root.join
       allow(Rails.root).to receive(:join)
@@ -48,6 +53,52 @@ RSpec.describe 'self_texts rake tasks' do
       end
     end
 
+    context 'when an existing EU reference differs' do
+      before do
+        CSV.open(csv_path, 'w', headers: true) do |csv|
+          csv << %w[CNKEY CN_CODE NAME_EN SelfText_EN NAME_DE SelfText_DE NAME_FR SelfText_FR]
+          csv << ['010121000080', '0101 21 00', 'Pure-bred', 'Updated EU reference', '', '', '', '']
+        end
+      end
+
+      it 'updates the reference, clears its embedding, and records an update version' do
+        record = create(:goods_nomenclature_self_text,
+                        goods_nomenclature_item_id: '0101210000',
+                        eu_self_text: 'Old EU reference',
+                        eu_embedding: stored_embedding)
+        version_count = record.versions.count
+
+        populate
+
+        expect(record.reload).to have_attributes(eu_self_text: 'Updated EU reference', eu_embedding: nil)
+        expect(record.versions.count).to eq(version_count + 1)
+        expect(record.versions.order(:id).last.event).to eq('update')
+      end
+    end
+
+    context 'when an existing EU reference is identical' do
+      before do
+        CSV.open(csv_path, 'w', headers: true) do |csv|
+          csv << %w[CNKEY CN_CODE NAME_EN SelfText_EN NAME_DE SelfText_DE NAME_FR SelfText_FR]
+          csv << ['010121000080', '0101 21 00', 'Pure-bred', 'Existing EU reference', '', '', '', '']
+        end
+      end
+
+      it 'preserves the reference, embedding, and version history' do
+        record = create(:goods_nomenclature_self_text,
+                        goods_nomenclature_item_id: '0101210000',
+                        eu_self_text: 'Existing EU reference',
+                        eu_embedding: stored_embedding)
+        embedding = record.reload.eu_embedding
+        version_count = record.versions.count
+
+        populate
+
+        expect(record.reload).to have_attributes(eu_self_text: 'Existing EU reference', eu_embedding: embedding)
+        expect(record.versions.count).to eq(version_count)
+      end
+    end
+
     context 'when CSV has no matching generated text' do
       before do
         CSV.open(csv_path, 'w', headers: true) do |csv|
@@ -81,6 +132,34 @@ RSpec.describe 'self_texts rake tasks' do
 
         record = GoodsNomenclatureSelfText.where(goods_nomenclature_item_id: '0101300000').first
         expect(record.eu_self_text).to be_nil
+      end
+    end
+
+    context 'when the CSV is missing' do
+      it 'prints its path and exits with status 1' do
+        expect { Rake::Task['self_texts:populate_eu_references'].invoke }
+          .to output("CSV not found at #{csv_path}\n").to_stdout
+          .and raise_error(SystemExit) { |error| expect(error.status).to eq(1) }
+      end
+    end
+
+    context 'when the CSV contains updated, unmatched, and blank rows' do
+      before do
+        create(:goods_nomenclature_self_text,
+               goods_nomenclature_item_id: '0101210000',
+               eu_self_text: 'Old EU reference')
+
+        CSV.open(csv_path, 'w', headers: true) do |csv|
+          csv << %w[CNKEY CN_CODE NAME_EN SelfText_EN NAME_DE SelfText_DE NAME_FR SelfText_FR]
+          csv << ['010121000080', '0101 21 00', 'Pure-bred', 'Updated EU reference', '', '', '', '']
+          csv << ['999999000080', '9999 99 00', 'Nonexistent', 'No matching text', '', '', '', '']
+          csv << ['010130000080', '0101 30 00', 'Asses', '', '', '', '', '']
+        end
+      end
+
+      it 'reports each completion count' do
+        expect { Rake::Task['self_texts:populate_eu_references'].invoke }
+          .to output("EU references populated: 1 updated, 1 no matching generated text, 1 blank\n").to_stdout
       end
     end
 


### PR DESCRIPTION
## What:
- Adds public Rake-task characterization for EU self-text reference imports.
- Covers embedding invalidation and preservation, PaperTrail versioning, missing-file failure, and completion counters.
- Changes only `spec/lib/tasks/self_texts_rake_spec.rb`; production code and RuboCop configuration are unchanged.

## Why:
`lib/tasks/self_texts.rake` remains a `Metrics/ModuleLength` hotspot at 419/100. This test-only prerequisite locks down the EU-reference import contract before that workflow is extracted in a separate, unstacked PR.

Local verification:
- `bundle exec rspec spec/lib/tasks/self_texts_rake_spec.rb --seed 20260716`: 10 examples, 0 failures
- Full tracked RuboCop target set: 2,383 files inspected, no offenses
- Three additional randomized focused runs: 10 examples, 0 failures each
- `git diff --check`: clean
- Target-cop inventory: unchanged at one `Metrics/ModuleLength` offense (419/100); the exact exclusion intentionally remains for the later refactor

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
This is test-only coverage with no production, configuration, database, API, worker, or runtime behavior changes.