### PR TITLE
Expose AI cost summaries in search analytics

### DIFF
--- a/app/serializers/api/admin/search_analytics_serializer.rb
+++ b/app/serializers/api/admin/search_analytics_serializer.rb
@@ -3,6 +3,22 @@ module Api
     class SearchAnalyticsSerializer
       include JSONAPI::Serializer
 
+      EMPTY_AI_COSTS = {
+        'summary' => {
+          'total_cost_usd' => 0.0,
+          'assisted_searches' => 0,
+          'average_cost_usd' => 0.0,
+          'p50_cost_usd' => 0.0,
+          'p90_cost_usd' => 0.0,
+          'priced_calls' => 0,
+          'unpriced_calls' => 0,
+          'pricing_coverage' => nil,
+          'complete' => true,
+        }.freeze,
+        'trend' => [].freeze,
+        'operations' => [].freeze,
+      }.freeze
+
       set_type :search_analytics
       set_id { |snapshot| "#{snapshot.service}-#{snapshot.period}-#{snapshot.view}" }
 
@@ -11,9 +27,11 @@ module Api
       attribute(:generated_at) { |snapshot| snapshot.generated_at.iso8601 }
       attribute(:data_through) { |snapshot| snapshot.data_through.iso8601 }
 
-      %w[summary summary_statuses trends comparisons request_sources ai_costs].each do |name|
+      %w[summary summary_statuses trends comparisons request_sources].each do |name|
         attribute(name.to_sym) { |snapshot| snapshot.payload.fetch(name, {}) }
       end
+
+      attribute(:ai_costs) { |snapshot| snapshot.payload.fetch('ai_costs', EMPTY_AI_COSTS) }
 
       attribute :improvement_terms do |snapshot|
         snapshot.payload.fetch('improvement_terms', [])

--- a/app/serializers/api/admin/search_analytics_serializer.rb
+++ b/app/serializers/api/admin/search_analytics_serializer.rb
@@ -11,7 +11,7 @@ module Api
       attribute(:generated_at) { |snapshot| snapshot.generated_at.iso8601 }
       attribute(:data_through) { |snapshot| snapshot.data_through.iso8601 }
 
-      %w[summary summary_statuses trends comparisons request_sources].each do |name|
+      %w[summary summary_statuses trends comparisons request_sources ai_costs].each do |name|
         attribute(name.to_sym) { |snapshot| snapshot.payload.fetch(name, {}) }
       end
 

--- a/app/services/search_analytics/cloudwatch_snapshot_query.rb
+++ b/app/services/search_analytics/cloudwatch_snapshot_query.rb
@@ -34,6 +34,8 @@ module SearchAnalytics
         summary_view_latency_rows: run_query(summary_view_latency_query),
         source_all_latency_rows: run_query(source_all_latency_query),
         source_view_latency_rows: run_query(source_view_latency_query),
+        ai_cost_summary_rows: run_query(ai_cost_summary_query),
+        ai_cost_trend_rows: run_query(ai_cost_trend_query),
         selection_rows: selection_queries.flat_map { |view, query| run_query(query).map { |row| row.merge('selectable_search_type' => view) } },
         selection_trend_rows: selection_trend_queries.flat_map { |view, query| run_query(query).map { |row| row.merge('selectable_search_type' => view) } },
         improvement_term_rows: improvement_term_queries.flat_map { |term_type, query| run_query(query).map { |row| row.merge('term_type' => term_type) } },
@@ -148,6 +150,62 @@ module SearchAnalytics
       QUERY
     end
 
+    def ai_cost_summary_query
+      <<~QUERY
+        fields request_id, service, event, event_kind, total_tokens, total_cost_usd, pricing_known
+        | #{log_stream_filter}
+        | #{search_ai_cost_filter}
+        | fields if(pricing_known = true and ispresent(total_cost_usd), total_cost_usd, 0) as known_cost_usd
+        | fields if(pricing_known = true and ispresent(total_cost_usd), 1, 0) as priced_call
+        | fields if(pricing_known = true and ispresent(total_cost_usd), 0, 1) as unpriced_call
+        | stats sum(known_cost_usd) as request_cost_usd,
+            sum(priced_call) as priced_calls,
+            sum(unpriced_call) as unpriced_calls by request_id
+        | stats sum(request_cost_usd) as total_cost_usd,
+            avg(request_cost_usd) as average_cost_usd,
+            pct(request_cost_usd, 50) as p50_cost_usd,
+            pct(request_cost_usd, 90) as p90_cost_usd,
+            count(*) as assisted_searches,
+            sum(priced_calls) as priced_calls,
+            sum(unpriced_calls) as unpriced_calls
+      QUERY
+    end
+
+    def ai_cost_trend_query
+      <<~QUERY
+        fields @timestamp, request_id, service, event, event_kind, input_tokens, cached_input_tokens, output_tokens, total_tokens, input_cost_usd, cached_input_cost_usd, output_cost_usd, total_cost_usd, pricing_known
+        | #{log_stream_filter}
+        | #{search_ai_cost_filter}
+        | fields if(pricing_known = true and service = "search", input_cost_usd, 0) as model_input_cost_usd
+        | fields if(pricing_known = true and service = "search", cached_input_cost_usd, 0) as cached_input_cost_usd
+        | fields if(pricing_known = true and service = "search", output_cost_usd, 0) as model_output_cost_usd
+        | fields if(pricing_known = true and service = "ai_usage", total_cost_usd, 0) as embedding_cost_usd
+        | fields if(pricing_known = true and ispresent(total_cost_usd), total_cost_usd, 0) as known_cost_usd
+        | fields if(pricing_known = true and ispresent(total_cost_usd), 1, 0) as priced_call
+        | fields if(pricing_known = true and ispresent(total_cost_usd), 0, 1) as unpriced_call
+        | stats sum(model_input_cost_usd) as input_cost_usd,
+            sum(cached_input_cost_usd) as cached_input_cost_usd,
+            sum(model_output_cost_usd) as output_cost_usd,
+            sum(embedding_cost_usd) as embedding_cost_usd,
+            sum(known_cost_usd) as total_cost_usd,
+            sum(input_tokens) as input_tokens,
+            sum(cached_input_tokens) as cached_input_tokens,
+            sum(output_tokens) as output_tokens,
+            sum(total_tokens) as total_tokens,
+            count(*) as calls,
+            sum(priced_call) as priced_calls,
+            sum(unpriced_call) as unpriced_calls by #{bucket_expression}, event_kind
+      QUERY
+    end
+
+    def search_ai_cost_filter
+      <<~FILTER.squish
+        filter ispresent(request_id) and ispresent(total_tokens) and
+          ((service = "search" and event = "api_call_completed") or
+          (service = "ai_usage" and event = "embedding_api_call_completed" and event_kind = "vector_search_query_embedding"))
+      FILTER
+    end
+
     def selection_queries
       {
         'classic' => selection_query('search_type = "classic" and results_type = "fuzzy_search"'),
@@ -209,7 +267,7 @@ module SearchAnalytics
     end
 
     class Aggregate
-      def initialize(period:, volume_rows:, zero_result_rows:, summary_all_latency_rows:, summary_view_latency_rows:, source_all_latency_rows:, source_view_latency_rows:, selection_rows:, selection_trend_rows:, improvement_term_rows:)
+      def initialize(period:, volume_rows:, zero_result_rows:, summary_all_latency_rows:, summary_view_latency_rows:, source_all_latency_rows:, source_view_latency_rows:, ai_cost_summary_rows:, ai_cost_trend_rows:, selection_rows:, selection_trend_rows:, improvement_term_rows:)
         @period = period
         @volume_rows = volume_rows
         @zero_result_rows = zero_result_rows
@@ -217,6 +275,8 @@ module SearchAnalytics
         @summary_view_latency_rows = summary_view_latency_rows
         @source_all_latency_rows = source_all_latency_rows
         @source_view_latency_rows = source_view_latency_rows
+        @ai_cost_summary_rows = ai_cost_summary_rows
+        @ai_cost_trend_rows = ai_cost_trend_rows
         @selection_rows = selection_rows
         @selection_trend_rows = selection_trend_rows
         @improvement_term_rows = improvement_term_rows
@@ -229,13 +289,14 @@ module SearchAnalytics
           'trends' => trends(view),
           'comparisons' => comparisons,
           'request_sources' => request_sources(view),
+          'ai_costs' => ai_costs(view),
           'improvement_terms' => improvement_terms(view),
         }
       end
 
     private
 
-      attr_reader :period, :volume_rows, :zero_result_rows, :summary_all_latency_rows, :summary_view_latency_rows, :source_all_latency_rows, :source_view_latency_rows, :selection_rows, :selection_trend_rows, :improvement_term_rows
+      attr_reader :period, :volume_rows, :zero_result_rows, :summary_all_latency_rows, :summary_view_latency_rows, :source_all_latency_rows, :source_view_latency_rows, :ai_cost_summary_rows, :ai_cost_trend_rows, :selection_rows, :selection_trend_rows, :improvement_term_rows
 
       def summary(view)
         searches = search_count(view)
@@ -256,6 +317,81 @@ module SearchAnalytics
           'volume' => volume_trend,
           'outcomes' => outcome_trend(view),
         }
+      end
+
+      def ai_costs(view)
+        return empty_ai_costs if view == 'classic'
+
+        {
+          'summary' => ai_cost_summary,
+          'trend' => ai_cost_trend,
+          'operations' => ai_cost_operations,
+        }
+      end
+
+      def empty_ai_costs
+        {
+          'summary' => ai_cost_summary({}),
+          'trend' => [],
+          'operations' => [],
+        }
+      end
+
+      def ai_cost_summary(row = ai_cost_summary_rows.first || {})
+        priced_calls = integer(row['priced_calls'])
+        unpriced_calls = integer(row['unpriced_calls'])
+        calls = priced_calls + unpriced_calls
+
+        {
+          'total_cost_usd' => decimal_number(row['total_cost_usd']),
+          'assisted_searches' => integer(row['assisted_searches']),
+          'average_cost_usd' => decimal_number(row['average_cost_usd']),
+          'p50_cost_usd' => decimal_number(row['p50_cost_usd']),
+          'p90_cost_usd' => decimal_number(row['p90_cost_usd']),
+          'priced_calls' => priced_calls,
+          'unpriced_calls' => unpriced_calls,
+          'pricing_coverage' => calls.positive? ? (priced_calls.to_f / calls).round(4) : nil,
+          'complete' => unpriced_calls.zero?,
+        }
+      end
+
+      def ai_cost_trend
+        buckets.map do |bucket|
+          rows = ai_cost_trend_rows.select { |row| iso8601(row['@timestamp']) == bucket }
+
+          {
+            'bucket' => bucket,
+            'input_cost_usd' => sum_decimal(rows, 'input_cost_usd'),
+            'output_cost_usd' => sum_decimal(rows, 'output_cost_usd'),
+            'embedding_cost_usd' => sum_decimal(rows, 'embedding_cost_usd'),
+            'total_cost_usd' => sum_decimal(rows, 'total_cost_usd'),
+          }
+        end
+      end
+
+      def ai_cost_operations
+        rows_by_event_kind = ai_cost_trend_rows.group_by { |row| row['event_kind'].to_s }
+
+        operations = rows_by_event_kind.filter_map do |event_kind, rows|
+          next if event_kind.blank?
+
+          {
+            'event_kind' => event_kind,
+            'calls' => sum_integer(rows, 'calls'),
+            'input_tokens' => sum_integer(rows, 'input_tokens'),
+            'cached_input_tokens' => sum_integer(rows, 'cached_input_tokens'),
+            'output_tokens' => sum_integer(rows, 'output_tokens'),
+            'total_tokens' => sum_integer(rows, 'total_tokens'),
+            'input_cost_usd' => sum_decimal(rows, 'input_cost_usd'),
+            'output_cost_usd' => sum_decimal(rows, 'output_cost_usd'),
+            'embedding_cost_usd' => sum_decimal(rows, 'embedding_cost_usd'),
+            'total_cost_usd' => sum_decimal(rows, 'total_cost_usd'),
+            'priced_calls' => sum_integer(rows, 'priced_calls'),
+            'unpriced_calls' => sum_integer(rows, 'unpriced_calls'),
+          }
+        end
+
+        operations.sort_by { |row| [-row['total_cost_usd'], row['event_kind']] }
       end
 
       def volume_trend
@@ -442,7 +578,7 @@ module SearchAnalytics
       end
 
       def buckets
-        @buckets ||= (volume_rows + zero_result_rows + selection_trend_rows)
+        @buckets ||= (volume_rows + zero_result_rows + selection_trend_rows + ai_cost_trend_rows)
           .filter_map { |row| iso8601(row['@timestamp']) }
           .uniq
           .sort
@@ -474,6 +610,18 @@ module SearchAnalytics
         Float(value || 0).to_i
       rescue ArgumentError, TypeError
         0
+      end
+
+      def sum_integer(rows, key) = rows.sum { |row| integer(row[key]) }
+
+      def sum_decimal(rows, key) = decimal_number(rows.sum { |row| decimal(row[key]) })
+
+      def decimal_number(value) = decimal(value).round(8).to_f
+
+      def decimal(value)
+        BigDecimal(value.to_s)
+      rescue ArgumentError, TypeError
+        0.to_d
       end
 
       def iso8601(value)

--- a/spec/requests/api/admin/search_analytics_controller_spec.rb
+++ b/spec/requests/api/admin/search_analytics_controller_spec.rb
@@ -159,6 +159,31 @@ RSpec.describe Api::Admin::SearchAnalyticsController do
       expect(response.parsed_body.dig('data', 'id')).to eq('uk-24h-all')
     end
 
+    it 'returns a stable empty AI cost contract for snapshots created before cost collection' do
+      SearchAnalyticsSnapshot.latest_for(service: TradeTariffBackend.service, period: '24h', view: 'all')
+        .update(payload: payload.except('ai_costs'))
+
+      get '/uk/admin/search_analytics.json',
+          params: { period: '24h', view: 'all' },
+          headers: request_headers(format: :json)
+
+      expect(response.parsed_body.dig('data', 'attributes', 'ai_costs')).to eq(
+        'summary' => {
+          'total_cost_usd' => 0.0,
+          'assisted_searches' => 0,
+          'average_cost_usd' => 0.0,
+          'p50_cost_usd' => 0.0,
+          'p90_cost_usd' => 0.0,
+          'priced_calls' => 0,
+          'unpriced_calls' => 0,
+          'pricing_coverage' => nil,
+          'complete' => true,
+        },
+        'trend' => [],
+        'operations' => [],
+      )
+    end
+
     context 'when no cached snapshot exists' do
       before do
         SearchAnalyticsSnapshot.dataset.delete

--- a/spec/requests/api/admin/search_analytics_controller_spec.rb
+++ b/spec/requests/api/admin/search_analytics_controller_spec.rb
@@ -29,6 +29,20 @@ RSpec.describe Api::Admin::SearchAnalyticsController do
           'backend_only' => { 'searches' => 320 },
           'unknown' => { 'searches' => 5 },
         },
+        'ai_costs' => {
+          'summary' => {
+            'total_cost_usd' => 0.0102,
+            'assisted_searches' => 2,
+            'pricing_coverage' => 0.8,
+            'complete' => false,
+          },
+          'trend' => [
+            { 'bucket' => '2026-06-10T09:00:00Z', 'input_cost_usd' => 0.004, 'output_cost_usd' => 0.006, 'embedding_cost_usd' => 0.0002 },
+          ],
+          'operations' => [
+            { 'event_kind' => 'interactive_search', 'calls' => 4, 'total_tokens' => 2_500, 'total_cost_usd' => 0.01 },
+          ],
+        },
         'improvement_terms' => [
           { 'query' => 'trainers', 'zero_results' => 18 },
         ],
@@ -100,6 +114,30 @@ RSpec.describe Api::Admin::SearchAnalyticsController do
               unknown: {
                 searches: 5,
               },
+            },
+            ai_costs: {
+              summary: {
+                total_cost_usd: 0.0102,
+                assisted_searches: 2,
+                pricing_coverage: 0.8,
+                complete: false,
+              },
+              trend: [
+                {
+                  bucket: '2026-06-10T09:00:00Z',
+                  input_cost_usd: 0.004,
+                  output_cost_usd: 0.006,
+                  embedding_cost_usd: 0.0002,
+                },
+              ],
+              operations: [
+                {
+                  event_kind: 'interactive_search',
+                  calls: 4,
+                  total_tokens: 2_500,
+                  total_cost_usd: 0.01,
+                },
+              ],
             },
             improvement_terms: [
               {

--- a/spec/services/search_analytics/cloudwatch_snapshot_query_spec.rb
+++ b/spec/services/search_analytics/cloudwatch_snapshot_query_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe SearchAnalytics::CloudwatchSnapshotQuery do
       start_query_response('summary_latency_by_view'),
       start_query_response('source_latency_all'),
       start_query_response('source_latency_by_view'),
+      start_query_response('ai_cost_summary'),
+      start_query_response('ai_cost_trend'),
       start_query_response('classic_selections'),
       start_query_response('internal_selections'),
       start_query_response('classic_selection_trend'),
@@ -56,6 +58,51 @@ RSpec.describe SearchAnalytics::CloudwatchSnapshotQuery do
         result_row('search_type' => 'interactive', 'request_source' => 'frontend', 'p90_latency_ms' => '2100'),
       ),
       complete_response(
+        result_row(
+          'total_cost_usd' => '0.0102',
+          'average_cost_usd' => '0.0051',
+          'p50_cost_usd' => '0.0048',
+          'p90_cost_usd' => '0.0075',
+          'assisted_searches' => '2',
+          'priced_calls' => '4',
+          'unpriced_calls' => '1',
+        ),
+      ),
+      complete_response(
+        result_row(
+          '@timestamp' => '2026-06-10 09:00:00.000',
+          'event_kind' => 'interactive_search',
+          'input_cost_usd' => '0.004',
+          'cached_input_cost_usd' => '0.0002',
+          'output_cost_usd' => '0.006',
+          'embedding_cost_usd' => '0',
+          'total_cost_usd' => '0.01',
+          'input_tokens' => '2000',
+          'cached_input_tokens' => '400',
+          'output_tokens' => '500',
+          'total_tokens' => '2500',
+          'calls' => '4',
+          'priced_calls' => '3',
+          'unpriced_calls' => '1',
+        ),
+        result_row(
+          '@timestamp' => '2026-06-10 09:00:00.000',
+          'event_kind' => 'vector_search_query_embedding',
+          'input_cost_usd' => '0',
+          'cached_input_cost_usd' => '0',
+          'output_cost_usd' => '0',
+          'embedding_cost_usd' => '0.0002',
+          'total_cost_usd' => '0.0002',
+          'input_tokens' => '10000',
+          'cached_input_tokens' => '0',
+          'output_tokens' => '0',
+          'total_tokens' => '10000',
+          'calls' => '1',
+          'priced_calls' => '1',
+          'unpriced_calls' => '0',
+        ),
+      ),
+      complete_response(
         result_row('source' => 'frontend', 'selected' => '2', 'selectable' => '35'),
         result_row('source' => 'backend_only', 'selected' => '1', 'selectable' => '7'),
         result_row('selected' => '1', 'selectable' => '5'),
@@ -87,7 +134,7 @@ RSpec.describe SearchAnalytics::CloudwatchSnapshotQuery do
       hash_including(
         query_string: a_string_including('filter @logStream like "ecs/backend-uk/"'),
       ),
-    ).exactly(12).times
+    ).exactly(14).times
     expect(client).not_to have_received(:start_query).with(
       hash_including(query_string: a_string_including('sort bin(')),
     )
@@ -133,6 +180,21 @@ RSpec.describe SearchAnalytics::CloudwatchSnapshotQuery do
     )
     expect(client).to have_received(:start_query).with(
       hash_including(
+        query_string: a_string_including('stats sum(request_cost_usd) as total_cost_usd'),
+      ),
+    ).once
+    expect(client).to have_received(:start_query).with(
+      hash_including(
+        query_string: a_string_including('service = "ai_usage" and event = "embedding_api_call_completed"'),
+      ),
+    ).twice
+    expect(client).to have_received(:start_query).with(
+      hash_including(
+        query_string: a_string_including('sum(embedding_cost_usd) as embedding_cost_usd'),
+      ),
+    ).once
+    expect(client).to have_received(:start_query).with(
+      hash_including(
         query_string: a_string_including('datefloor(@t, 1h) as @timestamp'),
       ),
     ).twice
@@ -172,7 +234,7 @@ RSpec.describe SearchAnalytics::CloudwatchSnapshotQuery do
       hash_including(
         query_string: a_string_including('filter @logStream like "ecs/backend-xi/"'),
       ),
-    ).exactly(12).times
+    ).exactly(14).times
   end
 
   it 'raises terminal unknown CloudWatch query statuses immediately' do
@@ -246,6 +308,35 @@ RSpec.describe SearchAnalytics::CloudwatchSnapshotQuery do
         'zero_result' => 6,
         'selected' => 6,
       },
+    )
+    expect(payloads.dig('all', 'ai_costs', 'summary')).to include(
+      'total_cost_usd' => 0.0102,
+      'assisted_searches' => 2,
+      'average_cost_usd' => 0.0051,
+      'p50_cost_usd' => 0.0048,
+      'p90_cost_usd' => 0.0075,
+      'pricing_coverage' => 0.8,
+      'complete' => false,
+    )
+    expect(payloads.dig('all', 'ai_costs', 'trend')).to contain_exactly(
+      {
+        'bucket' => '2026-06-10T09:00:00Z',
+        'input_cost_usd' => 0.004,
+        'output_cost_usd' => 0.006,
+        'embedding_cost_usd' => 0.0002,
+        'total_cost_usd' => 0.0102,
+      },
+    )
+    expect(payloads.dig('all', 'ai_costs', 'operations')).to match(
+      [
+        include('event_kind' => 'interactive_search', 'calls' => 4, 'total_tokens' => 2500, 'input_cost_usd' => 0.004, 'output_cost_usd' => 0.006, 'embedding_cost_usd' => 0.0, 'total_cost_usd' => 0.01, 'unpriced_calls' => 1),
+        include('event_kind' => 'vector_search_query_embedding', 'calls' => 1, 'total_tokens' => 10_000, 'input_cost_usd' => 0.0, 'output_cost_usd' => 0.0, 'embedding_cost_usd' => 0.0002, 'total_cost_usd' => 0.0002, 'unpriced_calls' => 0),
+      ],
+    )
+    expect(payloads.dig('classic', 'ai_costs')).to include(
+      'summary' => include('total_cost_usd' => 0.0, 'assisted_searches' => 0),
+      'trend' => [],
+      'operations' => [],
     )
     expect(payloads.dig('classic', 'trends', 'outcomes')).to contain_exactly(
       include(


### PR DESCRIPTION
## What:

- aggregate request-level AI cost percentiles and totals for search analytics windows
- expose hourly/daily model input, model output and embedding cost trends
- expose per-operation token and cost breakdowns with pricing coverage
- return an explicit empty cost payload for the classic search view

## Why:

The admin search dashboard currently shows operational search health but cannot account for the model and embedding spend behind AI-assisted searches. This adds a read-only aggregate contract without returning raw diagnostic rows.

The admin UI is implemented in a linked follow-up PR.

## Ticket:

N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:**

This is additive, read-only observability for an unused admin dashboard. It does not change search execution, indexing, tariff data or public API behaviour.

## Verification:

- `bundle exec rspec spec/services/search_analytics spec/requests/api/admin/search_analytics_controller_spec.rb spec/models/search_analytics_snapshot_spec.rb` — 23 examples, 0 failures
- Rubocop — 4 files, no offences
- pre-commit hooks — passed
- pre-push debride — passed