### PR TITLE
AI-1056: Remove status concept from customs tariff update pipeline

### DIFF
--- a/app/controllers/api/admin/customs_tariff_updates/chapter_notes_controller.rb
+++ b/app/controllers/api/admin/customs_tariff_updates/chapter_notes_controller.rb
@@ -62,7 +62,6 @@ module Api
             chapter_id: create_params[:chapter_id],
             content: create_params[:content],
             validity_start_date: customs_tariff_update.validity_start_date,
-            status: CustomsTariffChapterNote::PENDING,
           )
 
           if note.save(raise_on_failure: false)
@@ -127,7 +126,7 @@ module Api
         def previous_notes_index
           current_date = customs_tariff_update.validity_start_date
           prev = CustomsTariffUpdate
-            .exclude(status: CustomsTariffUpdate::FAILED)
+            .imported
             .where { validity_start_date < current_date }
             .order(Sequel.desc(:validity_start_date))
             .first

--- a/app/controllers/api/admin/customs_tariff_updates/reimport_controller.rb
+++ b/app/controllers/api/admin/customs_tariff_updates/reimport_controller.rb
@@ -3,7 +3,6 @@ module Api
     module CustomsTariffUpdates
       class ReimportController < BaseController
         def create
-          # No status guard — reimport is a recovery tool that must work on any update status
           worker = TradeTariffBackend.xi? ? XiCnReimportWorker : CustomsTariffReimportWorker
           worker.perform_async(customs_tariff_update.version)
           head :accepted

--- a/app/controllers/api/admin/customs_tariff_updates/section_notes_controller.rb
+++ b/app/controllers/api/admin/customs_tariff_updates/section_notes_controller.rb
@@ -72,7 +72,6 @@ module Api
             section_id: create_params[:section_id].to_i,
             content: create_params[:content],
             validity_start_date: customs_tariff_update.validity_start_date,
-            status: CustomsTariffSectionNote::PENDING,
           )
 
           if note.save(raise_on_failure: false)
@@ -116,7 +115,7 @@ module Api
         def previous_notes_index
           current_date = customs_tariff_update.validity_start_date
           prev = CustomsTariffUpdate
-            .exclude(status: CustomsTariffUpdate::FAILED)
+            .imported
             .where { validity_start_date < current_date }
             .order(Sequel.desc(:validity_start_date))
             .first

--- a/app/controllers/api/admin/customs_tariff_updates/sections_summary_controller.rb
+++ b/app/controllers/api/admin/customs_tariff_updates/sections_summary_controller.rb
@@ -111,7 +111,7 @@ module Api
           @previous_update ||= begin
             current_date = customs_tariff_update.validity_start_date
             CustomsTariffUpdate
-              .exclude(status: CustomsTariffUpdate::FAILED)
+              .imported
               .where { validity_start_date < current_date }
               .order(Sequel.desc(:validity_start_date))
               .first

--- a/app/lib/customs_tariff_importer/importer.rb
+++ b/app/lib/customs_tariff_importer/importer.rb
@@ -18,12 +18,12 @@ module CustomsTariffImporter
   private
 
     def import_document(fetched)
-      if CustomsTariffUpdate.exclude(status: CustomsTariffUpdate::FAILED).where(version: fetched.version).any?
+      if CustomsTariffUpdate.imported.where(version: fetched.version).any?
         Instrumentation.document_skipped(version: fetched.version, reason: :already_imported)
         return Result.new(status: :skipped, version: fetched.version)
       end
 
-      if CustomsTariffUpdate.where(file_checksum: fetched.checksum).any?
+      if CustomsTariffUpdate.imported.where(file_checksum: fetched.checksum).any?
         Instrumentation.document_skipped(version: fetched.version, reason: :duplicate_content)
         return Result.new(status: :duplicate_content, version: fetched.version)
       end
@@ -41,7 +41,6 @@ module CustomsTariffImporter
         update = CustomsTariffUpdate.create(
           version: fetched.version,
           validity_start_date: fetched.entry_into_force_on || fetched.published_on || Time.zone.today,
-          status: CustomsTariffUpdate::PENDING,
           source_url: fetched.url,
           s3_path:,
           file_checksum: fetched.checksum,
@@ -78,7 +77,6 @@ module CustomsTariffImporter
           chapter_id:,
           content:,
           validity_start_date: update.validity_start_date,
-          status: CustomsTariffChapterNote::PENDING,
         )
       end
     end
@@ -90,7 +88,6 @@ module CustomsTariffImporter
           section_id:,
           content:,
           validity_start_date: update.validity_start_date,
-          status: CustomsTariffSectionNote::PENDING,
         )
       end
     end
@@ -102,19 +99,18 @@ module CustomsTariffImporter
           rule_label:,
           content:,
           validity_start_date: update.validity_start_date,
-          status: CustomsTariffGeneralRule::PENDING,
         )
       end
     end
 
     def record_failure(version, message)
       return if version.blank?
-      return if CustomsTariffUpdate.where(version:).any?
+      return if CustomsTariffUpdate.imported.where(version:).any?
 
+      CustomsTariffUpdate.failed.where(version:).delete
       CustomsTariffUpdate.create(
         version:,
         validity_start_date: Time.zone.today,
-        status: CustomsTariffUpdate::FAILED,
         import_error: message,
       )
     rescue StandardError => e

--- a/app/lib/customs_tariff_importer/instrumentation.rb
+++ b/app/lib/customs_tariff_importer/instrumentation.rb
@@ -12,8 +12,8 @@ module CustomsTariffImporter
       instrument('import_run_started')
     end
 
-    def import_run_completed(imported:, skipped:, failed:, duration_ms:, review_backlog:)
-      instrument('import_run_completed', imported:, skipped:, failed:, duration_ms:, review_backlog:)
+    def import_run_completed(imported:, failed:, duration_ms:)
+      instrument('import_run_completed', imported:, failed:, duration_ms:)
     end
 
     def import_run_failed(error_class:, error_message:)
@@ -54,10 +54,6 @@ module CustomsTariffImporter
 
     def document_import_failed(version:, error_class:, error_message:)
       instrument('document_import_failed', version:, error_class:, error_message:)
-    end
-
-    def status_changed(version:, from_status:, to_status:, whodunnit:, review_backlog:)
-      instrument('status_changed', version:, from_status:, to_status:, whodunnit:, review_backlog:)
     end
 
     def section_note_updated(version:, section_id:, note_id:, whodunnit:)

--- a/app/lib/customs_tariff_importer/logger.rb
+++ b/app/lib/customs_tariff_importer/logger.rb
@@ -10,10 +10,8 @@ module CustomsTariffImporter
       info log_entry(
         event: 'import_run_completed',
         imported: event.payload[:imported],
-        skipped: event.payload[:skipped],
         failed: event.payload[:failed],
         duration_ms: event.payload[:duration_ms],
-        review_backlog: event.payload[:review_backlog],
       )
     end
 
@@ -92,17 +90,6 @@ module CustomsTariffImporter
         version: event.payload[:version],
         error_class: event.payload[:error_class],
         error_message: event.payload[:error_message],
-      )
-    end
-
-    def status_changed(event)
-      info log_entry(
-        event: 'status_changed',
-        version: event.payload[:version],
-        from_status: event.payload[:from_status],
-        to_status: event.payload[:to_status],
-        whodunnit: event.payload[:whodunnit],
-        review_backlog: event.payload[:review_backlog],
       )
     end
 

--- a/app/lib/customs_tariff_importer/reimporter.rb
+++ b/app/lib/customs_tariff_importer/reimporter.rb
@@ -6,7 +6,7 @@ module CustomsTariffImporter
         update = CustomsTariffUpdate.first(version:)
         reimport(update) if update # no-op if the version does not exist
       else
-        CustomsTariffUpdate.exclude(status: CustomsTariffUpdate::FAILED).each do |update|
+        CustomsTariffUpdate.imported.each do |update|
           reimport(update)
         end
       end
@@ -40,7 +40,6 @@ module CustomsTariffImporter
           section_id:,
           content: note_content,
           validity_start_date: update.validity_start_date,
-          status: CustomsTariffSectionNote::PENDING,
         )
       end
     end
@@ -52,7 +51,6 @@ module CustomsTariffImporter
           chapter_id:,
           content: note_content,
           validity_start_date: update.validity_start_date,
-          status: CustomsTariffChapterNote::PENDING,
         )
       end
     end
@@ -64,7 +62,6 @@ module CustomsTariffImporter
           rule_label:,
           content: note_content,
           validity_start_date: update.validity_start_date,
-          status: CustomsTariffGeneralRule::PENDING,
         )
       end
     end

--- a/app/lib/xi_cn_importer/document_fetcher.rb
+++ b/app/lib/xi_cn_importer/document_fetcher.rb
@@ -48,7 +48,7 @@ module XiCnImporter
         pub_date   = binding.dig('pub_date', 'value')&.then { |d| Date.parse(d) }
 
         next if CustomsTariffUpdate
-                  .exclude(status: CustomsTariffUpdate::FAILED)
+                  .imported
                   .where(version: celex)
                   .any?
 

--- a/app/lib/xi_cn_importer/importer.rb
+++ b/app/lib/xi_cn_importer/importer.rb
@@ -56,7 +56,6 @@ module XiCnImporter
       CustomsTariffUpdate.create(
         version: fetched.celex,
         validity_start_date: fetched.force_date,
-        status: CustomsTariffUpdate::PENDING,
         source_url: fetched.cellar_url,
         s3_path:,
         file_checksum: fetched.pdf_checksum,
@@ -71,7 +70,6 @@ module XiCnImporter
           section_id:,
           content:,
           validity_start_date: update.validity_start_date,
-          status: CustomsTariffSectionNote::PENDING,
         )
       end
     end
@@ -83,7 +81,6 @@ module XiCnImporter
           chapter_id:,
           content:,
           validity_start_date: update.validity_start_date,
-          status: CustomsTariffChapterNote::PENDING,
         )
       end
     end
@@ -95,20 +92,18 @@ module XiCnImporter
           rule_label:,
           content:,
           validity_start_date: update.validity_start_date,
-          status: CustomsTariffGeneralRule::PENDING,
         )
       end
     end
 
     def record_failure(celex, message)
       return if celex.blank?
-      return if CustomsTariffUpdate.exclude(status: CustomsTariffUpdate::FAILED).where(version: celex).any?
+      return if CustomsTariffUpdate.imported.where(version: celex).any?
 
-      CustomsTariffUpdate.where(version: celex, status: CustomsTariffUpdate::FAILED).delete
+      CustomsTariffUpdate.failed.where(version: celex).delete
       CustomsTariffUpdate.create(
         version: celex,
         validity_start_date: Time.zone.today,
-        status: CustomsTariffUpdate::FAILED,
         import_error: message,
       )
     rescue StandardError => e

--- a/app/lib/xi_cn_importer/instrumentation.rb
+++ b/app/lib/xi_cn_importer/instrumentation.rb
@@ -8,8 +8,8 @@ module XiCnImporter
       instrument('import_run_started')
     end
 
-    def import_run_completed(imported:, failed:, duration_ms:, review_backlog:)
-      instrument('import_run_completed', imported:, failed:, duration_ms:, review_backlog:)
+    def import_run_completed(imported:, failed:, duration_ms:)
+      instrument('import_run_completed', imported:, failed:, duration_ms:)
     end
 
     def import_run_failed(error_class:, error_message:)

--- a/app/lib/xi_cn_importer/logger.rb
+++ b/app/lib/xi_cn_importer/logger.rb
@@ -12,7 +12,6 @@ module XiCnImporter
         imported: event.payload[:imported],
         failed: event.payload[:failed],
         duration_ms: event.payload[:duration_ms],
-        review_backlog: event.payload[:review_backlog],
       )
     end
 

--- a/app/lib/xi_cn_importer/reimporter.rb
+++ b/app/lib/xi_cn_importer/reimporter.rb
@@ -7,7 +7,7 @@ module XiCnImporter
         update = CustomsTariffUpdate.first(version:)
         reimport(update) if update && update.s3_path&.start_with?("#{S3_KEY_PREFIX}/")
       else
-        CustomsTariffUpdate.exclude(status: CustomsTariffUpdate::FAILED).each do |update|
+        CustomsTariffUpdate.imported.each do |update|
           next unless update.s3_path&.start_with?("#{S3_KEY_PREFIX}/")
 
           reimport(update)
@@ -45,7 +45,6 @@ module XiCnImporter
             chapter_id:,
             content: note_content,
             validity_start_date: update.validity_start_date,
-            status: CustomsTariffChapterNote::PENDING,
           )
         end
 
@@ -55,7 +54,6 @@ module XiCnImporter
             rule_label:,
             content: note_content,
             validity_start_date: update.validity_start_date,
-            status: CustomsTariffGeneralRule::PENDING,
           )
         end
       end
@@ -68,7 +66,6 @@ module XiCnImporter
           section_id:,
           content: note_content,
           validity_start_date: update.validity_start_date,
-          status: CustomsTariffSectionNote::PENDING,
         )
       end
     end

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -25,11 +25,7 @@ class Chapter < GoodsNomenclature
   one_to_one :chapter_note, primary_key: :chapter_short_code
   one_to_one :customs_tariff_chapter_note, key: :chapter_id, primary_key: :chapter_short_code do |ds|
     ds.where(
-      customs_tariff_update_version: CustomsTariffUpdate.actual
-        .exclude(status: CustomsTariffUpdate::FAILED)
-        .order(Sequel.desc(:validity_start_date))
-        .select(:version)
-        .limit(1),
+      customs_tariff_update_version: CustomsTariffUpdate.latest.select(:version).limit(1),
     )
   end
 

--- a/app/models/customs_tariff_chapter_note.rb
+++ b/app/models/customs_tariff_chapter_note.rb
@@ -1,23 +1,5 @@
 class CustomsTariffChapterNote < Sequel::Model
-  PENDING  = 'pending'.freeze
-  APPROVED = 'approved'.freeze
-  REJECTED = 'rejected'.freeze
-
   plugin :has_paper_trail
 
   many_to_one :customs_tariff_update, key: :customs_tariff_update_version
-
-  dataset_module do
-    def pending
-      where(status: PENDING)
-    end
-
-    def approved
-      where(status: APPROVED)
-    end
-
-    def rejected
-      where(status: REJECTED)
-    end
-  end
 end

--- a/app/models/customs_tariff_general_rule.rb
+++ b/app/models/customs_tariff_general_rule.rb
@@ -1,8 +1,4 @@
 class CustomsTariffGeneralRule < Sequel::Model
-  PENDING  = 'pending'.freeze
-  APPROVED = 'approved'.freeze
-  REJECTED = 'rejected'.freeze
-
   many_to_one :customs_tariff_update, key: :customs_tariff_update_version
 
   def self.latest_rules
@@ -13,19 +9,5 @@ class CustomsTariffGeneralRule < Sequel::Model
     return [] unless latest_update
 
     latest_update.customs_tariff_general_rules
-  end
-
-  dataset_module do
-    def pending
-      where(status: PENDING)
-    end
-
-    def approved
-      where(status: APPROVED)
-    end
-
-    def rejected
-      where(status: REJECTED)
-    end
   end
 end

--- a/app/models/customs_tariff_section_note.rb
+++ b/app/models/customs_tariff_section_note.rb
@@ -1,23 +1,5 @@
 class CustomsTariffSectionNote < Sequel::Model
-  PENDING  = 'pending'.freeze
-  APPROVED = 'approved'.freeze
-  REJECTED = 'rejected'.freeze
-
   plugin :has_paper_trail
 
   many_to_one :customs_tariff_update, key: :customs_tariff_update_version
-
-  dataset_module do
-    def pending
-      where(status: PENDING)
-    end
-
-    def approved
-      where(status: APPROVED)
-    end
-
-    def rejected
-      where(status: REJECTED)
-    end
-  end
 end

--- a/app/models/customs_tariff_update.rb
+++ b/app/models/customs_tariff_update.rb
@@ -5,34 +5,13 @@ class CustomsTariffUpdate < Sequel::Model
   plugin :time_machine
   plugin :timestamps, update_on_create: true
 
-  PENDING = 'pending'.freeze
-  APPROVED          = 'approved'.freeze
-  REJECTED          = 'rejected'.freeze
-  FAILED            = 'failed'.freeze
-
   one_to_many :customs_tariff_chapter_notes, key: :customs_tariff_update_version
   one_to_many :customs_tariff_section_notes, key: :customs_tariff_update_version
   one_to_many :customs_tariff_general_rules, key: :customs_tariff_update_version, order: :rule_label
 
   dataset_module do
-    def pending
-      where(status: PENDING)
-    end
-
-    def approved
-      where(status: APPROVED)
-    end
-
-    def rejected
-      where(status: REJECTED)
-    end
-
-    def failed
-      where(status: FAILED)
-    end
-
-    def latest
-      actual.exclude(status: FAILED).order(Sequel.desc(:validity_start_date))
-    end
+    def failed   = exclude(import_error: nil)
+    def imported = where(import_error: nil)
+    def latest   = imported.actual.order(Sequel.desc(:validity_start_date))
   end
 end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -26,22 +26,11 @@ class Section < Sequel::Model
   one_to_one :section_note
 
   one_to_one :current_customs_tariff_section_note, class: :CustomsTariffSectionNote, key: :section_id, primary_key: :id do |ds|
-    ds.where(
-      customs_tariff_update_version: CustomsTariffUpdate.actual
-        .exclude(status: CustomsTariffUpdate::FAILED)
-        .order(Sequel.desc(:validity_start_date))
-        .select(:version)
-        .limit(1),
-    )
+    ds.where(customs_tariff_update_version: CustomsTariffUpdate.latest.select(:version).limit(1))
   end
+
   one_to_one :customs_tariff_section_note, key: :section_id, primary_key: :id do |ds|
-    ds.where(
-      customs_tariff_update_version: CustomsTariffUpdate.actual
-        .exclude(status: CustomsTariffUpdate::FAILED)
-        .order(Sequel.desc(:validity_start_date))
-        .select(:version)
-        .limit(1),
-    )
+    ds.where(customs_tariff_update_version: CustomsTariffUpdate.latest.select(:version).limit(1))
   end
 
   def public_section_note

--- a/app/serializers/api/admin/customs_tariff_update_serializer.rb
+++ b/app/serializers/api/admin/customs_tariff_update_serializer.rb
@@ -6,7 +6,7 @@ module Api
       set_type :customs_tariff_update
       set_id   :version
 
-      attributes :version, :status, :validity_start_date, :validity_end_date,
+      attributes :version, :import_error, :validity_start_date, :validity_end_date,
                  :source_url, :document_created_on, :created_at, :updated_at
     end
   end

--- a/app/services/tariff_knowledge/compressed_note_generator.rb
+++ b/app/services/tariff_knowledge/compressed_note_generator.rb
@@ -173,11 +173,7 @@ module TariffKnowledge
       return @current_source_version if defined?(@current_source_version)
 
       @current_source_version = TimeMachine.at(@time_machine_date ||= Time.current) do
-        CustomsTariffUpdate
-          .actual
-          .exclude(status: SourceGraphLoader::EXCLUDED_UPDATE_STATUSES)
-          .order(Sequel.desc(:validity_start_date))
-          .get(:version)
+        CustomsTariffUpdate.latest.get(:version)
       end
     end
 

--- a/app/services/tariff_knowledge/source_graph_loader.rb
+++ b/app/services/tariff_knowledge/source_graph_loader.rb
@@ -2,8 +2,6 @@ module TariffKnowledge
   class SourceGraphLoader
     BATCH_SIZE = 500
 
-    EXCLUDED_UPDATE_STATUSES = [CustomsTariffUpdate::FAILED].freeze
-
     RangeReference = Data.define(:type, :code)
     SourceAssociation = Data.define(:association, :label, :identifier, :title)
 
@@ -54,11 +52,7 @@ module TariffKnowledge
       # complete tariff source snapshot and Appendix 5a precedence is handled by
       # selecting the latest current snapshot, not by approval state.
       TimeMachine.at(@time_machine_date ||= Time.current) do
-        CustomsTariffUpdate
-          .actual
-          .exclude(status: EXCLUDED_UPDATE_STATUSES)
-          .order(Sequel.desc(:validity_start_date))
-          .first
+        CustomsTariffUpdate.latest.first
       end
     end
 

--- a/app/workers/import_customs_tariff_document_worker.rb
+++ b/app/workers/import_customs_tariff_document_worker.rb
@@ -14,21 +14,17 @@ class ImportCustomsTariffDocumentWorker
 
     results = CustomsTariffImporter::Importer.new.call
 
-    duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000).round(2)
+    duration_ms    = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000).round(2)
     imported_count = results.count { |r| r.status == :imported }
-    skipped_count = results.count { |r| %i[skipped duplicate_content].include?(r.status) }
-    failed_count = results.count { |r| r.status == :failed }
-    review_backlog = CustomsTariffUpdate.pending.count
+    failed_count   = results.count { |r| r.status == :failed }
 
     CustomsTariffImporter::Instrumentation.import_run_completed(
       imported: imported_count,
-      skipped: skipped_count,
       failed: failed_count,
       duration_ms:,
-      review_backlog:,
     )
 
-    notify_completed(imported_count:, skipped_count:, failed_count:, review_backlog:)
+    notify_completed(results)
   rescue StandardError => e
     CustomsTariffImporter::Instrumentation.import_run_failed(
       error_class: e.class.name,
@@ -40,22 +36,31 @@ class ImportCustomsTariffDocumentWorker
 
 private
 
-  def notify_completed(imported_count:, skipped_count:, failed_count:, review_backlog:)
-    return unless imported_count.positive? || failed_count.positive?
+  def notify_completed(results)
+    imported = results.select { |r| r.status == :imported }
+    failed   = results.select { |r| r.status == :failed }
 
-    status = failed_count.positive? ? 'completed with failures' : 'completed'
+    if imported.empty? && failed.empty?
+      notify_slack('Customs tariff document import completed. Nothing new to import.')
+      return
+    end
 
-    notify_slack(
-      "Customs tariff document import #{status}. " \
-      "imported: #{imported_count}, skipped: #{skipped_count}, failed: #{failed_count}, " \
-      "pending review: #{review_backlog}",
-    )
+    lines = []
+    imported.each { |r| lines << "  • Version ID: #{r.version} ✓" }
+    failed.each   { |r| lines << "  • Version ID: #{r.version} ✗ #{r.error}" }
+
+    counts = []
+    counts << "imported: #{imported.count}" if imported.any?
+    counts << "failed: #{failed.count}" if failed.any?
+
+    status = failed.any? ? 'completed with failures' : 'completed'
+    header = "Customs tariff document import #{status}. #{counts.join(', ')}"
+
+    notify_slack([header, *lines].join("\n"))
   end
 
   def notify_failed(error)
-    notify_slack(
-      "Customs tariff document import failed. #{error.class}: #{error.message}",
-    )
+    notify_slack("Customs tariff document import failed. #{error.class}: #{error.message}")
   end
 
   def notify_slack(message)

--- a/app/workers/import_xi_cn_document_worker.rb
+++ b/app/workers/import_xi_cn_document_worker.rb
@@ -14,16 +14,14 @@ class ImportXiCnDocumentWorker
     duration_ms    = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000).round(2)
     imported_count = results.count { |r| r.status == :imported }
     failed_count   = results.count { |r| r.status == :failed }
-    review_backlog = CustomsTariffUpdate.pending.count
 
     XiCnImporter::Instrumentation.import_run_completed(
       imported: imported_count,
       failed: failed_count,
       duration_ms:,
-      review_backlog:,
     )
 
-    notify_completed(imported_count:, failed_count:, review_backlog:)
+    notify_completed(results)
   rescue StandardError => e
     XiCnImporter::Instrumentation.import_run_failed(
       error_class: e.class.name,
@@ -35,16 +33,27 @@ class ImportXiCnDocumentWorker
 
 private
 
-  def notify_completed(imported_count:, failed_count:, review_backlog:)
-    return unless imported_count.positive? || failed_count.positive?
+  def notify_completed(results)
+    imported = results.select { |r| r.status == :imported }
+    failed   = results.select { |r| r.status == :failed }
 
-    status = failed_count.positive? ? 'completed with failures' : 'completed'
+    if imported.empty? && failed.empty?
+      notify_slack('XI Combined Nomenclature document import completed. Nothing new to import.')
+      return
+    end
 
-    notify_slack(
-      "XI Combined Nomenclature document import #{status}. " \
-      "imported: #{imported_count}, failed: #{failed_count}, " \
-      "pending review: #{review_backlog}",
-    )
+    lines = []
+    imported.each { |r| lines << "  • CELEX ID: #{r.celex} ✓" }
+    failed.each   { |r| lines << "  • CELEX ID: #{r.celex} ✗ #{r.error}" }
+
+    counts = []
+    counts << "imported: #{imported.count}" if imported.any?
+    counts << "failed: #{failed.count}" if failed.any?
+
+    status = failed.any? ? 'completed with failures' : 'completed'
+    header = "XI Combined Nomenclature document import #{status}. #{counts.join(', ')}"
+
+    notify_slack([header, *lines].join("\n"))
   end
 
   def notify_failed(error)

--- a/db/migrate/20260716120000_drop_status_from_customs_tariff_note_tables.rb
+++ b/db/migrate/20260716120000_drop_status_from_customs_tariff_note_tables.rb
@@ -1,0 +1,13 @@
+Sequel.migration do
+  up do
+    %i[customs_tariff_chapter_notes customs_tariff_section_notes customs_tariff_general_rules].each do |table|
+      alter_table(table) { drop_column :status }
+    end
+  end
+
+  down do
+    %i[customs_tariff_chapter_notes customs_tariff_section_notes customs_tariff_general_rules].each do |table|
+      alter_table(table) { add_column :status, String, null: false, default: 'pending' }
+    end
+  end
+end

--- a/db/migrate/20260716120100_drop_status_from_customs_tariff_updates.rb
+++ b/db/migrate/20260716120100_drop_status_from_customs_tariff_updates.rb
@@ -1,0 +1,9 @@
+Sequel.migration do
+  up do
+    alter_table(:customs_tariff_updates) { drop_column :status }
+  end
+
+  down do
+    alter_table(:customs_tariff_updates) { add_column :status, String, null: false, default: 'pending' }
+  end
+end

--- a/db/migrate/20260716120100_drop_status_from_customs_tariff_updates.rb
+++ b/db/migrate/20260716120100_drop_status_from_customs_tariff_updates.rb
@@ -4,6 +4,6 @@ Sequel.migration do
   end
 
   down do
-    alter_table(:customs_tariff_updates) { add_column :status, String, null: false, default: 'pending' }
+    alter_table(:customs_tariff_updates) { add_column :status, String, null: false, default: 'awaiting_approval' }
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1837,7 +1837,6 @@ CREATE TABLE uk.customs_tariff_chapter_notes (
     customs_tariff_update_version text NOT NULL,
     chapter_id character varying(2) NOT NULL,
     content text NOT NULL,
-    status text DEFAULT 'pending'::text NOT NULL,
     validity_start_date date,
     validity_end_date date
 );
@@ -1866,7 +1865,6 @@ CREATE TABLE uk.customs_tariff_general_rules (
     customs_tariff_update_version text NOT NULL,
     rule_label character varying(10) NOT NULL,
     content text NOT NULL,
-    status text DEFAULT 'pending'::text NOT NULL,
     validity_start_date date,
     validity_end_date date
 );
@@ -1895,7 +1893,6 @@ CREATE TABLE uk.customs_tariff_section_notes (
     customs_tariff_update_version text NOT NULL,
     section_id integer NOT NULL,
     content text NOT NULL,
-    status text DEFAULT 'pending'::text NOT NULL,
     validity_start_date date,
     validity_end_date date
 );
@@ -1923,7 +1920,6 @@ CREATE TABLE uk.customs_tariff_updates (
     version text NOT NULL,
     validity_start_date date NOT NULL,
     validity_end_date date,
-    status text DEFAULT 'awaiting_approval'::text NOT NULL,
     source_url text,
     s3_path text,
     file_checksum text,
@@ -14759,3 +14755,5 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20260609120000_create_tari
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260610100000_create_search_analytics_snapshots.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260626120000_create_tariff_knowledge_public_atar_rulings.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260708130000_add_derived_facts_to_public_atar_rulings.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20260716120000_drop_status_from_customs_tariff_note_tables.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20260716120100_drop_status_from_customs_tariff_updates.rb');

--- a/spec/factories/customs_tariff_update_factory.rb
+++ b/spec/factories/customs_tariff_update_factory.rb
@@ -2,22 +2,15 @@ FactoryBot.define do
   factory :customs_tariff_update do
     sequence(:version) { |n| "1.#{n}" }
     validity_start_date { Time.zone.today }
-    status { CustomsTariffUpdate::PENDING }
     source_url { 'https://assets.publishing.service.gov.uk/media/abc123/UKGT_1.30.docx' }
     s3_path { "data/customs_tariff_documents/uk/UKGT_#{version}.docx" }
     file_checksum { SecureRandom.hex(32) }
     document_created_on { Time.zone.today }
 
     trait :approved do
-      status { CustomsTariffUpdate::APPROVED }
-    end
-
-    trait :rejected do
-      status { CustomsTariffUpdate::REJECTED }
     end
 
     trait :failed do
-      status { CustomsTariffUpdate::FAILED }
       import_error { 'Parsing failed: unexpected document structure' }
     end
   end
@@ -26,19 +19,13 @@ FactoryBot.define do
     association :customs_tariff_update
     sequence(:chapter_id) { |n| sprintf('%02d', n % 99 + 1) }
     content { 'This chapter covers all live animals.' }
-    status { CustomsTariffChapterNote::PENDING }
 
     after(:build) do |note|
       note.customs_tariff_update_version = note.customs_tariff_update.version
     end
 
     trait :approved do
-      status { CustomsTariffChapterNote::APPROVED }
       validity_start_date { Time.zone.today }
-    end
-
-    trait :rejected do
-      status { CustomsTariffChapterNote::REJECTED }
     end
   end
 
@@ -46,19 +33,13 @@ FactoryBot.define do
     association :customs_tariff_update
     sequence(:section_id) { |n| (n % 21) + 1 }
     content { 'Any reference in this section to a particular genus or species of an animal includes a reference to the young of that genus or species.' }
-    status { CustomsTariffSectionNote::PENDING }
 
     after(:build) do |note|
       note.customs_tariff_update_version = note.customs_tariff_update.version
     end
 
     trait :approved do
-      status { CustomsTariffSectionNote::APPROVED }
       validity_start_date { Time.zone.today }
-    end
-
-    trait :rejected do
-      status { CustomsTariffSectionNote::REJECTED }
     end
   end
 
@@ -66,19 +47,13 @@ FactoryBot.define do
     association :customs_tariff_update
     sequence(:rule_label, &:to_s)
     content { 'Classification shall be determined according to the terms of the headings.' }
-    status { CustomsTariffGeneralRule::PENDING }
 
     after(:build) do |rule|
       rule.customs_tariff_update_version = rule.customs_tariff_update.version
     end
 
     trait :approved do
-      status { CustomsTariffGeneralRule::APPROVED }
       validity_start_date { Time.zone.today }
-    end
-
-    trait :rejected do
-      status { CustomsTariffGeneralRule::REJECTED }
     end
   end
 end

--- a/spec/lib/customs_tariff_importer/importer_spec.rb
+++ b/spec/lib/customs_tariff_importer/importer_spec.rb
@@ -59,10 +59,10 @@ RSpec.describe CustomsTariffImporter::Importer do
         )
       end
 
-      it 'creates a CustomsTariffUpdate record with pending status' do
+      it 'creates a CustomsTariffUpdate record without an import error' do
         expect { results }.to change(CustomsTariffUpdate, :count).by(1)
         update = CustomsTariffUpdate.where(version: '1.30').first
-        expect(update.status).to eq(CustomsTariffUpdate::PENDING)
+        expect(update.import_error).to be_nil
         expect(update.file_checksum).to eq(checksum)
       end
 
@@ -93,25 +93,22 @@ RSpec.describe CustomsTariffImporter::Importer do
         expect(CustomsTariffGeneralRule.where(customs_tariff_update_version: '1.30').count).to eq(2)
       end
 
-      it 'creates chapter notes with the update validity_start_date and pending status' do
+      it 'creates chapter notes with the update validity_start_date' do
         results
         note = CustomsTariffChapterNote.where(customs_tariff_update_version: '1.30').first
         expect(note.validity_start_date).to eq(entry_into_force_on)
-        expect(note.status).to eq(CustomsTariffChapterNote::PENDING)
       end
 
-      it 'creates section notes with the update validity_start_date and pending status' do
+      it 'creates section notes with the update validity_start_date' do
         results
         note = CustomsTariffSectionNote.where(customs_tariff_update_version: '1.30').first
         expect(note.validity_start_date).to eq(entry_into_force_on)
-        expect(note.status).to eq(CustomsTariffSectionNote::PENDING)
       end
 
-      it 'creates general rules with the update validity_start_date and pending status' do
+      it 'creates general rules with the update validity_start_date' do
         results
         rule = CustomsTariffGeneralRule.where(customs_tariff_update_version: '1.30').first
         expect(rule.validity_start_date).to eq(entry_into_force_on)
-        expect(rule.status).to eq(CustomsTariffGeneralRule::PENDING)
       end
 
       it 'emits a document_imported instrumentation event' do

--- a/spec/lib/customs_tariff_importer/instrumentation_spec.rb
+++ b/spec/lib/customs_tariff_importer/instrumentation_spec.rb
@@ -25,10 +25,10 @@ RSpec.describe CustomsTariffImporter::Instrumentation do
   describe '.import_run_completed' do
     it 'emits import_run_completed with counts and duration' do
       allow(ActiveSupport::Notifications).to receive(:instrument)
-      described_class.import_run_completed(imported: 2, skipped: 1, failed: 0, duration_ms: 1500.0, review_backlog: 3)
+      described_class.import_run_completed(imported: 2, failed: 0, duration_ms: 1500.0)
       expect(ActiveSupport::Notifications).to have_received(:instrument).with(
         'import_run_completed.customs_tariff_importer',
-        hash_including(imported: 2, skipped: 1, failed: 0, duration_ms: 1500.0, review_backlog: 3),
+        hash_including(imported: 2, failed: 0, duration_ms: 1500.0),
       )
     end
   end
@@ -117,17 +117,6 @@ RSpec.describe CustomsTariffImporter::Instrumentation do
       expect(ActiveSupport::Notifications).to have_received(:instrument).with(
         'document_import_failed.customs_tariff_importer',
         hash_including(version: '1.30', error_class: 'Sequel::Error', error_message: 'db error'),
-      )
-    end
-  end
-
-  describe '.status_changed' do
-    it 'emits status_changed with the operator and status transition' do
-      allow(ActiveSupport::Notifications).to receive(:instrument)
-      described_class.status_changed(version: '1.30', from_status: 'pending', to_status: 'approved', whodunnit: 'user-1', review_backlog: 2)
-      expect(ActiveSupport::Notifications).to have_received(:instrument).with(
-        'status_changed.customs_tariff_importer',
-        hash_including(version: '1.30', from_status: 'pending', to_status: 'approved', whodunnit: 'user-1', review_backlog: 2),
       )
     end
   end

--- a/spec/lib/customs_tariff_importer/logger_spec.rb
+++ b/spec/lib/customs_tariff_importer/logger_spec.rb
@@ -30,12 +30,14 @@ RSpec.describe CustomsTariffImporter::Logger do
 
       log_subscriber.import_run_completed(build_event(
                                             'import_run_completed',
-                                            payload: { imported: 2, skipped: 1, failed: 0, duration_ms: 3500.0, review_backlog: 3 },
+                                            payload: { imported: 2, failed: 0, duration_ms: 3500.0 },
                                           ))
 
       expect(log_subscriber).to have_received(:info) do |json|
         entry = JSON.parse(json)
-        expect(entry).to include('imported' => 2, 'skipped' => 1, 'failed' => 0, 'duration_ms' => 3500.0, 'review_backlog' => 3)
+        expect(entry).to include('imported' => 2, 'failed' => 0, 'duration_ms' => 3500.0)
+        expect(entry).not_to have_key('skipped')
+        expect(entry).not_to have_key('review_backlog')
       end
     end
   end
@@ -181,29 +183,6 @@ RSpec.describe CustomsTariffImporter::Logger do
       expect(log_subscriber).to have_received(:error) do |json|
         entry = JSON.parse(json)
         expect(entry).to include('event' => 'document_import_failed', 'version' => '1.30', 'error_class' => 'ActiveRecord::RecordInvalid')
-      end
-    end
-  end
-
-  describe '#status_changed' do
-    it 'logs the status transition and operator' do
-      allow(log_subscriber).to receive(:info)
-
-      log_subscriber.status_changed(build_event(
-                                      'status_changed',
-                                      payload: { version: '1.30', from_status: 'pending', to_status: 'approved', whodunnit: 'user-1', review_backlog: 2 },
-                                    ))
-
-      expect(log_subscriber).to have_received(:info) do |json|
-        entry = JSON.parse(json)
-        expect(entry).to include(
-          'event' => 'status_changed',
-          'version' => '1.30',
-          'from_status' => 'pending',
-          'to_status' => 'approved',
-          'whodunnit' => 'user-1',
-          'review_backlog' => 2,
-        )
       end
     end
   end

--- a/spec/lib/customs_tariff_importer/reimporter_spec.rb
+++ b/spec/lib/customs_tariff_importer/reimporter_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe CustomsTariffImporter::Reimporter do
   let(:update) do
     create(:customs_tariff_update,
            version: '1.31',
-           status: CustomsTariffUpdate::APPROVED,
            validity_start_date: Date.new(2026, 4, 1),
            s3_path: 'data/customs_tariff_documents/UKGT_1.31.docx')
   end
@@ -64,14 +63,10 @@ RSpec.describe CustomsTariffImporter::Reimporter do
         expect(chapter_note.content).to eq('All live animals are classified here.')
       end
 
-      it 'sets newly created notes to pending status' do
+      it 'creates notes without a status column' do
         reimporter.call
-
-        statuses = CustomsTariffSectionNote
-          .where(customs_tariff_update_version: update.version)
-          .select_map(:status)
-
-        expect(statuses).to all(eq(CustomsTariffSectionNote::PENDING))
+        note = CustomsTariffSectionNote.where(customs_tariff_update_version: update.version).first
+        expect(note.content).to eq('Live animals note.')
       end
     end
 
@@ -97,7 +92,6 @@ RSpec.describe CustomsTariffImporter::Reimporter do
       let(:second_update) do
         create(:customs_tariff_update,
                version: '1.30',
-               status: CustomsTariffUpdate::PENDING,
                validity_start_date: Date.new(2026, 3, 1),
                s3_path: 'data/customs_tariff_documents/UKGT_1.30.docx')
       end
@@ -118,8 +112,8 @@ RSpec.describe CustomsTariffImporter::Reimporter do
       end
     end
 
-    context 'when an update has FAILED status' do
-      before { update.update(status: CustomsTariffUpdate::FAILED) }
+    context 'when an update has import_error set' do
+      before { update.update(import_error: 'previous failure') }
 
       it 'skips failed updates' do
         allow(TariffSynchronizer::FileService).to receive(:get)
@@ -132,7 +126,6 @@ RSpec.describe CustomsTariffImporter::Reimporter do
       let(:other_update) do
         create(:customs_tariff_update,
                version: '1.30',
-               status: CustomsTariffUpdate::PENDING,
                validity_start_date: Date.new(2026, 3, 1),
                s3_path: 'data/customs_tariff_documents/UKGT_1.30.docx')
       end
@@ -152,8 +145,8 @@ RSpec.describe CustomsTariffImporter::Reimporter do
         expect(CustomsTariffSectionNote.where(customs_tariff_update_version: other_update.version).count).to eq(0)
       end
 
-      it 'reimports a FAILED update (no status filtering in single-version mode)' do
-        update.update(status: CustomsTariffUpdate::FAILED)
+      it 'reimports an update with import_error set (no filtering in single-version mode)' do
+        update.update(import_error: 'previous failure')
 
         reimporter.call(version: update.version)
 

--- a/spec/lib/xi_cn_importer/document_fetcher_spec.rb
+++ b/spec/lib/xi_cn_importer/document_fetcher_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe XiCnImporter::DocumentFetcher do
     end
 
     context 'when the version is already imported (not failed)' do
-      before { create(:customs_tariff_update, version: '32025R1926', status: CustomsTariffUpdate::PENDING) }
+      before { create(:customs_tariff_update, version: '32025R1926') }
 
       it 'skips the version and returns an empty array' do
         expect(fetcher.call).to be_empty

--- a/spec/lib/xi_cn_importer/importer_spec.rb
+++ b/spec/lib/xi_cn_importer/importer_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe XiCnImporter::Importer do
       expect(update).to have_attributes(
         version: celex,
         validity_start_date: force_date,
-        status: CustomsTariffUpdate::PENDING,
+        import_error: nil,
         source_url: fetched_result.cellar_url,
         s3_path: "data/customs_tariff_documents/xi/CN_#{celex}.pdf",
         file_checksum: pdf_checksum,
@@ -85,7 +85,6 @@ RSpec.describe XiCnImporter::Importer do
           section_id: 1,
           content: extracted_result.sections.fetch(1),
           validity_start_date: force_date,
-          status: CustomsTariffSectionNote::PENDING,
         ),
       )
       expect(chapters).to contain_exactly(
@@ -94,7 +93,6 @@ RSpec.describe XiCnImporter::Importer do
           chapter_id: '01',
           content: extracted_result.chapters.fetch('01'),
           validity_start_date: force_date,
-          status: CustomsTariffChapterNote::PENDING,
         ),
       )
       expect(general_rules).to contain_exactly(
@@ -103,7 +101,6 @@ RSpec.describe XiCnImporter::Importer do
           rule_label: '1',
           content: extracted_result.general_rules.fetch('1'),
           validity_start_date: force_date,
-          status: CustomsTariffGeneralRule::PENDING,
         ),
       )
     end
@@ -129,17 +126,16 @@ RSpec.describe XiCnImporter::Importer do
         CustomsTariffUpdate.create(
           version: celex,
           validity_start_date: 1.year.ago.to_date,
-          status: CustomsTariffUpdate::FAILED,
           import_error: 'previous failure',
         )
       end
 
-      it 'replaces it with one pending update' do
+      it 'replaces it with one imported update' do
         importer.call
 
         updates = CustomsTariffUpdate.where(version: celex).all
         expect(updates).to contain_exactly(
-          have_attributes(status: CustomsTariffUpdate::PENDING, import_error: nil),
+          have_attributes(import_error: nil),
         )
       end
     end
@@ -160,10 +156,7 @@ RSpec.describe XiCnImporter::Importer do
           error: 'persistence error',
         )
         expect(updates).to contain_exactly(
-          have_attributes(
-            status: CustomsTariffUpdate::FAILED,
-            import_error: 'persistence error',
-          ),
+          have_attributes(import_error: 'persistence error'),
         )
         expect(CustomsTariffSectionNote.where(customs_tariff_update_version: celex).count).to eq 0
         expect(CustomsTariffChapterNote.where(customs_tariff_update_version: celex).count).to eq 0
@@ -188,10 +181,10 @@ RSpec.describe XiCnImporter::Importer do
         expect(results.first.error).to eq 'parse error'
       end
 
-      it 'creates a failed CustomsTariffUpdate' do
+      it 'creates a failed CustomsTariffUpdate with the import error' do
         importer.call
         update = CustomsTariffUpdate.first(version: celex)
-        expect(update.status).to eq CustomsTariffUpdate::FAILED
+        expect(update.import_error).to eq 'parse error'
       end
 
       it 'instruments the failed import' do
@@ -205,14 +198,13 @@ RSpec.describe XiCnImporter::Importer do
         expect(XiCnImporter::Instrumentation).not_to have_received(:document_imported)
       end
 
-      context 'when a pre-existing FAILED record exists' do
+      context 'when a pre-existing failed record exists' do
         it 'refreshes the error message and timestamp' do
           old_error = 'previous import error'
           old_updated_at = travel_to 2.days.ago do
             CustomsTariffUpdate.create(
               version: celex,
               validity_start_date: Time.zone.today,
-              status: CustomsTariffUpdate::FAILED,
               import_error: old_error,
             ).updated_at
           end
@@ -222,7 +214,6 @@ RSpec.describe XiCnImporter::Importer do
           end
 
           update = CustomsTariffUpdate.first(version: celex)
-          expect(update.status).to eq CustomsTariffUpdate::FAILED
           expect(update.import_error).to eq 'parse error'
           expect(update.updated_at).to be > old_updated_at
         end

--- a/spec/models/customs_tariff_chapter_note_spec.rb
+++ b/spec/models/customs_tariff_chapter_note_spec.rb
@@ -9,16 +9,4 @@ RSpec.describe CustomsTariffChapterNote do
       }.to change { Version.where(item_type: 'CustomsTariffChapterNote', item_id: note.id.to_s).count }.by(1)
     end
   end
-
-  describe 'scopes' do
-    let!(:pending_note) { create(:customs_tariff_chapter_note) }
-    let!(:approved_note) { create(:customs_tariff_chapter_note, :approved) }
-    let!(:rejected_note) { create(:customs_tariff_chapter_note, :rejected) }
-
-    it 'filters by status', :aggregate_failures do
-      expect(described_class.pending.all).to contain_exactly(pending_note)
-      expect(described_class.approved.all).to contain_exactly(approved_note)
-      expect(described_class.rejected.all).to contain_exactly(rejected_note)
-    end
-  end
 end

--- a/spec/models/customs_tariff_general_rule_spec.rb
+++ b/spec/models/customs_tariff_general_rule_spec.rb
@@ -1,35 +1,4 @@
 RSpec.describe CustomsTariffGeneralRule do
-  describe 'status default' do
-    it 'defaults to pending' do
-      rule = create(:customs_tariff_general_rule)
-      expect(rule.status).to eq(CustomsTariffGeneralRule::PENDING)
-    end
-  end
-
-  describe 'dataset scopes' do
-    let!(:pending_rule)  { create(:customs_tariff_general_rule) }
-    let!(:approved_rule) { create(:customs_tariff_general_rule, :approved) }
-    let!(:rejected_rule) { create(:customs_tariff_general_rule, :rejected) }
-
-    describe '.pending' do
-      it 'returns only pending records' do
-        expect(described_class.pending.all).to contain_exactly(pending_rule)
-      end
-    end
-
-    describe '.approved' do
-      it 'returns only approved records' do
-        expect(described_class.approved.all).to contain_exactly(approved_rule)
-      end
-    end
-
-    describe '.rejected' do
-      it 'returns only rejected records' do
-        expect(described_class.rejected.all).to contain_exactly(rejected_rule)
-      end
-    end
-  end
-
   describe '.latest_rules' do
     it 'returns rules for the latest actual update version' do
       older_update = create(:customs_tariff_update, version: '1.30', validity_start_date: Date.new(2026, 1, 22))

--- a/spec/models/customs_tariff_section_note_spec.rb
+++ b/spec/models/customs_tariff_section_note_spec.rb
@@ -1,32 +1,12 @@
 RSpec.describe CustomsTariffSectionNote do
-  describe 'status default' do
-    it 'defaults to pending' do
-      note = create(:customs_tariff_section_note)
-      expect(note.status).to eq(CustomsTariffSectionNote::PENDING)
-    end
-  end
+  describe 'paper trail' do
+    let!(:update) { create(:customs_tariff_update) }
+    let!(:note)   { create(:customs_tariff_section_note, customs_tariff_update: update) }
 
-  describe 'dataset scopes' do
-    let!(:pending_note)  { create(:customs_tariff_section_note) }
-    let!(:approved_note) { create(:customs_tariff_section_note, :approved) }
-    let!(:rejected_note) { create(:customs_tariff_section_note, :rejected) }
-
-    describe '.pending' do
-      it 'returns only pending records' do
-        expect(described_class.pending.all).to contain_exactly(pending_note)
-      end
-    end
-
-    describe '.approved' do
-      it 'returns only approved records' do
-        expect(described_class.approved.all).to contain_exactly(approved_note)
-      end
-    end
-
-    describe '.rejected' do
-      it 'returns only rejected records' do
-        expect(described_class.rejected.all).to contain_exactly(rejected_note)
-      end
+    it 'creates a Version record when content is updated' do
+      expect {
+        note.update(content: 'Updated content for versioning test')
+      }.to change { Version.where(item_type: 'CustomsTariffSectionNote', item_id: note.id.to_s).count }.by(1)
     end
   end
 end

--- a/spec/models/customs_tariff_update_spec.rb
+++ b/spec/models/customs_tariff_update_spec.rb
@@ -1,37 +1,23 @@
 RSpec.describe CustomsTariffUpdate do
   describe 'dataset scopes' do
-    let!(:pending)  { create(:customs_tariff_update, status: CustomsTariffUpdate::PENDING) }
-    let!(:approved) { create(:customs_tariff_update, :approved) }
-    let!(:rejected) { create(:customs_tariff_update, :rejected) }
-    let!(:failed)   { create(:customs_tariff_update, :failed) }
-
-    describe '.pending' do
-      it 'returns only pending records' do
-        expect(described_class.pending.all).to contain_exactly(pending)
-      end
-    end
-
-    describe '.approved' do
-      it 'returns only approved records' do
-        expect(described_class.approved.all).to contain_exactly(approved)
-      end
-    end
-
-    describe '.rejected' do
-      it 'returns only rejected records' do
-        expect(described_class.rejected.all).to contain_exactly(rejected)
-      end
-    end
+    let!(:imported_update) { create(:customs_tariff_update) }
+    let!(:failed_update)   { create(:customs_tariff_update, :failed) }
 
     describe '.failed' do
-      it 'returns only failed records' do
-        expect(described_class.failed.all).to contain_exactly(failed)
+      it 'returns only records with an import error' do
+        expect(described_class.failed.all).to contain_exactly(failed_update)
+      end
+    end
+
+    describe '.imported' do
+      it 'returns only records without an import error' do
+        expect(described_class.imported.all).to contain_exactly(imported_update)
       end
     end
 
     describe '.latest' do
-      it 'returns the latest non-failed update for the current TimeMachine date' do
-        older_update = create(:customs_tariff_update, version: '1.30', validity_start_date: Date.new(2026, 1, 22))
+      it 'returns the latest imported update for the current TimeMachine date' do
+        older_update  = create(:customs_tariff_update, version: '1.30', validity_start_date: Date.new(2026, 1, 22))
         latest_update = create(:customs_tariff_update, version: '1.31', validity_start_date: Date.new(2026, 4, 1))
         create(:customs_tariff_update, :failed, version: '1.32', validity_start_date: Date.new(2026, 6, 1))
         create(:customs_tariff_update, version: '1.33', validity_start_date: Date.new(2026, 8, 1))

--- a/spec/requests/api/admin/customs_tariff_updates/chapter_notes_controller_spec.rb
+++ b/spec/requests/api/admin/customs_tariff_updates/chapter_notes_controller_spec.rb
@@ -138,8 +138,8 @@ RSpec.describe Api::Admin::CustomsTariffUpdates::ChapterNotesController do
       expect(CustomsTariffChapterNote.where(id: note.id).first).to be_nil
     end
 
-    it 'destroys when the parent update is rejected' do
-      update.update(status: CustomsTariffUpdate::REJECTED)
+    it 'destroys when the parent update has an import error' do
+      update.update(import_error: 'Import failed')
 
       delete "/uk/admin/customs_tariff_updates/#{update.version}/chapter_notes/#{note.chapter_id}.json",
              headers: request_headers(format: :json)
@@ -173,12 +173,11 @@ RSpec.describe Api::Admin::CustomsTariffUpdates::ChapterNotesController do
       expect(response.status).to eq(201)
       note = CustomsTariffChapterNote.order(Sequel.desc(:id)).first
       expect(note.chapter_id).to eq('03')
-      expect(note.status).to eq(CustomsTariffChapterNote::PENDING)
       expect(note.validity_start_date).to eq(update.validity_start_date)
     end
 
-    it 'creates when the parent update is rejected' do
-      update.update(status: CustomsTariffUpdate::REJECTED)
+    it 'creates when the parent update has an import error' do
+      update.update(import_error: 'Import failed')
       expect { make_request }.to change(CustomsTariffChapterNote, :count).by(1)
       expect(response.status).to eq(201)
     end
@@ -217,8 +216,8 @@ RSpec.describe Api::Admin::CustomsTariffUpdates::ChapterNotesController do
       expect(note.reload.content).to eq('Updated via response id')
     end
 
-    it 'updates when the parent update is rejected' do
-      update.update(status: CustomsTariffUpdate::REJECTED)
+    it 'updates when the parent update has an import error' do
+      update.update(import_error: 'Import failed')
 
       patch "/uk/admin/customs_tariff_updates/#{update.version}/chapter_notes/#{note.chapter_id}.json",
             params: { data: { type: 'customs_tariff_chapter_note', attributes: { content: 'Updated' } } },

--- a/spec/requests/api/admin/customs_tariff_updates/section_notes_controller_spec.rb
+++ b/spec/requests/api/admin/customs_tariff_updates/section_notes_controller_spec.rb
@@ -184,8 +184,8 @@ RSpec.describe Api::Admin::CustomsTariffUpdates::SectionNotesController do
       expect(note.reload.content).to eq('Updated via response id')
     end
 
-    it 'updates when the parent update is rejected' do
-      update.update(status: CustomsTariffUpdate::REJECTED)
+    it 'updates when the parent update has an import error' do
+      update.update(import_error: 'Import failed')
 
       patch "/uk/admin/customs_tariff_updates/#{update.version}/section_notes/#{note.section_id}.json",
             params: { data: { type: 'customs_tariff_section_note', attributes: { content: 'Updated' } } },
@@ -217,8 +217,8 @@ RSpec.describe Api::Admin::CustomsTariffUpdates::SectionNotesController do
       expect(CustomsTariffSectionNote.where(id: note.id).first).to be_nil
     end
 
-    it 'destroys when the parent update is rejected' do
-      update.update(status: CustomsTariffUpdate::REJECTED)
+    it 'destroys when the parent update has an import error' do
+      update.update(import_error: 'Import failed')
 
       delete "/uk/admin/customs_tariff_updates/#{update.version}/section_notes/#{note.section_id}.json",
              headers: request_headers(format: :json)
@@ -252,7 +252,7 @@ RSpec.describe Api::Admin::CustomsTariffUpdates::SectionNotesController do
       expect(attrs['content']).to eq('Manually added note content here')
     end
 
-    it 'sets status to pending and copies validity_start_date from the update' do
+    it 'copies validity_start_date from the update' do
       post "/uk/admin/customs_tariff_updates/#{update.version}/section_notes.json",
            params: { data: { type: 'customs_tariff_section_note',
                              attributes: { section_id: 8, content: 'Some note content here' } } },
@@ -261,12 +261,11 @@ RSpec.describe Api::Admin::CustomsTariffUpdates::SectionNotesController do
       note = CustomsTariffSectionNote.where(
         customs_tariff_update_version: update.version, section_id: 8,
       ).first
-      expect(note.status).to eq(CustomsTariffSectionNote::PENDING)
       expect(note.validity_start_date).to eq(Date.new(2026, 3, 1))
     end
 
-    it 'creates when the parent update is rejected' do
-      update.update(status: CustomsTariffUpdate::REJECTED)
+    it 'creates when the parent update has an import error' do
+      update.update(import_error: 'Import failed')
 
       post "/uk/admin/customs_tariff_updates/#{update.version}/section_notes.json",
            params: { data: { type: 'customs_tariff_section_note',

--- a/spec/requests/api/admin/customs_tariff_updates_controller_spec.rb
+++ b/spec/requests/api/admin/customs_tariff_updates_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Api::Admin::CustomsTariffUpdatesController do
       data = response_body['data']
       expect(data).to be_an(Array)
       expect(data.first['type']).to eq('customs_tariff_update')
-      expect(data.first.dig('attributes', 'status')).to be_a(String)
+      expect(data.first.dig('attributes', 'import_error')).to be_nil
       expect(response_body.dig('meta', 'pagination')).to include(
         'page' => 1,
         'per_page' => 1,
@@ -33,23 +33,11 @@ RSpec.describe Api::Admin::CustomsTariffUpdatesController do
       data = JSON.parse(response.body)['data']
       expect(data['type']).to eq('customs_tariff_update')
       expect(data.dig('attributes', 'version')).to eq(update.version)
-      expect(data.dig('attributes', 'status')).to be_a(String)
+      expect(data.dig('attributes', 'import_error')).to be_nil
     end
 
     it 'returns 404 for unknown version' do
       get '/uk/admin/customs_tariff_updates/does-not-exist.json', headers: request_headers(format: :json)
-
-      expect(response.status).to eq(404)
-    end
-  end
-
-  describe 'PATCH #status' do
-    let!(:update) { create(:customs_tariff_update) }
-
-    it 'is not routed' do
-      patch "/uk/admin/customs_tariff_updates/#{update.version}/status.json",
-            params: { data: { attributes: { status: 'approved' } } },
-            headers: request_headers(format: :json), as: :json
 
       expect(response.status).to eq(404)
     end

--- a/spec/services/tariff_knowledge/source_graph_loader_spec.rb
+++ b/spec/services/tariff_knowledge/source_graph_loader_spec.rb
@@ -640,68 +640,56 @@ RSpec.describe TariffKnowledge::SourceGraphLoader do
         .to eq('Heading 0101 covers current horses.')
     end
 
-    it 'uses pending and rejected updates as source graph versions' do
-      rejected_update = create(
+    it 'uses the most recently dated imported update as the source graph version' do
+      older_update = create(
         :customs_tariff_update,
-        :rejected,
         version: '1.32',
         validity_start_date: 1.day.ago,
       )
-      pending_update = create(
+      newer_update = create(
         :customs_tariff_update,
         version: '1.33',
         validity_start_date: Time.zone.today,
       )
       create(
         :customs_tariff_chapter_note,
-        :approved,
-        customs_tariff_update: update,
+        customs_tariff_update: older_update,
         chapter_id: '01',
-        content: 'Heading 0101 covers approved update horses.',
+        content: 'Heading 0101 covers older update horses.',
       )
       create(
         :customs_tariff_chapter_note,
-        :approved,
-        customs_tariff_update: rejected_update,
+        customs_tariff_update: newer_update,
         chapter_id: '01',
-        content: 'Heading 0101 covers rejected update horses.',
-      )
-      create(
-        :customs_tariff_chapter_note,
-        :approved,
-        customs_tariff_update: pending_update,
-        chapter_id: '01',
-        content: 'Heading 0101 covers pending update horses.',
+        content: 'Heading 0101 covers newer update horses.',
       )
 
       described_class.call
 
       expect(TariffKnowledge::Node.where(node_type: TariffKnowledge::Node::NOTE_SOURCE).select_map(:source_version))
-        .to contain_exactly(pending_update.version)
+        .to contain_exactly(newer_update.version)
       expect(TariffKnowledge::Node.by_key('note_source:customs_tariff_chapter_note:1.33:01').first.content)
-        .to eq('Heading 0101 covers pending update horses.')
+        .to eq('Heading 0101 covers newer update horses.')
     end
 
-    it 'loads note sources regardless of row status from the selected update' do
+    it 'loads all chapter notes from the selected update' do
       create(
         :customs_tariff_chapter_note,
-        :approved,
         customs_tariff_update: update,
         chapter_id: '01',
-        content: 'Heading 0101 covers approved source horses.',
+        content: 'Heading 0101 covers source horses.',
       )
       create(
         :customs_tariff_chapter_note,
         customs_tariff_update: update,
         chapter_id: '02',
-        content: 'Heading 0201 covers pending source cattle.',
+        content: 'Heading 0201 covers source cattle.',
       )
       create(
         :customs_tariff_chapter_note,
-        :rejected,
         customs_tariff_update: update,
         chapter_id: '03',
-        content: 'Heading 0201 covers rejected source cattle.',
+        content: 'Heading 0301 covers source sheep.',
       )
 
       described_class.call

--- a/spec/workers/import_customs_tariff_document_worker_spec.rb
+++ b/spec/workers/import_customs_tariff_document_worker_spec.rb
@@ -39,15 +39,11 @@ RSpec.describe ImportCustomsTariffDocumentWorker, type: :worker do
     end
 
     it 'emits import_run_completed with correct counts' do
-      create(:customs_tariff_update)
-
       perform
       expect(CustomsTariffImporter::Instrumentation).to have_received(:import_run_completed).with(
         imported: 1,
-        skipped: 0,
         failed: 0,
         duration_ms: a_kind_of(Float),
-        review_backlog: 1,
       )
     end
 
@@ -55,7 +51,7 @@ RSpec.describe ImportCustomsTariffDocumentWorker, type: :worker do
       perform
 
       expect(SlackNotifierService).to have_received(:call).with(
-        include('Customs tariff document import completed', 'imported: 1', 'skipped: 0', 'failed: 0'),
+        include('Customs tariff document import completed', 'imported: 1', 'Version ID: 1.30 ✓'),
       )
     end
 
@@ -80,17 +76,19 @@ RSpec.describe ImportCustomsTariffDocumentWorker, type: :worker do
       )
     end
 
-    it 'emits import_run_completed with skipped: 1' do
+    it 'emits import_run_completed with imported: 0, failed: 0' do
       perform
       expect(CustomsTariffImporter::Instrumentation).to have_received(:import_run_completed).with(
-        hash_including(imported: 0, skipped: 1, failed: 0),
+        hash_including(imported: 0, failed: 0),
       )
     end
 
-    it 'does not notify Slack' do
+    it 'sends a "Nothing new to import." Slack notification' do
       perform
 
-      expect(SlackNotifierService).not_to have_received(:call)
+      expect(SlackNotifierService).to have_received(:call).with(
+        include('Nothing new to import'),
+      )
     end
   end
 
@@ -105,7 +103,7 @@ RSpec.describe ImportCustomsTariffDocumentWorker, type: :worker do
     it 'emits import_run_completed with failed: 1' do
       perform
       expect(CustomsTariffImporter::Instrumentation).to have_received(:import_run_completed).with(
-        hash_including(imported: 0, skipped: 0, failed: 1),
+        hash_including(imported: 0, failed: 1),
       )
     end
 

--- a/spec/workers/import_xi_cn_document_worker_spec.rb
+++ b/spec/workers/import_xi_cn_document_worker_spec.rb
@@ -40,9 +40,10 @@ RSpec.describe ImportXiCnDocumentWorker do
         allow(importer_double).to receive(:call).and_return([])
       end
 
-      it 'does not send a Slack notification' do
+      it 'sends a "Nothing new to import." Slack notification' do
         worker.perform
-        expect(SlackNotifierService).not_to have_received(:call)
+        expect(SlackNotifierService).to have_received(:call)
+          .with(a_string_including('Nothing new to import'))
       end
     end
 


### PR DESCRIPTION
### Jira link

[AI-1056](https://transformuk.atlassian.net/browse/AI-1056)

### What?

Removes the `status` column concept entirely from the customs tariff notes pipeline. The `status` field (pending/approved/rejected/failed) existed on four tables but was misleading — the tariff always uses the latest imported notes regardless of any approval state, and the concept created confusion for both developers and operators.

Here's what's changed:

- **Two migrations** drop the `status` column from `customs_tariff_updates`, `customs_tariff_chapter_notes`, `customs_tariff_section_notes`, and `customs_tariff_general_rules`
- **`CustomsTariffUpdate`** replaces the old status-based dataset methods with three named scopes: `.imported` (no import_error), `.failed` (has import_error), and `.latest` (most recently dated imported update)
- **`CustomsTariffChapterNote`, `CustomsTariffSectionNote`, `CustomsTariffGeneralRule`** — pending/approved/rejected dataset methods removed; all notes for a given update are now loaded unconditionally
- **UK and XI importers, reimporters, and workers** updated to use the new scopes; `EXCLUDED_UPDATE_STATUSES` constant and the review backlog concept removed entirely
- **Admin serializer** now exposes `import_error` instead of `status`; admin controllers updated to use `.imported` and `.latest`
- **Slack notifications** simplified to list each version with a success or failure indicator and the error message where applicable

### Why?

The status concept was originally designed to support an operator approval workflow that was never fully implemented. In practice the tariff always serves the latest successfully imported notes, making the pending/approved/rejected states redundant. The failed state has been replaced with the existing `import_error` column, which already captured the error message — making status doubly redundant there too.

Removing it simplifies the import pipeline, eliminates the misleading review backlog metric from Slack notifications, and leaves the codebase in a state that accurately reflects how the system actually works.

### Risk

**Risk level:** 🟢

**Reason for rating:** The customs tariff notes feature has never been deployed to production, so there is no live data affected by the destructive migrations. This is a refactor of code that exists only in development and staging environments.

### Have you?

- [ ] Added documentation for new APIs
- [ ] Added new environment variables with correct values to all apps in all spaces

### Deployment risks

- Includes destructive migrations dropping the `status` column from four tables (`customs_tariff_updates`, `customs_tariff_chapter_notes`, `customs_tariff_section_notes`, `customs_tariff_general_rules`)
- **Requires a companion PR in `trade-tariff-admin`** to update the `CustomsTariff::Update` model (swap `status` attribute for `import_error`, add `failed?` predicate) and the updates controller. The admin app will break against this backend once deployed until that PR is also merged and deployed.