### PR TITLE
Remove straightforward RuboCop suppressions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,7 +21,6 @@ AllCops:
     - ".direnv/**/*"
     - "db/migrate/*"
     - "db/data_migrations/*"
-    - "config/puma.rb"
 
 RSpec:
   Language:

--- a/app/lib/reporting/differences/loaders/omitted_duty_measures.rb
+++ b/app/lib/reporting/differences/loaders/omitted_duty_measures.rb
@@ -49,7 +49,7 @@ module Reporting
 
             next if current_measures.nil?
 
-            past_measures.each_key do |past_measure|
+            past_measures.each do |past_measure|
               non_continuous_measures << past_measure unless current_measures.include?(past_measure)
             end
           end

--- a/app/lib/reporting/differences/loaders/omitted_duty_measures.rb
+++ b/app/lib/reporting/differences/loaders/omitted_duty_measures.rb
@@ -49,11 +49,9 @@ module Reporting
 
             next if current_measures.nil?
 
-            # rubocop:disable Style/HashEachMethods
-            past_measures.each do |past_measure, _|
+            past_measures.each_key do |past_measure|
               non_continuous_measures << past_measure unless current_measures.include?(past_measure)
             end
-            # rubocop:enable Style/HashEachMethods
           end
 
           non_continuous_measures.each { |measure| yield build_row_for(measure) }

--- a/app/lib/reporting/differences/renderers/overview.rb
+++ b/app/lib/reporting/differences/renderers/overview.rb
@@ -171,7 +171,7 @@ module Reporting
           @report = report
         end
 
-        def add_worksheet(data) # rubocop:disable Lint/UnusedMethodArgument
+        def add_worksheet(_data)
           worksheet = workbook.get_worksheet_by_name(name)
           dashboard_styles = build_dashboard_styles
 

--- a/config/initializers/notify.rb
+++ b/config/initializers/notify.rb
@@ -1,46 +1,47 @@
-NOTIFY_CONFIGURATION = if ENV['ENVIRONMENT'] == 'production'
-  { # rubocop:disable Layout/IndentationWidth
-    templates: {
-      enquiry_form: {
-        submission: '104e74e3-8f43-4642-a594-4d4ef931b121',
+NOTIFY_CONFIGURATION =
+  if ENV['ENVIRONMENT'] == 'production'
+    {
+      templates: {
+        enquiry_form: {
+          submission: '104e74e3-8f43-4642-a594-4d4ef931b121',
+        },
+        myott: {
+          stop_press: '3295f0bf-c75f-4202-8dcf-703e4564b932',
+          tariff_change: '5db33f13-7235-4ed8-b704-e3fddc01ee09',
+        },
       },
-      myott: {
-        stop_press: '3295f0bf-c75f-4202-8dcf-703e4564b932',
-        tariff_change: '5db33f13-7235-4ed8-b704-e3fddc01ee09',
+      reply_to: {
+        tariff_management: '61e19d5e-4fae-4b7e-aa2e-cd05a87f4cf8',
       },
-    },
-    reply_to: {
-      tariff_management: '61e19d5e-4fae-4b7e-aa2e-cd05a87f4cf8',
-    },
-  }
-elsif ENV['ENVIRONMENT'] == 'staging' # rubocop:disable Layout/ElseAlignment
-  {
-    templates: {
-      enquiry_form: {
-        submission: '6033e45a-7029-4c5a-b4d3-e52ba111c9b4',
+    }
+  elsif ENV['ENVIRONMENT'] == 'staging'
+    {
+      templates: {
+        enquiry_form: {
+          submission: '6033e45a-7029-4c5a-b4d3-e52ba111c9b4',
+        },
+        myott: {
+          stop_press: '92cf170e-d9a3-4dd4-bb4d-93bbe2c547aa',
+          tariff_change: '53c88c0c-69be-4375-829f-c6fbb1b9e2ef',
+        },
       },
-      myott: {
-        stop_press: '92cf170e-d9a3-4dd4-bb4d-93bbe2c547aa',
-        tariff_change: '53c88c0c-69be-4375-829f-c6fbb1b9e2ef',
+      reply_to: {
+        tariff_management: 'ed4f4168-e8c5-4b80-94b9-050c86a40f0f',
       },
-    },
-    reply_to: {
-      tariff_management: 'ed4f4168-e8c5-4b80-94b9-050c86a40f0f',
-    },
-  }
-else # development / default # rubocop:disable Layout/ElseAlignment
-  {
-    templates: {
-      enquiry_form: {
-        submission: '180f1b06-3d77-4da5-9b19-2101a74fd1b8',
+    }
+  else # development / default
+    {
+      templates: {
+        enquiry_form: {
+          submission: '180f1b06-3d77-4da5-9b19-2101a74fd1b8',
+        },
+        myott: {
+          stop_press: '41b0c946-8234-4c74-86fc-3db0beb72ecb',
+          tariff_change: 'd25ab0ca-0114-47dc-954a-488516301580',
+        },
       },
-      myott: {
-        stop_press: '41b0c946-8234-4c74-86fc-3db0beb72ecb',
-        tariff_change: 'd25ab0ca-0114-47dc-954a-488516301580',
+      reply_to: {
+        tariff_management: 'e780283a-471f-42ae-a573-4364ef604fea',
       },
-    },
-    reply_to: {
-      tariff_management: 'e780283a-471f-42ae-a573-4364ef604fea',
-    },
-  }
-end # rubocop:disable Layout/EndAlignment
+    }
+  end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -7,10 +7,10 @@ preload_app!
 rackup      Puma::Configuration::DEFAULTS[:rackup]
 environment ENV['RACK_ENV'] || 'development'
 
-rails_env = ENV.fetch("RAILS_ENV", "development")
+rails_env = ENV.fetch('RAILS_ENV', 'development')
 
 # Explicit HTTP bind,  default is 3000.
-if rails_env == "development"
+if rails_env == 'development'
   bind "tcp://0.0.0.0:#{ENV.fetch('PORT', 8080)}"
 end
 

--- a/lib/tasks/data_migrations.rake
+++ b/lib/tasks/data_migrations.rake
@@ -1,4 +1,5 @@
-task 'data:migrate:load' => :environment do # rubocop:disable Rake/Desc
+desc 'Load the data migration environment'
+task 'data:migrate:load' => :environment do
   require 'data_migrator'
   db_for_current_env
 end

--- a/lib/tasks/sidekiq.rake
+++ b/lib/tasks/sidekiq.rake
@@ -1,18 +1,17 @@
-# rubocop:disable Style/StringConcatenation
 require 'sidekiq/api'
 
 desc "Get status of batch. You must supply a :bid (batch id), e.g. `rake sidekiq:status['BYUxWr4GbojwaQ']`. Batch ID may be found in the Sidekiq::Worker, e.g., `rake sidekiq:workers`"
 task 'sidekiq:status', [:bid] => :environment do |_task, args|
   exit unless args[:bid]
   status = Sidekiq::Batch::Status.new(args[:bid])
-  puts 'batch:        ' + args[:bid]
-  puts 'total:        ' + status.total.to_s # jobs in the batch => 97
-  puts 'failures:     ' + status.failures.to_s # failed jobs so far => 5
-  puts 'pending:      ' + status.pending.to_s # jobs which have not succeeded yet => 17
-  puts 'created_at:   ' + status.created_at.to_s # => 2012-09-04 21:15:05 -0700
-  puts 'complete?:    ' + status.complete?.to_s # if all jobs have executed at least once => false
-  puts 'failure_info: ' + status.failure_info.inspect # an array of failed jobs
-  puts 'data:         ' + status.data.inspect # a hash of data about the batch which can easily be converted to JSON for javascript usage
+  puts "batch:        #{args[:bid]}"
+  puts "total:        #{status.total}" # jobs in the batch => 97
+  puts "failures:     #{status.failures}" # failed jobs so far => 5
+  puts "pending:      #{status.pending}" # jobs which have not succeeded yet => 17
+  puts "created_at:   #{status.created_at}" # => 2012-09-04 21:15:05 -0700
+  puts "complete?:    #{status.complete?}" # if all jobs have executed at least once => false
+  puts "failure_info: #{status.failure_info.inspect}" # an array of failed jobs
+  puts "data:         #{status.data.inspect}" # a hash of data about the batch which can easily be converted to JSON for javascript usage
 end
 
 desc "Print a list of current active worker set for all Sidekiq processes. A 'worker' is defined as a thread currently processing a job"
@@ -61,4 +60,3 @@ desc "CAUTION! Clear all of this app's Sidekiq queues from Redis (destructive)."
 task 'sidekiq:clear_queue' => :environment do
   Sidekiq.redis(&:flushdb)
 end
-# rubocop:enable Style/StringConcatenation

--- a/spec/config/initializers/notify_spec.rb
+++ b/spec/config/initializers/notify_spec.rb
@@ -1,0 +1,58 @@
+require 'open3'
+
+RSpec.describe 'Notify configuration' do
+  subject(:configuration_values) { notify_configuration_for(environment) }
+
+  let(:environment) { 'development' }
+
+  def notify_configuration_for(environment)
+    initializer = Rails.root.join('config/initializers/notify.rb')
+    script = <<~RUBY
+      load #{initializer.to_s.inspect}
+      puts [
+        NOTIFY_CONFIGURATION.dig(:templates, :enquiry_form, :submission),
+        NOTIFY_CONFIGURATION.dig(:templates, :myott, :tariff_change),
+        NOTIFY_CONFIGURATION.dig(:reply_to, :tariff_management),
+      ]
+    RUBY
+    output, error, status = Open3.capture3({ 'ENVIRONMENT' => environment }, RbConfig.ruby, '-e', script)
+
+    raise error unless status.success?
+
+    output.lines(chomp: true)
+  end
+
+  context 'when running in production' do
+    let(:environment) { 'production' }
+
+    it 'uses the production templates and reply-to address' do
+      expect(configuration_values).to eq(%w[
+        104e74e3-8f43-4642-a594-4d4ef931b121
+        5db33f13-7235-4ed8-b704-e3fddc01ee09
+        61e19d5e-4fae-4b7e-aa2e-cd05a87f4cf8
+      ])
+    end
+  end
+
+  context 'when running in staging' do
+    let(:environment) { 'staging' }
+
+    it 'uses the staging templates and reply-to address' do
+      expect(configuration_values).to eq(%w[
+        6033e45a-7029-4c5a-b4d3-e52ba111c9b4
+        53c88c0c-69be-4375-829f-c6fbb1b9e2ef
+        ed4f4168-e8c5-4b80-94b9-050c86a40f0f
+      ])
+    end
+  end
+
+  context 'when running in development' do
+    it 'uses the development templates and reply-to address' do
+      expect(configuration_values).to eq(%w[
+        180f1b06-3d77-4da5-9b19-2101a74fd1b8
+        d25ab0ca-0114-47dc-954a-488516301580
+        e780283a-471f-42ae-a573-4364ef604fea
+      ])
+    end
+  end
+end

--- a/spec/lib/reporting/differences/loaders/omitted_duty_measures_spec.rb
+++ b/spec/lib/reporting/differences/loaders/omitted_duty_measures_spec.rb
@@ -1,0 +1,50 @@
+RSpec.describe Reporting::Differences::Loaders::OmittedDutyMeasures do
+  describe '#data' do
+    it 'reports measures that applied a year ago but no longer apply' do
+      past_measure = double(
+        goods_nomenclature_item_id: '0101000000',
+        geographical_area_id: '1011',
+        measure_type_id: '112',
+        effective_start_date: Date.new(2025, 1, 2),
+        ordernumber: 'PAST',
+        additional_code_type_id: 'A',
+        additional_code_id: '123',
+      )
+      current_measure = double(
+        goods_nomenclature_item_id: '0101000000',
+        geographical_area_id: '1011',
+        measure_type_id: '112',
+        effective_start_date: Date.new(2026, 1, 2),
+        ordernumber: 'CURRENT',
+        additional_code_type_id: nil,
+        additional_code_id: nil,
+      )
+      past_declarable = double(
+        declarable?: true,
+        goods_nomenclature_item_id: '0101000000',
+        producline_suffix: '80',
+        applicable_measures: [past_measure],
+      )
+      current_declarable = double(
+        declarable?: true,
+        goods_nomenclature_item_id: '0101000000',
+        producline_suffix: '80',
+        applicable_measures: [current_measure],
+      )
+      chapters = {
+        (Time.zone.today - 1.year).iso8601 => double(descendants: [past_declarable]),
+        Time.zone.today.iso8601 => double(descendants: [current_declarable]),
+      }
+      report = double
+
+      allow(report).to receive(:each_chapter) do |eager:, as_of:, &block|
+        expect(eager).to eq(Reporting::Differences::GOODS_NOMENCLATURE_MEASURE_EAGER)
+        block.call(chapters.fetch(as_of))
+      end
+
+      expect(described_class.new(report).data).to eq([
+        ['0101000000', '1011', '112', '02/01', 'PAST', 'A123'],
+      ])
+    end
+  end
+end

--- a/spec/lib/reporting/differences/renderers/overview_spec.rb
+++ b/spec/lib/reporting/differences/renderers/overview_spec.rb
@@ -1,0 +1,36 @@
+RSpec.describe Reporting::Differences::Renderers::Overview do
+  describe '#add_worksheet' do
+    let(:worksheet) do
+      double(
+        append_row: nil,
+        last_row_number: 10,
+        set_column_width: nil,
+        write_url_opt: nil,
+      )
+    end
+    let(:workbook) do
+      double(
+        add_format: :dashboard_style,
+        get_worksheet_by_name: worksheet,
+      )
+    end
+    let(:report) do
+      double(
+        as_of: '2026-07-21',
+        bold_style: :bold_style,
+        centered_style: :centered_style,
+        regular_style: :regular_style,
+        workbook:,
+      )
+    end
+
+    it 'renders the overview dashboard through the report workbook interface' do
+      described_class.new(report).add_worksheet(Object.new)
+
+      expect(workbook).to have_received(:get_worksheet_by_name).with('Overview')
+      expect(worksheet).to have_received(:append_row).at_least(:once)
+      expect(worksheet).to have_received(:write_url_opt).at_least(:once)
+      expect(worksheet).to have_received(:set_column_width).exactly(6).times
+    end
+  end
+end

--- a/spec/lib/tasks/data_migrations_rake_spec.rb
+++ b/spec/lib/tasks/data_migrations_rake_spec.rb
@@ -1,0 +1,16 @@
+require 'open3'
+
+RSpec.describe 'Data migration Rake tasks' do
+  describe 'data:migrate:load' do
+    it 'documents its environment-loading purpose' do
+      output, status = Open3.capture2e(
+        Rails.root.join('bin/rake').to_s,
+        '-T',
+        'data:migrate:load',
+      )
+
+      expect(status).to be_success
+      expect(output).to include('rake data:migrate:load  # Load the data migration environment')
+    end
+  end
+end

--- a/spec/lib/tasks/sidekiq_rake_spec.rb
+++ b/spec/lib/tasks/sidekiq_rake_spec.rb
@@ -1,0 +1,38 @@
+RSpec.describe 'Sidekiq Rake tasks' do
+  describe 'sidekiq:status' do
+    subject(:task) { Rake::Task['sidekiq:status'] }
+
+    let(:status_class) { double }
+    let(:status) do
+      double(
+        complete?: false,
+        created_at: '2012-09-04 21:15:05 -0700',
+        data: { 'total' => 97 },
+        failure_info: ['failed job'],
+        failures: 5,
+        pending: 17,
+        total: 97,
+      )
+    end
+
+    before do
+      stub_const('Sidekiq::Batch::Status', status_class)
+      allow(status_class).to receive(:new).with('batch-id').and_return(status)
+    end
+
+    after { task.reenable }
+
+    it 'prints every batch status field' do
+      expect { task.invoke('batch-id') }.to output(<<~OUTPUT).to_stdout
+        batch:        batch-id
+        total:        97
+        failures:     5
+        pending:      17
+        created_at:   2012-09-04 21:15:05 -0700
+        complete?:    false
+        failure_info: ["failed job"]
+        data:         {"total" => 97}
+      OUTPUT
+    end
+  end
+end


### PR DESCRIPTION
## What:

- Replace five straightforward inline RuboCop suppressions with honest code changes.
- Bring `config/puma.rb` under linting and remove its broad exclusion.
- Add focused characterization for the reporting, Sidekiq task, data-migration task, and Notify configuration seams.
- Reduce the forced suppression inventory from 27 findings across 15 files to 9 findings across 9 judgment-required files.

## Why:

These suppressions covered formatting, collection iteration, interface arguments, string construction, and a Rake description rather than genuine framework incompatibilities. Removing them makes the configuration accurately describe the remaining exceptions without changing application behaviour.

The new omitted-duty characterization caught that `past_measures` is a `Set`, not a `Hash`; the final implementation therefore uses one-argument `Set#each` rather than the initially proposed `each_key` correction.

Verification:

- Full RSpec at seed 2314: 9,169 examples, 0 failures, 2 intentional draft Swagger pendings.
- Focused changed-area suite: 27 examples, 0 failures.
- Full tracked RuboCop: 2,385 files, 0 offenses.
- Forced suppression audit: 9 offenses across 9 remaining files; zero RSpec inline directives.
- Coverage on the full run: omitted-duty loader 78/79 executable lines; overview renderer 39/39; every changed Sidekiq output line executed.
- Notify production, staging, and development branches load in isolated subprocesses with their expected templates and reply-to IDs.
- The real `bin/rake -T` output covers the data-migration description; Puma syntax, YAML parsing, commit hooks, pre-push hooks, and `git diff --check` pass.

One independent full-suite seed exposed an existing order-dependent `ChangesTablePopulator` test failure outside this diff. The example passes alone, and the controlled seed 2314 passed on both untouched `main` and this final tree; no unrelated workaround is included here.

## Ticket:

N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:**

This is a behaviour-preserving lint cleanup with focused characterization and full-suite coverage. It changes no API, tariff-domain result, database schema, worker argument, or infrastructure behavior.