### PR TITLE
Fix note data migration after status removal

### DIFF
--- a/db/data_migrations/20260506130000_backfill_customs_tariff_note_approval_fields.rb
+++ b/db/data_migrations/20260506130000_backfill_customs_tariff_note_approval_fields.rb
@@ -5,11 +5,7 @@ Sequel.migration do
     %i[customs_tariff_section_notes customs_tariff_chapter_notes customs_tariff_general_rules].each do |table|
       run <<~SQL
         UPDATE #{table}
-        SET validity_start_date = customs_tariff_updates.validity_start_date,
-            status = CASE customs_tariff_updates.status
-                       WHEN 'failed' THEN 'pending'
-                       ELSE customs_tariff_updates.status
-                     END
+        SET validity_start_date = customs_tariff_updates.validity_start_date
         FROM customs_tariff_updates
         WHERE #{table}.customs_tariff_update_version = customs_tariff_updates.version
           AND #{table}.validity_start_date IS NULL

--- a/spec/db/data_migrations/backfill_customs_tariff_note_approval_fields_spec.rb
+++ b/spec/db/data_migrations/backfill_customs_tariff_note_approval_fields_spec.rb
@@ -1,0 +1,26 @@
+require 'data_migrator'
+
+RSpec.describe 'Backfill customs tariff note approval fields' do
+  subject(:run_migration) do
+    Sequel::TimestampMigrator.run_single(
+      Sequel::Model.db,
+      Rails.root.join('db/data_migrations/20260506130000_backfill_customs_tariff_note_approval_fields.rb').to_s,
+      table: DataMigrator::DATA_MIGRATIONS_TABLE,
+    )
+  end
+
+  let(:validity_start_date) { Date.new(2026, 5, 1) }
+  let(:customs_tariff_update) { create(:customs_tariff_update, validity_start_date:) }
+
+  it 'backfills only missing validity start dates against the current schema' do
+    section_note = create(:customs_tariff_section_note, customs_tariff_update:, validity_start_date: nil)
+    chapter_note = create(:customs_tariff_chapter_note, customs_tariff_update:, validity_start_date: nil)
+    general_rule = create(:customs_tariff_general_rule, customs_tariff_update:, validity_start_date: nil)
+    populated_note = create(:customs_tariff_section_note, customs_tariff_update:, validity_start_date: Date.new(2026, 4, 1))
+
+    run_migration
+
+    expect([section_note, chapter_note, general_rule, populated_note].map { _1.reload.validity_start_date })
+      .to eq([validity_start_date, validity_start_date, validity_start_date, Date.new(2026, 4, 1)])
+  end
+end


### PR DESCRIPTION
## What:

- [x] Remove the obsolete `status` assignment from the customs tariff note backfill

## Why:

The `status` columns were removed, but this pending data migration still referenced them. XI therefore fails the migration with `PG::UndefinedColumn` before it can backfill `validity_start_date`.

The remaining update is unchanged and idempotent.

## Ticket:

N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:**
The change only removes assignments to columns which no longer exist. It introduces no new data writes and leaves the existing validity date backfill unchanged.
