### PR TITLE
refactor(tariff-sync): extract file inspection

### DIFF
--- a/app/services/tariff_sync_file_inspector.rb
+++ b/app/services/tariff_sync_file_inspector.rb
@@ -1,0 +1,80 @@
+class TariffSyncFileInspector
+  class Error < StandardError; end
+
+  class << self
+    def call
+      require 'zip'
+
+      update = update_from_env_filename
+      raise Error, "File not found at path: #{update.file_path}" unless TariffSynchronizer::FileService.file_exists?(update.file_path)
+
+      print_file_inspection_header(update)
+      update.is_a?(TariffSynchronizer::CdsUpdate) ? inspect_cds_file(update) : inspect_taric_file(update)
+    end
+
+  private
+
+    def update_from_env_filename
+      filename = ENV['FILENAME']
+      unless filename
+        raise Error, 'Set FILENAME= to the full update filename (e.g. tariff_dailyExtract_v1_20240101T000000.gzip).'
+      end
+
+      TariffSynchronizer::BaseUpdate.where(filename:).first || raise(Error, "No update found with filename: #{filename}")
+    end
+
+    def print_file_inspection_header(update)
+      file_size = TariffSynchronizer::FileService.file_size(update.file_path)
+      $stdout.puts "=== File Inspection: #{update.filename} ===\n\n"
+      $stdout.puts "State      : #{update.state}"
+      $stdout.puts "Issue date : #{update.issue_date}"
+      $stdout.puts "File size  : #{file_size} bytes"
+      $stdout.puts
+    end
+
+    def inspect_cds_file(update)
+      counts = Hash.new(0)
+      counting_handler = Object.new
+      counting_handler.define_singleton_method(:process_xml_node) { |key, _hash| counts[key] += 1 }
+
+      zip_io = TariffSynchronizer::FileService.file_as_stringio(update)
+      Zip::File.open_buffer(zip_io) do |archive|
+        archive.entries.each do |entry|
+          CdsImporter::XmlParser::Reader.new(entry.get_input_stream, counting_handler).parse
+        end
+      end
+
+      print_counts('Total entity records', 'Entity', counts)
+    end
+
+    def inspect_taric_file(update)
+      xml_content = TariffSynchronizer::FileService.get(update.file_path)
+      doc = Nokogiri::XML(xml_content)
+      counts = Hash.new(0)
+      doc.xpath('//record').each do |record|
+        type = record.xpath('./*[1]').first&.name || 'unknown'
+        counts[type] += 1
+      end
+
+      $stdout.puts "Total transaction records: #{counts.values.sum}\n\n"
+      if counts.any?
+        print_counts_table('Record Type', counts)
+      else
+        $stdout.puts '(No records found - file may use a different XML structure)'
+      end
+    end
+
+    def print_counts(total_label, column_label, counts)
+      $stdout.puts "#{total_label}: #{counts.values.sum}\n\n"
+      print_counts_table(column_label, counts)
+    end
+
+    def print_counts_table(column_label, counts)
+      $stdout.puts sprintf('%-55s %6s', column_label, 'Count')
+      $stdout.puts '-' * 63
+      counts.sort_by { |_, value| -value }.each do |key, count|
+        $stdout.puts sprintf('%-55s %6d', key, count)
+      end
+    end
+  end
+end

--- a/lib/tasks/tariff_sync_tooling.rake
+++ b/lib/tasks/tariff_sync_tooling.rake
@@ -140,67 +140,9 @@ module_function
   end
 
   def inspect_file
-    require 'zip'
-
-    update = update_from_env_filename
-    abort "File not found at path: #{update.file_path}" unless TariffSynchronizer::FileService.file_exists?(update.file_path)
-
-    print_file_inspection_header(update)
-    update.is_a?(TariffSynchronizer::CdsUpdate) ? inspect_cds_file(update) : inspect_taric_file(update)
-  end
-
-  def print_file_inspection_header(update)
-    file_size = TariffSynchronizer::FileService.file_size(update.file_path)
-    puts "=== File Inspection: #{update.filename} ===\n\n"
-    puts "State      : #{update.state}"
-    puts "Issue date : #{update.issue_date}"
-    puts "File size  : #{file_size} bytes"
-    puts
-  end
-
-  def inspect_cds_file(update)
-    counts = Hash.new(0)
-    counting_handler = Object.new
-    counting_handler.define_singleton_method(:process_xml_node) { |key, _hash| counts[key] += 1 }
-
-    zip_io = TariffSynchronizer::FileService.file_as_stringio(update)
-    Zip::File.open_buffer(zip_io) do |archive|
-      archive.entries.each do |entry|
-        CdsImporter::XmlParser::Reader.new(entry.get_input_stream, counting_handler).parse
-      end
-    end
-
-    print_counts('Total entity records', 'Entity', counts)
-  end
-
-  def inspect_taric_file(update)
-    xml_content = TariffSynchronizer::FileService.get(update.file_path)
-    doc = Nokogiri::XML(xml_content)
-    counts = Hash.new(0)
-    doc.xpath('//record').each do |record|
-      type = record.xpath('./*[1]').first&.name || 'unknown'
-      counts[type] += 1
-    end
-
-    puts "Total transaction records: #{counts.values.sum}\n\n"
-    if counts.any?
-      print_counts_table('Record Type', counts)
-    else
-      puts '(No records found - file may use a different XML structure)'
-    end
-  end
-
-  def print_counts(total_label, column_label, counts)
-    puts "#{total_label}: #{counts.values.sum}\n\n"
-    print_counts_table(column_label, counts)
-  end
-
-  def print_counts_table(column_label, counts)
-    puts sprintf('%-55s %6s', column_label, 'Count')
-    puts '-' * 63
-    counts.sort_by { |_, value| -value }.each do |key, count|
-      puts sprintf('%-55s %6d', key, count)
-    end
+    TariffSyncFileInspector.call
+  rescue TariffSyncFileInspector::Error => e
+    abort e.message
   end
 
   def reset_failed


### PR DESCRIPTION
## What:
Extract the `tariff:sync:inspect_file` workflow into `TariffSyncFileInspector.call` while retaining `TariffSyncToolingTasks.inspect_file` as the public Rake-facing adapter.

The service owns update lookup, file guards, header output, CDS ZIP parsing, TARIC XML counting, and count formatting. Expected validation failures are converted back to status-1 `abort` calls at the Rake boundary. Status reporting, failure reporting, reset, and force-apply recovery behavior remain untouched.

## Why:
PR #3527 completed public-task characterization for every executable file-inspection branch. This cohesive extraction reduces `TariffSyncToolingTasks` from 194 to 146 counted lines while preserving operator behavior. Its exact `Metrics/ModuleLength` exclusion intentionally remains for later independent failure/status reporting slices.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Behavior-preserving structural extraction behind the unchanged public Rake task, with every executable line in the remaining task module and new service covered. Exact guards, status-1 exits, output/order, CDS/TARIC parsing, storage calls, and count formatting are preserved. No synchronization or recovery mutation changes.

## Verification:
- `bundle exec rspec spec/lib/tasks/tariff_sync_tooling_rake_spec.rb` — 46 examples, 0 failures on seeds 1, 8675309, and 20260720
- Focused coverage — remaining task module 124/124 and new service 50/50 executable lines covered
- `bin/rails zeitwerk:check` — All is good
- Changed-file RuboCop — 2 files inspected, 0 offenses
- Forced default `Metrics/ModuleLength` — task module 194→146/100; new service passes; exact task exclusion retained
- Full effective RuboCop — 2,393 targets inspected, 0 offenses
- Debride pre-push hook — passed
- `git diff --check` — clean
- Independent specification and code-quality reviews — passed with no findings
