### PR TITLE
AI-1070: Log experiment labels

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -52,6 +52,7 @@ protected
     payload[:user_agent] = request_user_agent
     payload[:request_source] = TradeTariffRequest.request_source
     payload[:client_id] = TradeTariffRequest.client_id
+    payload[:experiment] = TradeTariffRequest.experiment if TradeTariffRequest.experiment.present?
   end
 
 private
@@ -128,6 +129,7 @@ private
   def set_trade_tariff_request_id
     TradeTariffRequest.request_id = params[:request_id].presence || request.request_id
     TradeTariffRequest.request_source = TradeTariffRequest.request_source_for_user_agent(request_user_agent)
+    TradeTariffRequest.experiment = params[:experiment].presence
     TradeTariffRequest.client_id =
       extract_client_id_from_jwt(request.headers['Authorization']) ||
       request.headers['X-Client-Id']

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::API
   include JsonapiQueryOptions
 
   MAX_LOGGED_REQUEST_ID_LENGTH = 100
+  MAX_LOGGED_EXPERIMENT_LENGTH = 64
 
   include ActionController::Helpers
   include ::ActionController::MimeResponds
@@ -129,7 +130,7 @@ private
   def set_trade_tariff_request_id
     TradeTariffRequest.request_id = params[:request_id].presence || request.request_id
     TradeTariffRequest.request_source = TradeTariffRequest.request_source_for_user_agent(request_user_agent)
-    TradeTariffRequest.experiment = params[:experiment].presence
+    TradeTariffRequest.experiment = logged_experiment
     TradeTariffRequest.client_id =
       extract_client_id_from_jwt(request.headers['Authorization']) ||
       request.headers['X-Client-Id']
@@ -154,6 +155,13 @@ private
 
   def logged_request_id
     (TradeTariffRequest.request_id.presence || request.request_id).to_s.first(MAX_LOGGED_REQUEST_ID_LENGTH)
+  end
+
+  def logged_experiment
+    experiment = params[:experiment]
+    return unless experiment.is_a?(String) && experiment.length <= MAX_LOGGED_EXPERIMENT_LENGTH
+
+    experiment.presence
   end
 
   def request_user_agent

--- a/app/lib/search/logger.rb
+++ b/app/lib/search/logger.rb
@@ -302,6 +302,7 @@ module Search
       entry[:request_source] = event.payload[:request_source] if event.payload[:request_source].present?
       client_id = event.payload[:client_id].presence || TradeTariffRequest.client_id.presence
       entry[:client_id] = client_id if client_id
+      entry[:experiment] = TradeTariffRequest.experiment if TradeTariffRequest.experiment.present?
       entry.to_json
     end
 

--- a/app/lib/trade_tariff_request.rb
+++ b/app/lib/trade_tariff_request.rb
@@ -7,6 +7,7 @@ class TradeTariffRequest < ActiveSupport::CurrentAttributes
             :request_id,
             :request_source,
             :client_id,
+            :experiment,
             :green_lanes,
             :time_machine_now,
             # Controls how TimeMachine filters associated records in queries.

--- a/spec/lib/search/logger_spec.rb
+++ b/spec/lib/search/logger_spec.rb
@@ -51,6 +51,15 @@ RSpec.describe Search::Logger do
     ensure
       TradeTariffRequest.client_id = nil
     end
+
+    it 'includes the current experiment as a structured field' do
+      TradeTariffRequest.experiment = 'trstd-trdr'
+      logger_instance.public_send(method_name, build_event(event_name, payload))
+      json = parsed_log_output
+      expect(json['experiment']).to eq('trstd-trdr')
+    ensure
+      TradeTariffRequest.experiment = nil
+    end
   end
 
   describe '#search_started' do

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -111,6 +111,12 @@ RSpec.describe ApplicationController, type: :request do
         expect(payload[:request_id]).to eq('search-request-id')
       end
 
+      it 'adds the experiment label to the action controller payload' do
+        payload = process_action_payload_for(params: { experiment: 'trstd-trdr' })
+
+        expect(payload[:experiment]).to eq('trstd-trdr')
+      end
+
       it 'bounds request_id values added to the action controller payload' do
         long_request_id = 'a' * 101
         payload = process_action_payload_for(params: { request_id: long_request_id })

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -117,6 +117,18 @@ RSpec.describe ApplicationController, type: :request do
         expect(payload[:experiment]).to eq('trstd-trdr')
       end
 
+      it 'does not add oversized experiment labels to the action controller payload' do
+        payload = process_action_payload_for(params: { experiment: 'a' * 65 })
+
+        expect(payload).not_to have_key(:experiment)
+      end
+
+      it 'does not add nested experiment parameters to the action controller payload' do
+        payload = process_action_payload_for(params: { experiment: { label: 'trstd-trdr' } })
+
+        expect(payload).not_to have_key(:experiment)
+      end
+
       it 'bounds request_id values added to the action controller payload' do
         long_request_id = 'a' * 101
         payload = process_action_payload_for(params: { request_id: long_request_id })

--- a/spec/terraform/search_experiment_dashboard_spec.rb
+++ b/spec/terraform/search_experiment_dashboard_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+RSpec.describe 'search experiment dashboard Terraform' do
+  let(:dashboards_tf) { Rails.root.join('terraform/dashboards.tf').read }
+  let(:module_main_tf) { Rails.root.join('terraform/modules/search_experiment_dashboard/main.tf').read }
+  let(:search_dashboard_tf) { Rails.root.join('terraform/modules/search_dashboard/main.tf').read }
+
+  it 'wires the search experiment dashboard into the dashboard stack' do
+    expect(dashboards_tf).to include('module "search_experiment_dashboard"')
+    expect(dashboards_tf).to include('source = "./modules/search_experiment_dashboard"')
+    expect(dashboards_tf).to include('output "search_experiment_dashboard_url"')
+  end
+
+  it 'filters every widget through a visible experiment label variable' do
+    expect(module_main_tf).to match(/dashboard_name\s+= var\.dashboard_name != null \? var\.dashboard_name : "SearchExperiment-\$\{var\.environment\}"/)
+    expect(module_main_tf).to include('type         = "pattern"')
+    expect(module_main_tf).to include('pattern      = "EXPERIMENT_LABEL"')
+    expect(module_main_tf).to include('inputType    = "input"')
+    expect(module_main_tf).to include('defaultValue = "trstd-trdr"')
+    expect(module_main_tf).to include('experiment = \\"EXPERIMENT_LABEL\\"')
+  end
+
+  it 'covers experiment usage, performance, outcomes, questions, searches, and AI costs' do
+    expect(module_main_tf).to include('Search Volume and Outcomes')
+    expect(module_main_tf).to include('E2E Latency (p50/p90/p99)')
+    expect(module_main_tf).to include('Final Result Types')
+    expect(module_main_tf).to include('Questions per Search')
+    expect(module_main_tf).to include('Top Search Terms')
+    expect(module_main_tf).to include('AI Tokens and Cost')
+    expect(module_main_tf).to include('Recent Search Journeys')
+  end
+
+  it 'is discoverable from the search overview dashboard' do
+    expect(search_dashboard_tf).to include('Search Experiments')
+    expect(search_dashboard_tf).to include('SearchExperiment-${var.environment}')
+  end
+end

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -26,6 +26,7 @@ Terraform to deploy the service into AWS.
 | <a name="module_backend_xi"></a> [backend\_xi](#module\_backend\_xi) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.2.0 |
 | <a name="module_label_generator_dashboard"></a> [label\_generator\_dashboard](#module\_label\_generator\_dashboard) | ./modules/label_generator_dashboard | n/a |
 | <a name="module_search_dashboard"></a> [search\_dashboard](#module\_search\_dashboard) | ./modules/search_dashboard | n/a |
+| <a name="module_search_experiment_dashboard"></a> [search\_experiment\_dashboard](#module\_search\_experiment\_dashboard) | ./modules/search_experiment_dashboard | n/a |
 | <a name="module_search_operations_dashboard"></a> [search\_operations\_dashboard](#module\_search\_operations\_dashboard) | ./modules/search_operations_dashboard | n/a |
 | <a name="module_search_quality_dashboard"></a> [search\_quality\_dashboard](#module\_search\_quality\_dashboard) | ./modules/search_quality_dashboard | n/a |
 | <a name="module_self_text_generator_dashboard"></a> [self\_text\_generator\_dashboard](#module\_self\_text\_generator\_dashboard) | ./modules/self_text_generator_dashboard | n/a |
@@ -103,6 +104,7 @@ Terraform to deploy the service into AWS.
 | <a name="output_ai_costs_dashboard_url"></a> [ai\_costs\_dashboard\_url](#output\_ai\_costs\_dashboard\_url) | URL to the AI Costs CloudWatch dashboard |
 | <a name="output_label_generator_dashboard_url"></a> [label\_generator\_dashboard\_url](#output\_label\_generator\_dashboard\_url) | URL to the Label Generator CloudWatch dashboard |
 | <a name="output_search_dashboard_url"></a> [search\_dashboard\_url](#output\_search\_dashboard\_url) | URL to the Search CloudWatch dashboard |
+| <a name="output_search_experiment_dashboard_url"></a> [search\_experiment\_dashboard\_url](#output\_search\_experiment\_dashboard\_url) | URL to the Search Experiment CloudWatch dashboard |
 | <a name="output_search_operations_dashboard_url"></a> [search\_operations\_dashboard\_url](#output\_search\_operations\_dashboard\_url) | URL to the Search Operations CloudWatch dashboard |
 | <a name="output_search_quality_dashboard_url"></a> [search\_quality\_dashboard\_url](#output\_search\_quality\_dashboard\_url) | URL to the Search Quality CloudWatch dashboard |
 | <a name="output_self_text_generator_dashboard_url"></a> [self\_text\_generator\_dashboard\_url](#output\_self\_text\_generator\_dashboard\_url) | URL to the Self-Text Generator CloudWatch dashboard |

--- a/terraform/dashboards.tf
+++ b/terraform/dashboards.tf
@@ -37,6 +37,19 @@ output "search_dashboard_url" {
   value       = module.search_dashboard.dashboard_url
 }
 
+module "search_experiment_dashboard" {
+  source = "./modules/search_experiment_dashboard"
+
+  environment    = var.environment
+  log_group_name = "platform-logs-${var.environment}"
+  region         = var.region
+}
+
+output "search_experiment_dashboard_url" {
+  description = "URL to the Search Experiment CloudWatch dashboard"
+  value       = module.search_experiment_dashboard.dashboard_url
+}
+
 module "search_operations_dashboard" {
   source = "./modules/search_operations_dashboard"
 

--- a/terraform/modules/search_dashboard/main.tf
+++ b/terraform/modules/search_dashboard/main.tf
@@ -5,6 +5,7 @@ locals {
 
   search_operations_dashboard_url = "https://${var.region}.console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=SearchOperations-${var.environment}"
   search_quality_dashboard_url    = "https://${var.region}.console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=SearchQuality-${var.environment}"
+  search_experiment_dashboard_url = "https://${var.region}.console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=SearchExperiment-${var.environment}"
   label_dashboard_url             = "https://${var.region}.console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=LabelGenerator-${var.environment}"
   self_text_dashboard_url         = "https://${var.region}.console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=SelfTextGenerator-${var.environment}"
 }
@@ -27,7 +28,7 @@ resource "aws_cloudwatch_dashboard" "search" {
               "Long-range search health dashboard for quarter-scale trend viewing. Follows the RED method (Rate, Errors, Duration).",
               "**Healthy:** p90 latency < 5s, hard failures stay low, zero-result trends stable, and selections broadly track search volume.",
               "**Start here:** use this dashboard for 3-month trends. Open Operations for active troubleshooting and Quality for intercepts, zero-result terms, and result behaviour.",
-              "**Related:** [Search Operations](${local.search_operations_dashboard_url}) | [Search Quality](${local.search_quality_dashboard_url}) | [Label Generator](${local.label_dashboard_url}) | [Self-Text Generator](${local.self_text_dashboard_url})",
+              "**Related:** [Search Operations](${local.search_operations_dashboard_url}) | [Search Quality](${local.search_quality_dashboard_url}) | [Search Experiments](${local.search_experiment_dashboard_url}) | [Label Generator](${local.label_dashboard_url}) | [Self-Text Generator](${local.self_text_dashboard_url})",
             ])
           }
         }

--- a/terraform/modules/search_experiment_dashboard/README.md
+++ b/terraform/modules/search_experiment_dashboard/README.md
@@ -1,0 +1,45 @@
+# search_experiment_dashboard
+
+CloudWatch Logs Insights dashboard for a selected search experiment cohort.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.12.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.100.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [aws_cloudwatch_dashboard.search_experiment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_dashboard) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_dashboard_name"></a> [dashboard\_name](#input\_dashboard\_name) | Name of the CloudWatch dashboard | `string` | `null` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (e.g., development, staging, production) | `string` | n/a | yes |
+| <a name="input_log_group_name"></a> [log\_group\_name](#input\_log\_group\_name) | CloudWatch Log Group name where search instrumentation logs are sent | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | AWS region | `string` | `"eu-west-2"` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_dashboard_arn"></a> [dashboard\_arn](#output\_dashboard\_arn) | ARN of the CloudWatch dashboard |
+| <a name="output_dashboard_name"></a> [dashboard\_name](#output\_dashboard\_name) | Name of the CloudWatch dashboard |
+| <a name="output_dashboard_url"></a> [dashboard\_url](#output\_dashboard\_url) | URL to the CloudWatch dashboard |
+<!-- END_TF_DOCS -->

--- a/terraform/modules/search_experiment_dashboard/main.tf
+++ b/terraform/modules/search_experiment_dashboard/main.tf
@@ -1,0 +1,230 @@
+locals {
+  dashboard_name    = var.dashboard_name != null ? var.dashboard_name : "SearchExperiment-${var.environment}"
+  source            = "SOURCE '${var.log_group_name}'"
+  experiment_filter = "filter service = \"search\" and experiment = \"EXPERIMENT_LABEL\""
+
+  search_dashboard_url            = "https://${var.region}.console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=Search-${var.environment}"
+  search_operations_dashboard_url = "https://${var.region}.console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=SearchOperations-${var.environment}"
+  search_quality_dashboard_url    = "https://${var.region}.console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=SearchQuality-${var.environment}"
+}
+
+resource "aws_cloudwatch_dashboard" "search_experiment" {
+  dashboard_name = local.dashboard_name
+
+  dashboard_body = jsonencode({
+    variables = [
+      {
+        type         = "pattern"
+        pattern      = "EXPERIMENT_LABEL"
+        inputType    = "input"
+        id           = "experiment"
+        label        = "Experiment label"
+        defaultValue = "trstd-trdr"
+        visible      = true
+      }
+    ]
+    widgets = concat(
+      [
+        {
+          type   = "text"
+          x      = 0
+          y      = 0
+          width  = 24
+          height = 2
+          properties = {
+            markdown = join("\n", [
+              "## Trade Tariff Search Experiment",
+              "All widgets are scoped to the experiment label selected above and the dashboard time range.",
+              "**Start here:** compare search volume and latency, then inspect outcomes, questions, search terms, costs, and individual journeys.",
+              "**Related:** [Search Overview](${local.search_dashboard_url}) | [Search Operations](${local.search_operations_dashboard_url}) | [Search Quality](${local.search_quality_dashboard_url})",
+            ])
+          }
+        }
+      ],
+      [
+        {
+          type   = "log"
+          x      = 0
+          y      = 2
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Search Volume and Outcomes"
+            region = var.region
+            view   = "timeSeries"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.experiment_filter} and event in ["search_completed", "search_failed"]
+              | stats count(*) as searches by event, search_type, bin(1h)
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 8
+          y      = 2
+          width  = 8
+          height = 6
+          properties = {
+            title  = "E2E Latency (p50/p90/p99)"
+            region = var.region
+            view   = "timeSeries"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.experiment_filter} and event = "search_completed"
+              | stats pct(total_duration_ms, 50) as p50, pct(total_duration_ms, 90) as p90, pct(total_duration_ms, 99) as p99 by search_type, bin(1h)
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 16
+          y      = 2
+          width  = 8
+          height = 6
+          properties = {
+            title  = "AI Tokens and Cost"
+            region = var.region
+            view   = "timeSeries"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.experiment_filter} and event = "api_call_completed"
+              | stats sum(total_tokens) as tokens, sum(total_cost_usd) as cost_usd by operation, model, bin(1h)
+            EOT
+          }
+        },
+      ],
+      [
+        {
+          type   = "log"
+          x      = 0
+          y      = 8
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Final Result Types"
+            region = var.region
+            view   = "pie"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.experiment_filter} and event = "search_completed"
+              | stats count(*) as searches by search_type, results_type, final_result_type
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 8
+          y      = 8
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Questions per Search"
+            region = var.region
+            view   = "bar"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.experiment_filter} and event = "search_completed" and search_type = "interactive"
+              | stats count(*) as searches by total_questions
+              | sort total_questions asc
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 16
+          y      = 8
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Result Counts"
+            region = var.region
+            view   = "timeSeries"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.experiment_filter} and event = "search_completed"
+              | stats avg(result_count) as average, median(result_count) as median, sum(if(result_count = 0, 1, 0)) as zero_results by search_type, bin(1h)
+            EOT
+          }
+        },
+      ],
+      [
+        {
+          type   = "log"
+          x      = 0
+          y      = 14
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Top Search Terms"
+            region = var.region
+            query  = <<-EOT
+              ${local.source}
+              | ${local.experiment_filter} and event = "search_started"
+              | stats count(*) as searches by query, search_type
+              | sort searches desc
+              | limit 30
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 8
+          y      = 14
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Questions Returned"
+            region = var.region
+            query  = <<-EOT
+              ${local.source}
+              | ${local.experiment_filter} and event = "question_returned"
+              | fields @timestamp, request_id, effective_query, question_count, attempt_number, iteration, details
+              | sort @timestamp desc
+              | limit 30
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 16
+          y      = 14
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Errors"
+            region = var.region
+            query  = <<-EOT
+              ${local.source}
+              | ${local.experiment_filter}
+              | filter event = "search_failed" or final_result_type = "error" or response_type = "error"
+              | fields @timestamp, request_id, event, search_type, operation, error_type, error_message
+              | sort @timestamp desc
+              | limit 30
+            EOT
+          }
+        },
+      ],
+      [
+        {
+          type   = "log"
+          x      = 0
+          y      = 20
+          width  = 24
+          height = 8
+          properties = {
+            title  = "Recent Search Journeys"
+            region = var.region
+            query  = <<-EOT
+              ${local.source}
+              | ${local.experiment_filter}
+              | fields @timestamp, request_id, event, search_type, query, effective_query, question_count, answer_count, total_questions, result_count, results_type, final_result_type, total_duration_ms, duration_ms, operation, model, total_tokens, total_cost_usd, error_message, details
+              | sort @timestamp desc
+              | limit 100
+            EOT
+          }
+        },
+      ]
+    )
+  })
+}

--- a/terraform/modules/search_experiment_dashboard/outputs.tf
+++ b/terraform/modules/search_experiment_dashboard/outputs.tf
@@ -1,0 +1,14 @@
+output "dashboard_arn" {
+  description = "ARN of the CloudWatch dashboard"
+  value       = aws_cloudwatch_dashboard.search_experiment.dashboard_arn
+}
+
+output "dashboard_name" {
+  description = "Name of the CloudWatch dashboard"
+  value       = aws_cloudwatch_dashboard.search_experiment.dashboard_name
+}
+
+output "dashboard_url" {
+  description = "URL to the CloudWatch dashboard"
+  value       = "https://${var.region}.console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=${local.dashboard_name}"
+}

--- a/terraform/modules/search_experiment_dashboard/variables.tf
+++ b/terraform/modules/search_experiment_dashboard/variables.tf
@@ -1,0 +1,21 @@
+variable "environment" {
+  description = "Environment name (e.g., development, staging, production)"
+  type        = string
+}
+
+variable "log_group_name" {
+  description = "CloudWatch Log Group name where search instrumentation logs are sent"
+  type        = string
+}
+
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "eu-west-2"
+}
+
+variable "dashboard_name" {
+  description = "Name of the CloudWatch dashboard"
+  type        = string
+  default     = null
+}

--- a/terraform/modules/search_experiment_dashboard/versions.tf
+++ b/terraform/modules/search_experiment_dashboard/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">=1.12.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5"
+    }
+  }
+}


### PR DESCRIPTION
## What:
- [x] Capture the frontend `experiment` request parameter in `TradeTariffRequest`.
- [x] Reject nested and over-64-character experiment values before they reach structured logs.
- [x] Add the experiment label to structured Rails request logs.
- [x] Add the experiment label to every structured search event, including latency, question, result, and AI usage events.
- [x] Add a reusable, experiment-filtered CloudWatch dashboard for volume, latency, outcomes, questions, search terms, AI tokens/cost, errors, and journey drill-down.
- [x] Link the experiment dashboard from the Search Overview dashboard.
- [x] Cover request logging and dashboard configuration with automated tests.

## Why:
Time-boxed frontend experiments need a stable cohort field in backend production logs and a low-friction way for operators to understand cohort behaviour. The request-scoped current attribute makes experiment traffic queryable across existing instrumentation, while the dashboard's visible experiment-label input allows the same dashboard to be reused for future experiments.

Verified with the full RSpec suite (9,153 examples, 0 failures, 2 expected pending examples), Terraform format and validation, TFLint, RuboCop, pre-commit hooks, and the pre-push debride check.

## Ticket:
https://transformuk.atlassian.net/browse/AI-1070

## Risk:
**Risk level:** 🟢

**Reason for rating:**
This is a read-only observability change. It adds an optional bounded structured log field and a CloudWatch dashboard without altering search execution, API responses, persisted data, networking, or IAM.