### PR TITLE
test(self-texts): characterize regeneration task

### DIFF
--- a/spec/lib/tasks/self_texts_rake_spec.rb
+++ b/spec/lib/tasks/self_texts_rake_spec.rb
@@ -52,6 +52,56 @@ RSpec.describe 'self_texts rake tasks' do
     end
   end
 
+  describe 'self_texts:regenerate' do
+    subject(:regenerate) { Rake::Task['self_texts:regenerate'].invoke }
+
+    after { Rake::Task['self_texts:regenerate'].reenable }
+
+    it 'marks unedited current self-texts stale, versions them, and enqueues regeneration' do
+      eligible = create_list(:goods_nomenclature_self_text, 2)
+      eligible << create(:goods_nomenclature_self_text, :expired)
+      manually_edited = create(:goods_nomenclature_self_text, :manually_edited)
+      already_stale = create(:goods_nomenclature_self_text, :stale)
+      allow(GenerateSelfTextWorker).to receive(:perform_async) do
+        eligible.each do |record|
+          version = record.refresh.versions.order(:id).last
+          expect(record.stale).to be(true)
+          expect(version).to have_attributes(event: 'update')
+          expect(version.object['stale']).to be(true)
+        end
+      end
+
+      expect { regenerate }
+        .to output(<<~OUTPUT).to_stdout
+          Marked 3 self-texts as stale.
+          Enqueued regeneration. Check Sidekiq for progress.
+        OUTPUT
+        .and change(Version, :count).by(3)
+
+      expect(eligible.map { |record| record.refresh.stale }).to all(be(true))
+      expect(eligible.last.expired).to be(true)
+      expect(manually_edited.refresh.stale).to be(false)
+      expect(already_stale.refresh.stale).to be(true)
+      expect(GenerateSelfTextWorker).to have_received(:perform_async).with(no_args).once
+    end
+
+    it 'still enqueues regeneration without creating versions when no records change' do
+      create(:goods_nomenclature_self_text, :manually_edited)
+      create(:goods_nomenclature_self_text, :stale)
+      allow(GenerateSelfTextWorker).to receive(:perform_async)
+      version_count = Version.count
+
+      expect { regenerate }
+        .to output(<<~OUTPUT).to_stdout
+          Marked 0 self-texts as stale.
+          Enqueued regeneration. Check Sidekiq for progress.
+        OUTPUT
+
+      expect(Version.count).to eq(version_count)
+      expect(GenerateSelfTextWorker).to have_received(:perform_async).with(no_args).once
+    end
+  end
+
   describe 'self_texts:populate_eu_references' do
     subject(:populate) do
       suppress_output { Rake::Task['self_texts:populate_eu_references'].invoke }

--- a/spec/lib/tasks/self_texts_rake_spec.rb
+++ b/spec/lib/tasks/self_texts_rake_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe 'self_texts rake tasks' do
 
     after { Rake::Task['self_texts:regenerate'].reenable }
 
-    it 'marks unedited current self-texts stale, versions them, and enqueues regeneration' do
+    it 'marks unedited non-stale self-texts stale, versions them, and enqueues regeneration' do
       eligible = create_list(:goods_nomenclature_self_text, 2)
       eligible << create(:goods_nomenclature_self_text, :expired)
       manually_edited = create(:goods_nomenclature_self_text, :manually_edited)


### PR DESCRIPTION
## What:
- Adds public-task characterization for `self_texts:regenerate`.
- Covers eligible, manually edited, already stale, and expired self-text selection.
- Proves stale state and current PaperTrail snapshots exist before regeneration is enqueued.
- Covers the zero-update branch, exact output, and worker enqueueing.

## Why:
The regeneration workflow persists state, creates audit versions, and enqueues asynchronous work. This test-only precursor reduces risk before extracting it from the oversized `SelfTextsTasks` module in a later, unstacked PR.

Local verification:
- `bundle exec rspec spec/lib/tasks/self_texts_rake_spec.rb`: 17 examples, 0 failures across seeds 1, 8675309, and 20260717
- Full effective RuboCop target set: 2,386 files inspected, no offenses
- `git diff --check`: clean
- Independent specification and quality reviews: findings addressed; no remaining findings

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
This PR changes tests only. It does not change application code, Rake task behavior, persisted data, worker arguments, configuration, or RuboCop configuration.