### PR TITLE
refactor(self-texts): extract regenerator

### DIFF
--- a/app/services/self_text_regenerator.rb
+++ b/app/services/self_text_regenerator.rb
@@ -1,0 +1,12 @@
+class SelfTextRegenerator
+  def self.call
+    dataset = GoodsNomenclatureSelfText.where(stale: false, manually_edited: false)
+    item_ids = dataset.select_map(:goods_nomenclature_sid)
+    count = dataset.update(stale: true)
+    PaperTrail::BulkVersioning.record_current_versions_for_item_ids!(model: GoodsNomenclatureSelfText, item_ids:) if count.positive?
+    $stdout.puts "Marked #{count} self-texts as stale."
+
+    GenerateSelfTextWorker.perform_async
+    $stdout.puts 'Enqueued regeneration. Check Sidekiq for progress.'
+  end
+end

--- a/lib/tasks/self_texts.rake
+++ b/lib/tasks/self_texts.rake
@@ -6,14 +6,7 @@ module_function
   end
 
   def regenerate
-    dataset = GoodsNomenclatureSelfText.where(stale: false, manually_edited: false)
-    item_ids = dataset.select_map(:goods_nomenclature_sid)
-    count = dataset.update(stale: true)
-    PaperTrail::BulkVersioning.record_current_versions_for_item_ids!(model: GoodsNomenclatureSelfText, item_ids:) if count.positive?
-    puts "Marked #{count} self-texts as stale."
-
-    GenerateSelfTextWorker.perform_async
-    puts 'Enqueued regeneration. Check Sidekiq for progress.'
+    SelfTextRegenerator.call
   end
 
   def generate


### PR DESCRIPTION
## What:
- Extracts the `self_texts:regenerate` persistence and enqueue workflow from `SelfTextsTasks` into `SelfTextRegenerator`.
- Keeps the same environment-backed Rake task entry point.
- Preserves eligibility, bulk PaperTrail snapshots, stdout, and worker enqueue ordering.
- Reduces `SelfTextsTasks` from 311/100 to 305/100; its exact exclusion remains for later independent slices.

## Why:
PR #3510 first characterized eligible and ineligible records, expired-record inclusion, version snapshots before enqueueing, the zero-update path, exact output, and worker arguments. This covered extraction moves one cohesive workflow without changing behavior.

Local verification:
- `bundle exec rspec spec/lib/tasks/self_texts_rake_spec.rb`: 17 examples, 0 failures across seeds 1, 8675309, and 20260717
- Full effective RuboCop target set: 2,386 files inspected, no offenses
- `bundle exec rails zeitwerk:check`: All is good!
- Forced `Metrics/ModuleLength`: `SelfTextsTasks` 311→305; new service has no offense
- `git diff --check`: clean
- Independent specification and quality reviews: no findings

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
This is a covered, behavior-preserving extraction with no API, schema, task interface, worker argument, configuration, or runtime-policy change.