### PR TITLE
refactor(self-texts): extract embedding backfill

### DIFF
--- a/app/services/self_text_embedding_backfiller.rb
+++ b/app/services/self_text_embedding_backfiller.rb
@@ -1,0 +1,63 @@
+class SelfTextEmbeddingBackfiller
+  def self.call
+    new.call
+  end
+
+  def call
+    service = EmbeddingService.new
+    generated = embedding_records(:embedding, :self_text, :self_text)
+    $stdout.puts "Pass 1: #{generated.size} generated self-texts need embeddings..."
+    generate_embedding_batches(
+      service,
+      generated,
+      :embedding,
+      :self_text,
+      'Generated',
+      event_kind: 'self_text_embedding_backfill',
+    )
+
+    eu_references = embedding_records(:eu_embedding, :eu_self_text, :eu_self_text)
+    $stdout.puts "Pass 2: #{eu_references.size} EU references need embeddings..."
+    generate_embedding_batches(
+      service,
+      eu_references,
+      :eu_embedding,
+      :eu_self_text,
+      'EU',
+      event_kind: 'eu_self_text_embedding_backfill',
+    )
+    $stdout.puts 'Embedding generation complete.'
+  end
+
+private
+
+  def embedding_records(embedding_column, text_column, select_text_column)
+    GoodsNomenclatureSelfText
+      .where(embedding_column => nil)
+      .exclude(text_column => nil)
+      .select(:goods_nomenclature_sid, select_text_column)
+      .all
+  end
+
+  def generate_embedding_batches(service, records, embedding_column, text_column, label, event_kind:)
+    records.each_slice(EmbeddingService::BATCH_SIZE).with_index do |batch, index|
+      texts = batch.map { |record| record.public_send(text_column) }
+      embeddings = AiUsage::Instrumentation.embedding_api_call(
+        event_kind:,
+        batch_size: texts.size,
+        model: EmbeddingService::MODEL,
+      ) { service.embed_batch(texts, event_kind:) }
+      update_embeddings(batch, embeddings, embedding_column)
+      processed = [(index + 1) * EmbeddingService::BATCH_SIZE, records.size].min
+      $stdout.puts "  #{label}: #{processed}/#{records.size} embedded"
+    end
+  end
+
+  def update_embeddings(batch, embeddings, embedding_column)
+    batch.zip(embeddings).each do |record, embedding|
+      update_dataset = GoodsNomenclatureSelfText.where(goods_nomenclature_sid: record.goods_nomenclature_sid)
+      update_dataset.update(embedding_column => Sequel.lit("'[#{embedding.join(',')}]'::vector"))
+      PaperTrail::BulkVersioning.record_current_versions_for_dataset!(model: GoodsNomenclatureSelfText, dataset: update_dataset)
+    end
+  end
+end

--- a/lib/tasks/self_texts.rake
+++ b/lib/tasks/self_texts.rake
@@ -78,59 +78,7 @@ module_function
   end
 
   def generate_embeddings
-    service = EmbeddingService.new
-    generated = embedding_records(:embedding, :self_text, :self_text)
-    puts "Pass 1: #{generated.size} generated self-texts need embeddings..."
-    generate_embedding_batches(
-      service,
-      generated,
-      :embedding,
-      :self_text,
-      'Generated',
-      event_kind: 'self_text_embedding_backfill',
-    )
-
-    eu_references = embedding_records(:eu_embedding, :eu_self_text, :eu_self_text)
-    puts "Pass 2: #{eu_references.size} EU references need embeddings..."
-    generate_embedding_batches(
-      service,
-      eu_references,
-      :eu_embedding,
-      :eu_self_text,
-      'EU',
-      event_kind: 'eu_self_text_embedding_backfill',
-    )
-    puts 'Embedding generation complete.'
-  end
-
-  def embedding_records(embedding_column, text_column, select_text_column)
-    GoodsNomenclatureSelfText
-      .where(embedding_column => nil)
-      .exclude(text_column => nil)
-      .select(:goods_nomenclature_sid, select_text_column)
-      .all
-  end
-
-  def generate_embedding_batches(service, records, embedding_column, text_column, label, event_kind:)
-    records.each_slice(EmbeddingService::BATCH_SIZE).with_index do |batch, index|
-      texts = batch.map { |record| record.public_send(text_column) }
-      embeddings = AiUsage::Instrumentation.embedding_api_call(
-        event_kind:,
-        batch_size: texts.size,
-        model: EmbeddingService::MODEL,
-      ) { service.embed_batch(texts, event_kind:) }
-      update_embeddings(batch, embeddings, embedding_column)
-      processed = [(index + 1) * EmbeddingService::BATCH_SIZE, records.size].min
-      puts "  #{label}: #{processed}/#{records.size} embedded"
-    end
-  end
-
-  def update_embeddings(batch, embeddings, embedding_column)
-    batch.zip(embeddings).each do |record, embedding|
-      update_dataset = GoodsNomenclatureSelfText.where(goods_nomenclature_sid: record.goods_nomenclature_sid)
-      update_dataset.update(embedding_column => Sequel.lit("'[#{embedding.join(',')}]'::vector"))
-      PaperTrail::BulkVersioning.record_current_versions_for_dataset!(model: GoodsNomenclatureSelfText, dataset: update_dataset)
-    end
+    SelfTextEmbeddingBackfiller.call
   end
 
   def fix_encoding_artefacts


### PR DESCRIPTION
## What:
- Extracts the generated and EU self-text embedding backfill workflow from `SelfTextsTasks` into `SelfTextEmbeddingBackfiller`.
- Keeps `self_texts:generate_embeddings` as the same environment-backed Rake entry point and delegates to the Zeitwerk-loaded service.
- Reduces the `SelfTextsTasks` `Metrics/ModuleLength` offense from 387/100 to 339/100; the exact exclusion remains for later independent slices.

## Why:
PR #3505 first characterized the public task contract for vector mapping, persistence, PaperTrail versioning, existing-vector preservation, batching, progress, and instrumentation. This covered extraction gives that cohesive workflow a focused home without changing its behavior.

Behavior preserved:
- generated embeddings are completed before EU-reference embeddings
- dataset filters and selected columns
- record and text ordering
- full and partial batch handling
- AI usage instrumentation payloads and event kinds
- pgvector SQL persistence
- one PaperTrail update version per persisted embedding
- progress and completion output

Local verification:
- `bundle exec rspec spec/lib/tasks/self_texts_rake_spec.rb --seed 20260716`: 13 examples, 0 failures
- Three additional focused seeds: 13 examples, 0 failures each
- Full effective RuboCop target set: 2,384 files inspected, no offenses
- `bundle exec rails zeitwerk:check`: All is good!
- Changed-file pre-push hooks including debride: passed
- Forced `Metrics/ModuleLength`: `SelfTextsTasks` 387→339; new service has no offense
- `git diff --check`: clean
- Independent specification and quality reviews: no findings

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
This is a covered, behavior-preserving extraction with no API, database schema, task interface, worker argument, configuration, or runtime-policy change. The merged public-task characterization exercises every moved side effect.