### PR TITLE
Schedule tariff knowledge refresh in production

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -98,7 +98,7 @@
     RefreshTariffKnowledgeCompressedNotesWorker:
       cron: "0 3 * * *"
       description: "Refreshes tariff knowledge graph and compressed notes for current declarable goods"
-      enabled: <%= ENV.fetch('SERVICE', 'uk') == 'uk' && ENV.fetch('ENVIRONMENT', 'local') == 'staging' %>
+      enabled: <%= ENV.fetch('SERVICE', 'uk') == 'uk' %>
     ImportPublicAtarRulingsWorker:
       cron: "30 3 * * *"
       queue: within_1_day

--- a/spec/config/sidekiq_schedule_spec.rb
+++ b/spec/config/sidekiq_schedule_spec.rb
@@ -32,11 +32,14 @@ RSpec.describe 'config/sidekiq.yml' do
     expect(schedule).not_to include('CreateTariffKnowledgeDeclarableNodesWorker')
   end
 
-  it 'keeps tariff knowledge compressed note refresh disabled outside staging' do
+  it 'schedules the tariff knowledge compressed note refresh pipeline in production' do
     schedule = sidekiq_schedule(environment: 'production')
 
     expect(schedule).to include(
-      'RefreshTariffKnowledgeCompressedNotesWorker' => include('enabled' => false),
+      'RefreshTariffKnowledgeCompressedNotesWorker' => include(
+        'cron' => '0 3 * * *',
+        'enabled' => true,
+      ),
     )
   end
 


### PR DESCRIPTION
## What:
- enable the tariff knowledge compressed-note refresh schedule for the UK service in production as well as staging
- add regression coverage for the production Sidekiq schedule

## Why:
Compressed-note consumption is already controlled by the `search_compressed_notes_enabled` admin configuration. The data-generation pipeline should run automatically so that note evidence is populated and ready if the feature is enabled later.

The feature is currently unused, and its production admin configuration will remain disabled.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
This is a covered configuration change for an existing but currently unused feature. It prepares compressed-note data in production, while the disabled admin configuration prevents any live journey or API behaviour change.