### PR TITLE
Fix note data migration after status removal

### DIFF
--- a/db/data_migrations/20260506130000_backfill_customs_tariff_note_approval_fields.rb
+++ b/db/data_migrations/20260506130000_backfill_customs_tariff_note_approval_fields.rb
@@ -5,11 +5,7 @@ Sequel.migration do
     %i[customs_tariff_section_notes customs_tariff_chapter_notes customs_tariff_general_rules].each do |table|
       run <<~SQL
         UPDATE #{table}
-        SET validity_start_date = customs_tariff_updates.validity_start_date,
-            status = CASE customs_tariff_updates.status
-                       WHEN 'failed' THEN 'pending'
-                       ELSE customs_tariff_updates.status
-                     END
+        SET validity_start_date = customs_tariff_updates.validity_start_date
         FROM customs_tariff_updates
         WHERE #{table}.customs_tariff_update_version = customs_tariff_updates.version
           AND #{table}.validity_start_date IS NULL


### PR DESCRIPTION
## What:

- [x] Remove the obsolete `status` assignment from the customs tariff note backfill

## Why:

The `status` columns were removed, but this pending data migration still referenced them. XI therefore fails the migration with `PG::UndefinedColumn` before it can backfill `validity_start_date`.

The remaining update is unchanged and idempotent.

## Ticket:

N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:**
The change only removes assignments to columns which no longer exist. It introduces no new data writes and leaves the existing validity date backfill unchanged.
