### PR TITLE
test(self-texts): characterize coverage reporting

### DIFF
--- a/spec/lib/tasks/self_texts_rake_spec.rb
+++ b/spec/lib/tasks/self_texts_rake_spec.rb
@@ -2,6 +2,56 @@
 require 'csv'
 
 RSpec.describe 'self_texts rake tasks' do
+  describe 'self_texts:coverage' do
+    subject(:coverage) { Rake::Task['self_texts:coverage'].invoke }
+
+    after { Rake::Task['self_texts:coverage'].reenable }
+
+    it 'reports coverage, stale records, and generation-type counts' do
+      create(:chapter)
+      generated = create(:commodity)
+      stale = create(:commodity)
+      create(:commodity)
+      create(:goods_nomenclature_self_text,
+             goods_nomenclature: generated,
+             generation_type: 'mechanical')
+      create(:goods_nomenclature_self_text,
+             :stale,
+             goods_nomenclature: stale,
+             generation_type: 'ai')
+
+      expect { coverage }.to output(<<~OUTPUT).to_stdout
+        Self-Text Coverage Statistics
+        ------------------------------
+        Total GN (excl. chapters): 3
+        With self-text:            2
+        Missing:                   1
+        Coverage:                  66.67%
+        Stale:                     1
+        Needing work:              2
+
+        By generation type:
+          ai: 1
+          mechanical: 1
+      OUTPUT
+    end
+
+    it 'reports zero coverage when there are no goods nomenclatures' do
+      expect { coverage }.to output(<<~OUTPUT).to_stdout
+        Self-Text Coverage Statistics
+        ------------------------------
+        Total GN (excl. chapters): 0
+        With self-text:            0
+        Missing:                   0
+        Coverage:                  0%
+        Stale:                     0
+        Needing work:              0
+
+        By generation type:
+      OUTPUT
+    end
+  end
+
   describe 'self_texts:populate_eu_references' do
     subject(:populate) do
       suppress_output { Rake::Task['self_texts:populate_eu_references'].invoke }


### PR DESCRIPTION
## What:
- Adds public Rake-task characterization for `self_texts:coverage`.
- Verifies chapters are excluded from the total goods-nomenclature denominator.
- Covers missing and stale aggregation, combined work count, percentage rounding, and generation-type grouping/order.
- Locks the exact report format for both populated and empty datasets.

## Why:
Coverage reporting is the next cohesive part of the excluded `SelfTextsTasks` module. It had no direct task coverage, so this test-only precursor reduces the risk of a later independent extraction PR.

Local verification:
- `bundle exec rspec spec/lib/tasks/self_texts_rake_spec.rb --seed 20260716`: 15 examples, 0 failures
- Three additional focused seeds: 15 examples, 0 failures each
- Full effective RuboCop target set: 2,385 files inspected, no offenses
- Changed-file pre-push hooks: passed
- `git diff --check`: clean
- Independent specification and quality re-reviews: no findings

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Test-only change. It does not modify production code, task behavior, database schema, configuration, worker arguments, or runtime policy.