### PR TITLE
refactor(self-texts): extract generation runner

### DIFF
--- a/app/services/self_text_generation_runner.rb
+++ b/app/services/self_text_generation_runner.rb
@@ -1,0 +1,25 @@
+class SelfTextGenerationRunner
+  class << self
+    def call(chapter_code)
+      chapter_code ? generate_chapter(chapter_code) : enqueue_generation
+    end
+
+  private
+
+    def generate_chapter(chapter_code)
+      chapter = TimeMachine.now { Chapter.actual.by_code(chapter_code).take }
+
+      $stdout.puts "Generating self-texts for chapter #{chapter_code}..."
+      ai = GenerateSelfText::OtherSelfTextBuilder.call(chapter)
+      non_other_ai = GenerateSelfText::NonOtherSelfTextBuilder.call(chapter)
+      $stdout.puts "Other AI: #{ai.inspect}"
+      $stdout.puts "Non-Other AI: #{non_other_ai.inspect}"
+    end
+
+    def enqueue_generation
+      $stdout.puts 'Enqueuing self-text generation for all chapters...'
+      GenerateSelfTextWorker.perform_async
+      $stdout.puts 'Done. Check Sidekiq for progress.'
+    end
+  end
+end

--- a/lib/tasks/self_texts.rake
+++ b/lib/tasks/self_texts.rake
@@ -10,28 +10,7 @@ module_function
   end
 
   def generate
-    if ENV['CHAPTER']
-      generate_chapter
-    else
-      enqueue_generation
-    end
-  end
-
-  def generate_chapter
-    chapter = TimeMachine.now { Chapter.actual.by_code(ENV['CHAPTER']).take }
-    raise "Chapter #{ENV['CHAPTER']} not found" unless chapter
-
-    puts "Generating self-texts for chapter #{ENV['CHAPTER']}..."
-    ai = GenerateSelfText::OtherSelfTextBuilder.call(chapter)
-    non_other_ai = GenerateSelfText::NonOtherSelfTextBuilder.call(chapter)
-    puts "Other AI: #{ai.inspect}"
-    puts "Non-Other AI: #{non_other_ai.inspect}"
-  end
-
-  def enqueue_generation
-    puts 'Enqueuing self-text generation for all chapters...'
-    GenerateSelfTextWorker.perform_async
-    puts 'Done. Check Sidekiq for progress.'
+    SelfTextGenerationRunner.call(ENV['CHAPTER'])
   end
 
   def populate_eu_references


### PR DESCRIPTION
## Summary

- extract the characterized `self_texts:generate` workflow into a Zeitwerk service
- keep the Rake task as a thin delegation boundary
- preserve chapter selection, output, builder order, and background enqueue semantics
- rely directly on the repository's raising `Dataset#take` contract instead of retaining an unreachable fallback guard

The observed missing-chapter behavior remains `Sequel::RecordNotFound`; this is a behavior-preserving extraction.

## Verification

- `bundle exec rspec spec/lib/tasks/self_texts_rake_spec.rb --seed 1` — 20 examples, 0 failures
- `bundle exec rspec spec/lib/tasks/self_texts_rake_spec.rb --seed 8675309` — 20 examples, 0 failures
- `bundle exec rspec spec/lib/tasks/self_texts_rake_spec.rb --seed 20260717` — 20 examples, 0 failures
- `bundle exec rails zeitwerk:check` — all is good
- targeted RuboCop — 2 files, no offenses
- full effective RuboCop inventory — 2,388 files, no offenses
- forced inventory — 16 offenses across 9 exclusions; `SelfTextsTasks` reduced 305→287
- independent requirements review — compliant
- independent code-quality review — no findings after feedback resolution

**Risk level:** 🟢