### PR TITLE
Replace dynamic null object fallbacks

### DIFF
--- a/app/lib/null_object.rb
+++ b/app/lib/null_object.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Style/MissingRespondToMissing
 class NullObject
   def empty?
     true
@@ -7,9 +6,4 @@ class NullObject
   def blank?
     true
   end
-
-  def method_missing(*_args)
-    nil
-  end
 end
-# rubocop:enable Style/MissingRespondToMissing

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -78,11 +78,11 @@ class Chapter < GoodsNomenclature
   end
 
   def first_heading
-    headings.min_by(&:goods_nomenclature_item_id) || NullObject.new
+    headings.min_by(&:goods_nomenclature_item_id) || NullGoodsNomenclature.new
   end
 
   def last_heading
-    headings.max_by(&:goods_nomenclature_item_id) || NullObject.new
+    headings.max_by(&:goods_nomenclature_item_id) || NullGoodsNomenclature.new
   end
 
   def headings_from

--- a/app/models/null_goods_nomenclature.rb
+++ b/app/models/null_goods_nomenclature.rb
@@ -1,4 +1,12 @@
 class NullGoodsNomenclature < NullObject
+  attr_reader :description_html,
+              :description_indexed,
+              :description_plain,
+              :formatted_description,
+              :csv_formatted_description,
+              :consigned_from,
+              :short_code
+
   def description
     ''
   end

--- a/app/models/null_quota_event.rb
+++ b/app/models/null_quota_event.rb
@@ -1,0 +1,3 @@
+class NullQuotaEvent < NullObject
+  attr_reader :status
+end

--- a/app/models/public_users/null_commodity.rb
+++ b/app/models/public_users/null_commodity.rb
@@ -1,6 +1,9 @@
 module PublicUsers
   class NullCommodity < NullObject
-    attr_reader :goods_nomenclature_item_id
+    attr_reader :goods_nomenclature_item_id,
+                :validity_end_date,
+                :chapter_short_code,
+                :heading
 
     def initialize(goods_nomenclature_item_id:)
       super()

--- a/app/models/quota_event.rb
+++ b/app/models/quota_event.rb
@@ -16,7 +16,7 @@ class QuotaEvent
     if event.present?
       event_class_for(event[:event_type])
     else
-      NullObject.new
+      NullQuotaEvent.new
     end
   end
 

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -42,11 +42,11 @@ class Section < Sequel::Model
   end
 
   def first_chapter
-    chapters.first || NullObject.new
+    chapters.first || NullGoodsNomenclature.new
   end
 
   def last_chapter
-    chapters.last || NullObject.new
+    chapters.last || NullGoodsNomenclature.new
   end
 
   def chapter_from

--- a/spec/lib/null_object_spec.rb
+++ b/spec/lib/null_object_spec.rb
@@ -1,0 +1,12 @@
+RSpec.describe NullObject do
+  subject(:null_object) { described_class.new }
+
+  it 'is empty and blank', :aggregate_failures do
+    expect(null_object).to be_empty
+    expect(null_object).to be_blank
+  end
+
+  it 'does not silently accept unknown messages' do
+    expect { null_object.unknown_method }.to raise_error(NoMethodError)
+  end
+end

--- a/spec/models/chapter_spec.rb
+++ b/spec/models/chapter_spec.rb
@@ -254,6 +254,17 @@ RSpec.describe Chapter do
     end
   end
 
+  describe 'first and last heading when there are no headings' do
+    let(:chapter) { create :chapter, goods_nomenclature_item_id: '9900000000' }
+
+    it 'returns explicit null headings and nil bounds', :aggregate_failures do
+      expect(chapter.first_heading).to be_a(NullGoodsNomenclature)
+      expect(chapter.last_heading).to be_a(NullGoodsNomenclature)
+      expect(chapter.headings_from).to be_nil
+      expect(chapter.headings_to).to be_nil
+    end
+  end
+
   describe '#short_code' do
     let!(:chapter) { create :chapter, goods_nomenclature_item_id: '1200000000' }
 

--- a/spec/models/null_goods_nomenclature_spec.rb
+++ b/spec/models/null_goods_nomenclature_spec.rb
@@ -1,9 +1,19 @@
 RSpec.describe NullGoodsNomenclature do
   subject(:null_goods_nomenclature) { described_class.new }
 
-  describe '#description' do
-    it 'returns empty string' do
+  describe 'description fields' do
+    it 'returns the existing fallback values', :aggregate_failures do
       expect(null_goods_nomenclature.description).to eq('')
+      expect(null_goods_nomenclature.description_html).to be_nil
+      expect(null_goods_nomenclature.description_indexed).to be_nil
+      expect(null_goods_nomenclature.description_plain).to be_nil
+      expect(null_goods_nomenclature.formatted_description).to be_nil
+      expect(null_goods_nomenclature.csv_formatted_description).to be_nil
+      expect(null_goods_nomenclature.consigned_from).to be_nil
     end
+  end
+
+  it 'has no short code' do
+    expect(null_goods_nomenclature.short_code).to be_nil
   end
 end

--- a/spec/models/public_users/null_commodity_spec.rb
+++ b/spec/models/public_users/null_commodity_spec.rb
@@ -7,5 +7,8 @@ RSpec.describe PublicUsers::NullCommodity do
     expect(null_commodity.goods_nomenclature_item_id).to eq(goods_nomenclature_item_id)
     expect(null_commodity.id).to eq("null_#{goods_nomenclature_item_id}")
     expect(null_commodity.classification_description).to eq('')
+    expect(null_commodity.validity_end_date).to be_nil
+    expect(null_commodity.chapter_short_code).to be_nil
+    expect(null_commodity.heading).to be_nil
   end
 end

--- a/spec/models/quota_event_spec.rb
+++ b/spec/models/quota_event_spec.rb
@@ -35,10 +35,12 @@ RSpec.describe QuotaEvent do
     end
 
     context 'when no events exist' do
-      it 'returns NullObject' do
-        expect(
-          described_class.last_for(99_999, Time.zone.today),
-        ).to be_a(NullObject)
+      subject(:last_event) { described_class.last_for(99_999, Time.zone.today) }
+
+      it 'returns a blank null quota event without a status', :aggregate_failures do
+        expect(last_event).to be_a(NullQuotaEvent)
+        expect(last_event).to be_blank
+        expect(last_event.status).to be_nil
       end
     end
   end

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -104,4 +104,17 @@ RSpec.describe Section do
       end
     end
   end
+
+  describe 'first and last chapter' do
+    let(:section) { create(:section) }
+
+    context 'when the section has no chapters' do
+      it 'returns explicit null chapters and nil bounds', :aggregate_failures do
+        expect(section.first_chapter).to be_a(NullGoodsNomenclature)
+        expect(section.last_chapter).to be_a(NullGoodsNomenclature)
+        expect(section.chapter_from).to be_nil
+        expect(section.chapter_to).to be_nil
+      end
+    end
+  end
 end

--- a/spec/serializers/api/user/subscription_target/commodity_serializer_spec.rb
+++ b/spec/serializers/api/user/subscription_target/commodity_serializer_spec.rb
@@ -49,5 +49,31 @@ RSpec.describe Api::User::SubscriptionTarget::CommoditySerializer do
     it 'includes validity_end_date attribute' do
       expect(serialized[:data][:attributes]).to include(:validity_end_date)
     end
+
+    context 'with a null commodity' do
+      let(:serializable) do
+        PublicUsers::NullCommodity.new(goods_nomenclature_item_id: '9999999999')
+      end
+
+      let(:expected) do
+        {
+          data: {
+            id: 'null_9999999999',
+            type: :commodity,
+            attributes: {
+              chapter: nil,
+              heading: nil,
+              goods_nomenclature_item_id: '9999999999',
+              classification_description: '',
+              validity_end_date: nil,
+            },
+          },
+        }
+      end
+
+      it 'preserves the invalid-code fallback representation' do
+        expect(serialized).to eq(expected)
+      end
+    end
   end
 end


### PR DESCRIPTION
## What:

Replaces `NullObject#method_missing` with explicit null-object interfaces for quota events, goods nomenclatures, and public-user commodities. Removes the `Style/MissingRespondToMissing` suppression.

Adds coverage for empty quota, chapter, section, description, and serializer paths, plus a guard that unknown null-object messages raise normally.

## Why:

The catch-all returned `nil` for every message, hiding typos and making each null object’s supported interface implicit. Explicit fallbacks preserve all known return values while allowing RuboCop’s default rule.

## Ticket:

N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:**

Low-risk covered refactor with no intended output change. All known production callers have explicit interfaces and the caller-focused suite covers quota status, empty navigation bounds, missing descriptions, and invalid-code serialization.

## Verification:

- 223 caller-focused RSpec examples, 0 failures
- Zeitwerk eager-load check passes
- 2,387 tracked/new Ruby files inspected by RuboCop, 0 offences
- pre-commit and pre-push hooks pass