### PR TITLE
Remove RSpec RuboCop suppressions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,12 +19,8 @@ AllCops:
   Exclude:
     - ".bundle/**/*"
     - ".direnv/**/*"
-    - "db/schema.rb"
-    - "vendor/**/*"
-    - "bin/**"
     - "db/migrate/*"
     - "db/data_migrations/*"
-    - "tmp/**/*"
     - "config/puma.rb"
 
 RSpec:

--- a/spec/integration/cds_importer/cds_importer_spec.rb
+++ b/spec/integration/cds_importer/cds_importer_spec.rb
@@ -79,10 +79,11 @@ RSpec.describe CdsImporter do
     end
 
     context 'when some error appears' do
+      let(:entity_mapper) { instance_double(CdsImporter::EntityMapper) }
+
       before do
-        # rubocop:disable RSpec/AnyInstance
-        allow_any_instance_of(CdsImporter::EntityMapper).to receive(:build).and_raise(StandardError)
-        # rubocop:enable RSpec/AnyInstance
+        allow(CdsImporter::EntityMapper).to receive(:new).and_return(entity_mapper)
+        allow(entity_mapper).to receive(:build).and_raise(StandardError)
       end
 
       it 'raises ImportException' do

--- a/spec/integration/taric_synchronizer_spec.rb
+++ b/spec/integration/taric_synchronizer_spec.rb
@@ -29,11 +29,11 @@ RSpec.describe TaricSynchronizer do
 
         it 'marks taric update to be pending' do
           expect(taric_update).to be_pending
-          rescuing { described_class.apply }
+          expect { described_class.apply }.not_to raise_error
         end
 
         it 'marks taric update as failed' do
-          rescuing { described_class.apply }
+          expect { described_class.apply }.not_to raise_error
           expect(taric_update.reload).to be_failed
         end
       end
@@ -126,15 +126,15 @@ RSpec.describe TaricSynchronizer do
           data_migrations
 
           allow(Measure).to receive(:operation_klass).and_raise(StandardError)
-
-          rescuing { described_class.rollback(Time.zone.yesterday, keep: true) }
         end
 
         it 'leaves Taric updates in applid state' do
+          expect { described_class.rollback(Time.zone.yesterday, keep: true) }.to raise_error(StandardError)
           expect(update.reload).to be_applied
         end
 
         it 'leaves both todays and the earlier data migration record' do
+          expect { described_class.rollback(Time.zone.yesterday, keep: true) }.to raise_error(StandardError)
           expect(DataMigration.count).to be 2
         end
       end

--- a/spec/integration/taric_synchronizer_spec.rb
+++ b/spec/integration/taric_synchronizer_spec.rb
@@ -128,12 +128,12 @@ RSpec.describe TaricSynchronizer do
           allow(Measure).to receive(:operation_klass).and_raise(StandardError)
         end
 
-        it 'leaves Taric updates in applid state' do
+        it 'leaves Taric updates in applied state' do
           expect { described_class.rollback(Time.zone.yesterday, keep: true) }.to raise_error(StandardError)
           expect(update.reload).to be_applied
         end
 
-        it 'leaves both todays and the earlier data migration record' do
+        it "leaves both today's and the earlier data migration record" do
           expect { described_class.rollback(Time.zone.yesterday, keep: true) }.to raise_error(StandardError)
           expect(DataMigration.count).to be 2
         end

--- a/spec/lib/sequel/plugins/oplog_spec.rb
+++ b/spec/lib/sequel/plugins/oplog_spec.rb
@@ -1,9 +1,10 @@
-# rubocop:disable Lint/ConstantDefinitionInBlock
-# rubocop:disable RSpec/BeforeAfterAll
-# rubocop:disable RSpec/LeakyConstantDeclaration
-
 RSpec.describe Sequel::Plugins::Oplog do
-  before(:all) do
+  before do
+    create_schema
+    define_models
+  end
+
+  def create_schema
     db = Sequel::Model.db
 
     db.drop_table?(:test_records_oplog, cascade: true)
@@ -47,23 +48,16 @@ RSpec.describe Sequel::Plugins::Oplog do
       String :operation
       DateTime :operation_date
     end
-
-    class TestRecord < Sequel::Model(:test_records)
-      plugin :oplog, primary_key: :id
-      unrestrict_primary_key
-    end
-
-    class CompositeTestRecord < Sequel::Model(:composite_test_records)
-      plugin :oplog, primary_key: %i[part_a part_b]
-      unrestrict_primary_key
-    end
   end
 
-  before do
-    Sequel::Model.db[:test_records_oplog].truncate(restart: true, cascade: true)
-    Sequel::Model.db[:test_records].truncate(restart: true, cascade: true)
-    Sequel::Model.db[:composite_test_records_oplog].truncate(restart: true, cascade: true)
-    Sequel::Model.db[:composite_test_records].truncate(restart: true, cascade: true)
+  def define_models
+    stub_const('TestRecord', Class.new(Sequel::Model(:test_records)))
+    stub_const('CompositeTestRecord', Class.new(Sequel::Model(:composite_test_records)))
+
+    TestRecord.plugin :oplog, primary_key: :id
+    TestRecord.unrestrict_primary_key
+    CompositeTestRecord.plugin :oplog, primary_key: %i[part_a part_b]
+    CompositeTestRecord.unrestrict_primary_key
   end
 
   describe '#previous_record' do
@@ -396,7 +390,3 @@ RSpec.describe Sequel::Plugins::Oplog do
     end
   end
 end
-
-# rubocop:enable Lint/ConstantDefinitionInBlock
-# rubocop:enable RSpec/BeforeAfterAll
-# rubocop:enable RSpec/LeakyConstantDeclaration

--- a/spec/lib/sequel/plugins/optimized_many_to_many_spec.rb
+++ b/spec/lib/sequel/plugins/optimized_many_to_many_spec.rb
@@ -1,10 +1,26 @@
-# rubocop:disable RSpec/InstanceVariable
-# rubocop:disable Lint/ConstantDefinitionInBlock
-# rubocop:disable RSpec/BeforeAfterAll
-# rubocop:disable RSpec/LeakyConstantDeclaration
-
 RSpec.describe Sequel::Plugins::OptimizedManyToMany do
-  before(:all) do
+  let(:parent_one) { Parent.create(name: 'P1') }
+  let(:parent_two) { Parent.create(name: 'P2') }
+  let(:child_one) { Child.create(name: 'C1') }
+
+  before do
+    create_schema
+    define_models
+    create_fixture_records
+  end
+
+  def create_fixture_records
+    child_one
+    child_two = Child.create(name: 'C2')
+    child_three = Child.create(name: 'C3')
+
+    Sequel::Model.db[:parents_children].insert(parent_id: parent_one.id, child_id: child_one.id)
+    Sequel::Model.db[:parents_children].insert(parent_id: parent_one.id, child_id: child_two.id)
+    Sequel::Model.db[:parents_children].insert(parent_id: parent_two.id, child_id: child_three.id)
+    Grandchild.create(name: 'G1', child: child_one)
+  end
+
+  def create_schema
     db = Sequel::Model.db
     db.extension :pg_array
 
@@ -50,65 +66,41 @@ RSpec.describe Sequel::Plugins::OptimizedManyToMany do
       String  :postcode, null: false
       foreign_key :parent_id, :parents, on_delete: :cascade
     end
-
-    class Parent < Sequel::Model(:parents)
-      many_to_many :children,
-                   class: 'Child',
-                   join_table: :parents_children,
-                   left_key: :parent_id,
-                   left_primary_key: :id,
-                   right_key: :child_id,
-                   right_primary_key: :id,
-                   use_optimized: false
-    end
-
-    class Child < Sequel::Model(:children)
-      many_to_many :parents,
-                   class: 'Parent',
-                   join_table: :parents_children,
-                   left_key: :parent_id,
-                   left_primary_key: :id,
-                   right_key: :child_id,
-                   right_primary_key: :id,
-                   use_optimized: false
-
-      one_to_many :grandchildren, key: :child_id
-    end
-
-    class Grandchild < Sequel::Model(:grandchildren)
-      many_to_one :child
-    end
-
-    class Address < Sequel::Model(:addresses)
-      unrestrict_primary_key
-      set_primary_key %i[number postcode]
-    end
   end
 
-  before do
-    Sequel::Model.db[:parents_children].delete
-    Child.dataset.delete
-    Parent.dataset.delete
-    Grandchild.dataset.delete
+  def define_models
+    stub_const('Parent', Class.new(Sequel::Model(:parents)))
+    stub_const('Child', Class.new(Sequel::Model(:children)))
+    stub_const('Grandchild', Class.new(Sequel::Model(:grandchildren)))
+    stub_const('Address', Class.new(Sequel::Model(:addresses)))
 
-    @p1 = Parent.create(name: 'P1')
-    @p2 = Parent.create(name: 'P2')
+    Parent.many_to_many :children,
+                        class: 'Child',
+                        join_table: :parents_children,
+                        left_key: :parent_id,
+                        left_primary_key: :id,
+                        right_key: :child_id,
+                        right_primary_key: :id,
+                        use_optimized: false
 
-    @c1 = Child.create(name: 'C1')
-    @c2 = Child.create(name: 'C2')
-    @c3 = Child.create(name: 'C3')
-
-    Sequel::Model.db[:parents_children].insert(parent_id: @p1.id, child_id: @c1.id)
-    Sequel::Model.db[:parents_children].insert(parent_id: @p1.id, child_id: @c2.id)
-    Sequel::Model.db[:parents_children].insert(parent_id: @p2.id, child_id: @c3.id)
-
-    @g1 = Grandchild.create(name: 'G1', child: @c1)
+    Child.many_to_many :parents,
+                       class: 'Parent',
+                       join_table: :parents_children,
+                       left_key: :parent_id,
+                       left_primary_key: :id,
+                       right_key: :child_id,
+                       right_primary_key: :id,
+                       use_optimized: false
+    Child.one_to_many :grandchildren, key: :child_id
+    Grandchild.many_to_one :child
+    Address.unrestrict_primary_key
+    Address.set_primary_key %i[number postcode]
   end
 
   describe 'inbuilt many_to_many load' do
     it 'loads associated children normally' do
-      expect(@p1.children.map(&:name)).to contain_exactly('C1', 'C2')
-      expect(@p2.children.map(&:name)).to contain_exactly('C3')
+      expect(parent_one.children.map(&:name)).to contain_exactly('C1', 'C2')
+      expect(parent_two.children.map(&:name)).to contain_exactly('C3')
     end
   end
 
@@ -125,13 +117,13 @@ RSpec.describe Sequel::Plugins::OptimizedManyToMany do
     end
 
     it 'loads children with custom dataset' do
-      expect(@p1.optimized_children.map(&:name)).to contain_exactly('C1', 'C2')
+      expect(parent_one.optimized_children.map(&:name)).to contain_exactly('C1', 'C2')
     end
 
     it 'eager loads children with optimized' do
       parents = Parent.eager(:optimized_children).all
-      expect(parents.find { |p| p.id == @p1.id }.optimized_children.map(&:name)).to contain_exactly('C1', 'C2')
-      expect(parents.find { |p| p.id == @p2.id }.optimized_children.map(&:name)).to contain_exactly('C3')
+      expect(parents.find { |p| p.id == parent_one.id }.optimized_children.map(&:name)).to contain_exactly('C1', 'C2')
+      expect(parents.find { |p| p.id == parent_two.id }.optimized_children.map(&:name)).to contain_exactly('C3')
     end
   end
 
@@ -149,13 +141,13 @@ RSpec.describe Sequel::Plugins::OptimizedManyToMany do
     end
 
     it 'loads children with custom dataset' do
-      expect(@p1.optimized_children.map(&:name)).to eq(%w[C2 C1])
+      expect(parent_one.optimized_children.map(&:name)).to eq(%w[C2 C1])
     end
 
     it 'eager loads children with optimized' do
       parents = Parent.eager(:optimized_children).all
-      expect(parents.find { |p| p.id == @p1.id }.optimized_children.map(&:name)).to eq(%w[C2 C1])
-      expect(parents.find { |p| p.id == @p2.id }.optimized_children.map(&:name)).to contain_exactly('C3')
+      expect(parents.find { |p| p.id == parent_one.id }.optimized_children.map(&:name)).to eq(%w[C2 C1])
+      expect(parents.find { |p| p.id == parent_two.id }.optimized_children.map(&:name)).to contain_exactly('C3')
     end
   end
 
@@ -173,13 +165,13 @@ RSpec.describe Sequel::Plugins::OptimizedManyToMany do
     end
 
     it 'loads children with custom dataset' do
-      expect(@p1.optimized_children.map(&:name)).to eq(%w[C1 C2])
+      expect(parent_one.optimized_children.map(&:name)).to eq(%w[C1 C2])
     end
 
     it 'eager loads children with optimized' do
       parents = Parent.eager(:optimized_children).all
-      expect(parents.find { |p| p.id == @p1.id }.optimized_children.map(&:name)).to eq(%w[C1 C2])
-      expect(parents.find { |p| p.id == @p2.id }.optimized_children.map(&:name)).to contain_exactly('C3')
+      expect(parents.find { |p| p.id == parent_one.id }.optimized_children.map(&:name)).to eq(%w[C1 C2])
+      expect(parents.find { |p| p.id == parent_two.id }.optimized_children.map(&:name)).to contain_exactly('C3')
     end
   end
 
@@ -198,8 +190,8 @@ RSpec.describe Sequel::Plugins::OptimizedManyToMany do
 
     it 'uses normal dataset but optimized eager loader' do
       parents = Parent.eager(:cte_children).all
-      expect(parents.find { |p| p.id == @p1.id }.cte_children.map(&:name)).to contain_exactly('C1', 'C2')
-      expect(parents.find { |p| p.id == @p2.id }.cte_children.map(&:name)).to contain_exactly('C3')
+      expect(parents.find { |p| p.id == parent_one.id }.cte_children.map(&:name)).to contain_exactly('C1', 'C2')
+      expect(parents.find { |p| p.id == parent_two.id }.cte_children.map(&:name)).to contain_exactly('C3')
     end
   end
 
@@ -224,8 +216,8 @@ RSpec.describe Sequel::Plugins::OptimizedManyToMany do
 
     it 'eager loads nested associations (cte_children → grandchildren)' do
       parents = Parent.eager(cte_children: :grandchildren).all
-      p1 = parents.find { |p| p.id == @p1.id }
-      c1 = p1.cte_children.find { |c| c.id == @c1.id }
+      p1 = parents.find { |p| p.id == parent_one.id }
+      c1 = p1.cte_children.find { |c| c.id == child_one.id }
       expect(c1.grandchildren.map(&:name)).to eq(%w[G1])
     end
   end
@@ -241,26 +233,43 @@ RSpec.describe Sequel::Plugins::OptimizedManyToMany do
                           right_primary_key: %i[number postcode],
                           use_optimized: true
 
-      @a1 = Address.create(number: 1, postcode: 'A1')
-      @a2 = Address.create(number: 2, postcode: 'A2')
-      @a3 = Address.create(number: 3, postcode: 'A3')
+      address_one = Address.create(number: 1, postcode: 'A1')
+      address_two = Address.create(number: 2, postcode: 'A2')
+      address_three = Address.create(number: 3, postcode: 'A3')
 
-      Sequel::Model.db[:parents_addresses].insert(parent_id: @p1.id, number: @a1.number, postcode: @a1.postcode)
-      Sequel::Model.db[:parents_addresses].insert(parent_id: @p1.id, number: @a2.number, postcode: @a2.postcode)
-      Sequel::Model.db[:parents_addresses].insert(parent_id: @p2.id, number: @a3.number, postcode: @a3.postcode)
+      Sequel::Model.db[:parents_addresses].insert(
+        parent_id: parent_one.id,
+        number: address_one.number,
+        postcode: address_one.postcode,
+      )
+      Sequel::Model.db[:parents_addresses].insert(
+        parent_id: parent_one.id,
+        number: address_two.number,
+        postcode: address_two.postcode,
+      )
+      Sequel::Model.db[:parents_addresses].insert(
+        parent_id: parent_two.id,
+        number: address_three.number,
+        postcode: address_three.postcode,
+      )
     end
 
     it 'loads address with custom dataset' do
-      expect(@p1.addresses.map(&:number)).to contain_exactly(1, 2)
+      expect(parent_one.addresses.map(&:number)).to contain_exactly(1, 2)
     end
 
     it 'eager loads associations (parent → addresses)' do
       parents = Parent.eager(:addresses).all
-      expect(parents.find { |p| p.id == @p1.id }.addresses.map(&:number)).to contain_exactly(1, 2)
+      eager_parent = parents.find { |parent| parent.id == parent_one.id }
+
+      expect(eager_parent.addresses.map(&:number)).to contain_exactly(1, 2)
     end
   end
 
   describe 'with composite left primary key and use_optimized: true' do
+    let(:address_three) { Address.create(number: 3, postcode: 'A3') }
+    let(:parent_three) { Parent.create(name: 'P3') }
+
     before do
       Address.many_to_many :people,
                            class: 'Parent',
@@ -271,29 +280,34 @@ RSpec.describe Sequel::Plugins::OptimizedManyToMany do
                            left_primary_key: %i[number postcode],
                            use_optimized: true
 
-      @a1 = Address.create(number: 1, postcode: 'A1')
-      @a2 = Address.create(number: 2, postcode: 'A2')
-      @a3 = Address.create(number: 3, postcode: 'A3')
-
-      @p3 = Parent.create(name: 'P3')
-
-      Sequel::Model.db[:parents_addresses].insert(parent_id: @p1.id, number: @a1.number, postcode: @a1.postcode)
-      Sequel::Model.db[:parents_addresses].insert(parent_id: @p1.id, number: @a2.number, postcode: @a2.postcode)
-      Sequel::Model.db[:parents_addresses].insert(parent_id: @p2.id, number: @a3.number, postcode: @a3.postcode)
-      Sequel::Model.db[:parents_addresses].insert(parent_id: @p3.id, number: @a3.number, postcode: @a3.postcode)
+      insert_parent_address(parent_one, Address.create(number: 1, postcode: 'A1'))
+      insert_parent_address(parent_one, Address.create(number: 2, postcode: 'A2'))
+      insert_parent_address(parent_two, address_three)
+      insert_parent_address(parent_three, address_three)
     end
 
     it 'loads people with custom dataset' do
-      expect(@a3.people.map(&:id)).to eq([@p2.id, @p3.id])
+      expect(address_three.people.map(&:id)).to eq([parent_two.id, parent_three.id])
     end
 
     it 'eager loads associations (address → people)' do
       addresses = Address.eager(:people).all
-      expect(addresses.find { |a| a.number == @a3.number && a.postcode == @a3.postcode }.people.map(&:id)).to contain_exactly(@p2.id, @p3.id)
+      eager_address = addresses.find do |address|
+        address.number == address_three.number && address.postcode == address_three.postcode
+      end
+
+      expect(eager_address.people.map(&:id)).to contain_exactly(
+        parent_two.id,
+        parent_three.id,
+      )
     end
   end
+
+  def insert_parent_address(parent, address)
+    Sequel::Model.db[:parents_addresses].insert(
+      parent_id: parent.id,
+      number: address.number,
+      postcode: address.postcode,
+    )
+  end
 end
-# rubocop:enable RSpec/InstanceVariable
-# rubocop:enable Lint/ConstantDefinitionInBlock
-# rubocop:enable RSpec/BeforeAfterAll
-# rubocop:enable RSpec/LeakyConstantDeclaration

--- a/spec/lib/tasks/tariff_sync_tooling_rake_spec.rb
+++ b/spec/lib/tasks/tariff_sync_tooling_rake_spec.rb
@@ -1,234 +1,166 @@
-# rubocop:disable RSpec/MultipleDescribes
 require 'zip'
 
-RSpec.describe 'tariff:sync:status' do
-  after { Rake::Task['tariff:sync:status'].reenable }
+RSpec.describe 'tariff sync tooling tasks' do
+  describe 'tariff:sync:status' do
+    after { Rake::Task['tariff:sync:status'].reenable }
 
-  context 'with a mix of update states' do
-    let!(:applied_cds) { create(:cds_update, :applied, issue_date: 2.days.ago.to_date) }
-    let!(:pending_cds) { create(:cds_update, :pending, issue_date: 1.day.ago.to_date) }
-    let!(:failed_cds) do
-      create(:cds_update, :failed, issue_date: Date.current, exception_class: 'Sequel::DatabaseError: bad record')
+    context 'with a mix of update states' do
+      let!(:applied_cds) { create(:cds_update, :applied, issue_date: 2.days.ago.to_date) }
+      let!(:pending_cds) { create(:cds_update, :pending, issue_date: 1.day.ago.to_date) }
+      let!(:failed_cds) do
+        create(:cds_update, :failed, issue_date: Date.current, exception_class: 'Sequel::DatabaseError: bad record')
+      end
+
+      let(:output) do
+        original_stdout = $stdout
+        $stdout = StringIO.new
+        Rake::Task['tariff:sync:status'].invoke
+        $stdout.string
+      ensure
+        $stdout = original_stdout
+      end
+
+      before do
+        create(:taric_update, :applied, issue_date: 2.days.ago.to_date)
+        create(:taric_update, :pending, issue_date: 1.day.ago.to_date)
+        allow(TariffSynchronizer::CdsUpdate).to receive(:correct_filename_sequence?).and_return(true)
+        allow(TariffSynchronizer::TaricUpdate).to receive(:correct_filename_sequence?).and_return(false)
+      end
+
+      it 'shows both service sections', :aggregate_failures do
+        expect(output).to match(/UK \(CDS\)/)
+        expect(output).to match(/XI \(TARIC\)/)
+      end
+
+      it 'shows the last applied CDS filename' do
+        expect(output).to include(applied_cds.filename)
+      end
+
+      it 'shows pending CDS filename' do
+        expect(output).to include(pending_cds.filename)
+      end
+
+      it 'shows failed CDS filename and error class', :aggregate_failures do
+        expect(output).to include(failed_cds.filename)
+        expect(output).to match(/Sequel::DatabaseError/)
+      end
+
+      it 'shows OK sequence for CDS and INVALID for TARIC', :aggregate_failures do
+        expect(output).to match(/Sequence\s+: OK/)
+        expect(output).to match(/Sequence\s+: INVALID/)
+      end
     end
 
-    let(:output) do
-      original_stdout = $stdout
-      $stdout = StringIO.new
-      Rake::Task['tariff:sync:status'].invoke
-      $stdout.string
-    ensure
-      $stdout = original_stdout
-    end
+    context 'with no updates' do
+      before do
+        allow(TariffSynchronizer::CdsUpdate).to receive(:correct_filename_sequence?).and_return(true)
+        allow(TariffSynchronizer::TaricUpdate).to receive(:correct_filename_sequence?).and_return(true)
+      end
 
-    before do
-      create(:taric_update, :applied, issue_date: 2.days.ago.to_date)
-      create(:taric_update, :pending, issue_date: 1.day.ago.to_date)
-      allow(TariffSynchronizer::CdsUpdate).to receive(:correct_filename_sequence?).and_return(true)
-      allow(TariffSynchronizer::TaricUpdate).to receive(:correct_filename_sequence?).and_return(false)
-    end
-
-    it 'shows both service sections', :aggregate_failures do
-      expect(output).to match(/UK \(CDS\)/)
-      expect(output).to match(/XI \(TARIC\)/)
-    end
-
-    it 'shows the last applied CDS filename' do
-      expect(output).to include(applied_cds.filename)
-    end
-
-    it 'shows pending CDS filename' do
-      expect(output).to include(pending_cds.filename)
-    end
-
-    it 'shows failed CDS filename and error class', :aggregate_failures do
-      expect(output).to include(failed_cds.filename)
-      expect(output).to match(/Sequel::DatabaseError/)
-    end
-
-    it 'shows OK sequence for CDS and INVALID for TARIC', :aggregate_failures do
-      expect(output).to match(/Sequence\s+: OK/)
-      expect(output).to match(/Sequence\s+: INVALID/)
-    end
-  end
-
-  context 'with no updates' do
-    before do
-      allow(TariffSynchronizer::CdsUpdate).to receive(:correct_filename_sequence?).and_return(true)
-      allow(TariffSynchronizer::TaricUpdate).to receive(:correct_filename_sequence?).and_return(true)
-    end
-
-    it 'shows none for last applied' do
-      expect { Rake::Task['tariff:sync:status'].invoke }
-        .to output(/Last applied\s+: none/).to_stdout
-    end
-  end
-end
-
-RSpec.describe 'tariff:sync:failures' do
-  after { Rake::Task['tariff:sync:failures'].reenable }
-
-  context 'with no failed updates' do
-    it 'reports no failures' do
-      expect { Rake::Task['tariff:sync:failures'].invoke }
-        .to output(/No failed updates/).to_stdout
-    end
-  end
-
-  context 'with a failed CDS update' do
-    let!(:failed_cds) do
-      create(:cds_update, :failed,
-             issue_date: Date.current,
-             exception_class: 'Sequel::DatabaseError: constraint violation')
-    end
-
-    let(:output) do
-      original_stdout = $stdout
-      $stdout = StringIO.new
-      Rake::Task['tariff:sync:failures'].invoke
-      $stdout.string
-    ensure
-      $stdout = original_stdout
-    end
-
-    it 'lists the filename and service', :aggregate_failures do
-      expect(output).to include(failed_cds.filename)
-      expect(output).to include('UK/CDS')
-    end
-
-    it 'shows the error class' do
-      expect(output).to match(/Sequel::DatabaseError/)
-    end
-
-    it 'does not show CDS error counts' do
-      expect(output).not_to match(/CDS errors\s+:/)
-    end
-
-    it 'suggests running failure_detail' do
-      expect(output).to include('failure_detail')
-    end
-  end
-
-  context 'with a failed TARIC update' do
-    let!(:failed_taric) { create(:taric_update, :failed, issue_date: Date.current) }
-
-    it 'shows XI/TARIC as the service' do
-      expect { Rake::Task['tariff:sync:failures'].invoke }
-        .to output(/XI\/TARIC/).to_stdout
-    end
-
-    it 'shows the presence error count when present' do
-      TariffSynchronizer::TariffUpdatePresenceError.create(
-        tariff_update_filename: failed_taric.filename,
-        model_name: 'GoodsNomenclature',
-        details: { some: 'detail' },
-      )
-
-      expect { Rake::Task['tariff:sync:failures'].invoke }
-        .to output(/Presence errors\s+: 1/).to_stdout
-    end
-  end
-end
-
-RSpec.describe 'tariff:sync:failure_detail' do
-  after do
-    Rake::Task['tariff:sync:failure_detail'].reenable
-    ENV.delete('FILENAME')
-  end
-
-  context 'without FILENAME set' do
-    it 'aborts with an instruction' do
-      expect { suppress_output { Rake::Task['tariff:sync:failure_detail'].invoke } }
-        .to raise_error(SystemExit)
-    end
-  end
-
-  context 'with an unknown filename' do
-    before { ENV['FILENAME'] = 'nonexistent.gzip' }
-
-    it 'aborts' do
-      expect { suppress_output { Rake::Task['tariff:sync:failure_detail'].invoke } }
-        .to raise_error(SystemExit)
-    end
-  end
-
-  context 'with a failed CDS update' do
-    let!(:update) do
-      create(:cds_update, :failed,
-             filesize: 12_345,
-             exception_class: 'Sequel::DatabaseError: bad column',
-             exception_backtrace: "line 1\nline 2\nline 3",
-             exception_queries: 'SELECT * FROM measures',
-             inserts: { operations: {}, total_count: 0 }.to_json)
-    end
-
-    let(:output) do
-      original_stdout = $stdout
-      $stdout = StringIO.new
-      Rake::Task['tariff:sync:failure_detail'].invoke
-      $stdout.string
-    ensure
-      $stdout = original_stdout
-    end
-
-    before { ENV['FILENAME'] = update.filename }
-
-    it 'shows the service, state and issue date', :aggregate_failures do
-      expect(output).to match(/UK \(CDS\)/)
-      expect(output).to match(/State\s+: F/)
-      expect(output).to match(/Issue date\s+: #{update.issue_date}/)
-    end
-
-    it 'shows the file size' do
-      expect(output).to match(/12345 bytes/)
-    end
-
-    it 'shows the exception class' do
-      expect(output).to match(/Sequel::DatabaseError: bad column/)
-    end
-
-    it 'shows the backtrace', :aggregate_failures do
-      expect(output).to match(/line 1/)
-      expect(output).to match(/line 2/)
-    end
-
-    it 'shows the last SQL queries' do
-      expect(output).to match(/SELECT \* FROM measures/)
-    end
-
-    it 'shows the previous import operation counts' do
-      expect(output).to match(/total_count/)
-    end
-
-    it 'does not show CDS error details' do
-      expect(output).not_to match(/CDS Record Errors/)
-    end
-
-    context 'with malformed stored counts' do
-      let(:malformed_inserts) { '{"operations":' }
-
-      before { update.update(inserts: malformed_inserts) }
-
-      it 'shows the raw stored value' do
-        expect(output).to include(<<~OUTPUT)
-          === Previous Import Operation Counts ===
-
-          #{malformed_inserts}
-        OUTPUT
+      it 'shows none for last applied' do
+        expect { Rake::Task['tariff:sync:status'].invoke }
+          .to output(/Last applied\s+: none/).to_stdout
       end
     end
   end
 
-  context 'with a failed TARIC update' do
-    let!(:update) { create(:taric_update, :failed) }
+  describe 'tariff:sync:failures' do
+    after { Rake::Task['tariff:sync:failures'].reenable }
 
-    before { ENV['FILENAME'] = update.filename }
-
-    it 'shows XI (TARIC) as the service' do
-      expect { Rake::Task['tariff:sync:failure_detail'].invoke }
-        .to output(/XI \(TARIC\)/).to_stdout
+    context 'with no failed updates' do
+      it 'reports no failures' do
+        expect { Rake::Task['tariff:sync:failures'].invoke }
+          .to output(/No failed updates/).to_stdout
+      end
     end
 
-    context 'with associated presence errors' do
+    context 'with a failed CDS update' do
+      let!(:failed_cds) do
+        create(:cds_update, :failed,
+               issue_date: Date.current,
+               exception_class: 'Sequel::DatabaseError: constraint violation')
+      end
+
+      let(:output) do
+        original_stdout = $stdout
+        $stdout = StringIO.new
+        Rake::Task['tariff:sync:failures'].invoke
+        $stdout.string
+      ensure
+        $stdout = original_stdout
+      end
+
+      it 'lists the filename and service', :aggregate_failures do
+        expect(output).to include(failed_cds.filename)
+        expect(output).to include('UK/CDS')
+      end
+
+      it 'shows the error class' do
+        expect(output).to match(/Sequel::DatabaseError/)
+      end
+
+      it 'does not show CDS error counts' do
+        expect(output).not_to match(/CDS errors\s+:/)
+      end
+
+      it 'suggests running failure_detail' do
+        expect(output).to include('failure_detail')
+      end
+    end
+
+    context 'with a failed TARIC update' do
+      let!(:failed_taric) { create(:taric_update, :failed, issue_date: Date.current) }
+
+      it 'shows XI/TARIC as the service' do
+        expect { Rake::Task['tariff:sync:failures'].invoke }
+          .to output(/XI\/TARIC/).to_stdout
+      end
+
+      it 'shows the presence error count when present' do
+        TariffSynchronizer::TariffUpdatePresenceError.create(
+          tariff_update_filename: failed_taric.filename,
+          model_name: 'GoodsNomenclature',
+          details: { some: 'detail' },
+        )
+
+        expect { Rake::Task['tariff:sync:failures'].invoke }
+          .to output(/Presence errors\s+: 1/).to_stdout
+      end
+    end
+  end
+
+  describe 'tariff:sync:failure_detail' do
+    after do
+      Rake::Task['tariff:sync:failure_detail'].reenable
+      ENV.delete('FILENAME')
+    end
+
+    context 'without FILENAME set' do
+      it 'aborts with an instruction' do
+        expect { suppress_output { Rake::Task['tariff:sync:failure_detail'].invoke } }
+          .to raise_error(SystemExit)
+      end
+    end
+
+    context 'with an unknown filename' do
+      before { ENV['FILENAME'] = 'nonexistent.gzip' }
+
+      it 'aborts' do
+        expect { suppress_output { Rake::Task['tariff:sync:failure_detail'].invoke } }
+          .to raise_error(SystemExit)
+      end
+    end
+
+    context 'with a failed CDS update' do
+      let!(:update) do
+        create(:cds_update, :failed,
+               filesize: 12_345,
+               exception_class: 'Sequel::DatabaseError: bad column',
+               exception_backtrace: "line 1\nline 2\nline 3",
+               exception_queries: 'SELECT * FROM measures',
+               inserts: { operations: {}, total_count: 0 }.to_json)
+      end
+
       let(:output) do
         original_stdout = $stdout
         $stdout = StringIO.new
@@ -238,275 +170,343 @@ RSpec.describe 'tariff:sync:failure_detail' do
         $stdout = original_stdout
       end
 
+      before { ENV['FILENAME'] = update.filename }
+
+      it 'shows the service, state and issue date', :aggregate_failures do
+        expect(output).to match(/UK \(CDS\)/)
+        expect(output).to match(/State\s+: F/)
+        expect(output).to match(/Issue date\s+: #{update.issue_date}/)
+      end
+
+      it 'shows the file size' do
+        expect(output).to match(/12345 bytes/)
+      end
+
+      it 'shows the exception class' do
+        expect(output).to match(/Sequel::DatabaseError: bad column/)
+      end
+
+      it 'shows the backtrace', :aggregate_failures do
+        expect(output).to match(/line 1/)
+        expect(output).to match(/line 2/)
+      end
+
+      it 'shows the last SQL queries' do
+        expect(output).to match(/SELECT \* FROM measures/)
+      end
+
+      it 'shows the previous import operation counts' do
+        expect(output).to match(/total_count/)
+      end
+
+      it 'does not show CDS error details' do
+        expect(output).not_to match(/CDS Record Errors/)
+      end
+
+      context 'with malformed stored counts' do
+        let(:malformed_inserts) { '{"operations":' }
+
+        before { update.update(inserts: malformed_inserts) }
+
+        it 'shows the raw stored value' do
+          expect(output).to include(<<~OUTPUT)
+            === Previous Import Operation Counts ===
+
+            #{malformed_inserts}
+          OUTPUT
+        end
+      end
+    end
+
+    context 'with a failed TARIC update' do
+      let!(:update) { create(:taric_update, :failed) }
+
+      before { ENV['FILENAME'] = update.filename }
+
+      it 'shows XI (TARIC) as the service' do
+        expect { Rake::Task['tariff:sync:failure_detail'].invoke }
+          .to output(/XI \(TARIC\)/).to_stdout
+      end
+
+      context 'with associated presence errors' do
+        let(:output) do
+          original_stdout = $stdout
+          $stdout = StringIO.new
+          Rake::Task['tariff:sync:failure_detail'].invoke
+          $stdout.string
+        ensure
+          $stdout = original_stdout
+        end
+
+        before do
+          TariffSynchronizer::TariffUpdatePresenceError.create(
+            tariff_update_filename: update.filename,
+            model_name: 'GoodsNomenclature',
+            details: { some: 'detail' },
+          )
+        end
+
+        it 'shows presence errors with model name', :aggregate_failures do
+          expect(output).to match(/Presence Errors/)
+          expect(output).to match(/GoodsNomenclature/)
+        end
+      end
+    end
+  end
+
+  describe 'tariff:sync:inspect_file' do
+    after do
+      Rake::Task['tariff:sync:inspect_file'].reenable
+      ENV.delete('FILENAME')
+    end
+
+    context 'without FILENAME set' do
+      it 'aborts with an instruction' do
+        expect { suppress_output { Rake::Task['tariff:sync:inspect_file'].invoke } }
+          .to raise_error(SystemExit)
+      end
+    end
+
+    context 'with an unknown filename' do
+      before { ENV['FILENAME'] = 'nonexistent.gzip' }
+
+      it 'aborts' do
+        expect { suppress_output { Rake::Task['tariff:sync:inspect_file'].invoke } }
+          .to raise_error(SystemExit)
+      end
+    end
+
+    context 'with a CDS update whose file is not found' do
+      let!(:update) { create(:cds_update, :pending) }
+
       before do
-        TariffSynchronizer::TariffUpdatePresenceError.create(
-          tariff_update_filename: update.filename,
-          model_name: 'GoodsNomenclature',
-          details: { some: 'detail' },
-        )
+        ENV['FILENAME'] = update.filename
+        allow(TariffSynchronizer::FileService).to receive(:file_exists?).and_return(false)
       end
 
-      it 'shows presence errors with model name', :aggregate_failures do
-        expect(output).to match(/Presence Errors/)
-        expect(output).to match(/GoodsNomenclature/)
+      it 'aborts' do
+        expect { suppress_output { Rake::Task['tariff:sync:inspect_file'].invoke } }
+          .to raise_error(SystemExit)
       end
     end
-  end
-end
 
-RSpec.describe 'tariff:sync:inspect_file' do
-  after do
-    Rake::Task['tariff:sync:inspect_file'].reenable
-    ENV.delete('FILENAME')
-  end
+    context 'with a pending CDS update' do
+      let!(:update) { create(:cds_update, :pending) }
 
-  context 'without FILENAME set' do
-    it 'aborts with an instruction' do
-      expect { suppress_output { Rake::Task['tariff:sync:inspect_file'].invoke } }
-        .to raise_error(SystemExit)
-    end
-  end
+      let(:empty_zip) do
+        Zip::OutputStream.write_buffer { |zip|
+          zip.put_next_entry('data.xml')
+          zip.write('<root><level1><level2/></level1></root>')
+        }.tap(&:rewind)
+      end
 
-  context 'with an unknown filename' do
-    before { ENV['FILENAME'] = 'nonexistent.gzip' }
+      let(:output) do
+        original_stdout = $stdout
+        $stdout = StringIO.new
+        Rake::Task['tariff:sync:inspect_file'].invoke
+        $stdout.string
+      ensure
+        $stdout = original_stdout
+      end
 
-    it 'aborts' do
-      expect { suppress_output { Rake::Task['tariff:sync:inspect_file'].invoke } }
-        .to raise_error(SystemExit)
-    end
-  end
+      before do
+        ENV['FILENAME'] = update.filename
+        allow(TariffSynchronizer::FileService).to receive_messages(file_exists?: true, file_size: 4096)
+        allow(TariffSynchronizer::FileService).to receive(:file_as_stringio).with(update).and_return(empty_zip)
+      end
 
-  context 'with a CDS update whose file is not found' do
-    let!(:update) { create(:cds_update, :pending) }
+      it 'shows the file header with state and size', :aggregate_failures do
+        expect(output).to match(/State\s+: P/)
+        expect(output).to match(/4096 bytes/)
+      end
 
-    before do
-      ENV['FILENAME'] = update.filename
-      allow(TariffSynchronizer::FileService).to receive(:file_exists?).and_return(false)
-    end
-
-    it 'aborts' do
-      expect { suppress_output { Rake::Task['tariff:sync:inspect_file'].invoke } }
-        .to raise_error(SystemExit)
-    end
-  end
-
-  context 'with a pending CDS update' do
-    let!(:update) { create(:cds_update, :pending) }
-
-    let(:empty_zip) do
-      Zip::OutputStream.write_buffer { |zip|
-        zip.put_next_entry('data.xml')
-        zip.write('<root><level1><level2/></level1></root>')
-      }.tap(&:rewind)
+      it 'shows the entity record summary' do
+        expect(output).to match(/Total entity records:/)
+      end
     end
 
-    let(:output) do
-      original_stdout = $stdout
-      $stdout = StringIO.new
-      Rake::Task['tariff:sync:inspect_file'].invoke
-      $stdout.string
-    ensure
-      $stdout = original_stdout
-    end
+    context 'with a pending TARIC update' do
+      let!(:update) { create(:taric_update, :pending) }
 
-    before do
-      ENV['FILENAME'] = update.filename
-      allow(TariffSynchronizer::FileService).to receive_messages(file_exists?: true, file_size: 4096)
-      allow(TariffSynchronizer::FileService).to receive(:file_as_stringio).with(update).and_return(empty_zip)
-    end
+      let(:taric_xml) do
+        StringIO.new(<<~XML)
+          <envelope>
+            <record><GoodsNomenclature/></record>
+            <record><GoodsNomenclature/></record>
+            <record><Measure/></record>
+          </envelope>
+        XML
+      end
 
-    it 'shows the file header with state and size', :aggregate_failures do
-      expect(output).to match(/State\s+: P/)
-      expect(output).to match(/4096 bytes/)
-    end
+      let(:output) do
+        original_stdout = $stdout
+        $stdout = StringIO.new
+        Rake::Task['tariff:sync:inspect_file'].invoke
+        $stdout.string
+      ensure
+        $stdout = original_stdout
+      end
 
-    it 'shows the entity record summary' do
-      expect(output).to match(/Total entity records:/)
-    end
-  end
+      before do
+        ENV['FILENAME'] = update.filename
+        allow(TariffSynchronizer::FileService).to receive_messages(file_exists?: true, file_size: 2048)
+        allow(TariffSynchronizer::FileService).to receive(:get).with(update.file_path).and_return(taric_xml)
+      end
 
-  context 'with a pending TARIC update' do
-    let!(:update) { create(:taric_update, :pending) }
+      it 'shows the file header', :aggregate_failures do
+        expect(output).to match(/State\s+: P/)
+        expect(output).to match(/2048 bytes/)
+      end
 
-    let(:taric_xml) do
-      StringIO.new(<<~XML)
-        <envelope>
-          <record><GoodsNomenclature/></record>
-          <record><GoodsNomenclature/></record>
-          <record><Measure/></record>
-        </envelope>
-      XML
-    end
+      it 'shows the transaction record summary with counts', :aggregate_failures do
+        expect(output).to match(/Total transaction records: 3/)
+        expect(output).to match(/GoodsNomenclature\s+2/)
+        expect(output).to match(/Measure\s+1/)
+      end
 
-    let(:output) do
-      original_stdout = $stdout
-      $stdout = StringIO.new
-      Rake::Task['tariff:sync:inspect_file'].invoke
-      $stdout.string
-    ensure
-      $stdout = original_stdout
-    end
+      context 'without transaction records' do
+        let(:taric_xml) { StringIO.new('<envelope/>') }
 
-    before do
-      ENV['FILENAME'] = update.filename
-      allow(TariffSynchronizer::FileService).to receive_messages(file_exists?: true, file_size: 2048)
-      allow(TariffSynchronizer::FileService).to receive(:get).with(update.file_path).and_return(taric_xml)
-    end
+        it 'shows the exact empty-file summary' do
+          expect(output).to eq(<<~OUTPUT)
+            === File Inspection: #{update.filename} ===
 
-    it 'shows the file header', :aggregate_failures do
-      expect(output).to match(/State\s+: P/)
-      expect(output).to match(/2048 bytes/)
-    end
+            State      : P
+            Issue date : #{update.issue_date}
+            File size  : 2048 bytes
 
-    it 'shows the transaction record summary with counts', :aggregate_failures do
-      expect(output).to match(/Total transaction records: 3/)
-      expect(output).to match(/GoodsNomenclature\s+2/)
-      expect(output).to match(/Measure\s+1/)
-    end
+            Total transaction records: 0
 
-    context 'without transaction records' do
-      let(:taric_xml) { StringIO.new('<envelope/>') }
-
-      it 'shows the exact empty-file summary' do
-        expect(output).to eq(<<~OUTPUT)
-          === File Inspection: #{update.filename} ===
-
-          State      : P
-          Issue date : #{update.issue_date}
-          File size  : 2048 bytes
-
-          Total transaction records: 0
-
-          (No records found - file may use a different XML structure)
-        OUTPUT
+            (No records found - file may use a different XML structure)
+          OUTPUT
+        end
       end
     end
   end
+
+  describe 'tariff:sync:reset_failed' do
+    after { Rake::Task['tariff:sync:reset_failed'].reenable }
+
+    context 'with no failed updates' do
+      it 'reports nothing to reset' do
+        expect { Rake::Task['tariff:sync:reset_failed'].invoke }
+          .to output(/No failed updates to reset/).to_stdout
+      end
+    end
+
+    context 'with failed updates' do
+      let!(:failed_cds) do
+        create(:cds_update, :failed,
+               exception_class: 'SomeError',
+               exception_backtrace: 'backtrace',
+               exception_queries: 'SELECT 1')
+      end
+      let!(:failed_taric) { create(:taric_update, :failed, exception_class: 'OtherError') }
+
+      it 'resets all failed updates to pending', :aggregate_failures do
+        suppress_output { Rake::Task['tariff:sync:reset_failed'].invoke }
+
+        expect(failed_cds.reload.state).to eq('P')
+        expect(failed_taric.reload.state).to eq('P')
+      end
+
+      it 'clears exception fields', :aggregate_failures do
+        suppress_output { Rake::Task['tariff:sync:reset_failed'].invoke }
+
+        reloaded = failed_cds.reload
+        expect(reloaded.exception_class).to be_nil
+        expect(reloaded.exception_backtrace).to be_nil
+        expect(reloaded.exception_queries).to be_nil
+      end
+
+      it 'reports how many were reset' do
+        expect { Rake::Task['tariff:sync:reset_failed'].invoke }
+          .to output(/2 update\(s\) reset to pending/).to_stdout
+      end
+
+      it 'suggests running apply next' do
+        expect { Rake::Task['tariff:sync:reset_failed'].invoke }
+          .to output(/tariff:sync:apply/).to_stdout
+      end
+    end
+  end
+
+  describe 'tariff:sync:force_apply' do
+    after do
+      Rake::Task['tariff:sync:force_apply'].reenable
+      ENV.delete('FILENAME')
+      ENV.delete('CONFIRM')
+    end
+
+    context 'without FILENAME set' do
+      it 'aborts' do
+        expect { suppress_output { Rake::Task['tariff:sync:force_apply'].invoke } }
+          .to raise_error(SystemExit)
+      end
+    end
+
+    context 'with FILENAME but without CONFIRM=yes' do
+      let!(:update) { create(:cds_update, :failed) }
+
+      before { ENV['FILENAME'] = update.filename }
+
+      it 'exits without applying' do
+        expect { suppress_output { Rake::Task['tariff:sync:force_apply'].invoke } }
+          .to raise_error(SystemExit)
+      end
+
+      it 'warns about data loss' do
+        expect { Rake::Task['tariff:sync:force_apply'].invoke }
+          .to output(/WITHOUT importing its data/).to_stderr
+      rescue SystemExit
+        nil
+      end
+
+      it 'does not change the update state' do
+        suppress_output { Rake::Task['tariff:sync:force_apply'].invoke }
+      rescue SystemExit
+        expect(update.reload.state).to eq('F')
+      end
+    end
+
+    context 'with CONFIRM=yes against a non-failed update' do
+      let!(:update) { create(:cds_update, :pending) }
+
+      before do
+        ENV['FILENAME'] = update.filename
+        ENV['CONFIRM']  = 'yes'
+      end
+
+      it 'aborts with a state error' do
+        expect { suppress_output { Rake::Task['tariff:sync:force_apply'].invoke } }
+          .to raise_error(SystemExit)
+      end
+    end
+
+    context 'with CONFIRM=yes against a failed update' do
+      let!(:update) { create(:cds_update, :failed) }
+
+      before do
+        ENV['FILENAME'] = update.filename
+        ENV['CONFIRM']  = 'yes'
+      end
+
+      it 'marks the update as applied' do
+        suppress_output { Rake::Task['tariff:sync:force_apply'].invoke }
+
+        expect(update.reload.state).to eq('A')
+      end
+
+      it 'sets applied_at' do
+        suppress_output { Rake::Task['tariff:sync:force_apply'].invoke }
+
+        expect(update.reload.applied_at).to be_present
+      end
+
+      it 'confirms the action in output' do
+        expect { Rake::Task['tariff:sync:force_apply'].invoke }
+          .to output(/marked as applied/).to_stdout
+      end
+    end
+  end
 end
-
-RSpec.describe 'tariff:sync:reset_failed' do
-  after { Rake::Task['tariff:sync:reset_failed'].reenable }
-
-  context 'with no failed updates' do
-    it 'reports nothing to reset' do
-      expect { Rake::Task['tariff:sync:reset_failed'].invoke }
-        .to output(/No failed updates to reset/).to_stdout
-    end
-  end
-
-  context 'with failed updates' do
-    let!(:failed_cds) do
-      create(:cds_update, :failed,
-             exception_class: 'SomeError',
-             exception_backtrace: 'backtrace',
-             exception_queries: 'SELECT 1')
-    end
-    let!(:failed_taric) { create(:taric_update, :failed, exception_class: 'OtherError') }
-
-    it 'resets all failed updates to pending', :aggregate_failures do
-      suppress_output { Rake::Task['tariff:sync:reset_failed'].invoke }
-
-      expect(failed_cds.reload.state).to eq('P')
-      expect(failed_taric.reload.state).to eq('P')
-    end
-
-    it 'clears exception fields', :aggregate_failures do
-      suppress_output { Rake::Task['tariff:sync:reset_failed'].invoke }
-
-      reloaded = failed_cds.reload
-      expect(reloaded.exception_class).to be_nil
-      expect(reloaded.exception_backtrace).to be_nil
-      expect(reloaded.exception_queries).to be_nil
-    end
-
-    it 'reports how many were reset' do
-      expect { Rake::Task['tariff:sync:reset_failed'].invoke }
-        .to output(/2 update\(s\) reset to pending/).to_stdout
-    end
-
-    it 'suggests running apply next' do
-      expect { Rake::Task['tariff:sync:reset_failed'].invoke }
-        .to output(/tariff:sync:apply/).to_stdout
-    end
-  end
-end
-
-RSpec.describe 'tariff:sync:force_apply' do
-  after do
-    Rake::Task['tariff:sync:force_apply'].reenable
-    ENV.delete('FILENAME')
-    ENV.delete('CONFIRM')
-  end
-
-  context 'without FILENAME set' do
-    it 'aborts' do
-      expect { suppress_output { Rake::Task['tariff:sync:force_apply'].invoke } }
-        .to raise_error(SystemExit)
-    end
-  end
-
-  context 'with FILENAME but without CONFIRM=yes' do
-    let!(:update) { create(:cds_update, :failed) }
-
-    before { ENV['FILENAME'] = update.filename }
-
-    it 'exits without applying' do
-      expect { suppress_output { Rake::Task['tariff:sync:force_apply'].invoke } }
-        .to raise_error(SystemExit)
-    end
-
-    it 'warns about data loss' do
-      expect { Rake::Task['tariff:sync:force_apply'].invoke }
-        .to output(/WITHOUT importing its data/).to_stderr
-    rescue SystemExit
-      nil
-    end
-
-    it 'does not change the update state' do
-      suppress_output { Rake::Task['tariff:sync:force_apply'].invoke }
-    rescue SystemExit
-      expect(update.reload.state).to eq('F')
-    end
-  end
-
-  context 'with CONFIRM=yes against a non-failed update' do
-    let!(:update) { create(:cds_update, :pending) }
-
-    before do
-      ENV['FILENAME'] = update.filename
-      ENV['CONFIRM']  = 'yes'
-    end
-
-    it 'aborts with a state error' do
-      expect { suppress_output { Rake::Task['tariff:sync:force_apply'].invoke } }
-        .to raise_error(SystemExit)
-    end
-  end
-
-  context 'with CONFIRM=yes against a failed update' do
-    let!(:update) { create(:cds_update, :failed) }
-
-    before do
-      ENV['FILENAME'] = update.filename
-      ENV['CONFIRM']  = 'yes'
-    end
-
-    it 'marks the update as applied' do
-      suppress_output { Rake::Task['tariff:sync:force_apply'].invoke }
-
-      expect(update.reload.state).to eq('A')
-    end
-
-    it 'sets applied_at' do
-      suppress_output { Rake::Task['tariff:sync:force_apply'].invoke }
-
-      expect(update.reload.applied_at).to be_present
-    end
-
-    it 'confirms the action in output' do
-      expect { Rake::Task['tariff:sync:force_apply'].invoke }
-        .to output(/marked as applied/).to_stdout
-    end
-  end
-end
-# rubocop:enable RSpec/MultipleDescribes

--- a/spec/models/green_lanes/measure_spec.rb
+++ b/spec/models/green_lanes/measure_spec.rb
@@ -63,15 +63,13 @@ RSpec.describe GreenLanes::Measure do
 
       it { is_expected.to be_instance_of Commodity }
 
-      # rubocop:disable RSpec::EmptyExampleGroup
       context 'with expired goods_nomenclature' do
         before { gn.update(validity_end_date: 2.days.ago) }
 
         it_with_refresh_materialized_view 'returns nil' do
-          expect(measure.goods_nomenclature).to be nil
+          expect(measure.goods_nomenclature).to be_nil
         end
       end
-      # rubocop:enable RSpec::EmptyExampleGroup
     end
 
     describe '#geographical_area' do

--- a/spec/models/measure_condition_permutations/calculator_spec.rb
+++ b/spec/models/measure_condition_permutations/calculator_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe MeasureConditionPermutations::Calculator do
   end
 
   describe 'filtering measure_conditions' do
-    # rubocop:disable RSpec/LetSetup
     subject :measure_conditions do
       calculator.permutation_groups
                 .flat_map(&:permutations)
@@ -15,19 +14,27 @@ RSpec.describe MeasureConditionPermutations::Calculator do
     end
 
     shared_examples 'an included measure condition' do
-      it { expect(measure_conditions).to include(measure_condition) }
+      it do
+        expected_condition = measure_condition
+
+        expect(measure_conditions).to include(expected_condition)
+      end
     end
 
     shared_examples_for 'an excluded measure condition' do
-      it { expect(measure_conditions).not_to include(measure_condition) }
+      it do
+        excluded_condition = measure_condition
+
+        expect(measure_conditions).not_to include(excluded_condition)
+      end
     end
 
     it_behaves_like 'an included measure condition' do
-      let!(:measure_condition) { measure.measure_conditions.first }
+      let(:measure_condition) { measure.measure_conditions.first }
     end
 
     it_behaves_like 'an included measure condition' do
-      let!(:measure_condition) do
+      let(:measure_condition) do
         create(
           :measure_condition,
           :negative,
@@ -38,7 +45,7 @@ RSpec.describe MeasureConditionPermutations::Calculator do
     end
 
     it_behaves_like 'an included measure condition' do
-      let!(:measure_condition) do
+      let(:measure_condition) do
         create(
           :measure_condition,
           :negative,
@@ -49,7 +56,7 @@ RSpec.describe MeasureConditionPermutations::Calculator do
     end
 
     it_behaves_like 'an included measure condition' do
-      let!(:measure_condition) do
+      let(:measure_condition) do
         create(
           :measure_condition,
           :negative,
@@ -60,7 +67,7 @@ RSpec.describe MeasureConditionPermutations::Calculator do
     end
 
     it_behaves_like 'an excluded measure condition' do
-      let!(:measure_condition) do
+      let(:measure_condition) do
         create(
           :measure_condition,
           :negative,
@@ -70,7 +77,7 @@ RSpec.describe MeasureConditionPermutations::Calculator do
     end
 
     it_behaves_like 'an excluded measure condition' do
-      let!(:measure_condition) do
+      let(:measure_condition) do
         create(
           :measure_condition,
           :cds_waiver,
@@ -80,7 +87,7 @@ RSpec.describe MeasureConditionPermutations::Calculator do
     end
 
     it_behaves_like 'an excluded measure condition' do
-      let!(:measure_condition) do
+      let(:measure_condition) do
         create(
           :measure_condition,
           :negative,
@@ -88,7 +95,6 @@ RSpec.describe MeasureConditionPermutations::Calculator do
         )
       end
     end
-    # rubocop:enable RSpec/LetSetup
   end
 
   describe '#permutation_groups' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -30,7 +30,6 @@ RSpec.configure do |config|
   config.alias_it_should_behave_like_to :it_is_associated, 'it is associated'
   config.include RequestSpecHelper, type: :request
   config.include SynchronizerHelper
-  config.include RescueHelper
   config.include ActiveSupport::Testing::TimeHelpers
 
   config.include_context 'with fake global rules of origin data'

--- a/spec/support/rescue_helper.rb
+++ b/spec/support/rescue_helper.rb
@@ -1,8 +1,0 @@
-# rubocop:disable Lint/SuppressedException
-module RescueHelper
-  def rescuing
-    yield
-  rescue StandardError
-  end
-end
-# rubocop:enable Lint/SuppressedException

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -21,10 +21,19 @@ module JsonapiSwaggerParameters
 end
 
 module SwaggerSecurityParameters
-  # Rswag reads header parameters by method name, including OpenAPI header casing.
-  # rubocop:disable Naming/MethodName
-  define_method(:Authorization) { 'Bearer test-token' }
-  # rubocop:enable Naming/MethodName
+  AUTHORIZATION_HEADER = :Authorization
+
+  # Rswag dispatches OAuth-derived header names as messages and does not expose
+  # the `getter:` override supported by ordinary OpenAPI parameters.
+  def method_missing(method_name, ...)
+    return 'Bearer test-token' if method_name == AUTHORIZATION_HEADER
+
+    super
+  end
+
+  def respond_to_missing?(method_name, include_private = false)
+    method_name == AUTHORIZATION_HEADER || super
+  end
 end
 
 module SwaggerErrorResponses

--- a/spec/swagger_helper_spec.rb
+++ b/spec/swagger_helper_spec.rb
@@ -5,6 +5,20 @@ RSpec.describe 'swagger helper configuration' do
 
   let(:components) { swagger_doc.fetch(:components) }
 
+  describe SwaggerSecurityParameters do
+    subject(:security_parameters) { helper_class.new }
+
+    let(:helper_class) { Class.new { include SwaggerSecurityParameters } }
+
+    it 'responds to the OAuth header message required by rswag' do
+      expect(security_parameters).to respond_to(:Authorization)
+    end
+
+    it 'provides the test bearer token through the OAuth header message' do
+      expect(security_parameters.public_send(:Authorization)).to eq('Bearer test-token')
+    end
+  end
+
   it 'sets public endpoints to require read-only OAuth scope by default' do
     expect(swagger_doc.fetch(:security)).to eq(
       [

--- a/spec/unit/taric_synchronizer_spec.rb
+++ b/spec/unit/taric_synchronizer_spec.rb
@@ -1,4 +1,3 @@
-# rubocop:disable RSpec/AnyInstance
 RSpec.describe TaricSynchronizer, :truncation do
   describe '.update_type' do
     it 'always returns TaricUpdate regardless of the SERVICE env var' do
@@ -73,9 +72,12 @@ RSpec.describe TaricSynchronizer, :truncation do
     end
 
     context 'when a download exception' do
+      let(:connection) { instance_double(Faraday::Connection) }
+
       before do
         allow(described_class).to receive(:sync_variables_set?).and_return(true)
-        allow_any_instance_of(Faraday::Connection).to receive(:get).and_raise(Faraday::Error, 'Foo')
+        allow(Faraday).to receive(:new).and_return(connection)
+        allow(connection).to receive(:get).and_raise(Faraday::Error, 'Foo')
       end
 
       it 'raises a retriable download error and emits a download_retried event' do
@@ -105,8 +107,10 @@ RSpec.describe TaricSynchronizer, :truncation do
     end
 
     context 'when successful' do
+      let(:taric_importer) { instance_double(TaricImporter, import: nil) }
+
       before do
-        allow_any_instance_of(TaricImporter).to receive(:import)
+        allow(TaricImporter).to receive(:new).and_return(taric_importer)
         allow(TariffSynchronizer::TariffLogger).to receive(:failed_update)
         allow(TradeTariffBackend).to receive(:service).and_return('xi')
         applied_update
@@ -246,4 +250,3 @@ RSpec.describe TaricSynchronizer, :truncation do
     end
   end
 end
-# rubocop:enable RSpec/AnyInstance

--- a/spec/unit/tariff_synchronizer/cds_update_downloader_spec.rb
+++ b/spec/unit/tariff_synchronizer/cds_update_downloader_spec.rb
@@ -3,6 +3,9 @@ RSpec.describe TariffSynchronizer::CdsUpdateDownloader do
   let(:downloader) { described_class.new(example_date) }
 
   describe '#perform' do
+    let(:response) { instance_double(Net::HTTPResponse, body: body.to_json) }
+    let(:tariff_downloader) { instance_double(TariffSynchronizer::TariffDownloader, perform: nil) }
+
     let(:body) do
       [{
         'filename' => 'tariff_dailyExtract_v1_20201010T235959.gzip',
@@ -22,13 +25,8 @@ RSpec.describe TariffSynchronizer::CdsUpdateDownloader do
     end
 
     before do
-      # rubocop:disable RSpec/VerifiedDoubleReference
-      allow(downloader).to receive(:response) { instance_double('Response', body: body.to_json) }
-      # rubocop:enable RSpec/VerifiedDoubleReference
-
-      # rubocop:disable RSpec/AnyInstance
-      allow_any_instance_of(TariffSynchronizer::TariffDownloader).to receive(:perform)
-      # rubocop:enable RSpec/AnyInstance
+      allow(downloader).to receive(:response).and_return(response)
+      allow(TariffSynchronizer::TariffDownloader).to receive(:new).and_return(tariff_downloader)
     end
 
     it 'emits a download_started instrumentation event' do
@@ -39,14 +37,6 @@ RSpec.describe TariffSynchronizer::CdsUpdateDownloader do
 
     context 'when response contains example_date' do
       it 'calls TariffDownloader for requested date..5 days ago', :aggregate_failures do
-        allow(TariffSynchronizer::TariffDownloader).to receive(:new).with(
-          body[0]['filename'], body[0]['downloadURL'], example_date, TariffSynchronizer::CdsUpdate
-        ).and_call_original
-
-        allow(TariffSynchronizer::TariffDownloader).to receive(:new).with(
-          body[1]['filename'], body[1]['downloadURL'], example_date - 5.days, TariffSynchronizer::CdsUpdate
-        ).and_call_original
-
         downloader.perform
 
         expect(TariffSynchronizer::TariffDownloader).to have_received(:new).with(


### PR DESCRIPTION
## What:
- Removes every inline RuboCop disable/enable directive under spec/.
- Replaces shared before(:all) database schemas, leaked Sequel model constants, instance-variable fixtures, any-instance stubs, eager setup, and swallowed exceptions with scoped structural alternatives.
- Removes four AllCops exclusions already supplied by inherited GOV.UK configuration.

## Why:
These suppressions concealed 82 offenses across ten spec/support files. The changes address the underlying isolation, fixture, and collaborator boundaries without weakening cops or moving suppressions into configuration. The effective configuration still excludes bin/**, tmp/**/*, vendor/**/*, and db/schema.rb through inheritance.

Before: 10 spec files with inline directives; 82 offenses when disable comments were ignored.
After: 0 spec files with inline directives; 1,084 spec files pass with disable comments ignored.

Verification:
- 186 focused examples, 0 failures.
- Full RSpec: 9,162 examples, 0 failures, 2 existing draft Swagger pendings.
- Forced spec RuboCop: 1,084 files, 0 offenses.
- Full tracked-source RuboCop: 2,379 effective files, 0 offenses.
- Both affected Sequel plugin suites pass on randomized seeds, including the seed that exposed fixture-order drift during the refactor.
- Commit and pre-push hooks pass.
- git diff --check passes.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Tests and lint configuration only; production code and runtime behaviour are unchanged. Existing focused coverage and the full suite pass.