### PR TITLE
fix(rubocop): restore honest length configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,20 +47,17 @@ RSpec/VariableName:
   Exclude:
     - 'spec/swagger/**/*'
 
-Layout/LineLength:
-  Max: 120
-
-Metrics/AbcSize:
-  Max: 20
-
-# The listed files are known hotspots; this cop is enforced everywhere else.
-# Remove each entry as its hotspot is refactored.
+# Rails route manifests are declarative DSL containers. Block length does not
+# provide useful signal inside them, while the cop remains enforced elsewhere.
 Metrics/BlockLength:
   Enabled: true
   Exclude:
     - 'app/engines/admin_api.rb'
     - 'app/engines/v1_api.rb'
     - 'app/engines/v2_api.rb'
+
+Metrics/ModuleLength:
+  Enabled: true
 
 RSpec/SpecFilePathFormat:
   Enabled: true
@@ -108,14 +105,6 @@ Rails/FindBy:
 # bang/non-bang persistence methods.
 Rails/SaveBang:
   Enabled: false
-
-# Legacy codebase-wide documentation policy cop with many existing offenses;
-# left disabled until documentation standards can be introduced deliberately.
-Style/Documentation:
-  Enabled: false
-
-Style/GuardClause:
-  MinBodyLength: 2
 
 Style/OptionalBooleanParameter:
   Exclude:


### PR DESCRIPTION
## What:
Makes the remaining RuboCop configuration accurately express repository policy:

- restores `Metrics/ModuleLength: Enabled: true` with no exclusions
- retains `Metrics/BlockLength` enforcement with only the three Rails route-manifest DSL exceptions
- replaces the temporary-hotspot comment with the deliberate DSL rationale
- removes ineffective local settings for disabled GOV.UK cops (`Layout/LineLength`, `Metrics/AbcSize`, and `Style/GuardClause`)
- removes the redundant local `Style/Documentation` disable

## Why:
PR #3537 correctly removed the final `ModuleLength` hotspot, but deleting the whole local block also reverted the cop to GOV.UK's disabled default. This restores the intentional stricter repository policy without reintroducing exclusions.

The remaining route findings are declarative `routes.draw`/`namespace`/`scope` containers. Splitting them would reduce route locality without providing useful runtime complexity signal.

## Verification:
- Effective config: `Metrics/ModuleLength` enabled, max 100, no exclusions
- Effective config: removed settings fall back to inherited GOV.UK values
- Full RuboCop: 2,401 files, 0 offenses
- Force-default length audit: 10 offenses, all in the three documented route DSL files; zero ModuleLength offenses
- YAML, commit, pre-push, and diff checks pass

No production or test code changes.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Configuration-only cleanup. The newly restored cop already has zero offenses across the repository, and all removed entries were ineffective or redundant under the inherited GOV.UK configuration.