### PR TITLE
AI-1070: Improve production UAT observability

### DIFF
--- a/app/lib/ai_usage/logger.rb
+++ b/app/lib/ai_usage/logger.rb
@@ -33,7 +33,9 @@ module AiUsage
     end
 
     def log_entry(data)
-      data.merge(service: 'ai_usage', timestamp: Time.current.iso8601).to_json
+      entry = data.merge(service: 'ai_usage', timestamp: Time.current.iso8601)
+      entry[:experiment] = TradeTariffRequest.experiment if TradeTariffRequest.experiment.present?
+      entry.to_json
     end
 
     def add_ai_usage_fields!(data, event)

--- a/spec/lib/ai_usage/logger_spec.rb
+++ b/spec/lib/ai_usage/logger_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'stringio'
+
+RSpec.describe AiUsage::Logger do
+  let(:log_output) { StringIO.new }
+  let(:test_logger) { ActiveSupport::Logger.new(log_output) }
+  let(:log_subscriber) do
+    logger = test_logger
+    described_class.new.tap do |subscriber|
+      subscriber.define_singleton_method(:logger) { logger }
+    end
+  end
+
+  def build_event
+    ActiveSupport::Notifications::Event.new(
+      'embedding_api_call_completed.ai_usage',
+      Time.current,
+      Time.current,
+      SecureRandom.hex(5),
+      {
+        event_kind: 'vector_search_query_embedding',
+        model: 'text-embedding-3-small',
+        request_id: 'req-1',
+        total_tokens: 42,
+      },
+    )
+  end
+
+  it 'includes the current experiment on embedding usage logs' do
+    TradeTariffRequest.experiment = 'trstd-trdr'
+
+    log_subscriber.embedding_api_call_completed(build_event)
+
+    log_output.rewind
+    expect(JSON.parse(log_output.read.lines.last)).to include(
+      'service' => 'ai_usage',
+      'event' => 'embedding_api_call_completed',
+      'experiment' => 'trstd-trdr',
+    )
+  ensure
+    TradeTariffRequest.experiment = nil
+  end
+
+  it 'omits the experiment field outside a labelled request' do
+    TradeTariffRequest.experiment = nil
+
+    log_subscriber.embedding_api_call_completed(build_event)
+
+    log_output.rewind
+    expect(JSON.parse(log_output.read.lines.last)).not_to have_key('experiment')
+  end
+end

--- a/spec/terraform/search_experiment_dashboard_spec.rb
+++ b/spec/terraform/search_experiment_dashboard_spec.rb
@@ -18,16 +18,69 @@ RSpec.describe 'search experiment dashboard Terraform' do
     expect(module_main_tf).to include('inputType    = "input"')
     expect(module_main_tf).to include('defaultValue = "trstd-trdr"')
     expect(module_main_tf).to include('experiment = \\"EXPERIMENT_LABEL\\"')
+
+    queries = module_main_tf.scan(/query\s+= <<-EOT\n(.*?)\n\s+EOT/m).flatten
+    expect(queries).not_to be_empty
+    expect(queries).to all(match(/\$\{local\.(?:search|experiment|ai_cost)_filter\}/))
   end
 
   it 'covers experiment usage, performance, outcomes, questions, searches, and AI costs' do
-    expect(module_main_tf).to include('Search Volume and Outcomes')
+    expect(module_main_tf).to include('UAT Period Totals')
     expect(module_main_tf).to include('E2E Latency (p50/p90/p99)')
     expect(module_main_tf).to include('Final Result Types')
     expect(module_main_tf).to include('Questions per Search')
     expect(module_main_tf).to include('Top Search Terms')
-    expect(module_main_tf).to include('AI Tokens and Cost')
-    expect(module_main_tf).to include('Recent Search Journeys')
+    expect(module_main_tf).to include('Total AI Cost by Operation')
+    expect(module_main_tf).to include('Recent UAT Events')
+  end
+
+  it 'explains how to interpret and investigate the production UAT cohort' do
+    expect(module_main_tf).to include('Production UAT')
+    expect(module_main_tf).to include('Requests are counted, not unique users')
+    expect(module_main_tf).to include('Set the dashboard time range to the UAT window')
+    expect(module_main_tf).to include('copy the request ID into admin search diagnostics')
+    expect(module_main_tf).to include('Recent UAT Events')
+    expect(module_main_tf).not_to include('Recent Search Journeys')
+  end
+
+  it 'separates period cost and token totals and exposes incomplete pricing' do
+    expect(module_main_tf).to include('service = \\"ai_usage\\" and event = \\"embedding_api_call_completed\\"')
+    expect(module_main_tf).to include('event_kind = \\"vector_search_query_embedding\\"')
+    expect(module_main_tf).to include('if(ispresent(operation), operation, event_kind) as ai_operation')
+    expect(module_main_tf).to include('Total AI Cost by Operation')
+    expect(module_main_tf).to include('filter pricing_known = true and ispresent(total_cost_usd)')
+    expect(module_main_tf).to include('stats sum(total_cost_usd) as total_cost_usd by ai_operation, model')
+    expect(module_main_tf).to include('AI Token Totals by Operation')
+    expect(module_main_tf).to include('sum(input_tokens) as input_tokens')
+    expect(module_main_tf).to include('sum(output_tokens) as output_tokens')
+    expect(module_main_tf).to include('Unknown Pricing Events')
+    expect(module_main_tf).to include('pricing_known = false or not ispresent(total_cost_usd)')
+    expect(module_main_tf).not_to include('AI Tokens and Cost')
+  end
+
+  it 'summarises the UAT period and exposes the behaviour needed for diagnosis' do
+    expect(module_main_tf).to include('UAT Period Totals')
+    expect(module_main_tf).to include('as completed_requests')
+    expect(module_main_tf).to include('as hard_failures')
+    expect(module_main_tf).to include('as error_outcomes')
+    expect(module_main_tf).to include('as zero_result_requests')
+    expect(module_main_tf).to include('as selections')
+    expect(module_main_tf).to include('Questions and Answers')
+    expect(module_main_tf).to include('event in ["question_returned", "answer_returned"]')
+    expect(module_main_tf).to include('Selected Results')
+    expect(module_main_tf).to include('goods_nomenclature_item_id')
+    expect(module_main_tf).to include('Top Zero-Result Terms')
+  end
+
+  it 'shows provider latency by operation so slow requests can be diagnosed' do
+    expect(module_main_tf).to include('AI API Latency (p50/p90/p99)')
+    expect(module_main_tf).to include('pct(duration_ms, 50) as p50')
+    expect(module_main_tf).to include('by operation, bin(1h)')
+  end
+
+  it 'uses a single outcome dimension for the result-type pie chart' do
+    expect(module_main_tf).to include('stats count(*) as searches by final_result_type')
+    expect(module_main_tf).not_to include('by search_type, results_type, final_result_type')
   end
 
   it 'is discoverable from the search overview dashboard' do

--- a/terraform/modules/search_experiment_dashboard/README.md
+++ b/terraform/modules/search_experiment_dashboard/README.md
@@ -1,6 +1,6 @@
 # search_experiment_dashboard
 
-CloudWatch Logs Insights dashboard for a selected search experiment cohort.
+CloudWatch Logs Insights dashboard for reviewing a labelled production-UAT search cohort. It summarises request outcomes, latency, AI usage and cost, search behaviour, and request IDs for diagnostic follow-up.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/terraform/modules/search_experiment_dashboard/main.tf
+++ b/terraform/modules/search_experiment_dashboard/main.tf
@@ -1,7 +1,9 @@
 locals {
   dashboard_name    = var.dashboard_name != null ? var.dashboard_name : "SearchExperiment-${var.environment}"
   source            = "SOURCE '${var.log_group_name}'"
-  experiment_filter = "filter service = \"search\" and experiment = \"EXPERIMENT_LABEL\""
+  experiment_filter = "filter experiment = \"EXPERIMENT_LABEL\""
+  search_filter     = "${local.experiment_filter} and service = \"search\""
+  ai_cost_filter    = "${local.experiment_filter} and ((service = \"search\" and event = \"api_call_completed\") or (service = \"ai_usage\" and event = \"embedding_api_call_completed\" and event_kind = \"vector_search_query_embedding\"))"
 
   search_dashboard_url            = "https://${var.region}.console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=Search-${var.environment}"
   search_operations_dashboard_url = "https://${var.region}.console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=SearchOperations-${var.environment}"
@@ -33,9 +35,10 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
           height = 2
           properties = {
             markdown = join("\n", [
-              "## Trade Tariff Search Experiment",
-              "All widgets are scoped to the experiment label selected above and the dashboard time range.",
-              "**Start here:** compare search volume and latency, then inspect outcomes, questions, search terms, costs, and individual journeys.",
+              "## Trade Tariff Search Production UAT",
+              "All widgets are scoped to the experiment label selected above. Requests are counted, not unique users.",
+              "**Start here:** Set the dashboard time range to the UAT window, then review volume, reliability, latency, outcomes, questions, search terms, and costs.",
+              "**Investigate:** copy the request ID into admin search diagnostics to reconstruct an individual request.",
               "**Related:** [Search Overview](${local.search_dashboard_url}) | [Search Operations](${local.search_operations_dashboard_url}) | [Search Quality](${local.search_quality_dashboard_url})",
             ])
           }
@@ -46,24 +49,45 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
           type   = "log"
           x      = 0
           y      = 2
-          width  = 8
+          width  = 6
           height = 6
           properties = {
-            title  = "Search Volume and Outcomes"
+            title  = "UAT Period Totals"
+            region = var.region
+            view   = "bar"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.search_filter} and event in ["search_completed", "search_failed", "result_selected"]
+              | stats sum(if(event = "search_completed", 1, 0)) as completed_requests,
+                  sum(if(event = "search_failed", 1, 0)) as hard_failures,
+                  sum(if(event = "search_completed" and final_result_type = "error", 1, 0)) as error_outcomes,
+                  sum(if(event = "search_completed" and result_count = 0, 1, 0)) as zero_result_requests,
+                  sum(if(event = "result_selected", 1, 0)) as selections
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 6
+          y      = 2
+          width  = 6
+          height = 6
+          properties = {
+            title  = "Hourly Request Volume"
             region = var.region
             view   = "timeSeries"
             query  = <<-EOT
               ${local.source}
-              | ${local.experiment_filter} and event in ["search_completed", "search_failed"]
+              | ${local.search_filter} and event in ["search_completed", "search_failed"]
               | stats count(*) as searches by event, search_type, bin(1h)
             EOT
           }
         },
         {
           type   = "log"
-          x      = 8
+          x      = 12
           y      = 2
-          width  = 8
+          width  = 6
           height = 6
           properties = {
             title  = "E2E Latency (p50/p90/p99)"
@@ -71,25 +95,28 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
             view   = "timeSeries"
             query  = <<-EOT
               ${local.source}
-              | ${local.experiment_filter} and event = "search_completed"
+              | ${local.search_filter} and event = "search_completed"
               | stats pct(total_duration_ms, 50) as p50, pct(total_duration_ms, 90) as p90, pct(total_duration_ms, 99) as p99 by search_type, bin(1h)
             EOT
           }
         },
         {
           type   = "log"
-          x      = 16
+          x      = 18
           y      = 2
-          width  = 8
+          width  = 6
           height = 6
           properties = {
-            title  = "AI Tokens and Cost"
+            title  = "Total AI Cost by Operation"
             region = var.region
-            view   = "timeSeries"
+            view   = "bar"
             query  = <<-EOT
               ${local.source}
-              | ${local.experiment_filter} and event = "api_call_completed"
-              | stats sum(total_tokens) as tokens, sum(total_cost_usd) as cost_usd by operation, model, bin(1h)
+              | ${local.ai_cost_filter}
+              | fields if(ispresent(operation), operation, event_kind) as ai_operation
+              | filter pricing_known = true and ispresent(total_cost_usd)
+              | stats sum(total_cost_usd) as total_cost_usd by ai_operation, model
+              | sort total_cost_usd desc
             EOT
           }
         },
@@ -102,13 +129,15 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
           width  = 8
           height = 6
           properties = {
-            title  = "Final Result Types"
+            title  = "AI Token Totals by Operation"
             region = var.region
-            view   = "pie"
+            view   = "bar"
             query  = <<-EOT
               ${local.source}
-              | ${local.experiment_filter} and event = "search_completed"
-              | stats count(*) as searches by search_type, results_type, final_result_type
+              | ${local.ai_cost_filter}
+              | fields if(ispresent(operation), operation, event_kind) as ai_operation
+              | stats sum(input_tokens) as input_tokens, sum(output_tokens) as output_tokens, sum(total_tokens) as total_tokens by ai_operation, model
+              | sort total_tokens desc
             EOT
           }
         },
@@ -119,14 +148,16 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
           width  = 8
           height = 6
           properties = {
-            title  = "Questions per Search"
+            title  = "Unknown Pricing Events"
             region = var.region
-            view   = "bar"
             query  = <<-EOT
               ${local.source}
-              | ${local.experiment_filter} and event = "search_completed" and search_type = "interactive"
-              | stats count(*) as searches by total_questions
-              | sort total_questions asc
+              | ${local.ai_cost_filter}
+              | fields if(ispresent(operation), operation, event_kind) as ai_operation
+              | filter pricing_known = false or not ispresent(total_cost_usd)
+              | stats count(*) as events, sum(total_tokens) as total_tokens, sum(total_cost_usd) as partial_cost_usd by ai_operation, model
+              | sort events desc, partial_cost_usd desc, total_tokens desc
+              | limit 50
             EOT
           }
         },
@@ -137,12 +168,66 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
           width  = 8
           height = 6
           properties = {
+            title  = "AI API Latency (p50/p90/p99)"
+            region = var.region
+            view   = "timeSeries"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.search_filter} and event = "api_call_completed"
+              | stats pct(duration_ms, 50) as p50, pct(duration_ms, 90) as p90, pct(duration_ms, 99) as p99 by operation, bin(1h)
+            EOT
+          }
+        },
+      ],
+      [
+        {
+          type   = "log"
+          x      = 0
+          y      = 14
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Final Result Types"
+            region = var.region
+            view   = "pie"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.search_filter} and event = "search_completed"
+              | stats count(*) as searches by final_result_type
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 8
+          y      = 14
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Questions per Search"
+            region = var.region
+            view   = "bar"
+            query  = <<-EOT
+              ${local.source}
+              | ${local.search_filter} and event = "search_completed" and search_type = "interactive"
+              | stats count(*) as searches by total_questions
+              | sort total_questions asc
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 16
+          y      = 14
+          width  = 8
+          height = 6
+          properties = {
             title  = "Result Counts"
             region = var.region
             view   = "timeSeries"
             query  = <<-EOT
               ${local.source}
-              | ${local.experiment_filter} and event = "search_completed"
+              | ${local.search_filter} and event = "search_completed"
               | stats avg(result_count) as average, median(result_count) as median, sum(if(result_count = 0, 1, 0)) as zero_results by search_type, bin(1h)
             EOT
           }
@@ -152,7 +237,7 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
         {
           type   = "log"
           x      = 0
-          y      = 14
+          y      = 20
           width  = 8
           height = 6
           properties = {
@@ -160,7 +245,7 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
             region = var.region
             query  = <<-EOT
               ${local.source}
-              | ${local.experiment_filter} and event = "search_started"
+              | ${local.search_filter} and event = "search_started"
               | stats count(*) as searches by query, search_type
               | sort searches desc
               | limit 30
@@ -170,25 +255,25 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
         {
           type   = "log"
           x      = 8
-          y      = 14
+          y      = 20
           width  = 8
           height = 6
           properties = {
-            title  = "Questions Returned"
+            title  = "Questions and Answers"
             region = var.region
             query  = <<-EOT
               ${local.source}
-              | ${local.experiment_filter} and event = "question_returned"
-              | fields @timestamp, request_id, effective_query, question_count, attempt_number, iteration, details
+              | ${local.search_filter} and event in ["question_returned", "answer_returned"]
+              | fields @timestamp, request_id, event, effective_query, question_count, answer_count, confidence_levels, attempt_number, iteration, details
               | sort @timestamp desc
-              | limit 30
+              | limit 50
             EOT
           }
         },
         {
           type   = "log"
           x      = 16
-          y      = 14
+          y      = 20
           width  = 8
           height = 6
           properties = {
@@ -196,7 +281,7 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
             region = var.region
             query  = <<-EOT
               ${local.source}
-              | ${local.experiment_filter}
+              | ${local.search_filter}
               | filter event = "search_failed" or final_result_type = "error" or response_type = "error"
               | fields @timestamp, request_id, event, search_type, operation, error_type, error_message
               | sort @timestamp desc
@@ -209,16 +294,54 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
         {
           type   = "log"
           x      = 0
-          y      = 20
+          y      = 26
+          width  = 12
+          height = 6
+          properties = {
+            title  = "Top Zero-Result Terms"
+            region = var.region
+            query  = <<-EOT
+              ${local.source}
+              | ${local.search_filter} and event = "search_completed" and result_count = 0
+              | stats count(*) as searches by query, search_type
+              | sort searches desc
+              | limit 30
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 12
+          y      = 26
+          width  = 12
+          height = 6
+          properties = {
+            title  = "Selected Results"
+            region = var.region
+            query  = <<-EOT
+              ${local.source}
+              | ${local.search_filter} and event = "result_selected"
+              | stats count(*) as selections by goods_nomenclature_item_id, goods_nomenclature_class
+              | sort selections desc
+              | limit 30
+            EOT
+          }
+        },
+      ],
+      [
+        {
+          type   = "log"
+          x      = 0
+          y      = 32
           width  = 24
           height = 8
           properties = {
-            title  = "Recent Search Journeys"
+            title  = "Recent UAT Events"
             region = var.region
             query  = <<-EOT
               ${local.source}
               | ${local.experiment_filter}
-              | fields @timestamp, request_id, event, search_type, query, effective_query, question_count, answer_count, total_questions, result_count, results_type, final_result_type, total_duration_ms, duration_ms, operation, model, total_tokens, total_cost_usd, error_message, details
+              | fields @timestamp, request_id, service, event, event_kind, search_type, query, effective_query, question_count, answer_count, total_questions, result_count, results_type, final_result_type, total_duration_ms, duration_ms, operation, model, total_tokens, total_cost_usd, error_message, details
               | sort @timestamp desc
               | limit 100
             EOT


### PR DESCRIPTION
## What:
- [x] Reframe the experiment dashboard as a labelled production-UAT diagnostic view rather than an A/B experiment comparison.
- [x] Add period totals and hourly views for request volume, failures, error outcomes, zero results, selections, and end-to-end latency.
- [x] Surface final outcomes, result counts, top and zero-result searches, questions and answers, selected results, errors, and recent request IDs for diagnostic follow-up.
- [x] Separate AI cost and token totals, expose unknown pricing, and add provider latency by operation.
- [x] Propagate the request experiment label to vector-query embedding usage logs so UAT cost totals are complete.
- [x] Add focused coverage for the dashboard queries and AI usage logging.

## Why:
This is currently a time-boxed UAT in production, not an A/B experiment. Operators need one experiment-scoped view that shows how the labelled traffic behaved and makes obvious reliability, latency, search-quality, and cost issues easy to find and trace back to individual requests. This follows #3541, which introduced the label and initial dashboard.

Verified on the rebased commit with the full RSpec suite (9,160 examples, 0 failures, 2 expected pending examples), Terraform format and validation, TFLint, RuboCop, all pre-commit hooks, and the pre-push debride check.

## Ticket:
https://transformuk.atlassian.net/browse/AI-1070

## Risk:
**Risk level:** 🟢

**Reason for rating:**
This is a read-only observability change. It tightens a CloudWatch dashboard and adds existing request context to structured AI usage logs without altering search execution, API responses, persisted data, networking, or IAM.