### PR TITLE
Parse TimeMachine dates in the application time zone

### DIFF
--- a/app/lib/time_machine.rb
+++ b/app/lib/time_machine.rb
@@ -1,5 +1,3 @@
-require 'date'
-
 module TimeMachine
   def self.no_time_machine
     previous = TradeTariffRequest.time_machine_now
@@ -17,9 +15,7 @@ module TimeMachine
   def self.at(datetime)
     datetime = Time.current if datetime.blank?
     datetime = begin
-      # rubocop:disable Style/DateTime
-      DateTime.parse(datetime.to_s)
-      # rubocop:enable Style/DateTime
+      Time.zone.parse(datetime.to_s) || Time.current
     rescue ArgumentError
       Time.current
     end

--- a/spec/unit/time_machine_spec.rb
+++ b/spec/unit/time_machine_spec.rb
@@ -29,6 +29,34 @@ RSpec.describe TimeMachine do
         expect(Commodity.actual.all).to     include second_commodity
       end
     end
+
+    it 'uses the configured time zone for a date string with an explicit offset', :aggregate_failures do
+      described_class.at('2024-06-01T12:34:56+01:00') do
+        point_in_time = described_class.point_in_time
+
+        expect(point_in_time).to be_a(ActiveSupport::TimeWithZone)
+        expect(point_in_time).to eq(Time.iso8601('2024-06-01T12:34:56+01:00'))
+        expect(point_in_time.time_zone).to eq(Time.zone)
+      end
+    end
+
+    it 'parses a Date at midnight' do
+      described_class.at(Date.new(2024, 6, 1)) do
+        expect(described_class.point_in_time).to eq(Time.zone.local(2024, 6, 1))
+      end
+    end
+
+    it 'restores the outer point in time after nested travel' do
+      described_class.at('2024-06-01') do
+        outer_point_in_time = described_class.point_in_time
+
+        described_class.at('2025-07-02') do
+          expect(described_class.point_in_time).to eq(Time.zone.local(2025, 7, 2))
+        end
+
+        expect(described_class.point_in_time).to eq(outer_point_in_time)
+      end
+    end
   end
 
   describe '.now' do


### PR DESCRIPTION
## What:

Replaces `DateTime.parse` in `TimeMachine.at` with `Time.zone.parse`, removing the `Style/DateTime` suppression and the now-unused `date` require.

Adds direct coverage for configured-zone parsing, explicit offsets, `Date` inputs, and nested restoration.

## Why:

`DateTime` is unnecessary in this Rails boundary. Parsing through the configured UTC application zone preserves offset-free date semantics, preserves the instant represented by offset-bearing inputs, and avoids host-timezone-dependent behaviour.

## Ticket:

N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:**

Low-risk covered refactor of date parsing with no intended query-boundary change. Direct and representative caller tests cover TimeMachine, Sequel filtering, request dates, commodity validity, and tariff-change snapshots.

## Verification:

- 114 direct and representative caller RSpec examples, 0 failures
- Zeitwerk eager-load check passes
- 2,387 tracked/new Ruby files inspected by RuboCop, 0 offences
- pre-commit and pre-push hooks pass