### PR TITLE
Characterize invalid ATAR request delays

### DIFF
--- a/spec/lib/tasks/tariff_knowledge_rake_spec.rb
+++ b/spec/lib/tasks/tariff_knowledge_rake_spec.rb
@@ -131,6 +131,18 @@ RSpec.describe 'tariff_knowledge rake tasks' do
   end
 
   describe 'tariff_knowledge:atars:import' do
+    around do |example|
+      original_request_delay = [false, nil]
+      original_request_delay = [ENV.key?('ATAR_REQUEST_DELAY'), ENV['ATAR_REQUEST_DELAY']]
+      example.run
+    ensure
+      if original_request_delay.first
+        ENV['ATAR_REQUEST_DELAY'] = original_request_delay.last
+      else
+        ENV.delete('ATAR_REQUEST_DELAY')
+      end
+    end
+
     it 'imports public ATAR rulings inline' do
       allow(TariffKnowledge::PublicAtarRulingImporter).to receive(:call)
         .and_return(public_atar_import_result(created_count: 1, updated_count: 1))
@@ -155,6 +167,32 @@ RSpec.describe 'tariff_knowledge rake tasks' do
       else
         ENV.delete('ATAR_MAX_PAGES')
       end
+    end
+
+    it 'rejects a non-numeric request delay before importing or refreshing search' do
+      allow(TariffKnowledge::PublicAtarRulingImporter).to receive(:call)
+      allow(TariffKnowledge::PublicAtarSearchRefresh).to receive(:call)
+      ENV['ATAR_REQUEST_DELAY'] = 'not-a-number'
+
+      expect {
+        suppress_output { Rake::Task['tariff_knowledge:atars:import'].invoke }
+      }.to raise_error(ArgumentError, 'ATAR_REQUEST_DELAY must be numeric')
+
+      expect(TariffKnowledge::PublicAtarRulingImporter).not_to have_received(:call)
+      expect(TariffKnowledge::PublicAtarSearchRefresh).not_to have_received(:call)
+    end
+
+    it 'rejects a negative request delay before importing or refreshing search' do
+      allow(TariffKnowledge::PublicAtarRulingImporter).to receive(:call)
+      allow(TariffKnowledge::PublicAtarSearchRefresh).to receive(:call)
+      ENV['ATAR_REQUEST_DELAY'] = '-0.1'
+
+      expect {
+        suppress_output { Rake::Task['tariff_knowledge:atars:import'].invoke }
+      }.to raise_error(ArgumentError, 'ATAR_REQUEST_DELAY must be numeric')
+
+      expect(TariffKnowledge::PublicAtarRulingImporter).not_to have_received(:call)
+      expect(TariffKnowledge::PublicAtarSearchRefresh).not_to have_received(:call)
     end
   end
 


### PR DESCRIPTION
## What:
Add public Rake-task characterization for nonnumeric and negative `ATAR_REQUEST_DELAY` values. Both cases assert the current exact error and confirm that neither the public ATAR importer nor search refresh begins.

The spec restores the environment variable exactly, including whether it was originally absent, empty, or populated. No production or RuboCop configuration changes are included.

## Why:
`lib/tasks/tariff_knowledge.rake` has one uncovered executable line in its request-delay parsing path. Locking down this behavior reduces the risk of the next independent PR, which will extract public ATAR import-option parsing and remove the task module's `Metrics/ModuleLength` exclusion.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Test-only characterization of existing public-task behavior. Production code, task behavior, and RuboCop configuration are unchanged.

## Verification:
- `bundle exec rspec spec/lib/tasks/tariff_knowledge_rake_spec.rb` — 16 examples, 0 failures on seeds 1, 8675309, and 20260720
- Focused coverage — `lib/tasks/tariff_knowledge.rake` 110/110 executable lines covered
- Changed-file RuboCop — 1 file inspected, 0 offenses
- Full committed-head effective RuboCop — 2,395 targets inspected, 0 offenses
- Debride pre-push hook — passed
- `git diff --check` — clean
- Independent specification and code-quality reviews — passed with no findings