### PR TITLE
refactor(rubocop): extract synchronizer rollback concern

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -62,13 +62,6 @@ Metrics/BlockLength:
     - 'app/engines/v1_api.rb'
     - 'app/engines/v2_api.rb'
 
-# The listed files are known hotspots; this cop is enforced everywhere else.
-# Remove each entry as its hotspot is refactored.
-Metrics/ModuleLength:
-  Enabled: true
-  Exclude:
-    - 'app/lib/tariff_synchronizer.rb'
-
 RSpec/SpecFilePathFormat:
   Enabled: true
   Exclude:

--- a/app/lib/tariff_synchronizer.rb
+++ b/app/lib/tariff_synchronizer.rb
@@ -1,4 +1,6 @@
 module TariffSynchronizer
+  include Rollback
+
   class FailedUpdatesError < StandardError; end
 
   delegate :instrument, :subscribe, to: ActiveSupport::Notifications
@@ -58,49 +60,6 @@ module TariffSynchronizer
     TariffSynchronizer::Instrumentation.lock_failed(phase: 'apply')
   end
 
-  def rollback_updates(update_type, rollback_date, keep: false)
-    Rails.autoloaders.main.eager_load
-
-    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-
-    TradeTariffBackend.with_redis_lock do
-      TariffSynchronizer::Instrumentation.lock_acquired(phase: 'rollback')
-
-      date = Date.parse(rollback_date.to_s)
-      updates = update_type.where { issue_date > date }
-      # Count before the transaction — updates may be deleted when keep is false.
-      files_count = updates.count
-      # TARIC deletes by operation_date; only CDS needs filenames in memory.
-      update_filenames = update_type == TaricUpdate ? [] : updates.pluck(:filename)
-
-      Sequel::Model.db.transaction do
-        oplog_based_models.each do |model|
-          delete_oplog_rows_for_rollback(model, update_type, update_filenames, date)
-        end
-
-        TariffChangesJobStatus.find(operation_date: date)&.mark_changes_pending!
-
-        updates.each do |update|
-          update.mark_as_pending
-          update.clear_applied_at
-          update.clear_errors
-          update.delete unless keep
-        end
-
-        DataMigration.since(date.end_of_day).delete
-      end
-
-      duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000).round(2)
-      TariffSynchronizer::Instrumentation.rollback_completed(
-        rollback_date: date.iso8601,
-        duration_ms:,
-        files_count:,
-      )
-    end
-  rescue Redlock::LockError
-    TariffSynchronizer::Instrumentation.lock_failed(phase: 'rollback')
-  end
-
   def date_range_since_oldest_pending_update
     oldest_pending_update = BaseUpdate.oldest_pending
     return [] if oldest_pending_update.blank?
@@ -155,24 +114,6 @@ module TariffSynchronizer
 
   def update_to
     ENV['DATE'] ? Date.parse(ENV['DATE']) : Time.zone.today
-  end
-
-  def oplog_based_models
-    sequel_models.select do |model|
-      model.plugins.include?(Sequel::Plugins::Oplog)
-    end
-  end
-
-  # CDS stamps filename on oplog inserts and rolls back by filename.
-  # TARIC does not populate filename; roll back by operation_date (indexed).
-  def delete_oplog_rows_for_rollback(model, update_type, update_filenames, date)
-    dataset = model.operation_klass
-
-    if update_type == TaricUpdate
-      dataset.where(Sequel[:operation_date] > date).delete
-    else
-      dataset.where(filename: update_filenames).delete
-    end
   end
 
   def sequel_models

--- a/app/lib/tariff_synchronizer/rollback.rb
+++ b/app/lib/tariff_synchronizer/rollback.rb
@@ -1,0 +1,66 @@
+module TariffSynchronizer
+  module Rollback
+    def rollback_updates(update_type, rollback_date, keep: false)
+      Rails.autoloaders.main.eager_load
+
+      start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+      TradeTariffBackend.with_redis_lock do
+        TariffSynchronizer::Instrumentation.lock_acquired(phase: 'rollback')
+
+        date = Date.parse(rollback_date.to_s)
+        updates = update_type.where { issue_date > date }
+        # Count before the transaction — updates may be deleted when keep is false.
+        files_count = updates.count
+        # TARIC deletes by operation_date; only CDS needs filenames in memory.
+        update_filenames = update_type == TaricUpdate ? [] : updates.pluck(:filename)
+
+        Sequel::Model.db.transaction do
+          oplog_based_models.each do |model|
+            delete_oplog_rows_for_rollback(model, update_type, update_filenames, date)
+          end
+
+          TariffChangesJobStatus.find(operation_date: date)&.mark_changes_pending!
+
+          updates.each do |update|
+            update.mark_as_pending
+            update.clear_applied_at
+            update.clear_errors
+            update.delete unless keep
+          end
+
+          DataMigration.since(date.end_of_day).delete
+        end
+
+        duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000).round(2)
+        TariffSynchronizer::Instrumentation.rollback_completed(
+          rollback_date: date.iso8601,
+          duration_ms:,
+          files_count:,
+        )
+      end
+    rescue Redlock::LockError
+      TariffSynchronizer::Instrumentation.lock_failed(phase: 'rollback')
+    end
+
+  private
+
+    def oplog_based_models
+      sequel_models.select do |model|
+        model.plugins.include?(Sequel::Plugins::Oplog)
+      end
+    end
+
+    # CDS stamps filename on oplog inserts and rolls back by filename.
+    # TARIC does not populate filename; roll back by operation_date (indexed).
+    def delete_oplog_rows_for_rollback(model, update_type, update_filenames, date)
+      dataset = model.operation_klass
+
+      if update_type == TaricUpdate
+        dataset.where(Sequel[:operation_date] > date).delete
+      else
+        dataset.where(filename: update_filenames).delete
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What:
Extracts the shared tariff rollback orchestration into `TariffSynchronizer::Rollback` and includes it from `TariffSynchronizer`.

Removes the final `Metrics/ModuleLength` exclusion and its now-empty configuration block.

## Why:
Rollback is a cohesive concern with its own lock, transaction, update reset/deletion, oplog cleanup, data-migration cleanup, and instrumentation lifecycle. Moving it intact brings both modules under the default GOV.UK RuboCop limit without changing behavior.

This follows merged characterization PR #3536 and is based directly on its merged main commit.

## Verification:
- Combined CDS/TARIC rollback surface: 63 examples, 0 failures on seeds 1, 8675309, and 20260720
- Extracted module: 33/33 executable lines covered
- Zeitwerk check passes
- 2,401 tracked targets pass RuboCop
- Force-default length inventory: 10 remaining offenses, all route-DSL `Metrics/BlockLength` findings
- Debride, commit hooks, pre-push hook, and diff check pass

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Covered refactor with no intended behavior change. The moved rollback code is unchanged, and direct plus integration coverage exercises CDS/TARIC rollback semantics, lock behavior, transaction effects, deletion selection, and instrumentation.