### PR TITLE
Inherit the GOV.UK RSpec RuboCop policy

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ inherit_gem:
   rubocop-govuk:
     - config/default.yml
     - config/rails.yml
+    - config/rspec.yml
 
 inherit_mode:
   merge:
@@ -42,11 +43,6 @@ RSpec:
         - it_with_refresh_materialized_view
         - run_test!
 
-# rswag requires let names to match HTTP header names (e.g. let(:Accept)), which are PascalCase.
-RSpec/VariableName:
-  Exclude:
-    - 'spec/swagger/**/*'
-
 # Rails route manifests are declarative DSL containers. Block length does not
 # provide useful signal inside them, while the cop remains enforced elsewhere.
 Metrics/BlockLength:
@@ -75,17 +71,8 @@ RSpec/ContextWording:
     - for
 
 RSpec/MultipleMemoizedHelpers:
+  Enabled: true
   Max: 10
-
-# Legacy spec-shape policy cop with many existing offenses; left disabled until
-# specs can be refactored in targeted behaviour-preserving changes.
-RSpec/ExampleLength:
-  Enabled: false
-
-# Legacy spec-shape policy cop with many existing offenses; left disabled until
-# specs can be refactored in targeted behaviour-preserving changes.
-RSpec/NestedGroups:
-  Enabled: false
 
 # swagger:generate intentionally omits :environment — rswag:specs:swaggerize
 # runs rspec in a subprocess and does not need Rails loaded in this process.
@@ -112,11 +99,6 @@ Style/OptionalBooleanParameter:
 
 Style/StringLiterals:
   EnforcedStyle: single_quotes
-
-# Legacy spec-shape policy cop with many existing offenses; left disabled until
-# specs can be refactored in targeted behaviour-preserving changes.
-RSpec/MultipleExpectations:
-  Enabled: false
 
 Custom/SidekiqComplexArguments:
   Enabled: true

--- a/lib/tasks/swagger.rake
+++ b/lib/tasks/swagger.rake
@@ -75,9 +75,24 @@ module_function
   def post_process
     return unless File.exist?(SWAGGER_JSON_PATH)
 
-    doc = JSON.parse(File.read(SWAGGER_JSON_PATH))
+    doc = remove_rswag_getters(JSON.parse(File.read(SWAGGER_JSON_PATH)))
     doc['paths'] = public_paths(doc['paths']) if doc['paths']
     File.write(SWAGGER_JSON_PATH, "#{JSON.pretty_generate(doc)}\n")
+  end
+
+  def remove_rswag_getters(value)
+    # `getter` maps OpenAPI names to Ruby helpers while specs run, but is not
+    # part of the OpenAPI schema and rswag retains it on path-level parameters.
+    case value
+    when Hash
+      value.each_with_object({}) do |(key, child), result|
+        result[key] = remove_rswag_getters(child) unless key == 'getter'
+      end
+    when Array
+      value.map { |child| remove_rswag_getters(child) }
+    else
+      value
+    end
   end
 
   def public_paths(paths)

--- a/spec/bin/db_replicate_spec.rb
+++ b/spec/bin/db_replicate_spec.rb
@@ -3,7 +3,7 @@
 require 'open3'
 require 'tmpdir'
 
-RSpec.describe 'bin/db-replicate' do # rubocop:disable RSpec/DescribeClass
+RSpec.describe 'bin/db-replicate' do
   let(:script_path) { File.expand_path('../../bin/db-replicate', __dir__) }
   let(:tempdir) { Dir.mktmpdir }
 

--- a/spec/config/database_yml_spec.rb
+++ b/spec/config/database_yml_spec.rb
@@ -3,7 +3,6 @@
 require 'erb'
 require 'yaml'
 
-# rubocop:disable RSpec/DescribeClass
 RSpec.describe 'Database configuration' do
   subject(:production_config) do
     YAML.safe_load(
@@ -75,4 +74,3 @@ RSpec.describe 'Database configuration' do
       .fetch(:application_name)
   end
 end
-# rubocop:enable RSpec/DescribeClass

--- a/spec/config/initializers/ses_v2_to_addresses_coercion_spec.rb
+++ b/spec/config/initializers/ses_v2_to_addresses_coercion_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'ses_v2_to_addresses_coercion initializer' do # rubocop:disable RSpec/DescribeClass
+RSpec.describe 'ses_v2_to_addresses_coercion initializer' do
   # The mail gem normalises a single-recipient To: header to a plain String.
   # The SES v2 delivery method passes message.to directly to the AWS SDK,
   # which requires an Array. This spec verifies that the prepended module

--- a/spec/config/sidekiq_schedule_spec.rb
+++ b/spec/config/sidekiq_schedule_spec.rb
@@ -1,7 +1,6 @@
 require 'erb'
 require 'yaml'
 
-# rubocop:disable RSpec/DescribeClass
 RSpec.describe 'config/sidekiq.yml' do
   def sidekiq_schedule(environment:, service: 'uk')
     original_environment = ENV.fetch('ENVIRONMENT', nil)
@@ -59,4 +58,3 @@ RSpec.describe 'config/sidekiq.yml' do
     end
   end
 end
-# rubocop:enable RSpec/DescribeClass

--- a/spec/lib/sequel/plugins/oplog_spec.rb
+++ b/spec/lib/sequel/plugins/oplog_spec.rb
@@ -1,6 +1,6 @@
-# rubocop:disable Style/ConstantDefinitionInBlock
-# rubocop:disable Style/BeforeAfterAll
-# rubocop:disable Style/LeakyConstantDeclaration
+# rubocop:disable Lint/ConstantDefinitionInBlock
+# rubocop:disable RSpec/BeforeAfterAll
+# rubocop:disable RSpec/LeakyConstantDeclaration
 
 RSpec.describe Sequel::Plugins::Oplog do
   before(:all) do
@@ -397,6 +397,6 @@ RSpec.describe Sequel::Plugins::Oplog do
   end
 end
 
-# rubocop:enable Style/ConstantDefinitionInBlock
-# rubocop:enable Style/BeforeAfterAll
-# rubocop:enable Style/LeakyConstantDeclaration
+# rubocop:enable Lint/ConstantDefinitionInBlock
+# rubocop:enable RSpec/BeforeAfterAll
+# rubocop:enable RSpec/LeakyConstantDeclaration

--- a/spec/lib/sequel/plugins/optimized_many_to_many_spec.rb
+++ b/spec/lib/sequel/plugins/optimized_many_to_many_spec.rb
@@ -1,7 +1,7 @@
-# rubocop:disable Style/InstanceVariable
-# rubocop:disable Style/ConstantDefinitionInBlock
-# rubocop:disable Style/BeforeAfterAll
-# rubocop:disable Style/LeakyConstantDeclaration
+# rubocop:disable RSpec/InstanceVariable
+# rubocop:disable Lint/ConstantDefinitionInBlock
+# rubocop:disable RSpec/BeforeAfterAll
+# rubocop:disable RSpec/LeakyConstantDeclaration
 
 RSpec.describe Sequel::Plugins::OptimizedManyToMany do
   before(:all) do
@@ -293,7 +293,7 @@ RSpec.describe Sequel::Plugins::OptimizedManyToMany do
     end
   end
 end
-# rubocop:enable Style/InstanceVariable
-# rubocop:enable Style/ConstantDefinitionInBlock
-# rubocop:enable Style/BeforeAfterAll
-# rubocop:enable Style/LeakyConstantDeclaration
+# rubocop:enable RSpec/InstanceVariable
+# rubocop:enable Lint/ConstantDefinitionInBlock
+# rubocop:enable RSpec/BeforeAfterAll
+# rubocop:enable RSpec/LeakyConstantDeclaration

--- a/spec/lib/tasks/admin_configurations_rake_spec.rb
+++ b/spec/lib/tasks/admin_configurations_rake_spec.rb
@@ -1,4 +1,3 @@
-# rubocop:disable RSpec/DescribeClass
 RSpec.describe 'admin_configurations:seed' do
   subject(:seed) do
     suppress_output { Rake::Task['admin_configurations:seed'].invoke }
@@ -402,4 +401,3 @@ RSpec.describe 'admin_configurations:seed' do
     expect(AdminConfiguration.where(name: 'description_intercept_templates').first.config_type).to eq('object_template')
   end
 end
-# rubocop:enable RSpec/DescribeClass

--- a/spec/lib/tasks/green_lanes_rake_spec.rb
+++ b/spec/lib/tasks/green_lanes_rake_spec.rb
@@ -1,4 +1,3 @@
-# rubocop:disable RSpec/DescribeClass
 require 'csv'
 require 'fileutils'
 require 'tmpdir'
@@ -249,4 +248,3 @@ RSpec.describe 'green_lanes rake tasks' do
     }.merge(overrides))
   end
 end
-# rubocop:enable RSpec/DescribeClass

--- a/spec/lib/tasks/labels_rake_spec.rb
+++ b/spec/lib/tasks/labels_rake_spec.rb
@@ -1,4 +1,3 @@
-# rubocop:disable RSpec/DescribeClass
 RSpec.describe 'labels tasks' do
   around do |example|
     original_chapter = ENV.fetch('CHAPTER', nil)
@@ -395,4 +394,3 @@ RSpec.describe 'labels tasks' do
     end
   end
 end
-# rubocop:enable RSpec/DescribeClass

--- a/spec/lib/tasks/myott_rake_spec.rb
+++ b/spec/lib/tasks/myott_rake_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe 'myott:send_watchlist_survey' do # rubocop:disable RSpec/DescribeClass
+RSpec.describe 'myott:send_watchlist_survey' do
   subject(:send_watchlist_survey) { Rake::Task['myott:send_watchlist_survey'].invoke }
 
   let!(:user_with_stop_press_subscription) { create(:public_user, :with_active_stop_press_subscription) }

--- a/spec/lib/tasks/paper_trail_rake_spec.rb
+++ b/spec/lib/tasks/paper_trail_rake_spec.rb
@@ -1,4 +1,3 @@
-# rubocop:disable RSpec/DescribeClass
 RSpec.describe 'paper_trail:reset_initial_versions' do
   subject(:run_task) { suppress_output { Rake::Task['paper_trail:reset_initial_versions'].invoke } }
 
@@ -37,4 +36,3 @@ RSpec.describe 'paper_trail:reset_initial_versions' do
     expect(service).to have_received(:call)
   end
 end
-# rubocop:enable RSpec/DescribeClass

--- a/spec/lib/tasks/self_texts_rake_spec.rb
+++ b/spec/lib/tasks/self_texts_rake_spec.rb
@@ -1,4 +1,3 @@
-# rubocop:disable RSpec/DescribeClass
 require 'csv'
 require 'stringio'
 
@@ -726,4 +725,3 @@ RSpec.describe 'self_texts rake tasks' do
     end
   end
 end
-# rubocop:enable RSpec/DescribeClass

--- a/spec/lib/tasks/swagger_rake_tasks_spec.rb
+++ b/spec/lib/tasks/swagger_rake_tasks_spec.rb
@@ -1,0 +1,41 @@
+RSpec.describe SwaggerRakeTasks do
+  describe '.remove_rswag_getters' do
+    subject(:processed_document) { described_class.remove_rswag_getters(document) }
+
+    let(:document) do
+      {
+        'paths' => {
+          '/api/search' => {
+            'parameters' => [
+              { 'name' => 'Accept', 'getter' => 'accept', 'in' => 'header' },
+              { '$ref' => '#/components/parameters/accept_header' },
+            ],
+          },
+        },
+        'components' => {
+          'parameters' => {
+            'accept_header' => { 'name' => 'Accept', 'getter' => 'accept', 'in' => 'header' },
+          },
+        },
+      }
+    end
+
+    it 'recursively removes rswag getter metadata' do
+      expect(processed_document).to eq(
+        'paths' => {
+          '/api/search' => {
+            'parameters' => [
+              { 'name' => 'Accept', 'in' => 'header' },
+              { '$ref' => '#/components/parameters/accept_header' },
+            ],
+          },
+        },
+        'components' => {
+          'parameters' => {
+            'accept_header' => { 'name' => 'Accept', 'in' => 'header' },
+          },
+        },
+      )
+    end
+  end
+end

--- a/spec/lib/tasks/tariff_knowledge_rake_spec.rb
+++ b/spec/lib/tasks/tariff_knowledge_rake_spec.rb
@@ -1,4 +1,3 @@
-# rubocop:disable RSpec/DescribeClass
 RSpec.describe 'tariff_knowledge rake tasks' do
   def public_atar_import_result(**overrides)
     TariffKnowledge::PublicAtarRulingImporter::Result.new(**{
@@ -289,4 +288,3 @@ RSpec.describe 'tariff_knowledge rake tasks' do
     end
   end
 end
-# rubocop:enable RSpec/DescribeClass

--- a/spec/lib/tasks/tariff_sync_tooling_rake_spec.rb
+++ b/spec/lib/tasks/tariff_sync_tooling_rake_spec.rb
@@ -1,4 +1,4 @@
-# rubocop:disable RSpec/DescribeClass, RSpec/MultipleDescribes
+# rubocop:disable RSpec/MultipleDescribes
 require 'zip'
 
 RSpec.describe 'tariff:sync:status' do
@@ -509,4 +509,4 @@ RSpec.describe 'tariff:sync:force_apply' do
     end
   end
 end
-# rubocop:enable RSpec/DescribeClass, RSpec/MultipleDescribes
+# rubocop:enable RSpec/MultipleDescribes

--- a/spec/swagger/api/v2/additional_code_types_spec.rb
+++ b/spec/swagger/api/v2/additional_code_types_spec.rb
@@ -1,10 +1,10 @@
 require 'swagger_helper'
 
 RSpec.describe 'Additional Code Types', swagger_doc: 'v2/swagger.json', type: :request do
-  let(:Accept) { 'application/vnd.hmrc.2.0+json' }
+  let(:accept) { 'application/vnd.hmrc.2.0+json' }
 
   path '/api/additional_code_types' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
 

--- a/spec/swagger/api/v2/additional_codes_spec.rb
+++ b/spec/swagger/api/v2/additional_codes_spec.rb
@@ -1,7 +1,7 @@
 require 'swagger_helper'
 
 RSpec.describe 'Additional Codes', swagger_doc: 'v2/swagger.json', type: :request do
-  let(:Accept) { 'application/vnd.hmrc.2.0+json' }
+  let(:accept) { 'application/vnd.hmrc.2.0+json' }
 
   path '/api/additional_codes/search' do
     parameter '$ref' => '#/components/parameters/accept_header'

--- a/spec/swagger/api/v2/certificate_types_spec.rb
+++ b/spec/swagger/api/v2/certificate_types_spec.rb
@@ -1,10 +1,10 @@
 require 'swagger_helper'
 
 RSpec.describe 'Certificate Types', swagger_doc: 'v2/swagger.json', type: :request do
-  let(:Accept) { 'application/vnd.hmrc.2.0+json' }
+  let(:accept) { 'application/vnd.hmrc.2.0+json' }
 
   path '/api/certificate_types' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'Accept header for V2 JSON responses. Use `application/vnd.hmrc.2.0+json`.'
 

--- a/spec/swagger/api/v2/certificates_spec.rb
+++ b/spec/swagger/api/v2/certificates_spec.rb
@@ -1,7 +1,7 @@
 require 'swagger_helper'
 
 RSpec.describe 'Certificates', swagger_doc: 'v2/swagger.json', type: :request do
-  let(:Accept) { 'application/vnd.hmrc.2.0+json' }
+  let(:accept) { 'application/vnd.hmrc.2.0+json' }
 
   certificate_list_item_schema = {
     type: :object,
@@ -53,7 +53,7 @@ RSpec.describe 'Certificates', swagger_doc: 'v2/swagger.json', type: :request do
   }.freeze
 
   path '/api/certificates' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'Accept header for V2 JSON responses. Use `application/vnd.hmrc.2.0+json`.'
 
@@ -84,7 +84,7 @@ RSpec.describe 'Certificates', swagger_doc: 'v2/swagger.json', type: :request do
   end
 
   path '/api/certificates/search' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'Accept header for V2 JSON responses. Use `application/vnd.hmrc.2.0+json`.'
     parameter name: :description, in: :query, required: false,

--- a/spec/swagger/api/v2/changes_spec.rb
+++ b/spec/swagger/api/v2/changes_spec.rb
@@ -1,7 +1,7 @@
 require 'swagger_helper'
 
 RSpec.describe 'Changes', swagger_doc: 'v2/swagger.json', type: :request do
-  let(:Accept) { 'application/vnd.hmrc.2.0+json' }
+  let(:accept) { 'application/vnd.hmrc.2.0+json' }
 
   change_item_schema = {
     type: :object,
@@ -23,7 +23,7 @@ RSpec.describe 'Changes', swagger_doc: 'v2/swagger.json', type: :request do
   }.freeze
 
   path '/api/changes' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
 
@@ -52,7 +52,7 @@ RSpec.describe 'Changes', swagger_doc: 'v2/swagger.json', type: :request do
   end
 
   path '/api/changes/{as_of}' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
     parameter name: :as_of, in: :path, required: true,

--- a/spec/swagger/api/v2/chapters_spec.rb
+++ b/spec/swagger/api/v2/chapters_spec.rb
@@ -1,10 +1,10 @@
 require 'swagger_helper'
 
 RSpec.describe 'Chapters', swagger_doc: 'v2/swagger.json', type: :request do
-  let(:Accept) { 'application/vnd.hmrc.2.0+json' }
+  let(:accept) { 'application/vnd.hmrc.2.0+json' }
 
   path '/api/chapters' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
 
@@ -48,7 +48,7 @@ RSpec.describe 'Chapters', swagger_doc: 'v2/swagger.json', type: :request do
   end
 
   path '/api/chapters/{id}' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
     parameter name: :id, in: :path, required: true,
@@ -166,7 +166,7 @@ RSpec.describe 'Chapters', swagger_doc: 'v2/swagger.json', type: :request do
   end
 
   path '/api/chapters/{id}/changes' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
     parameter name: :id, in: :path, required: true,

--- a/spec/swagger/api/v2/chemical_substances_spec.rb
+++ b/spec/swagger/api/v2/chemical_substances_spec.rb
@@ -1,10 +1,10 @@
 require 'swagger_helper'
 
 RSpec.describe 'Chemical Substances', swagger_doc: 'v2/swagger.json', type: :request do
-  let(:Accept) { 'application/vnd.hmrc.2.0+json' }
+  let(:accept) { 'application/vnd.hmrc.2.0+json' }
 
   path '/api/chemical_substances' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
     parameter name: 'filter[cas_rn]', in: :query, required: false,

--- a/spec/swagger/api/v2/chemicals_spec.rb
+++ b/spec/swagger/api/v2/chemicals_spec.rb
@@ -1,7 +1,7 @@
 require 'swagger_helper'
 
 RSpec.describe 'Chemicals', swagger_doc: 'v2/swagger.json', type: :request do
-  let(:Accept) { 'application/vnd.hmrc.2.0+json' }
+  let(:accept) { 'application/vnd.hmrc.2.0+json' }
 
   chemical_item_schema = {
     type: :object,
@@ -20,7 +20,7 @@ RSpec.describe 'Chemicals', swagger_doc: 'v2/swagger.json', type: :request do
   }.freeze
 
   path '/api/chemicals' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
 
@@ -49,7 +49,7 @@ RSpec.describe 'Chemicals', swagger_doc: 'v2/swagger.json', type: :request do
   end
 
   path '/api/chemicals/search' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
     parameter name: :name, in: :query, required: false,
@@ -91,7 +91,7 @@ RSpec.describe 'Chemicals', swagger_doc: 'v2/swagger.json', type: :request do
   end
 
   path '/api/chemicals/{id}' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
     parameter name: :id, in: :path, required: true,

--- a/spec/swagger/api/v2/classification_search_spec.rb
+++ b/spec/swagger/api/v2/classification_search_spec.rb
@@ -1,10 +1,10 @@
 require 'swagger_helper'
 
 RSpec.describe 'Classification Search', skip: 'Draft MCP API docs are held back until release', swagger_doc: 'v2/swagger.json', type: :request do
-  let(:Accept) { 'application/vnd.hmrc.2.0+json' }
+  let(:accept) { 'application/vnd.hmrc.2.0+json' }
 
   path '/api/classification_search' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
     parameter name: :q, in: :query, required: true,

--- a/spec/swagger/api/v2/commodities_spec.rb
+++ b/spec/swagger/api/v2/commodities_spec.rb
@@ -1,7 +1,7 @@
 require 'swagger_helper'
 
 RSpec.describe 'Commodities', swagger_doc: 'v2/swagger.json', type: :request do
-  let(:Accept) { 'application/vnd.hmrc.2.0+json' }
+  let(:accept) { 'application/vnd.hmrc.2.0+json' }
 
   path '/api/commodities/{id}' do
     parameter '$ref' => '#/components/parameters/accept_header'
@@ -229,7 +229,7 @@ RSpec.describe 'Commodities', swagger_doc: 'v2/swagger.json', type: :request do
   end
 
   path '/api/commodities/{id}/changes' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
     parameter name: :id, in: :path, required: true,

--- a/spec/swagger/api/v2/description_intercepts_spec.rb
+++ b/spec/swagger/api/v2/description_intercepts_spec.rb
@@ -1,10 +1,10 @@
 require 'swagger_helper'
 
 RSpec.describe 'Description Intercepts', swagger_doc: 'v2/swagger.json', type: :request do
-  let(:Accept) { 'application/vnd.hmrc.2.0+json' }
+  let(:accept) { 'application/vnd.hmrc.2.0+json' }
 
   path '/api/description_intercepts' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
     parameter name: :source, in: :query, required: false,

--- a/spec/swagger/api/v2/exchange_rates_spec.rb
+++ b/spec/swagger/api/v2/exchange_rates_spec.rb
@@ -1,16 +1,16 @@
 require 'swagger_helper'
 
 RSpec.describe 'Exchange Rates', swagger_doc: 'v2/swagger.json', type: :request do
-  let(:Accept) { 'application/vnd.hmrc.2.0+json' }
+  let(:accept) { 'application/vnd.hmrc.2.0+json' }
 
   path '/api/exchange_rates/{id}' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
     parameter name: :id, in: :path, required: true,
               schema: { type: :string, pattern: '^\d{4}-\d{1,2}$' },
               description: 'Year and month in "YYYY-M" format (e.g. "2024-3")'
-    parameter name: 'filter[type]', in: :query, required: true,
+    parameter name: 'filter[type]', getter: :filter_type, in: :query, required: true,
               schema: { type: :string, enum: %w[monthly spot average] },
               description: 'Rate type to retrieve'
 
@@ -67,14 +67,14 @@ RSpec.describe 'Exchange Rates', swagger_doc: 'v2/swagger.json', type: :request 
         end
 
         let(:id) { '2024-3' }
-        let(:'filter[type]') { 'monthly' }
+        let(:filter_type) { 'monthly' }
 
         run_test!
       end
 
       response '404', 'invalid year/month format' do
         let(:id) { 'invalid' }
-        let(:'filter[type]') { 'monthly' }
+        let(:filter_type) { 'monthly' }
 
         run_test!
       end
@@ -82,13 +82,13 @@ RSpec.describe 'Exchange Rates', swagger_doc: 'v2/swagger.json', type: :request 
   end
 
   path '/api/exchange_rates/period_lists/{year}' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
     parameter name: :year, in: :path, required: true,
               schema: { type: :integer },
               description: 'Four-digit year to filter periods (e.g. 2024)'
-    parameter name: 'filter[type]', in: :query, required: true,
+    parameter name: 'filter[type]', getter: :filter_type, in: :query, required: true,
               schema: { type: :string, enum: %w[monthly spot average] },
               description: 'Rate type'
 
@@ -143,7 +143,7 @@ RSpec.describe 'Exchange Rates', swagger_doc: 'v2/swagger.json', type: :request 
         end
 
         let(:year) { 2024 }
-        let(:'filter[type]') { 'monthly' }
+        let(:filter_type) { 'monthly' }
 
         run_test!
       end

--- a/spec/swagger/api/v2/footnote_types_spec.rb
+++ b/spec/swagger/api/v2/footnote_types_spec.rb
@@ -1,10 +1,10 @@
 require 'swagger_helper'
 
 RSpec.describe 'Footnote Types', swagger_doc: 'v2/swagger.json', type: :request do
-  let(:Accept) { 'application/vnd.hmrc.2.0+json' }
+  let(:accept) { 'application/vnd.hmrc.2.0+json' }
 
   path '/api/footnote_types' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'Accept header for V2 JSON responses. Use `application/vnd.hmrc.2.0+json`.'
 

--- a/spec/swagger/api/v2/footnotes_spec.rb
+++ b/spec/swagger/api/v2/footnotes_spec.rb
@@ -1,10 +1,10 @@
 require 'swagger_helper'
 
 RSpec.describe 'Footnotes', swagger_doc: 'v2/swagger.json', type: :request do
-  let(:Accept) { 'application/vnd.hmrc.2.0+json' }
+  let(:accept) { 'application/vnd.hmrc.2.0+json' }
 
   path '/api/footnotes/search' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'Accept header for V2 JSON responses. Use `application/vnd.hmrc.2.0+json`.'
     parameter name: :description, in: :query, required: false,

--- a/spec/swagger/api/v2/geographical_areas_spec.rb
+++ b/spec/swagger/api/v2/geographical_areas_spec.rb
@@ -1,7 +1,7 @@
 require 'swagger_helper'
 
 RSpec.describe 'Geographical Areas', swagger_doc: 'v2/swagger.json', type: :request do
-  let(:Accept) { 'application/vnd.hmrc.2.0+json' }
+  let(:accept) { 'application/vnd.hmrc.2.0+json' }
 
   geographical_area_item_schema = {
     type: :object,
@@ -21,7 +21,7 @@ RSpec.describe 'Geographical Areas', swagger_doc: 'v2/swagger.json', type: :requ
   }.freeze
 
   path '/api/geographical_areas' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
     parameter name: 'filter[exclude_none]', in: :query, required: false,
@@ -53,7 +53,7 @@ RSpec.describe 'Geographical Areas', swagger_doc: 'v2/swagger.json', type: :requ
   end
 
   path '/api/geographical_areas/countries' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
     parameter name: 'filter[exclude_none]', in: :query, required: false,
@@ -85,7 +85,7 @@ RSpec.describe 'Geographical Areas', swagger_doc: 'v2/swagger.json', type: :requ
   end
 
   path '/api/geographical_areas/{id}' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
     parameter name: :id, in: :path, required: true,

--- a/spec/swagger/api/v2/goods_nomenclatures_spec.rb
+++ b/spec/swagger/api/v2/goods_nomenclatures_spec.rb
@@ -1,7 +1,7 @@
 require 'swagger_helper'
 
 RSpec.describe 'Goods Nomenclatures', swagger_doc: 'v2/swagger.json', type: :request do
-  let(:Accept) { 'application/vnd.hmrc.2.0+json' }
+  let(:accept) { 'application/vnd.hmrc.2.0+json' }
 
   goods_nomenclature_item_schema = {
     type: :object,
@@ -45,7 +45,7 @@ RSpec.describe 'Goods Nomenclatures', swagger_doc: 'v2/swagger.json', type: :req
   }.freeze
 
   path '/api/goods_nomenclatures/{id}' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
     parameter name: :id, in: :path, required: true,
@@ -81,7 +81,7 @@ RSpec.describe 'Goods Nomenclatures', swagger_doc: 'v2/swagger.json', type: :req
   end
 
   path '/api/goods_nomenclatures/section/{position}' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
     parameter name: :position, in: :path, required: true,
@@ -114,7 +114,7 @@ RSpec.describe 'Goods Nomenclatures', swagger_doc: 'v2/swagger.json', type: :req
   end
 
   path '/api/goods_nomenclatures/chapter/{chapter_id}' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
     parameter name: :chapter_id, in: :path, required: true,
@@ -147,7 +147,7 @@ RSpec.describe 'Goods Nomenclatures', swagger_doc: 'v2/swagger.json', type: :req
   end
 
   path '/api/goods_nomenclatures/heading/{heading_id}' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
     parameter name: :heading_id, in: :path, required: true,

--- a/spec/swagger/api/v2/headings_spec.rb
+++ b/spec/swagger/api/v2/headings_spec.rb
@@ -1,10 +1,10 @@
 require 'swagger_helper'
 
 RSpec.describe 'Headings', swagger_doc: 'v2/swagger.json', type: :request do
-  let(:Accept) { 'application/vnd.hmrc.2.0+json' }
+  let(:accept) { 'application/vnd.hmrc.2.0+json' }
 
   path '/api/headings/{id}' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
     parameter name: :id, in: :path, required: true,
@@ -138,7 +138,7 @@ RSpec.describe 'Headings', swagger_doc: 'v2/swagger.json', type: :request do
   end
 
   path '/api/headings/{id}/commodities' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
     parameter name: :id, in: :path, required: true,
@@ -176,7 +176,7 @@ RSpec.describe 'Headings', swagger_doc: 'v2/swagger.json', type: :request do
   end
 
   path '/api/headings/{id}/changes' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
     parameter name: :id, in: :path, required: true,

--- a/spec/swagger/api/v2/live_issues_spec.rb
+++ b/spec/swagger/api/v2/live_issues_spec.rb
@@ -1,10 +1,10 @@
 require 'swagger_helper'
 
 RSpec.describe 'Live Issues', swagger_doc: 'v2/swagger.json', type: :request do
-  let(:Accept) { 'application/vnd.hmrc.2.0+json' }
+  let(:accept) { 'application/vnd.hmrc.2.0+json' }
 
   path '/api/live_issues' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
     parameter name: 'filter[status]', in: :query, required: false,

--- a/spec/swagger/api/v2/measure_actions_spec.rb
+++ b/spec/swagger/api/v2/measure_actions_spec.rb
@@ -1,10 +1,10 @@
 require 'swagger_helper'
 
 RSpec.describe 'Measure Actions', swagger_doc: 'v2/swagger.json', type: :request do
-  let(:Accept) { 'application/vnd.hmrc.2.0+json' }
+  let(:accept) { 'application/vnd.hmrc.2.0+json' }
 
   path '/api/measure_actions' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
 

--- a/spec/swagger/api/v2/measure_condition_codes_spec.rb
+++ b/spec/swagger/api/v2/measure_condition_codes_spec.rb
@@ -1,10 +1,10 @@
 require 'swagger_helper'
 
 RSpec.describe 'Measure Condition Codes', swagger_doc: 'v2/swagger.json', type: :request do
-  let(:Accept) { 'application/vnd.hmrc.2.0+json' }
+  let(:accept) { 'application/vnd.hmrc.2.0+json' }
 
   path '/api/measure_condition_codes' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'Accept header for V2 JSON responses. Use `application/vnd.hmrc.2.0+json`.'
 

--- a/spec/swagger/api/v2/measure_types_spec.rb
+++ b/spec/swagger/api/v2/measure_types_spec.rb
@@ -1,7 +1,7 @@
 require 'swagger_helper'
 
 RSpec.describe 'Measure Types', swagger_doc: 'v2/swagger.json', type: :request do
-  let(:Accept) { 'application/vnd.hmrc.2.0+json' }
+  let(:accept) { 'application/vnd.hmrc.2.0+json' }
 
   measure_type_item_schema = {
     type: :object,
@@ -26,7 +26,7 @@ RSpec.describe 'Measure Types', swagger_doc: 'v2/swagger.json', type: :request d
   }.freeze
 
   path '/api/measure_types' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
 
@@ -55,7 +55,7 @@ RSpec.describe 'Measure Types', swagger_doc: 'v2/swagger.json', type: :request d
   end
 
   path '/api/measure_types/{id}' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
     parameter name: :id, in: :path, required: true,

--- a/spec/swagger/api/v2/measures_spec.rb
+++ b/spec/swagger/api/v2/measures_spec.rb
@@ -1,10 +1,10 @@
 require 'swagger_helper'
 
 RSpec.describe 'Measures', swagger_doc: 'v2/swagger.json', type: :request do
-  let(:Accept) { 'application/vnd.hmrc.2.0+json' }
+  let(:accept) { 'application/vnd.hmrc.2.0+json' }
 
   path '/api/measures/{id}' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
     parameter name: :id, in: :path, required: true,

--- a/spec/swagger/api/v2/monetary_exchange_rates_spec.rb
+++ b/spec/swagger/api/v2/monetary_exchange_rates_spec.rb
@@ -1,10 +1,10 @@
 require 'swagger_helper'
 
 RSpec.describe 'Monetary Exchange Rates', swagger_doc: 'v2/swagger.json', type: :request do
-  let(:Accept) { 'application/vnd.hmrc.2.0+json' }
+  let(:accept) { 'application/vnd.hmrc.2.0+json' }
 
   path '/api/monetary_exchange_rates' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
 

--- a/spec/swagger/api/v2/news_spec.rb
+++ b/spec/swagger/api/v2/news_spec.rb
@@ -1,10 +1,10 @@
 require 'swagger_helper'
 
 RSpec.describe 'News', swagger_doc: 'v2/swagger.json', type: :request do
-  let(:Accept) { 'application/vnd.hmrc.2.0+json' }
+  let(:accept) { 'application/vnd.hmrc.2.0+json' }
 
   path '/api/news/items' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
     parameter name: :page, in: :query, required: false,
@@ -77,7 +77,7 @@ RSpec.describe 'News', swagger_doc: 'v2/swagger.json', type: :request do
   end
 
   path '/api/news/items/{id}' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
     parameter name: :id, in: :path, required: true,
@@ -130,7 +130,7 @@ RSpec.describe 'News', swagger_doc: 'v2/swagger.json', type: :request do
   end
 
   path '/api/news/collections' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
 
@@ -173,7 +173,7 @@ RSpec.describe 'News', swagger_doc: 'v2/swagger.json', type: :request do
   end
 
   path '/api/news/years' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
     parameter name: :service, in: :query, required: false,

--- a/spec/swagger/api/v2/preference_codes_spec.rb
+++ b/spec/swagger/api/v2/preference_codes_spec.rb
@@ -1,7 +1,7 @@
 require 'swagger_helper'
 
 RSpec.describe 'Preference Codes', swagger_doc: 'v2/swagger.json', type: :request do
-  let(:Accept) { 'application/vnd.hmrc.2.0+json' }
+  let(:accept) { 'application/vnd.hmrc.2.0+json' }
 
   preference_code_item_schema = {
     type: :object,
@@ -19,7 +19,7 @@ RSpec.describe 'Preference Codes', swagger_doc: 'v2/swagger.json', type: :reques
   }.freeze
 
   path '/api/preference_codes' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
 
@@ -46,7 +46,7 @@ RSpec.describe 'Preference Codes', swagger_doc: 'v2/swagger.json', type: :reques
   end
 
   path '/api/preference_codes/{id}' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
     parameter name: :id, in: :path, required: true,

--- a/spec/swagger/api/v2/quota_order_numbers_spec.rb
+++ b/spec/swagger/api/v2/quota_order_numbers_spec.rb
@@ -1,10 +1,10 @@
 require 'swagger_helper'
 
 RSpec.describe 'Quota Order Numbers', swagger_doc: 'v2/swagger.json', type: :request do
-  let(:Accept) { 'application/vnd.hmrc.2.0+json' }
+  let(:accept) { 'application/vnd.hmrc.2.0+json' }
 
   path '/api/quota_order_numbers' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
 

--- a/spec/swagger/api/v2/quotas_spec.rb
+++ b/spec/swagger/api/v2/quotas_spec.rb
@@ -1,10 +1,10 @@
 require 'swagger_helper'
 
 RSpec.describe 'Quotas', swagger_doc: 'v2/swagger.json', type: :request do
-  let(:Accept) { 'application/vnd.hmrc.2.0+json' }
+  let(:accept) { 'application/vnd.hmrc.2.0+json' }
 
   path '/api/quotas/search' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
     parameter name: :order_number, in: :query, required: false,

--- a/spec/swagger/api/v2/rules_of_origin_spec.rb
+++ b/spec/swagger/api/v2/rules_of_origin_spec.rb
@@ -3,7 +3,7 @@ require 'swagger_helper'
 RSpec.describe 'Rules of Origin', swagger_doc: 'v2/swagger.json', type: :request do
   include_context 'with fake global rules of origin data'
 
-  let(:Accept) { 'application/vnd.hmrc.2.0+json' }
+  let(:accept) { 'application/vnd.hmrc.2.0+json' }
 
   scheme_item_schema = {
     type: :object,
@@ -26,7 +26,7 @@ RSpec.describe 'Rules of Origin', swagger_doc: 'v2/swagger.json', type: :request
   }.freeze
 
   path '/api/rules_of_origin_schemes' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
 
@@ -53,7 +53,7 @@ RSpec.describe 'Rules of Origin', swagger_doc: 'v2/swagger.json', type: :request
   end
 
   path '/api/rules_of_origin_schemes/{heading_code}/{country_code}' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
     parameter name: :heading_code, in: :path, required: true,
@@ -89,7 +89,7 @@ RSpec.describe 'Rules of Origin', swagger_doc: 'v2/swagger.json', type: :request
   end
 
   path '/api/rules_of_origin_schemes/{commodity_code}' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
     parameter name: :commodity_code, in: :path, required: true,

--- a/spec/swagger/api/v2/search_references_spec.rb
+++ b/spec/swagger/api/v2/search_references_spec.rb
@@ -1,10 +1,10 @@
 require 'swagger_helper'
 
 RSpec.describe 'Search References', swagger_doc: 'v2/swagger.json', type: :request do
-  let(:Accept) { 'application/vnd.hmrc.2.0+json' }
+  let(:accept) { 'application/vnd.hmrc.2.0+json' }
 
   path '/api/search_references' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
     parameter name: 'query[letter]', in: :query, required: false,

--- a/spec/swagger/api/v2/search_spec.rb
+++ b/spec/swagger/api/v2/search_spec.rb
@@ -1,7 +1,7 @@
 require 'swagger_helper'
 
 RSpec.describe 'Search', swagger_doc: 'v2/swagger.json', type: :request do
-  let(:Accept) { 'application/vnd.hmrc.2.0+json' }
+  let(:accept) { 'application/vnd.hmrc.2.0+json' }
 
   search_match_groups_schema = {
     type: :object,

--- a/spec/swagger/api/v2/sections_spec.rb
+++ b/spec/swagger/api/v2/sections_spec.rb
@@ -2,10 +2,10 @@ require 'swagger_helper'
 
 RSpec.describe 'Sections', swagger_doc: 'v2/swagger.json', type: :request do
   # Provides Accept header for all requests in this file.
-  let(:Accept) { 'application/vnd.hmrc.2.0+json' }
+  let(:accept) { 'application/vnd.hmrc.2.0+json' }
 
   path '/api/sections' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
 
@@ -53,7 +53,7 @@ RSpec.describe 'Sections', swagger_doc: 'v2/swagger.json', type: :request do
   end
 
   path '/api/sections/{id}' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
     parameter name: :id, in: :path, required: true,
@@ -155,7 +155,7 @@ RSpec.describe 'Sections', swagger_doc: 'v2/swagger.json', type: :request do
   end
 
   path '/api/sections/{id}/chapters' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
     parameter name: :id, in: :path, required: true,

--- a/spec/swagger/api/v2/simplified_procedural_code_measures_spec.rb
+++ b/spec/swagger/api/v2/simplified_procedural_code_measures_spec.rb
@@ -1,10 +1,10 @@
 require 'swagger_helper'
 
 RSpec.describe 'Simplified Procedural Code Measures', swagger_doc: 'v2/swagger.json', type: :request do
-  let(:Accept) { 'application/vnd.hmrc.2.0+json' }
+  let(:accept) { 'application/vnd.hmrc.2.0+json' }
 
   path '/api/simplified_procedural_code_measures' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
     parameter name: 'filter[simplified_procedural_code]', in: :query, required: false,

--- a/spec/swagger/api/v2/subheadings_spec.rb
+++ b/spec/swagger/api/v2/subheadings_spec.rb
@@ -1,10 +1,10 @@
 require 'swagger_helper'
 
 RSpec.describe 'Subheadings', swagger_doc: 'v2/swagger.json', type: :request do
-  let(:Accept) { 'application/vnd.hmrc.2.0+json' }
+  let(:accept) { 'application/vnd.hmrc.2.0+json' }
 
   path '/api/subheadings/{id}' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
     parameter name: :id, in: :path, required: true,

--- a/spec/swagger/api/v2/updates_spec.rb
+++ b/spec/swagger/api/v2/updates_spec.rb
@@ -1,10 +1,10 @@
 require 'swagger_helper'
 
 RSpec.describe 'Updates', swagger_doc: 'v2/swagger.json', type: :request do
-  let(:Accept) { 'application/vnd.hmrc.2.0+json' }
+  let(:accept) { 'application/vnd.hmrc.2.0+json' }
 
   path '/api/updates/latest' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
 

--- a/spec/swagger/api/v2/validity_periods_spec.rb
+++ b/spec/swagger/api/v2/validity_periods_spec.rb
@@ -1,7 +1,7 @@
 require 'swagger_helper'
 
 RSpec.describe 'Validity Periods', swagger_doc: 'v2/swagger.json', type: :request do
-  let(:Accept) { 'application/vnd.hmrc.2.0+json' }
+  let(:accept) { 'application/vnd.hmrc.2.0+json' }
 
   validity_period_item_schema = {
     type: :object,
@@ -38,7 +38,7 @@ RSpec.describe 'Validity Periods', swagger_doc: 'v2/swagger.json', type: :reques
   }.freeze
 
   path '/api/headings/{heading_id}/validity_periods' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
     parameter name: :heading_id, in: :path, required: true,
@@ -71,7 +71,7 @@ RSpec.describe 'Validity Periods', swagger_doc: 'v2/swagger.json', type: :reques
   end
 
   path '/api/subheadings/{subheading_id}/validity_periods' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
     parameter name: :subheading_id, in: :path, required: true,
@@ -104,7 +104,7 @@ RSpec.describe 'Validity Periods', swagger_doc: 'v2/swagger.json', type: :reques
   end
 
   path '/api/commodities/{commodity_id}/validity_periods' do
-    parameter name: :Accept, in: :header, required: true,
+    parameter name: :Accept, getter: :accept, in: :header, required: true,
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
     parameter name: :commodity_id, in: :path, required: true,

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -129,6 +129,7 @@ RSpec.configure do |config|
         parameters: {
           accept_header: {
             name: 'Accept',
+            getter: :accept,
             in: :header,
             required: true,
             schema: {

--- a/spec/swagger_helper_spec.rb
+++ b/spec/swagger_helper_spec.rb
@@ -1,8 +1,6 @@
 require 'swagger_helper'
 
-# rubocop:disable RSpec/DescribeClass
 RSpec.describe 'swagger helper configuration' do
-  # rubocop:enable RSpec/DescribeClass
   subject(:swagger_doc) { RSpec.configuration.openapi_specs.fetch('v2/swagger.json') }
 
   let(:components) { swagger_doc.fetch(:components) }

--- a/spec/terraform/ai_costs_dashboard_spec.rb
+++ b/spec/terraform/ai_costs_dashboard_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe 'AI costs dashboard Terraform' do # rubocop:disable RSpec/DescribeClass
+RSpec.describe 'AI costs dashboard Terraform' do
   let(:dashboards_tf) { Rails.root.join('terraform/dashboards.tf').read }
   let(:module_main_tf) { Rails.root.join('terraform/modules/ai_costs_dashboard/main.tf').read }
 

--- a/spec/terraform/database_replication_spec.rb
+++ b/spec/terraform/database_replication_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe 'database replication Terraform' do # rubocop:disable RSpec/DescribeClass
+RSpec.describe 'database replication Terraform' do
   let(:backend_job_tf) { Rails.root.join('terraform/backend_job.tf').read }
 
   it 'execs the replication script from the EventBridge task override' do

--- a/spec/unit/taric_synchronizer_spec.rb
+++ b/spec/unit/taric_synchronizer_spec.rb
@@ -246,5 +246,4 @@ RSpec.describe TaricSynchronizer, :truncation do
     end
   end
 end
-# rubocop:enable RSpec/MultipleExpectations
 # rubocop:enable RSpec/AnyInstance

--- a/spec/unit/tariff_synchronizer/base_update_importer_spec.rb
+++ b/spec/unit/tariff_synchronizer/base_update_importer_spec.rb
@@ -64,5 +64,4 @@ RSpec.describe TariffSynchronizer::BaseUpdateImporter do
       expect(email.encoded).to include('(Sequel::Postgres::Database) ROLLBACK')
     end
   end
-  # rubocop:enable RSpec/MultipleExpectations
 end

--- a/spec/unit/tariff_synchronizer/taric_update_downloader_patched_spec.rb
+++ b/spec/unit/tariff_synchronizer/taric_update_downloader_patched_spec.rb
@@ -50,7 +50,6 @@ RSpec.describe TariffSynchronizer::TaricUpdateDownloaderPatched do
           TariffSynchronizer::TaricUpdate,
         ).once.ordered
       end
-      # rubocop:enable RSpec/MultipleExpectations
     end
   end
 end


### PR DESCRIPTION
## What:

- Inherit the RSpec policy supplied by `rubocop-govuk`.
- Replace non-compliant rswag memoized helper names with Ruby-style names while preserving their OpenAPI names.
- Remove redundant RSpec cop configuration and obsolete inline directives.
- Strip rswag-only `getter` metadata during Swagger post-processing, with regression coverage.

## Why:

The existing broad `RSpec/VariableName` exclusion claimed rswag required PascalCase `let` names. Rswag supports a separate getter, so the exclusion was unnecessary and hid drift from the default GOV.UK RSpec setup.

This keeps the intentional local RSpec policy (including the memoized-helper limit) while removing lazy or redundant exceptions. Generated `swagger/v2/swagger.json` remains unchanged.

## Ticket:

N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
This is a lint/test configuration cleanup with behaviour-preserving spec changes. All changed specs pass and Swagger regeneration produces no committed API document diff.

## Verification:

- 358 changed-file examples, 0 failures, 2 intentional pending
- 106 Swagger examples, 0 failures, 2 intentional pending
- 58 changed files inspected by RuboCop, no offenses
- Full worktree tracked-file RuboCop run, no offenses
- `bin/generate-swagger`, with no diff in `swagger/v2/swagger.json`
- Commit and push hooks passed