### PR TITLE
refactor(self-texts): extract EU reference importer

### DIFF
--- a/app/services/eu_reference_self_text_importer.rb
+++ b/app/services/eu_reference_self_text_importer.rb
@@ -1,0 +1,57 @@
+require 'csv'
+
+class EuReferenceSelfTextImporter
+  def self.call(csv_path)
+    new(csv_path).call
+  end
+
+  def initialize(csv_path)
+    @csv_path = csv_path
+  end
+
+  def call
+    missing_csv! unless File.exist?(csv_path)
+
+    stats = { updated: 0, skipped_no_match: 0, skipped_blank: 0 }
+    CSV.foreach(csv_path, headers: true) { |row| populate_eu_reference(row, stats) }
+    $stdout.puts "EU references populated: #{stats[:updated]} updated, #{stats[:skipped_no_match]} no matching generated text, #{stats[:skipped_blank]} blank"
+  end
+
+private
+
+  attr_reader :csv_path
+
+  def missing_csv!
+    $stdout.puts "CSV not found at #{csv_path}"
+    raise SystemExit.new(1, 'exit')
+  end
+
+  def populate_eu_reference(row, stats)
+    code = row['CN_CODE']
+    eu_text = row['SelfText_EN']&.strip
+
+    return stats[:skipped_blank] += 1 if code.blank? || eu_text.blank?
+
+    normalized = code.gsub(/\s/, '').ljust(10, '0')
+    dataset = update_dataset(normalized, eu_text)
+    item_ids = dataset.select_map(:goods_nomenclature_sid)
+    count = dataset.update(eu_self_text: eu_text, eu_embedding: nil)
+    PaperTrail::BulkVersioning.record_current_versions_for_item_ids!(model: GoodsNomenclatureSelfText, item_ids:) if count.positive?
+    update_stats(stats, normalized, count)
+  end
+
+  def update_dataset(normalized, eu_text)
+    GoodsNomenclatureSelfText
+      .where(goods_nomenclature_item_id: normalized)
+      .where(Sequel.|({ eu_self_text: nil }, Sequel.~(eu_self_text: eu_text)))
+  end
+
+  def update_stats(stats, normalized, count)
+    if count.positive?
+      stats[:updated] += count
+    else
+      existing = GoodsNomenclatureSelfText.where(goods_nomenclature_item_id: normalized).count
+      stats[:skipped_no_match] += 1 if existing.zero?
+    end
+  end
+end

--- a/app/services/eu_reference_self_text_importer.rb
+++ b/app/services/eu_reference_self_text_importer.rb
@@ -10,19 +10,17 @@ class EuReferenceSelfTextImporter
   end
 
   def call
-    missing_csv! unless File.exist?(csv_path)
+    missing_csv! unless File.exist?(@csv_path)
 
     stats = { updated: 0, skipped_no_match: 0, skipped_blank: 0 }
-    CSV.foreach(csv_path, headers: true) { |row| populate_eu_reference(row, stats) }
+    CSV.foreach(@csv_path, headers: true) { |row| populate_eu_reference(row, stats) }
     $stdout.puts "EU references populated: #{stats[:updated]} updated, #{stats[:skipped_no_match]} no matching generated text, #{stats[:skipped_blank]} blank"
   end
 
 private
 
-  attr_reader :csv_path
-
   def missing_csv!
-    $stdout.puts "CSV not found at #{csv_path}"
+    $stdout.puts "CSV not found at #{@csv_path}"
     raise SystemExit.new(1, 'exit')
   end
 

--- a/lib/tasks/self_texts.rake
+++ b/lib/tasks/self_texts.rake
@@ -73,48 +73,8 @@ module_function
   end
 
   def populate_eu_references
-    require 'csv'
-
     csv_path = Rails.root.join('data/CN2026_SelfText_EN_DE_FR.csv')
-    missing_csv!(csv_path) unless File.exist?(csv_path)
-
-    stats = { updated: 0, skipped_no_match: 0, skipped_blank: 0 }
-    CSV.foreach(csv_path, headers: true) { |row| populate_eu_reference(row, stats) }
-    puts "EU references populated: #{stats[:updated]} updated, #{stats[:skipped_no_match]} no matching generated text, #{stats[:skipped_blank]} blank"
-  end
-
-  def missing_csv!(csv_path)
-    puts "CSV not found at #{csv_path}"
-    exit 1
-  end
-
-  def populate_eu_reference(row, stats)
-    code = row['CN_CODE']
-    eu_text = row['SelfText_EN']&.strip
-
-    return stats[:skipped_blank] += 1 if code.blank? || eu_text.blank?
-
-    normalized = code.gsub(/\s/, '').ljust(10, '0')
-    dataset = eu_reference_update_dataset(normalized, eu_text)
-    item_ids = dataset.select_map(:goods_nomenclature_sid)
-    count = dataset.update(eu_self_text: eu_text, eu_embedding: nil)
-    PaperTrail::BulkVersioning.record_current_versions_for_item_ids!(model: GoodsNomenclatureSelfText, item_ids:) if count.positive?
-    update_eu_reference_stats(stats, normalized, count)
-  end
-
-  def eu_reference_update_dataset(normalized, eu_text)
-    GoodsNomenclatureSelfText
-      .where(goods_nomenclature_item_id: normalized)
-      .where(Sequel.|({ eu_self_text: nil }, Sequel.~(eu_self_text: eu_text)))
-  end
-
-  def update_eu_reference_stats(stats, normalized, count)
-    if count.positive?
-      stats[:updated] += count
-    else
-      existing = GoodsNomenclatureSelfText.where(goods_nomenclature_item_id: normalized).count
-      stats[:skipped_no_match] += 1 if existing.zero?
-    end
+    EuReferenceSelfTextImporter.call(csv_path)
   end
 
   def generate_embeddings


### PR DESCRIPTION
## What:
- Extracts the EU-reference self-text import workflow from `SelfTextsTasks` into `EuReferenceSelfTextImporter`.
- Keeps `self_texts:populate_eu_references` as the same environment-backed Rake entry point and delegates after selecting the same CSV path.
- Reduces the `SelfTextsTasks` `Metrics/ModuleLength` offense from 419/100 to 387/100; the exact exclusion remains for later independent slices.

## Why:
PR #3502 first characterized the public task contract. This covered extraction gives the CSV import workflow a focused Zeitwerk-loaded home without changing task names, output, failure behavior, SQL updates, embedding invalidation, or PaperTrail versioning.

Behavior preserved:
- CSV row order, normalization, blank and unmatched handling
- Sequel predicates and update ordering
- item IDs captured before update
- `eu_embedding` invalidation
- PaperTrail bulk versions only for changed rows
- exact missing-file output and status 1
- exact completion counters and return behavior

Local verification:
- `bundle exec rspec spec/lib/tasks/self_texts_rake_spec.rb --seed 20260716`: 10 examples, 0 failures
- Three additional focused seeds: 10 examples, 0 failures each
- Full effective RuboCop target set: 2,384 files inspected, no offenses
- `bundle exec rails zeitwerk:check`: All is good!
- Forced `Metrics/ModuleLength`: `SelfTextsTasks` 419→387; new service has no offense
- `git diff --check`: clean
- Independent specification and quality reviews: no findings

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
This is a covered, behavior-preserving extraction with no API, database schema, task interface, worker argument, configuration, or runtime-policy change. The merged public-task characterization exercises every moved side effect.