### PR TITLE
refactor: extract public ATAR import options

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -69,7 +69,6 @@ Metrics/ModuleLength:
   Exclude:
     - 'app/lib/tariff_synchronizer.rb'
     - 'app/models/measure.rb'
-    - 'lib/tasks/tariff_knowledge.rake'
 
 RSpec/SpecFilePathFormat:
   Enabled: true

--- a/app/services/tariff_knowledge/public_atar_import_options.rb
+++ b/app/services/tariff_knowledge/public_atar_import_options.rb
@@ -1,0 +1,33 @@
+module TariffKnowledge
+  class PublicAtarImportOptions
+    def self.call = new.call
+
+    def call
+      {
+        limit: integer_env('ATAR_LIMIT', nil),
+        max_pages: integer_env('ATAR_MAX_PAGES', 50),
+        request_delay: float_env('ATAR_REQUEST_DELAY', PublicAtarRulingSource::DEFAULT_REQUEST_DELAY),
+        max_retries: integer_env('ATAR_MAX_RETRIES', PublicAtarRulingSource::DEFAULT_MAX_RETRIES),
+      }
+    end
+
+  private
+
+    def integer_env(name, default = nil, min: 1)
+      value = ENV.fetch(name, default)
+      return if value.blank?
+
+      integer = Integer(value, exception: false)
+      raise ArgumentError, "#{name} must be an integer" if integer.nil? || integer < min
+
+      integer
+    end
+
+    def float_env(name, default, min: 0.0)
+      number = Float(ENV.fetch(name, default), exception: false)
+      raise ArgumentError, "#{name} must be numeric" if number.nil? || number < min
+
+      number
+    end
+  end
+end

--- a/lib/tasks/tariff_knowledge.rake
+++ b/lib/tasks/tariff_knowledge.rake
@@ -48,7 +48,7 @@ module_function
   def import_atars
     return unless uk_service?
 
-    result = TariffKnowledge::PublicAtarRulingImporter.call(public_atar_import_options)
+    result = TariffKnowledge::PublicAtarRulingImporter.call(**TariffKnowledge::PublicAtarImportOptions.call)
     refreshed_sids = TariffKnowledge::PublicAtarSearchRefresh.call(result.refresh_goods_nomenclature_item_ids)
     puts "Public ATAR import complete: #{result.seen_count} seen, #{result.created_count} created, #{result.updated_count} updated, #{result.failed_count} failed."
     puts "Public ATAR search refresh complete: #{refreshed_sids.size} goods nomenclatures refreshed or queued."
@@ -66,34 +66,6 @@ module_function
 
     puts 'Skipping public ATAR import outside UK service mode.'
     false
-  end
-
-  def public_atar_import_options
-    {
-      limit: integer_env('ATAR_LIMIT', nil),
-      max_pages: integer_env('ATAR_MAX_PAGES', 50),
-      request_delay: float_env('ATAR_REQUEST_DELAY', TariffKnowledge::PublicAtarRulingSource::DEFAULT_REQUEST_DELAY),
-      max_retries: integer_env('ATAR_MAX_RETRIES', TariffKnowledge::PublicAtarRulingSource::DEFAULT_MAX_RETRIES),
-    }
-  end
-
-  def integer_env(name, default = nil, min: 1)
-    value = ENV.fetch(name, default)
-    return if value.blank?
-
-    Integer(value).tap do |integer|
-      raise ArgumentError, "#{name} must be at least #{min}" if integer < min
-    end
-  rescue ArgumentError
-    raise ArgumentError, "#{name} must be an integer"
-  end
-
-  def float_env(name, default, min: 0.0)
-    Float(ENV.fetch(name, default)).tap do |number|
-      raise ArgumentError, "#{name} must be at least #{min}" if number < min
-    end
-  rescue ArgumentError
-    raise ArgumentError, "#{name} must be numeric"
   end
 
   def validate_note_structures

--- a/spec/lib/tasks/tariff_knowledge_rake_spec.rb
+++ b/spec/lib/tasks/tariff_knowledge_rake_spec.rb
@@ -132,25 +132,35 @@ RSpec.describe 'tariff_knowledge rake tasks' do
 
   describe 'tariff_knowledge:atars:import' do
     around do |example|
-      original_request_delay = [false, nil]
-      original_request_delay = [ENV.key?('ATAR_REQUEST_DELAY'), ENV['ATAR_REQUEST_DELAY']]
+      original_values = {}
+      names = %w[ATAR_LIMIT ATAR_MAX_PAGES ATAR_REQUEST_DELAY ATAR_MAX_RETRIES]
+      original_values = names.index_with { |name| [ENV.key?(name), ENV[name]] }
+      names.each { |name| ENV.delete(name) }
+
       example.run
     ensure
-      if original_request_delay.first
-        ENV['ATAR_REQUEST_DELAY'] = original_request_delay.last
-      else
-        ENV.delete('ATAR_REQUEST_DELAY')
+      original_values.each do |name, (present, value)|
+        present ? ENV[name] = value : ENV.delete(name)
       end
     end
 
     it 'imports public ATAR rulings inline' do
-      allow(TariffKnowledge::PublicAtarRulingImporter).to receive(:call)
-        .and_return(public_atar_import_result(created_count: 1, updated_count: 1))
+      allow(TariffKnowledge::PublicAtarRulingImporter).to receive(:call).with(
+        limit: nil,
+        max_pages: 50,
+        request_delay: TariffKnowledge::PublicAtarRulingSource::DEFAULT_REQUEST_DELAY,
+        max_retries: TariffKnowledge::PublicAtarRulingSource::DEFAULT_MAX_RETRIES,
+      ).and_return(public_atar_import_result(created_count: 1, updated_count: 1))
       allow(TariffKnowledge::PublicAtarSearchRefresh).to receive(:call).and_return([1])
 
       suppress_output { Rake::Task['tariff_knowledge:atars:import'].invoke }
 
-      expect(TariffKnowledge::PublicAtarRulingImporter).to have_received(:call)
+      expect(TariffKnowledge::PublicAtarRulingImporter).to have_received(:call).with(
+        limit: nil,
+        max_pages: 50,
+        request_delay: TariffKnowledge::PublicAtarRulingSource::DEFAULT_REQUEST_DELAY,
+        max_retries: TariffKnowledge::PublicAtarRulingSource::DEFAULT_MAX_RETRIES,
+      )
       expect(TariffKnowledge::PublicAtarSearchRefresh).to have_received(:call).with(%w[6302100000])
     end
 

--- a/spec/services/tariff_knowledge/public_atar_import_options_spec.rb
+++ b/spec/services/tariff_knowledge/public_atar_import_options_spec.rb
@@ -1,0 +1,64 @@
+RSpec.describe TariffKnowledge::PublicAtarImportOptions do
+  subject(:options) { described_class.call }
+
+  around do |example|
+    original_values = {}
+    names = %w[ATAR_LIMIT ATAR_MAX_PAGES ATAR_REQUEST_DELAY ATAR_MAX_RETRIES]
+    original_values = names.index_with { |name| [ENV.key?(name), ENV[name]] }
+    names.each { |name| ENV.delete(name) }
+
+    example.run
+  ensure
+    original_values.each do |name, (present, value)|
+      present ? ENV[name] = value : ENV.delete(name)
+    end
+  end
+
+  it 'returns the importer defaults when environment options are unset' do
+    expect(options).to eq(
+      limit: nil,
+      max_pages: 50,
+      request_delay: TariffKnowledge::PublicAtarRulingSource::DEFAULT_REQUEST_DELAY,
+      max_retries: TariffKnowledge::PublicAtarRulingSource::DEFAULT_MAX_RETRIES,
+    )
+  end
+
+  it 'coerces configured environment options' do
+    ENV['ATAR_LIMIT'] = '12'
+    ENV['ATAR_MAX_PAGES'] = '4'
+    ENV['ATAR_REQUEST_DELAY'] = '0.75'
+    ENV['ATAR_MAX_RETRIES'] = '2'
+
+    expect(options).to eq(limit: 12, max_pages: 4, request_delay: 0.75, max_retries: 2)
+  end
+
+  it 'treats a blank limit as absent' do
+    ENV['ATAR_LIMIT'] = ''
+
+    expect(options[:limit]).to be_nil
+  end
+
+  it 'reports an invalid integer option as an integer' do
+    ENV['ATAR_MAX_PAGES'] = 'oops'
+
+    expect { options }.to raise_error(ArgumentError, 'ATAR_MAX_PAGES must be an integer')
+  end
+
+  it 'reports a below-minimum integer option as an integer' do
+    ENV['ATAR_MAX_PAGES'] = '0'
+
+    expect { options }.to raise_error(ArgumentError, 'ATAR_MAX_PAGES must be an integer')
+  end
+
+  it 'reports an invalid float option as numeric' do
+    ENV['ATAR_REQUEST_DELAY'] = 'oops'
+
+    expect { options }.to raise_error(ArgumentError, 'ATAR_REQUEST_DELAY must be numeric')
+  end
+
+  it 'reports a below-minimum float option as numeric' do
+    ENV['ATAR_REQUEST_DELAY'] = '-0.1'
+
+    expect { options }.to raise_error(ArgumentError, 'ATAR_REQUEST_DELAY must be numeric')
+  end
+end


### PR DESCRIPTION
## What:

- Extract public ATAR environment-option parsing from the Rake task module into `TariffKnowledge::PublicAtarImportOptions`.
- Preserve lazy environment reads, defaults, validation messages, and importer keyword arguments.
- Remove the now-unneeded exact `Metrics/ModuleLength` exclusion for `lib/tasks/tariff_knowledge.rake`.

## Why:

The task module was 111 lines against GOV.UK RuboCop's default 100-line `Metrics/ModuleLength` limit. The extracted service leaves the operational adapter at 89 lines without weakening the cop or changing task behaviour.

This is the next unstacked slice in the RuboCop configuration-honesty programme and relies on the characterization merged in #3530.

## Ticket:

No ticket/issue.

## Risk:

**Risk level:** 🟢

**Reason for rating:**

Low risk: this is a covered, behaviour-preserving refactor with no API, persistence, tariff-data, or worker-semantics change. The public Rake task and parser have focused coverage, including exact validation errors and keyword delegation.

## Verification:

- Focused specs: 23 examples, 0 failures under seeds `1`, `8675309`, and `20260720`
- `bin/rails zeitwerk:check`
- Changed-file RuboCop: 4 files, 0 offenses
- Full effective RuboCop: 2,397 targets, 0 offenses
- Forced-default inventory: 12 offenses across 5 remaining exclusions (down from 13 across 6)
- `git diff --check`
- Pre-push `debride` hook