### PR TITLE
refactor(tariff-sync): extract failure details

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -70,7 +70,6 @@ Metrics/ModuleLength:
     - 'app/lib/tariff_synchronizer.rb'
     - 'app/models/measure.rb'
     - 'lib/tasks/tariff_knowledge.rake'
-    - 'lib/tasks/tariff_sync_tooling.rake'
 
 RSpec/SpecFilePathFormat:
   Enabled: true

--- a/app/services/tariff_sync_failure_detail_reporter.rb
+++ b/app/services/tariff_sync_failure_detail_reporter.rb
@@ -1,0 +1,80 @@
+class TariffSyncFailureDetailReporter
+  class Error < StandardError; end
+
+  class << self
+    def call
+      update = update_from_env_filename
+      print_header(update)
+      print_exception(update)
+      print_presence_errors(update)
+      print_previous_import_counts(update)
+    end
+
+  private
+
+    def update_from_env_filename
+      filename = ENV['FILENAME']
+      unless filename
+        raise Error, 'Set FILENAME= to the full update filename (e.g. tariff_dailyExtract_v1_20240101T000000.gzip).'
+      end
+
+      TariffSynchronizer::BaseUpdate.where(filename:).first || raise(Error, "No update found with filename: #{filename}")
+    end
+
+    def print_header(update)
+      service = update.is_a?(TariffSynchronizer::CdsUpdate) ? 'UK (CDS)' : 'XI (TARIC)'
+      $stdout.puts "=== Failure Detail: #{update.filename} ===\n\n"
+      $stdout.puts "Service    : #{service}"
+      $stdout.puts "State      : #{update.state}"
+      $stdout.puts "Issue date : #{update.issue_date}"
+      $stdout.puts "File size  : #{update.filesize ? "#{update.filesize} bytes" : 'unknown'}"
+      $stdout.puts "Created at : #{update.created_at}"
+      $stdout.puts "Updated at : #{update.updated_at}"
+    end
+
+    def print_exception(update)
+      return if update.exception_class.blank?
+
+      $stdout.puts "\n=== Exception ===\n\n"
+      $stdout.puts update.exception_class
+      $stdout.puts
+      print_exception_backtrace(update)
+      print_exception_queries(update)
+    end
+
+    def print_exception_backtrace(update)
+      return if update.exception_backtrace.blank?
+
+      $stdout.puts "=== Backtrace (first 20 lines) ===\n\n"
+      update.exception_backtrace.split("\n").first(20).each { |line| $stdout.puts line }
+    end
+
+    def print_exception_queries(update)
+      return if update.exception_queries.blank?
+
+      $stdout.puts "\n=== Last SQL Queries ===\n\n"
+      $stdout.puts update.exception_queries
+    end
+
+    def print_presence_errors(update)
+      presence_errors = update.presence_errors
+      return if presence_errors.empty?
+
+      $stdout.puts "\n=== Presence Errors (#{presence_errors.count} total, showing first 10) ===\n\n"
+      presence_errors.first(10).each_with_index do |error, index|
+        $stdout.puts "#{index + 1}. #{error.model_name}"
+        $stdout.puts error.details.inspect
+        $stdout.puts
+      end
+    end
+
+    def print_previous_import_counts(update)
+      return if update.inserts.blank?
+
+      $stdout.puts "\n=== Previous Import Operation Counts ===\n\n"
+      $stdout.puts JSON.pretty_generate(JSON.parse(update.inserts))
+    rescue JSON::ParserError
+      $stdout.puts update.inserts
+    end
+  end
+end

--- a/lib/tasks/tariff_sync_tooling.rake
+++ b/lib/tasks/tariff_sync_tooling.rake
@@ -69,74 +69,9 @@ module_function
   end
 
   def failure_detail
-    update = update_from_env_filename
-    print_failure_detail_header(update)
-    print_exception_detail(update)
-    print_presence_errors(update)
-    print_previous_import_counts(update)
-  end
-
-  def update_from_env_filename
-    filename = ENV['FILENAME']
-    abort 'Set FILENAME= to the full update filename (e.g. tariff_dailyExtract_v1_20240101T000000.gzip).' unless filename
-
-    TariffSynchronizer::BaseUpdate.where(filename:).first || abort("No update found with filename: #{filename}")
-  end
-
-  def print_failure_detail_header(update)
-    service = update.is_a?(TariffSynchronizer::CdsUpdate) ? 'UK (CDS)' : 'XI (TARIC)'
-    puts "=== Failure Detail: #{update.filename} ===\n\n"
-    puts "Service    : #{service}"
-    puts "State      : #{update.state}"
-    puts "Issue date : #{update.issue_date}"
-    puts "File size  : #{update.filesize ? "#{update.filesize} bytes" : 'unknown'}"
-    puts "Created at : #{update.created_at}"
-    puts "Updated at : #{update.updated_at}"
-  end
-
-  def print_exception_detail(update)
-    return if update.exception_class.blank?
-
-    puts "\n=== Exception ===\n\n"
-    puts update.exception_class
-    puts
-    print_exception_backtrace(update)
-    print_exception_queries(update)
-  end
-
-  def print_exception_backtrace(update)
-    return if update.exception_backtrace.blank?
-
-    puts "=== Backtrace (first 20 lines) ===\n\n"
-    update.exception_backtrace.split("\n").first(20).each { |line| puts line }
-  end
-
-  def print_exception_queries(update)
-    return if update.exception_queries.blank?
-
-    puts "\n=== Last SQL Queries ===\n\n"
-    puts update.exception_queries
-  end
-
-  def print_presence_errors(update)
-    presence_errors = update.presence_errors
-    return if presence_errors.empty?
-
-    puts "\n=== Presence Errors (#{presence_errors.count} total, showing first 10) ===\n\n"
-    presence_errors.first(10).each_with_index do |error, index|
-      puts "#{index + 1}. #{error.model_name}"
-      puts error.details.inspect
-      puts
-    end
-  end
-
-  def print_previous_import_counts(update)
-    return if update.inserts.blank?
-
-    puts "\n=== Previous Import Operation Counts ===\n\n"
-    puts JSON.pretty_generate(JSON.parse(update.inserts))
-  rescue JSON::ParserError
-    puts update.inserts
+    TariffSyncFailureDetailReporter.call
+  rescue TariffSyncFailureDetailReporter::Error => e
+    abort e.message
   end
 
   def inspect_file


### PR DESCRIPTION
## What:
Extract the `tariff:sync:failure_detail` single-update report into `TariffSyncFailureDetailReporter.call` while retaining `TariffSyncToolingTasks.failure_detail` as the public Rake-facing adapter.

The service owns filename/update lookup, report headers, exception/backtrace/query output, presence errors, and previous import counts. Expected validation failures are converted back to status-1 `abort` calls at the Rake boundary. Status, failure-list, file-inspection, reset, and force-apply behavior remain untouched.

`TariffSyncToolingTasks` falls from 146 to 94 counted lines, so its exact `Metrics/ModuleLength` exclusion is removed.

## Why:
Merged PRs #3527 and #3528 provide complete public-task characterization for the reporting behavior and its edge cases. This cohesive extraction brings the remaining task adapter under GOV.UK RuboCop's default module-length limit without changing synchronization or recovery mutations.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Behavior-preserving structural extraction behind the unchanged public Rake task. Every executable line in the remaining task module and new reporter is covered. Exact output/order, status-1 guards, service classification, backtrace and presence-error limits, SQL output, JSON formatting, and malformed-JSON fallback are preserved. No synchronization or recovery mutation changes.

## Verification:
- `bundle exec rspec spec/lib/tasks/tariff_sync_tooling_rake_spec.rb` — 46 examples, 0 failures on seeds 1, 8675309, and 20260720
- Focused coverage — remaining task module 80/80 and new reporter 52/52 executable lines covered
- `bin/rails zeitwerk:check` — All is good
- Changed-file RuboCop — 2 files inspected, 0 offenses
- Default `Metrics/ModuleLength` — `TariffSyncToolingTasks` is 94/100; exact exclusion removed
- Full committed-head effective RuboCop — 2,395 targets inspected, 0 offenses
- Debride pre-push hook — passed
- `git diff --check` — clean
- Independent specification and code-quality reviews — passed with no findings
