### PR TITLE
refactor(labels): extract loading workflows

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -69,7 +69,6 @@ Metrics/ModuleLength:
   Exclude:
     - 'app/lib/tariff_synchronizer.rb'
     - 'app/models/measure.rb'
-    - 'lib/tasks/labels.rake'
     - 'lib/tasks/tariff_knowledge.rake'
     - 'lib/tasks/tariff_sync_tooling.rake'
 

--- a/app/services/label_regenerator.rb
+++ b/app/services/label_regenerator.rb
@@ -1,0 +1,53 @@
+class LabelRegenerator
+  class << self
+    def call
+      load_self_texts
+      confirm_regeneration!
+      delete_labels
+      enqueue_generation
+    end
+
+  private
+
+    def load_self_texts
+      csv_path = ENV['CSV_PATH']
+      SelfTextLookupService.csv_path = csv_path if csv_path.present?
+      $stdout.puts "Loading self-texts from #{SelfTextLookupService.csv_path}..."
+      ensure_csv_exists!
+      SelfTextLookupService.reload!
+      $stdout.puts "Loaded #{SelfTextLookupService.count} self-texts"
+    end
+
+    def ensure_csv_exists!
+      return if File.exist?(SelfTextLookupService.csv_path)
+
+      $stdout.puts "ERROR: Self-texts CSV not found at #{SelfTextLookupService.csv_path}"
+      $stdout.puts 'Set CSV_PATH environment variable or place file at data/CN2026_SelfText_EN_DE_FR.csv'
+      raise SystemExit.new(1, 'exit')
+    end
+
+    def confirm_regeneration!
+      return if ENV['CONFIRM'] == 'true'
+
+      $stdout.puts "\nWARNING: This will delete ALL existing labels and regenerate them."
+      $stdout.puts 'Set CONFIRM=true to proceed.'
+      raise SystemExit.new(1, 'exit')
+    end
+
+    def delete_labels
+      $stdout.puts "\nDeleting all labels..."
+      label_dataset = GoodsNomenclatureLabel.dataset
+      deleted_count = label_dataset.count
+      PaperTrail::BulkVersioning.record_destroy_versions_for_dataset!(dataset: label_dataset) if deleted_count.positive?
+      label_dataset.delete
+      $stdout.puts "Deleted #{deleted_count} labels"
+      $stdout.puts "\nEnqueuing label generation..."
+    end
+
+    def enqueue_generation
+      $stdout.puts 'Enqueuing label generation...'
+      RelabelGoodsNomenclatureWorker.perform_async
+      $stdout.puts 'Done. Check Sidekiq for progress.'
+    end
+  end
+end

--- a/app/services/label_self_text_loader.rb
+++ b/app/services/label_self_text_loader.rb
@@ -1,0 +1,24 @@
+class LabelSelfTextLoader
+  SAMPLE_CODES = %w[0101210000 0102292100 8471300000].freeze
+
+  class << self
+    def call
+      csv_path = ENV['CSV_PATH']
+      SelfTextLookupService.csv_path = csv_path if csv_path.present?
+      $stdout.puts "Loading self-texts from #{SelfTextLookupService.csv_path}..."
+      SelfTextLookupService.reload!
+      $stdout.puts "Loaded #{SelfTextLookupService.count} self-texts"
+      print_samples
+    end
+
+  private
+
+    def print_samples
+      $stdout.puts "\nSample lookups:"
+      SAMPLE_CODES.each do |code|
+        text = SelfTextLookupService.lookup(code)
+        $stdout.puts "  #{code}: #{text || '(not found)'}"
+      end
+    end
+  end
+end

--- a/lib/tasks/labels.rake
+++ b/lib/tasks/labels.rake
@@ -42,21 +42,7 @@ module_function
   end
 
   def load_self_texts
-    csv_path = ENV['CSV_PATH']
-    SelfTextLookupService.csv_path = csv_path if csv_path.present?
-
-    puts "Loading self-texts from #{SelfTextLookupService.csv_path}..."
-    SelfTextLookupService.reload!
-    puts "Loaded #{SelfTextLookupService.count} self-texts"
-    print_sample_self_text_lookups
-  end
-
-  def print_sample_self_text_lookups
-    puts "\nSample lookups:"
-    %w[0101210000 0102292100 8471300000].each do |code|
-      text = SelfTextLookupService.lookup(code)
-      puts "  #{code}: #{text || '(not found)'}"
-    end
+    LabelSelfTextLoader.call
   end
 
   def relabel
@@ -130,43 +116,7 @@ module_function
   end
 
   def nuke_and_regenerate
-    load_self_texts_for_regeneration
-    confirm_regeneration!
-    delete_labels
-    generate
-  end
-
-  def load_self_texts_for_regeneration
-    csv_path = ENV['CSV_PATH']
-    SelfTextLookupService.csv_path = csv_path if csv_path.present?
-    puts "Loading self-texts from #{SelfTextLookupService.csv_path}..."
-
-    unless File.exist?(SelfTextLookupService.csv_path)
-      puts "ERROR: Self-texts CSV not found at #{SelfTextLookupService.csv_path}"
-      puts 'Set CSV_PATH environment variable or place file at data/CN2026_SelfText_EN_DE_FR.csv'
-      exit 1
-    end
-
-    SelfTextLookupService.reload!
-    puts "Loaded #{SelfTextLookupService.count} self-texts"
-  end
-
-  def confirm_regeneration!
-    return if ENV['CONFIRM'] == 'true'
-
-    puts "\nWARNING: This will delete ALL existing labels and regenerate them."
-    puts 'Set CONFIRM=true to proceed.'
-    exit 1
-  end
-
-  def delete_labels
-    puts "\nDeleting all labels..."
-    label_dataset = GoodsNomenclatureLabel.dataset
-    deleted_count = label_dataset.count
-    PaperTrail::BulkVersioning.record_destroy_versions_for_dataset!(dataset: label_dataset) if deleted_count.positive?
-    label_dataset.delete
-    puts "Deleted #{deleted_count} labels"
-    puts "\nEnqueuing label generation..."
+    LabelRegenerator.call
   end
 end
 


### PR DESCRIPTION
## What:
Extract the ordinary self-text CSV-loading workflow into `LabelSelfTextLoader.call` and the destructive delete/regenerate workflow into `LabelRegenerator.call`.

`LabelsTasks` retains its public task-facing methods as thin delegates and falls from 138 to 96 counted lines. The exact `lib/tasks/labels.rake` `Metrics/ModuleLength` exclusion is removed.

## Why:
Merged PRs #3522 and #3525 now characterize both workflows at the public Rake-task boundary. Keeping two services preserves their intentionally different missing-file behavior while giving each workflow a single owner and bringing the remaining task module under GOV.UK RuboCop's default length limit.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Covered structural extraction behind unchanged public Rake task methods. CSV path semantics, cache reloads, exact output/order, status-1 guards, PaperTrail versioning-before-deletion, zero-label handling, and zero-argument Sidekiq enqueueing are unchanged.

## Verification:
- `bundle exec rspec spec/lib/tasks/labels_rake_spec.rb` — 14 examples, 0 failures on seeds 1, 8675309, and 20260717
- `bin/rails zeitwerk:check` — All is good
- Targeted RuboCop — 3 changed Ruby files, 0 offenses
- Default `Metrics/ModuleLength` — task module and both services pass; `LabelsTasks` is 96/100
- Full effective RuboCop — 2,393 targets inspected, 0 offenses
- Debride pre-push hook — passed after sole-use private helpers were inlined; no whitelist added
- `git diff --check` — clean
- Independent specification and code-quality reviews — final amended SHA passed with no findings
