### PR TITLE
Remove seeds mixin RuboCop suppression

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,6 @@
 require_relative '../app/helpers/materialize_view_helper'
-# rubocop:disable Style/MixinUsage
-include MaterializeViewHelper
-# rubocop:enable Style/MixinUsage
 
 # Populate materialized views after a db:structure:load. If any view was
 # created WITH NO DATA, refresh! will detect "has not been populated" and
 # fall back to a blocking refresh automatically.
-refresh_materialized_view
+MaterializeViewHelper.refresh_materialized_view


### PR DESCRIPTION
## What:

- [x] Call `MaterializeViewHelper.refresh_materialized_view` directly from `db/seeds.rb`
- [x] Remove the `Style/MixinUsage` suppression

## Why:

`MaterializeViewHelper` already exposes `refresh_materialized_view` as a module function, so `db/seeds.rb` does not need to mix the helper into the top-level object. The helper implementation is unchanged and its existing 5 examples pass.

## Ticket:

N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:**
This is a direct call to the existing public module function. The helper implementation is unchanged and covered by its existing specs.