### PR TITLE
refactor(self-texts): extract coverage reporter

### DIFF
--- a/app/services/self_text_coverage_reporter.rb
+++ b/app/services/self_text_coverage_reporter.rb
@@ -1,0 +1,42 @@
+class SelfTextCoverageReporter
+  def self.call
+    new.call
+  end
+
+  def call
+    TimeMachine.now { print_stats(coverage_stats) }
+  end
+
+private
+
+  def coverage_stats
+    total_gn = GoodsNomenclature.actual.non_hidden.count - Chapter.actual.count
+    total_self_texts = GoodsNomenclatureSelfText.count
+    missing = total_gn - total_self_texts
+    stale = GoodsNomenclatureSelfText.where(stale: true).count
+
+    {
+      total_gn:,
+      total_self_texts:,
+      missing:,
+      stale:,
+      needing_work: missing + stale,
+      coverage: total_gn.positive? ? (total_self_texts * 100.0 / total_gn).round(2) : 0,
+      by_type: GoodsNomenclatureSelfText.group_and_count(:generation_type).order(:generation_type).all,
+    }
+  end
+
+  def print_stats(stats)
+    $stdout.puts 'Self-Text Coverage Statistics'
+    $stdout.puts '-' * 30
+    $stdout.puts "Total GN (excl. chapters): #{stats[:total_gn]}"
+    $stdout.puts "With self-text:            #{stats[:total_self_texts]}"
+    $stdout.puts "Missing:                   #{stats[:missing]}"
+    $stdout.puts "Coverage:                  #{stats[:coverage]}%"
+    $stdout.puts "Stale:                     #{stats[:stale]}"
+    $stdout.puts "Needing work:              #{stats[:needing_work]}"
+    $stdout.puts
+    $stdout.puts 'By generation type:'
+    stats[:by_type].each { |row| $stdout.puts "  #{row[:generation_type]}: #{row[:count]}" }
+  end
+end

--- a/lib/tasks/self_texts.rake
+++ b/lib/tasks/self_texts.rake
@@ -2,38 +2,7 @@ module SelfTextsTasks
 module_function
 
   def coverage
-    TimeMachine.now { print_coverage_stats(coverage_stats) }
-  end
-
-  def coverage_stats
-    total_gn = GoodsNomenclature.actual.non_hidden.count - Chapter.actual.count
-    total_self_texts = GoodsNomenclatureSelfText.count
-    missing = total_gn - total_self_texts
-    stale = GoodsNomenclatureSelfText.where(stale: true).count
-
-    {
-      total_gn:,
-      total_self_texts:,
-      missing:,
-      stale:,
-      needing_work: missing + stale,
-      coverage: total_gn.positive? ? (total_self_texts * 100.0 / total_gn).round(2) : 0,
-      by_type: GoodsNomenclatureSelfText.group_and_count(:generation_type).order(:generation_type).all,
-    }
-  end
-
-  def print_coverage_stats(stats)
-    puts 'Self-Text Coverage Statistics'
-    puts '-' * 30
-    puts "Total GN (excl. chapters): #{stats[:total_gn]}"
-    puts "With self-text:            #{stats[:total_self_texts]}"
-    puts "Missing:                   #{stats[:missing]}"
-    puts "Coverage:                  #{stats[:coverage]}%"
-    puts "Stale:                     #{stats[:stale]}"
-    puts "Needing work:              #{stats[:needing_work]}"
-    puts
-    puts 'By generation type:'
-    stats[:by_type].each { |row| puts "  #{row[:generation_type]}: #{row[:count]}" }
+    SelfTextCoverageReporter.call
   end
 
   def regenerate


### PR DESCRIPTION
## What:
- Extracts self-text coverage calculation and reporting from `SelfTextsTasks` into `SelfTextCoverageReporter`.
- Keeps `self_texts:coverage` as the same environment-backed Rake entry point and delegates to the Zeitwerk-loaded service.
- Reduces the `SelfTextsTasks` `Metrics/ModuleLength` offense from 339/100 to 311/100; the exact exclusion remains for later independent slices.

## Why:
PR #3508 first characterized chapter exclusion, missing/stale/work aggregation, percentage rounding, generation-type grouping/order, exact output, and the zero-denominator branch. This covered extraction gives the cohesive report a focused home without changing behavior.

Local verification:
- `bundle exec rspec spec/lib/tasks/self_texts_rake_spec.rb --seed 20260716`: 15 examples, 0 failures
- Three additional focused seeds: 15 examples, 0 failures each
- Full effective RuboCop target set: 2,385 files inspected, no offenses
- `bundle exec rails zeitwerk:check`: All is good!
- Changed-file pre-push hooks including debride: passed
- Forced `Metrics/ModuleLength`: `SelfTextsTasks` 339→311; new service has no offense
- `git diff --check`: clean
- Independent specification and quality reviews: no findings

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
This is a covered, behavior-preserving extraction with no API, database schema, task interface, worker argument, configuration, or runtime-policy change. The merged public-task characterization exercises every moved calculation and output branch.