### PR TITLE
test(tariff-sync): characterize tooling edge cases

### DIFF
--- a/spec/lib/tasks/tariff_sync_tooling_rake_spec.rb
+++ b/spec/lib/tasks/tariff_sync_tooling_rake_spec.rb
@@ -202,6 +202,20 @@ RSpec.describe 'tariff:sync:failure_detail' do
     it 'does not show CDS error details' do
       expect(output).not_to match(/CDS Record Errors/)
     end
+
+    context 'with malformed stored counts' do
+      let(:malformed_inserts) { '{"operations":' }
+
+      before { update.update(inserts: malformed_inserts) }
+
+      it 'shows the raw stored value' do
+        expect(output).to include(<<~OUTPUT)
+          === Previous Import Operation Counts ===
+
+          #{malformed_inserts}
+        OUTPUT
+      end
+    end
   end
 
   context 'with a failed TARIC update' do
@@ -348,6 +362,24 @@ RSpec.describe 'tariff:sync:inspect_file' do
       expect(output).to match(/Total transaction records: 3/)
       expect(output).to match(/GoodsNomenclature\s+2/)
       expect(output).to match(/Measure\s+1/)
+    end
+
+    context 'without transaction records' do
+      let(:taric_xml) { StringIO.new('<envelope/>') }
+
+      it 'shows the exact empty-file summary' do
+        expect(output).to eq(<<~OUTPUT)
+          === File Inspection: #{update.filename} ===
+
+          State      : P
+          Issue date : #{update.issue_date}
+          File size  : 2048 bytes
+
+          Total transaction records: 0
+
+          (No records found - file may use a different XML structure)
+        OUTPUT
+      end
     end
   end
 end


### PR DESCRIPTION
## What:
Add public Rake-task characterization for the two remaining executable coverage gaps in `tariff_sync_tooling.rake`:

- malformed stored import-count JSON falls back to its raw value
- an empty TARIC file reports the zero total before the no-records warning, with exact output preserved

## Why:
These operator-facing behaviors need to be protected before extracting file-inspection, failure-detail, and status-reporting concerns in later independent PRs. This test-only slice raises the task file from 160/162 to 162/162 covered executable lines without changing production behavior.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Tests only. No production code, configuration, task behavior, or synchronization behavior changes.

## Verification:
- `bundle exec rspec spec/lib/tasks/tariff_sync_tooling_rake_spec.rb` — 46 examples, 0 failures on seeds 1, 8675309, and 20260720
- Focused coverage — 162/162 executable lines covered in `lib/tasks/tariff_sync_tooling.rake`
- Changed-file RuboCop — 1 file inspected, 0 offenses
- Full effective RuboCop — 2,134 targets inspected, 0 offenses
- Debride pre-push hook — passed
- `git diff --check` — clean
- Independent specification and code-quality reviews — passed with no findings
