### PR TITLE
HMRC-2511: Add hybrid query quality guardrail

### DIFF
--- a/app/lib/admin_configuration_seeder/configs.yml
+++ b/app/lib/admin_configuration_seeder/configs.yml
@@ -78,6 +78,14 @@
   config_type: integer
   description: "Reciprocal rank fusion constant used by hybrid retrieval: score = 1/(rank + k). Higher values flatten rank differences."
   string_default: rrf_k
+- name: hybrid_query_guardrail_enabled
+  config_type: boolean
+  description: "Reject hybrid retrieval queries whose raw maximum vector similarity is below the separately configured query-level threshold. Defaults off so current search behaviour is preserved."
+  default: hybrid_query_guardrail_enabled
+- name: hybrid_query_guardrail_threshold
+  config_type: integer
+  description: "Minimum raw maximum vector similarity (0-100) required for a hybrid query when the query guardrail is enabled. This is separate from the vector candidate threshold."
+  string_default: hybrid_query_guardrail_threshold
 - name: vector_ef_search
   config_type: integer
   description: "HNSW ef_search value used by vector retrieval, including the vector leg of hybrid retrieval. Higher values may improve recall at the cost of latency."

--- a/app/lib/search/instrumentation/result_events.rb
+++ b/app/lib/search/instrumentation/result_events.rb
@@ -59,11 +59,11 @@ module Search
         )
       end
 
-      def query_guardrail_decided(request_id:, query:, effective_query:, iteration:, enabled:, accepted:, max_score:, threshold:, reason:)
+      def query_guardrail_decided(request_id:, search_type:, query:, effective_query:, iteration:, enabled:, accepted:, max_score:, threshold:, reason:)
         instrument(
           'query_guardrail_decided',
           request_id:,
-          search_type: 'interactive',
+          search_type:,
           query:,
           effective_query:,
           iteration:,

--- a/app/lib/search/instrumentation/result_events.rb
+++ b/app/lib/search/instrumentation/result_events.rb
@@ -59,6 +59,23 @@ module Search
         )
       end
 
+      def query_guardrail_decided(request_id:, query:, effective_query:, iteration:, enabled:, accepted:, max_score:, threshold:, reason:)
+        instrument(
+          'query_guardrail_decided',
+          request_id:,
+          search_type: 'interactive',
+          query:,
+          effective_query:,
+          iteration:,
+          variant: enabled ? 'fixed_vector_score' : 'control',
+          enabled:,
+          accepted:,
+          max_score:,
+          threshold:,
+          reason:,
+        )
+      end
+
       def question_returned(request_id:, question_count:, attempt_number:, iteration: nil, effective_query: nil, questions: nil)
         payload = { request_id:, search_type: 'interactive', question_count:, attempt_number:, iteration:, effective_query: }
         payload[:details] = { questions: questions } if questions

--- a/app/lib/search/logger.rb
+++ b/app/lib/search/logger.rb
@@ -284,6 +284,23 @@ module Search
       info log_entry(data, event)
     end
 
+    def query_guardrail_decided(event)
+      info log_entry({
+        event: 'query_guardrail_decided',
+        request_id: event.payload[:request_id],
+        search_type: event.payload[:search_type],
+        query: event.payload[:query],
+        effective_query: event.payload[:effective_query],
+        iteration: event.payload[:iteration],
+        variant: event.payload[:variant],
+        enabled: event.payload[:enabled],
+        accepted: event.payload[:accepted],
+        max_score: event.payload[:max_score],
+        threshold: event.payload[:threshold],
+        reason: event.payload[:reason],
+      }, event)
+    end
+
     def result_selected(event)
       info log_entry({
         event: 'result_selected',

--- a/app/models/admin_configuration.rb
+++ b/app/models/admin_configuration.rb
@@ -146,6 +146,8 @@ class AdminConfiguration < Sequel::Model(Sequel[:admin_configurations].qualify(:
     'input_sanitiser_enabled' => true,
     'input_sanitiser_max_length' => 1000,
     'retrieval_method' => 'hybrid',
+    'hybrid_query_guardrail_enabled' => false,
+    'hybrid_query_guardrail_threshold' => 32,
     'rrf_k' => 60,
     'vector_ef_search' => 100,
     'vector_score_threshold' => 35,

--- a/app/models/admin_configuration.rb
+++ b/app/models/admin_configuration.rb
@@ -303,6 +303,7 @@ class AdminConfiguration < Sequel::Model(Sequel[:admin_configurations].qualify(:
     validates_includes %w[string markdown boolean options multi_options integer nested_options object_template], :config_type
     validate_unique_name if new?
     validate_value_for_type
+    validate_hybrid_query_guardrail_threshold
   end
 
   def before_validation
@@ -349,8 +350,14 @@ private
     end
   end
 
-  def t(key)
-    I18n.t("sequel.errors.models.admin_configuration.#{key}")
+  def validate_hybrid_query_guardrail_threshold
+    return unless name == 'hybrid_query_guardrail_threshold' && config_type == 'integer'
+
+    errors.add(:value, t('value.out_of_range', min: 0, max: 100)) unless (0..100).cover?(self[:value].to_i)
+  end
+
+  def t(key, **options)
+    I18n.t("sequel.errors.models.admin_configuration.#{key}", **options)
   end
 
   def clear_expand_search_cache_if_needed

--- a/app/services/api/internal/search_service.rb
+++ b/app/services/api/internal/search_service.rb
@@ -256,7 +256,8 @@ module Api
         result = HybridRetrievalService.call(
           query: q, expanded_query: search_expanded_query,
           as_of: as_of, request_id: request_id, limit: opensearch_result_limit,
-          filter_prefixes: filter_prefixes, iteration: search_iteration
+          filter_prefixes: filter_prefixes, iteration: search_iteration,
+          search_type: 'interactive'
         )
 
         RetrievalResult.new(

--- a/app/services/api/internal/search_service.rb
+++ b/app/services/api/internal/search_service.rb
@@ -367,11 +367,14 @@ module Api
           vector_score_threshold: AdminConfiguration.integer_value('vector_score_threshold'),
           vector_ef_search: AdminConfiguration.integer_value('vector_ef_search'),
           rrf_k: AdminConfiguration.integer_value('rrf_k'),
+          hybrid_query_guardrail_threshold: AdminConfiguration.integer_value('hybrid_query_guardrail_threshold'),
           interactive_search_duplicate_question_guard_model: model_configuration('interactive_search_duplicate_question_guard_model'),
           search_model: model_configuration('search_model'),
           expand_model: model_configuration('expand_model'),
           filter_prefixes: filter_prefixes,
-        }.compact_blank
+        }.compact_blank.tap do |configuration|
+          configuration[:hybrid_query_guardrail_enabled] = AdminConfiguration.enabled?('hybrid_query_guardrail_enabled')
+        end
       end
 
       def model_configuration(name)

--- a/app/services/api/v2/classification_search_service.rb
+++ b/app/services/api/v2/classification_search_service.rb
@@ -28,6 +28,7 @@ module Api
           as_of: parse_date(@params[:as_of]),
           request_id: request_id,
           limit: limit,
+          search_type: 'classification',
         )
 
         ClassificationSearchResultSerializer.serialize(

--- a/app/services/hybrid_retrieval_service.rb
+++ b/app/services/hybrid_retrieval_service.rb
@@ -28,9 +28,8 @@ class HybridRetrievalService
     opensearch_items = opensearch_leg.value&.results || []
     vector_items = vector_leg.value&.results || []
 
-    merged = rrf_merge(opensearch_items, vector_items)
     decision = query_guardrail_decision(vector_leg)
-    merged = [] unless decision[:accepted]
+    merged = decision[:accepted] ? rrf_merge(opensearch_items, vector_items) : []
     Search::Instrumentation.query_guardrail_decided(
       request_id: @request_id,
       query: @query,

--- a/app/services/hybrid_retrieval_service.rb
+++ b/app/services/hybrid_retrieval_service.rb
@@ -26,9 +26,18 @@ class HybridRetrievalService
     end
 
     opensearch_items = opensearch_leg.value&.results || []
-    vector_items = vector_leg.value || []
+    vector_items = vector_leg.value&.results || []
 
     merged = rrf_merge(opensearch_items, vector_items)
+    decision = query_guardrail_decision(vector_leg)
+    merged = [] unless decision[:accepted]
+    Search::Instrumentation.query_guardrail_decided(
+      request_id: @request_id,
+      query: @query,
+      effective_query: @expanded_query,
+      iteration: @iteration,
+      **decision,
+    )
     Search::Instrumentation.retrieval_results_returned(
       request_id: @request_id,
       query: @query,
@@ -60,12 +69,12 @@ private
       when :opensearch
         OpensearchRetrievalService.call(**opensearch_args)
       when :vector
-        VectorRetrievalService.call(**vector_args)
+        VectorRetrievalService.call_with_diagnostics(**vector_args)
       end
     end
 
     duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start) * 1000).round(2)
-    count = leg == :opensearch ? result&.results&.size || 0 : result&.size || 0
+    count = result&.results&.size || 0
 
     Search::Instrumentation.retrieval_leg_completed(
       request_id: @request_id, leg: leg, duration_ms: duration_ms, result_count: count, status: 'success',
@@ -79,7 +88,7 @@ private
       stage: 'before_rrf',
       leg: leg,
       iteration: @iteration,
-      results: leg == :opensearch ? result&.results || [] : result || [],
+      results: result&.results || [],
     )
 
     LegResult.new(value: result, error: nil)
@@ -135,6 +144,25 @@ private
     scores
       .sort_by { |_sid, score| -score }
       .map { |sid, score| build_result(items_by_sid[sid], score) }
+  end
+
+  def query_guardrail_decision(vector_leg)
+    enabled = AdminConfiguration.enabled?('hybrid_query_guardrail_enabled')
+    max_score = vector_leg.value&.max_score
+    return { enabled:, accepted: true, max_score:, threshold: nil, reason: 'disabled' } unless enabled
+
+    threshold = AdminConfiguration.integer_value('hybrid_query_guardrail_threshold') / 100.0
+    reason = if vector_leg.error
+               'vector_unavailable'
+             elsif max_score.nil?
+               'no_vector_candidates'
+             elsif max_score >= threshold
+               'accepted'
+             else
+               'below_threshold'
+             end
+
+    { enabled:, accepted: reason == 'accepted', max_score:, threshold:, reason: }
   end
 
   def build_result(item, score)

--- a/app/services/hybrid_retrieval_service.rb
+++ b/app/services/hybrid_retrieval_service.rb
@@ -3,11 +3,11 @@ class HybridRetrievalService
   LegResult = Data.define(:value, :error)
   Result = Data.define(:results, :expanded_query, :source_results)
 
-  def self.call(query:, as_of:, expanded_query: nil, request_id: nil, limit: 30, filter_prefixes: [], iteration: nil)
-    new(query:, as_of:, expanded_query:, request_id:, limit:, filter_prefixes:, iteration:).call
+  def self.call(query:, as_of:, expanded_query: nil, request_id: nil, limit: 30, filter_prefixes: [], iteration: nil, search_type: 'interactive')
+    new(query:, as_of:, expanded_query:, request_id:, limit:, filter_prefixes:, iteration:, search_type:).call
   end
 
-  def initialize(query:, as_of:, expanded_query: nil, request_id: nil, limit: 30, filter_prefixes: [], iteration: nil)
+  def initialize(query:, as_of:, expanded_query: nil, request_id: nil, limit: 30, filter_prefixes: [], iteration: nil, search_type: 'interactive')
     @query = query
     @expanded_query = expanded_query.presence || query
     @as_of = as_of
@@ -15,6 +15,7 @@ class HybridRetrievalService
     @limit = limit
     @filter_prefixes = Array(filter_prefixes).compact_blank
     @iteration = iteration
+    @search_type = search_type
   end
 
   def call
@@ -32,6 +33,7 @@ class HybridRetrievalService
     merged = decision[:accepted] ? rrf_merge(opensearch_items, vector_items) : []
     Search::Instrumentation.query_guardrail_decided(
       request_id: @request_id,
+      search_type: @search_type,
       query: @query,
       effective_query: @expanded_query,
       iteration: @iteration,
@@ -41,7 +43,7 @@ class HybridRetrievalService
       request_id: @request_id,
       query: @query,
       effective_query: @expanded_query,
-      search_type: 'interactive',
+      search_type: @search_type,
       retrieval_method: 'hybrid',
       stage: 'after_rrf',
       iteration: @iteration,
@@ -82,7 +84,7 @@ private
       request_id: @request_id,
       query: @query,
       effective_query: @expanded_query,
-      search_type: 'interactive',
+      search_type: @search_type,
       retrieval_method: 'hybrid',
       stage: 'before_rrf',
       leg: leg,
@@ -148,9 +150,9 @@ private
   def query_guardrail_decision(vector_leg)
     enabled = AdminConfiguration.enabled?('hybrid_query_guardrail_enabled')
     max_score = vector_leg.value&.max_score
-    return { enabled:, accepted: true, max_score:, threshold: nil, reason: 'disabled' } unless enabled
+    threshold = query_guardrail_threshold
+    return { enabled:, accepted: true, max_score:, threshold:, reason: 'disabled' } unless enabled
 
-    threshold = AdminConfiguration.integer_value('hybrid_query_guardrail_threshold') / 100.0
     reason = if vector_leg.error
                'vector_unavailable'
              elsif max_score.nil?
@@ -162,6 +164,12 @@ private
              end
 
     { enabled:, accepted: reason == 'accepted', max_score:, threshold:, reason: }
+  end
+
+  def query_guardrail_threshold
+    percentage = AdminConfiguration.integer_value('hybrid_query_guardrail_threshold')
+    percentage = AdminConfiguration.default_for('hybrid_query_guardrail_threshold') unless (0..100).cover?(percentage)
+    percentage / 100.0
   end
 
   def build_result(item, score)

--- a/app/services/vector_retrieval_service.rb
+++ b/app/services/vector_retrieval_service.rb
@@ -1,6 +1,12 @@
 class VectorRetrievalService
+  Result = Data.define(:results, :max_score)
+
   def self.call(query:, limit: 80, filter_prefixes: [], request_id: nil)
     new(query:, limit:, filter_prefixes:, request_id:).call
+  end
+
+  def self.call_with_diagnostics(query:, limit: 80, filter_prefixes: [], request_id: nil)
+    new(query:, limit:, filter_prefixes:, request_id:).call_with_diagnostics
   end
 
   def initialize(query:, limit: 80, filter_prefixes: [], request_id: nil)
@@ -11,6 +17,10 @@ class VectorRetrievalService
   end
 
   def call
+    call_with_diagnostics.results
+  end
+
+  def call_with_diagnostics
     query_embedding = AiUsage::Instrumentation.embedding_api_call(
       event_kind: 'vector_search_query_embedding',
       batch_size: 1,
@@ -20,21 +30,18 @@ class VectorRetrievalService
     vector_literal = "'[#{query_embedding.join(',')}]'::vector"
 
     ranked_rows = fetch_ranked_sids(vector_literal)
+    ordered_sids = ranked_rows.map { |row| row[:goods_nomenclature_sid] }
+    gn_by_sid = load_goods_nomenclatures(ordered_sids)
+    ranked_rows = eligible_ranked_rows(ranked_rows, gn_by_sid)
+    max_score = ranked_rows.first&.[](:score)&.to_f
     ranked_rows = apply_score_threshold(ranked_rows)
-    return [] if ranked_rows.empty?
 
     scores_by_sid = ranked_rows.each_with_object({}) { |r, h| h[r[:goods_nomenclature_sid]] = r[:score]&.to_f }
     ordered_sids = ranked_rows.map { |r| r[:goods_nomenclature_sid] }
 
-    gn_by_sid = load_goods_nomenclatures(ordered_sids)
+    results = ordered_sids.map { |sid| build_result(gn_by_sid.fetch(sid), scores_by_sid[sid]) }
 
-    ordered_sids.filter_map do |sid|
-      gn = gn_by_sid[sid]
-      next unless gn
-      next if !search_non_declarables? && !gn.declarable?
-
-      build_result(gn, scores_by_sid[sid])
-    end
+    Result.new(results:, max_score:)
   end
 
 private
@@ -42,6 +49,15 @@ private
   def apply_score_threshold(rows)
     threshold = AdminConfiguration.integer_value('vector_score_threshold') / 100.0
     rows.select { |r| r[:score].to_f >= threshold }
+  end
+
+  def eligible_ranked_rows(rows, gn_by_sid)
+    include_non_declarables = search_non_declarables?
+
+    rows.select do |row|
+      goods_nomenclature = gn_by_sid[row[:goods_nomenclature_sid]]
+      goods_nomenclature && (include_non_declarables || goods_nomenclature.declarable?)
+    end
   end
 
   def fetch_ranked_sids(vector_literal)

--- a/app/services/vector_retrieval_service.rb
+++ b/app/services/vector_retrieval_service.rb
@@ -30,16 +30,19 @@ class VectorRetrievalService
     vector_literal = "'[#{query_embedding.join(',')}]'::vector"
 
     ranked_rows = fetch_ranked_sids(vector_literal)
-    ordered_sids = ranked_rows.map { |row| row[:goods_nomenclature_sid] }
-    gn_by_sid = load_goods_nomenclatures(ordered_sids)
-    ranked_rows = eligible_ranked_rows(ranked_rows, gn_by_sid)
+    ranked_rows = eligible_ranked_rows(ranked_rows)
     max_score = ranked_rows.first&.[](:score)&.to_f
     ranked_rows = apply_score_threshold(ranked_rows)
+    return Result.new(results: [], max_score:) if ranked_rows.empty?
 
     scores_by_sid = ranked_rows.each_with_object({}) { |r, h| h[r[:goods_nomenclature_sid]] = r[:score]&.to_f }
     ordered_sids = ranked_rows.map { |r| r[:goods_nomenclature_sid] }
+    gn_by_sid = load_goods_nomenclatures(ordered_sids)
 
-    results = ordered_sids.map { |sid| build_result(gn_by_sid.fetch(sid), scores_by_sid[sid]) }
+    results = ordered_sids.filter_map do |sid|
+      goods_nomenclature = gn_by_sid[sid]
+      build_result(goods_nomenclature, scores_by_sid[sid]) if goods_nomenclature
+    end
 
     Result.new(results:, max_score:)
   end
@@ -51,13 +54,20 @@ private
     rows.select { |r| r[:score].to_f >= threshold }
   end
 
-  def eligible_ranked_rows(rows, gn_by_sid)
-    include_non_declarables = search_non_declarables?
+  def eligible_ranked_rows(rows)
+    return rows if search_non_declarables?
 
-    rows.select do |row|
-      goods_nomenclature = gn_by_sid[row[:goods_nomenclature_sid]]
-      goods_nomenclature && (include_non_declarables || goods_nomenclature.declarable?)
-    end
+    sids = rows.map { |row| row[:goods_nomenclature_sid] }
+    eligible_sids = GoodsNomenclature
+      .actual
+      .declarable
+      .where(goods_nomenclatures__goods_nomenclature_sid: sids)
+      .then { |dataset| apply_filter_prefixes(dataset, Sequel[:goods_nomenclatures][:goods_nomenclature_item_id]) }
+      .unordered
+      .select_map(Sequel[:goods_nomenclatures][:goods_nomenclature_sid])
+      .to_set
+
+    rows.select { |row| eligible_sids.include?(row[:goods_nomenclature_sid]) }
   end
 
   def fetch_ranked_sids(vector_literal)

--- a/app/services/vector_retrieval_service.rb
+++ b/app/services/vector_retrieval_service.rb
@@ -17,10 +17,24 @@ class VectorRetrievalService
   end
 
   def call
-    call_with_diagnostics.results
+    ranked_rows = apply_score_threshold(fetch_ranked_rows_for_query)
+    return [] if ranked_rows.empty?
+
+    build_results(ranked_rows, enforce_eligibility: true)
   end
 
   def call_with_diagnostics
+    ranked_rows = eligible_ranked_rows(fetch_ranked_rows_for_query)
+    max_score = ranked_rows.first&.[](:score)&.to_f
+    ranked_rows = apply_score_threshold(ranked_rows)
+    return Result.new(results: [], max_score:) if ranked_rows.empty?
+
+    Result.new(results: build_results(ranked_rows), max_score:)
+  end
+
+private
+
+  def fetch_ranked_rows_for_query
     query_embedding = AiUsage::Instrumentation.embedding_api_call(
       event_kind: 'vector_search_query_embedding',
       batch_size: 1,
@@ -29,25 +43,23 @@ class VectorRetrievalService
     ) { embedding_service.embed(@query, event_kind: 'vector_search_query_embedding') }
     vector_literal = "'[#{query_embedding.join(',')}]'::vector"
 
-    ranked_rows = fetch_ranked_sids(vector_literal)
-    ranked_rows = eligible_ranked_rows(ranked_rows)
-    max_score = ranked_rows.first&.[](:score)&.to_f
-    ranked_rows = apply_score_threshold(ranked_rows)
-    return Result.new(results: [], max_score:) if ranked_rows.empty?
+    fetch_ranked_sids(vector_literal)
+  end
 
+  def build_results(ranked_rows, enforce_eligibility: false)
     scores_by_sid = ranked_rows.each_with_object({}) { |r, h| h[r[:goods_nomenclature_sid]] = r[:score]&.to_f }
     ordered_sids = ranked_rows.map { |r| r[:goods_nomenclature_sid] }
     gn_by_sid = load_goods_nomenclatures(ordered_sids)
+    include_non_declarables = search_non_declarables? if enforce_eligibility
 
-    results = ordered_sids.filter_map do |sid|
+    ordered_sids.filter_map do |sid|
       goods_nomenclature = gn_by_sid[sid]
-      build_result(goods_nomenclature, scores_by_sid[sid]) if goods_nomenclature
+      next unless goods_nomenclature
+      next if enforce_eligibility && !include_non_declarables && !goods_nomenclature.declarable?
+
+      build_result(goods_nomenclature, scores_by_sid[sid])
     end
-
-    Result.new(results:, max_score:)
   end
-
-private
 
   def apply_score_threshold(rows)
     threshold = AdminConfiguration.integer_value('vector_score_threshold') / 100.0
@@ -55,7 +67,7 @@ private
   end
 
   def eligible_ranked_rows(rows)
-    return rows if search_non_declarables?
+    return rows if rows.empty? || search_non_declarables?
 
     sids = rows.map { |row| row[:goods_nomenclature_sid] }
     eligible_sids = GoodsNomenclature

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,6 +23,7 @@ en:
             blank: must not be blank
             invalid_boolean: must be true or false
             invalid_integer: "must be a whole number"
+            out_of_range: "must be between %{min} and %{max}"
             invalid_options: must be a hash with selected and options keys
             no_options: must include an options array
             invalid_nested_options: must be a hash with selected and options keys

--- a/docs/architecture/search-and-indexing.md
+++ b/docs/architecture/search-and-indexing.md
@@ -55,6 +55,17 @@ Relevant code paths include:
 - `app/workers/relabel_goods_nomenclature_worker.rb`
 - `app/workers/goods_nomenclature_reconciliation_worker.rb`
 
+## Hybrid Query Guardrail
+
+Hybrid retrieval can apply a query-level quality guardrail after both retrieval legs have completed and before results are returned. It uses the highest raw vector similarity for an eligible commodity, before the separate per-candidate vector threshold is applied.
+
+The guardrail is controlled through admin configuration:
+
+- `hybrid_query_guardrail_enabled` defaults to off, preserving the existing hybrid behaviour.
+- `hybrid_query_guardrail_threshold` defaults to `32`, representing a similarity of `0.32`.
+
+When enabled, hybrid retrieval returns no suggestions if the maximum score is below the threshold, no eligible vector candidate exists, or the vector leg is unavailable. The `query_guardrail_decided.search` instrumentation event records the effective variant, score, threshold, outcome, and reason so A/B-test results can be attributed to the control.
+
 Guided classification search can also attach bounded chapter- and section-note evidence to retrieved candidates. [Tariff knowledge notes](../tariff-knowledge-notes.md) documents extraction, graph edges, compressed-note materialisation and deduplication, prompt selection, and request-ID diagnostics.
 
 ## Query Expansion Deadline

--- a/spec/lib/search/instrumentation_spec.rb
+++ b/spec/lib/search/instrumentation_spec.rb
@@ -635,6 +635,7 @@ RSpec.describe Search::Instrumentation do
 
       described_class.query_guardrail_decided(
         request_id: 'req-1',
+        search_type: 'interactive',
         query: 'book a dentist appointment',
         effective_query: 'dentist appointment',
         iteration: 2,
@@ -666,19 +667,30 @@ RSpec.describe Search::Instrumentation do
 
       described_class.query_guardrail_decided(
         request_id: 'req-1',
+        search_type: 'interactive',
         query: 'horses',
         effective_query: 'horses',
         iteration: 1,
         enabled: false,
         accepted: true,
         max_score: 0.55,
-        threshold: nil,
+        threshold: 0.32,
         reason: 'disabled',
       )
 
       expect(ActiveSupport::Notifications).to have_received(:instrument).with(
         'query_guardrail_decided.search',
-        hash_including(variant: 'control', enabled: false, accepted: true, reason: 'disabled'),
+        request_id: 'req-1',
+        search_type: 'interactive',
+        query: 'horses',
+        effective_query: 'horses',
+        iteration: 1,
+        variant: 'control',
+        enabled: false,
+        accepted: true,
+        max_score: 0.55,
+        threshold: 0.32,
+        reason: 'disabled',
       )
     end
   end

--- a/spec/lib/search/instrumentation_spec.rb
+++ b/spec/lib/search/instrumentation_spec.rb
@@ -629,6 +629,60 @@ RSpec.describe Search::Instrumentation do
     end
   end
 
+  describe '.query_guardrail_decided' do
+    it 'instruments the configured variant, score, threshold, and decision' do
+      allow(ActiveSupport::Notifications).to receive(:instrument)
+
+      described_class.query_guardrail_decided(
+        request_id: 'req-1',
+        query: 'book a dentist appointment',
+        effective_query: 'dentist appointment',
+        iteration: 2,
+        enabled: true,
+        accepted: false,
+        max_score: 0.31,
+        threshold: 0.32,
+        reason: 'below_threshold',
+      )
+
+      expect(ActiveSupport::Notifications).to have_received(:instrument).with(
+        'query_guardrail_decided.search',
+        request_id: 'req-1',
+        search_type: 'interactive',
+        query: 'book a dentist appointment',
+        effective_query: 'dentist appointment',
+        iteration: 2,
+        variant: 'fixed_vector_score',
+        enabled: true,
+        accepted: false,
+        max_score: 0.31,
+        threshold: 0.32,
+        reason: 'below_threshold',
+      )
+    end
+
+    it 'identifies disabled decisions as the control variant' do
+      allow(ActiveSupport::Notifications).to receive(:instrument)
+
+      described_class.query_guardrail_decided(
+        request_id: 'req-1',
+        query: 'horses',
+        effective_query: 'horses',
+        iteration: 1,
+        enabled: false,
+        accepted: true,
+        max_score: 0.55,
+        threshold: nil,
+        reason: 'disabled',
+      )
+
+      expect(ActiveSupport::Notifications).to have_received(:instrument).with(
+        'query_guardrail_decided.search',
+        hash_including(variant: 'control', enabled: false, accepted: true, reason: 'disabled'),
+      )
+    end
+  end
+
   describe '.question_returned' do
     it 'instruments the question_returned event' do
       allow(ActiveSupport::Notifications).to receive(:instrument)

--- a/spec/lib/search/logger_spec.rb
+++ b/spec/lib/search/logger_spec.rb
@@ -602,6 +602,8 @@ RSpec.describe Search::Logger do
       expect(parsed_log_output).to include(
         'event' => 'query_guardrail_decided',
         'request_id' => 'req-1',
+        'search_type' => 'interactive',
+        'query' => 'book a dentist appointment',
         'effective_query' => 'dentist appointment',
         'iteration' => 2,
         'variant' => 'fixed_vector_score',

--- a/spec/lib/search/logger_spec.rb
+++ b/spec/lib/search/logger_spec.rb
@@ -579,6 +579,41 @@ RSpec.describe Search::Logger do
     end
   end
 
+  describe '#query_guardrail_decided' do
+    let(:payload) do
+      {
+        request_id: 'req-1',
+        search_type: 'interactive',
+        query: 'book a dentist appointment',
+        effective_query: 'dentist appointment',
+        iteration: 2,
+        variant: 'fixed_vector_score',
+        enabled: true,
+        accepted: false,
+        max_score: 0.31,
+        threshold: 0.32,
+        reason: 'below_threshold',
+      }
+    end
+
+    it 'logs the attributable query guardrail decision' do
+      logger_instance.query_guardrail_decided(build_event('query_guardrail_decided', payload))
+
+      expect(parsed_log_output).to include(
+        'event' => 'query_guardrail_decided',
+        'request_id' => 'req-1',
+        'effective_query' => 'dentist appointment',
+        'iteration' => 2,
+        'variant' => 'fixed_vector_score',
+        'enabled' => true,
+        'accepted' => false,
+        'max_score' => 0.31,
+        'threshold' => 0.32,
+        'reason' => 'below_threshold',
+      )
+    end
+  end
+
   describe '#result_selected' do
     let(:payload) { { request_id: 'req-1', goods_nomenclature_item_id: '4202210000', goods_nomenclature_class: 'Commodity' } }
 

--- a/spec/lib/tasks/admin_configurations_rake_spec.rb
+++ b/spec/lib/tasks/admin_configurations_rake_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe 'admin_configurations:seed' do
     Rake::Task['admin_configurations:seed'].reenable
   end
 
-  it 'creates all 49 admin configurations', :aggregate_failures do
-    expect { seed }.to change(AdminConfiguration, :count).by(49)
+  it 'creates all 51 admin configurations', :aggregate_failures do
+    expect { seed }.to change(AdminConfiguration, :count).by(51)
 
     names = AdminConfiguration.order(:name).select_map(:name)
     expect(names).to eq(%w[
@@ -474,7 +474,7 @@ RSpec.describe 'admin_configurations:seed' do
   it 'patches existing configurations when their type changes' do
     create(:admin_configuration, name: 'description_intercept_templates', config_type: 'string', value: 'legacy')
 
-    expect { seed }.to change(AdminConfiguration, :count).by(48)
+    expect { seed }.to change(AdminConfiguration, :count).by(50)
     expect(AdminConfiguration.where(name: 'description_intercept_templates').first.config_type).to eq('object_template')
   end
 end

--- a/spec/lib/tasks/admin_configurations_rake_spec.rb
+++ b/spec/lib/tasks/admin_configurations_rake_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe 'admin_configurations:seed' do
       expand_search_min_results
       expand_search_min_score
       expand_search_when_needed_enabled
+      hybrid_query_guardrail_enabled
+      hybrid_query_guardrail_threshold
       input_sanitiser_enabled
       input_sanitiser_max_length
       interactive_search_duplicate_question_guard_context
@@ -389,6 +391,18 @@ RSpec.describe 'admin_configurations:seed' do
     expect(config.config_type).to eq('integer')
     expect(config.area).to eq('classification')
     expect(config.value).to eq(AdminConfiguration.default_for('rrf_k'))
+  end
+
+  it 'seeds the hybrid query guardrail disabled with its separately configurable threshold', :aggregate_failures do
+    seed
+
+    enabled = AdminConfiguration.where(name: 'hybrid_query_guardrail_enabled').first
+    threshold = AdminConfiguration.where(name: 'hybrid_query_guardrail_threshold').first
+
+    expect(enabled.config_type).to eq('boolean')
+    expect(enabled.value).to be(false)
+    expect(threshold.config_type).to eq('integer')
+    expect(threshold.value).to eq(32)
   end
 
   it 'seeds suggestion toggle configs as booleans', :aggregate_failures do

--- a/spec/models/admin_configuration_spec.rb
+++ b/spec/models/admin_configuration_spec.rb
@@ -228,6 +228,27 @@ RSpec.describe AdminConfiguration do
           expect(config.errors[:value]).to be_present
         end
       end
+
+      context 'with the hybrid query guardrail threshold' do
+        let(:value) { 50 }
+        let(:attrs) do
+          {
+            name: 'hybrid_query_guardrail_threshold',
+            config_type: 'integer',
+            value: value,
+          }
+        end
+
+        it 'accepts the inclusive 0 to 100 range', :aggregate_failures do
+          expect(config.set(value: 0)).to be_valid
+          expect(config.set(value: 100)).to be_valid
+        end
+
+        it 'rejects values outside the 0 to 100 range', :aggregate_failures do
+          expect(config.set(value: -1)).not_to be_valid
+          expect(config.set(value: 101)).not_to be_valid
+        end
+      end
     end
 
     describe 'integer normalization' do

--- a/spec/requests/api/v2/classification_search_controller_spec.rb
+++ b/spec/requests/api/v2/classification_search_controller_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe 'Classification search API' do
         as_of: Time.zone.today,
         request_id: 'test-request-id',
         limit: 5,
+        search_type: 'classification',
       )
     end
 

--- a/spec/services/api/internal/search_service_spec.rb
+++ b/spec/services/api/internal/search_service_spec.rb
@@ -51,7 +51,10 @@ RSpec.describe Api::Internal::SearchService do
     end
 
     it 'emits interactive configuration diagnostics including the duplicate question guard gate' do
-      allow(Search::Instrumentation).to receive(:interactive_configuration_used)
+      captured_configuration = nil
+      allow(Search::Instrumentation).to receive(:interactive_configuration_used) do |configuration:, **|
+        captured_configuration = configuration
+      end
       allow(TradeTariffBackend.search_client).to receive(:search).and_return({ 'hits' => { 'hits' => [] } })
 
       described_class.new(q: 'multimeter leads').call
@@ -62,12 +65,15 @@ RSpec.describe Api::Internal::SearchService do
         skip_question: nil,
         configuration: hash_including(
           interactive_search_duplicate_question_guard_enabled: true,
+          hybrid_query_guardrail_enabled: false,
+          hybrid_query_guardrail_threshold: 32,
           interactive_search_duplicate_question_guard_model: {
             selected: 'gpt-5-nano-2025-08-07',
             reasoning_effort: 'low',
           },
         ),
       )
+      expect(captured_configuration.fetch(:hybrid_query_guardrail_enabled)).to be(false)
     end
 
     context 'when exact match via search_reference suggestion' do

--- a/spec/services/api/internal/search_service_spec.rb
+++ b/spec/services/api/internal/search_service_spec.rb
@@ -1361,7 +1361,11 @@ RSpec.describe Api::Internal::SearchService do
         described_class.new(q: 'horses').call
 
         expect(HybridRetrievalService).to have_received(:call).with(
-          hash_including(query: 'horses', expanded_query: 'pure-bred breeding horses'),
+          hash_including(
+            query: 'horses',
+            expanded_query: 'pure-bred breeding horses',
+            search_type: 'interactive',
+          ),
         )
       end
 

--- a/spec/services/hybrid_retrieval_service_spec.rb
+++ b/spec/services/hybrid_retrieval_service_spec.rb
@@ -34,9 +34,8 @@ RSpec.describe HybridRetrievalService do
     ]
   end
 
-  let(:vector_max_score) { 0.31 }
   let(:vector_diagnostics) do
-    VectorRetrievalService::Result.new(results: vector_results, max_score: vector_max_score)
+    VectorRetrievalService::Result.new(results: vector_results, max_score: 0.31)
   end
 
   let(:expanded_query) { 'expanded horses' }

--- a/spec/services/hybrid_retrieval_service_spec.rb
+++ b/spec/services/hybrid_retrieval_service_spec.rb
@@ -34,6 +34,11 @@ RSpec.describe HybridRetrievalService do
     ]
   end
 
+  let(:vector_max_score) { 0.31 }
+  let(:vector_diagnostics) do
+    VectorRetrievalService::Result.new(results: vector_results, max_score: vector_max_score)
+  end
+
   let(:expanded_query) { 'expanded horses' }
 
   let(:opensearch_result) do
@@ -45,11 +50,15 @@ RSpec.describe HybridRetrievalService do
 
   before do
     allow(OpensearchRetrievalService).to receive(:call).and_return(opensearch_result)
-    allow(VectorRetrievalService).to receive(:call).and_return(vector_results)
+    allow(VectorRetrievalService).to receive(:call_with_diagnostics).and_return(vector_diagnostics)
+    allow(AdminConfiguration).to receive(:enabled?).and_call_original
+    allow(AdminConfiguration).to receive(:enabled?).with('hybrid_query_guardrail_enabled').and_return(false)
     allow(AdminConfiguration).to receive(:integer_value).and_call_original
     allow(AdminConfiguration).to receive(:integer_value).with('rrf_k').and_return(60)
+    allow(AdminConfiguration).to receive(:integer_value).with('hybrid_query_guardrail_threshold').and_return(32)
     allow(Search::Instrumentation).to receive(:retrieval_leg_completed)
     allow(Search::Instrumentation).to receive(:retrieval_results_returned)
+    allow(Search::Instrumentation).to receive(:query_guardrail_decided)
   end
 
   describe '#call' do
@@ -63,7 +72,9 @@ RSpec.describe HybridRetrievalService do
       expect(OpensearchRetrievalService).to have_received(:call).with(
         query: 'horses', expanded_query: expanded_query, as_of: as_of, request_id: nil, limit: 30,
       )
-      expect(VectorRetrievalService).to have_received(:call).with(query: expanded_query, limit: 30, request_id: nil)
+      expect(VectorRetrievalService).to have_received(:call_with_diagnostics).with(
+        query: expanded_query, limit: 30, request_id: nil,
+      )
     end
 
     it 'passes filter prefixes to both retrieval legs' do
@@ -75,7 +86,7 @@ RSpec.describe HybridRetrievalService do
         query: 'horses', expanded_query: expanded_query,
         as_of: as_of, request_id: nil, limit: 30, filter_prefixes: %w[0101]
       )
-      expect(VectorRetrievalService).to have_received(:call).with(
+      expect(VectorRetrievalService).to have_received(:call_with_diagnostics).with(
         query: expanded_query, limit: 30, filter_prefixes: %w[0101], request_id: nil,
       )
     end
@@ -120,6 +131,68 @@ RSpec.describe HybridRetrievalService do
       described_class.call(query: 'horses', as_of: Time.zone.today)
 
       expect(AdminConfiguration).to have_received(:integer_value).with('rrf_k')
+    end
+
+    context 'when the hybrid query guardrail is enabled' do
+      before do
+        allow(AdminConfiguration).to receive(:enabled?).with('hybrid_query_guardrail_enabled').and_return(true)
+      end
+
+      it 'returns no suggestions when the raw vector score is below the configured threshold' do
+        result = described_class.call(
+          query: 'book a dentist appointment', expanded_query: expanded_query, as_of: Time.zone.today,
+        )
+
+        expect(result.results).to be_empty
+        expect(Search::Instrumentation).to have_received(:query_guardrail_decided).with(
+          request_id: nil,
+          query: 'book a dentist appointment',
+          effective_query: 'expanded horses',
+          iteration: nil,
+          enabled: true,
+          accepted: false,
+          max_score: 0.31,
+          threshold: 0.32,
+          reason: 'below_threshold',
+        )
+      end
+
+      it 'returns the merged suggestions when the raw vector score meets the configured threshold' do
+        allow(VectorRetrievalService).to receive(:call_with_diagnostics).and_return(
+          VectorRetrievalService::Result.new(results: vector_results, max_score: 0.32),
+        )
+
+        result = described_class.call(query: 'horses', as_of: Time.zone.today)
+
+        expect(result.results).not_to be_empty
+        expect(Search::Instrumentation).to have_received(:query_guardrail_decided).with(
+          hash_including(accepted: true, max_score: 0.32, threshold: 0.32, reason: 'accepted'),
+        )
+      end
+
+      it 'distinguishes no eligible vector candidates from a low score' do
+        allow(VectorRetrievalService).to receive(:call_with_diagnostics).and_return(
+          VectorRetrievalService::Result.new(results: [], max_score: nil),
+        )
+
+        result = described_class.call(query: 'book a dentist appointment', as_of: Time.zone.today)
+
+        expect(result.results).to be_empty
+        expect(Search::Instrumentation).to have_received(:query_guardrail_decided).with(
+          hash_including(accepted: false, max_score: nil, reason: 'no_vector_candidates'),
+        )
+      end
+
+      it 'fails closed when the vector score needed by the guardrail is unavailable' do
+        allow(VectorRetrievalService).to receive(:call_with_diagnostics).and_raise(StandardError, 'vector down')
+
+        result = described_class.call(query: 'horses', as_of: Time.zone.today)
+
+        expect(result.results).to be_empty
+        expect(Search::Instrumentation).to have_received(:query_guardrail_decided).with(
+          hash_including(accepted: false, max_score: nil, reason: 'vector_unavailable'),
+        )
+      end
     end
 
     it 'emits retrieval_leg_completed for both legs' do
@@ -173,7 +246,7 @@ RSpec.describe HybridRetrievalService do
 
     context 'when vector leg fails' do
       before do
-        allow(VectorRetrievalService).to receive(:call).and_raise(StandardError, 'vector down')
+        allow(VectorRetrievalService).to receive(:call_with_diagnostics).and_raise(StandardError, 'vector down')
       end
 
       it 'falls back to opensearch results' do
@@ -204,7 +277,7 @@ RSpec.describe HybridRetrievalService do
     context 'when both legs fail' do
       before do
         allow(OpensearchRetrievalService).to receive(:call).and_raise(StandardError, 'opensearch down')
-        allow(VectorRetrievalService).to receive(:call).and_raise(StandardError, 'vector down')
+        allow(VectorRetrievalService).to receive(:call_with_diagnostics).and_raise(StandardError, 'vector down')
       end
 
       it 'raises a retrieval failure' do

--- a/spec/services/hybrid_retrieval_service_spec.rb
+++ b/spec/services/hybrid_retrieval_service_spec.rb
@@ -155,6 +155,7 @@ RSpec.describe HybridRetrievalService do
           threshold: 0.32,
           reason: 'below_threshold',
         )
+        expect(AdminConfiguration).not_to have_received(:integer_value).with('rrf_k')
       end
 
       it 'returns the merged suggestions when the raw vector score meets the configured threshold' do

--- a/spec/services/hybrid_retrieval_service_spec.rb
+++ b/spec/services/hybrid_retrieval_service_spec.rb
@@ -127,6 +127,34 @@ RSpec.describe HybridRetrievalService do
       expect(result.expanded_query).to eq(expanded_query)
     end
 
+    it 'attributes guardrail telemetry to the calling search journey' do
+      described_class.call(query: 'horses', as_of: Time.zone.today, search_type: 'classification')
+
+      expect(Search::Instrumentation).to have_received(:query_guardrail_decided).with(
+        hash_including(search_type: 'classification'),
+      )
+    end
+
+    it 'emits an attributable control decision with the configured threshold' do
+      described_class.call(
+        query: 'horses', expanded_query: expanded_query, as_of: Time.zone.today,
+        request_id: 'req-1', iteration: 2
+      )
+
+      expect(Search::Instrumentation).to have_received(:query_guardrail_decided).with(
+        request_id: 'req-1',
+        search_type: 'interactive',
+        query: 'horses',
+        effective_query: expanded_query,
+        iteration: 2,
+        enabled: false,
+        accepted: true,
+        max_score: 0.31,
+        threshold: 0.32,
+        reason: 'disabled',
+      )
+    end
+
     it 'reads rrf_k from AdminConfiguration' do
       described_class.call(query: 'horses', as_of: Time.zone.today)
 
@@ -146,6 +174,7 @@ RSpec.describe HybridRetrievalService do
         expect(result.results).to be_empty
         expect(Search::Instrumentation).to have_received(:query_guardrail_decided).with(
           request_id: nil,
+          search_type: 'interactive',
           query: 'book a dentist appointment',
           effective_query: 'expanded horses',
           iteration: nil,
@@ -168,6 +197,16 @@ RSpec.describe HybridRetrievalService do
         expect(result.results).not_to be_empty
         expect(Search::Instrumentation).to have_received(:query_guardrail_decided).with(
           hash_including(accepted: true, max_score: 0.32, threshold: 0.32, reason: 'accepted'),
+        )
+      end
+
+      it 'falls back to the default threshold if persisted configuration is out of range' do
+        allow(AdminConfiguration).to receive(:integer_value).with('hybrid_query_guardrail_threshold').and_return(101)
+
+        described_class.call(query: 'horses', as_of: Time.zone.today)
+
+        expect(Search::Instrumentation).to have_received(:query_guardrail_decided).with(
+          hash_including(accepted: false, threshold: 0.32, reason: 'below_threshold'),
         )
       end
 

--- a/spec/services/vector_retrieval_service_spec.rb
+++ b/spec/services/vector_retrieval_service_spec.rb
@@ -99,6 +99,16 @@ RSpec.describe VectorRetrievalService do
       expect(result.max_score).to be_nil
     end
 
+    it 'does not query eligibility when vector search returns no candidates' do
+      allow(GoodsNomenclature).to receive(:actual).and_call_original
+
+      result = service.call_with_diagnostics
+
+      expect(result.results).to be_empty
+      expect(result.max_score).to be_nil
+      expect(GoodsNomenclature).not_to have_received(:actual)
+    end
+
     context 'when search_non_declarables is enabled' do
       before do
         allow(AdminConfiguration).to receive(:enabled?).and_call_original
@@ -212,10 +222,12 @@ RSpec.describe VectorRetrievalService do
         # Identical embeddings produce a perfect cosine similarity of 1.0,
         # so threshold must exceed 100 to filter them out
         allow(AdminConfiguration).to receive(:integer_value).with('vector_score_threshold').and_return(101)
+        allow(GoodsNomenclature).to receive(:actual).and_call_original
 
         results = service.call
 
         expect(results).to be_empty
+        expect(GoodsNomenclature).not_to have_received(:actual)
       end
 
       it 'exposes the maximum raw score before candidate filtering for hybrid query controls' do
@@ -246,6 +258,31 @@ RSpec.describe VectorRetrievalService do
         expect(result.results).to be_empty
         expect(result.max_score).to be_within(0.0001).of(1.0)
         expect(sql.grep(/goods_nomenclature_descriptions|goods_nomenclature_description_periods/i)).to be_empty
+      end
+
+      it 'uses the highest eligible raw score across multiple candidates' do
+        low_score_commodity = create(:commodity, :with_description, :declarable,
+                                     goods_nomenclature_item_id: '0101210001',
+                                     producline_suffix: GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX)
+        high_score_commodity = create(:commodity, :with_description, :declarable,
+                                      goods_nomenclature_item_id: '0101210002',
+                                      producline_suffix: GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX)
+
+        [low_score_commodity, high_score_commodity].each do |commodity|
+          create(:goods_nomenclature_self_text,
+                 goods_nomenclature_sid: commodity.goods_nomenclature_sid,
+                 goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
+                 self_text: 'Pure-bred breeding horses')
+        end
+
+        populate_search_embedding(low_score_commodity.goods_nomenclature_sid, query_embedding.map(&:-@))
+        populate_search_embedding(high_score_commodity.goods_nomenclature_sid, query_embedding)
+        allow(AdminConfiguration).to receive(:integer_value).with('vector_score_threshold').and_return(101)
+
+        result = described_class.call_with_diagnostics(query: 'live horses')
+
+        expect(result.results).to be_empty
+        expect(result.max_score).to be_within(0.0001).of(1.0)
       end
     end
 

--- a/spec/services/vector_retrieval_service_spec.rb
+++ b/spec/services/vector_retrieval_service_spec.rb
@@ -231,10 +231,21 @@ RSpec.describe VectorRetrievalService do
         populate_search_embedding(commodity.goods_nomenclature_sid, query_embedding)
         allow(AdminConfiguration).to receive(:integer_value).with('vector_score_threshold').and_return(101)
 
-        result = service.call_with_diagnostics
+        sql = []
+        subscriber = ActiveSupport::Notifications.subscribe(/sql\.sequel/) do |*args|
+          event = ActiveSupport::Notifications::Event.new(*args)
+          sql << event.payload[:sql].to_s
+        end
+
+        begin
+          result = service.call_with_diagnostics
+        ensure
+          ActiveSupport::Notifications.unsubscribe(subscriber)
+        end
 
         expect(result.results).to be_empty
         expect(result.max_score).to be_within(0.0001).of(1.0)
+        expect(sql.grep(/goods_nomenclature_descriptions|goods_nomenclature_description_periods/i)).to be_empty
       end
     end
 

--- a/spec/services/vector_retrieval_service_spec.rb
+++ b/spec/services/vector_retrieval_service_spec.rb
@@ -81,6 +81,24 @@ RSpec.describe VectorRetrievalService do
       expect(results).to be_empty
     end
 
+    it 'excludes non-declarable candidates from the diagnostic maximum score' do
+      heading = create(:heading, :with_description, :non_declarable,
+                       goods_nomenclature_item_id: '0101000000',
+                       producline_suffix: GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX)
+
+      create(:goods_nomenclature_self_text,
+             goods_nomenclature_sid: heading.goods_nomenclature_sid,
+             goods_nomenclature_item_id: heading.goods_nomenclature_item_id,
+             self_text: 'Live horses heading')
+
+      populate_search_embedding(heading.goods_nomenclature_sid, query_embedding)
+
+      result = service.call_with_diagnostics
+
+      expect(result.results).to be_empty
+      expect(result.max_score).to be_nil
+    end
+
     context 'when search_non_declarables is enabled' do
       before do
         allow(AdminConfiguration).to receive(:enabled?).and_call_original
@@ -198,6 +216,25 @@ RSpec.describe VectorRetrievalService do
         results = service.call
 
         expect(results).to be_empty
+      end
+
+      it 'exposes the maximum raw score before candidate filtering for hybrid query controls' do
+        commodity = create(:commodity, :with_description, :declarable,
+                           goods_nomenclature_item_id: '0101210000',
+                           producline_suffix: GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX)
+
+        create(:goods_nomenclature_self_text,
+               goods_nomenclature_sid: commodity.goods_nomenclature_sid,
+               goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
+               self_text: 'Pure-bred breeding horses')
+
+        populate_search_embedding(commodity.goods_nomenclature_sid, query_embedding)
+        allow(AdminConfiguration).to receive(:integer_value).with('vector_score_threshold').and_return(101)
+
+        result = service.call_with_diagnostics
+
+        expect(result.results).to be_empty
+        expect(result.max_score).to be_within(0.0001).of(1.0)
       end
     end
 


### PR DESCRIPTION
## What:

- [x] Add a disabled-by-default admin configuration for the hybrid query-quality guardrail
- [x] Keep the query-level threshold separate from the existing vector candidate threshold
- [x] Capture the maximum raw score from eligible vector candidates before candidate filtering
- [x] Reject low-confidence, candidate-less, or vector-unavailable hybrid queries when the guardrail is enabled
- [x] Emit attributable control and fixed-score telemetry with the effective query and iteration
- [x] Document the control and cover the affected admin, retrieval, instrumentation, internal search, and public V2 boundaries
- [x] Verify 313 relevant RSpec examples and the touched Ruby files

```mermaid
flowchart TD
    QUERY[Hybrid query] --> LEGS[Run retrieval legs]
    LEGS --> GATE{Guardrail enabled}
    GATE -->|No| RESULTS[Return fused results]
    GATE -->|Yes| SCORE{Score meets threshold}
    SCORE -->|Yes| RESULTS
    SCORE -->|No| EMPTY[Return no suggestions]

    classDef box stroke:#6366f1,stroke-width:2px
    class QUERY,LEGS,GATE,SCORE,RESULTS,EMPTY box
```

## Why:

Hybrid retrieval can return irrelevant OpenSearch suggestions even when the vector leg has weak semantic similarity. The existing vector threshold filters individual vector candidates but does not control the overall hybrid query.

The fixed 0.32 query-level threshold is an explainable first control for the hybrid retrieval A/B test. In the prototype corpus of 1,000 negative and 1,000 positive queries, including original and simplified ATaR descriptions, it increased negative-query rejection from 70.4% to 97.8% while retaining results for 98.0% of positive controls and preserving expected-code recall at 78.7% versus 79.2% under current behaviour.

The new control remains disabled by default. Labelled production shadow evaluation is still required before enabling it.

## Ticket:

[HMRC-2511](https://transformuk.atlassian.net/browse/HMRC-2511)

## Risk:

**Risk level:** 🟢

**Reason for rating:** The configuration is additive and disabled by default, so deployment preserves existing search behaviour. Enabling or tuning it does not require a deployment, and the change does not alter API contracts, database schema, or search indexes.