### PR TITLE
AI-1080: Add a soft timeout to query expansion

### DIFF
--- a/app/lib/openai_client.rb
+++ b/app/lib/openai_client.rb
@@ -19,6 +19,15 @@ class OpenaiClient
     end
   end
 
+  class DeadlineExceeded < StandardError
+    attr_reader :elapsed_seconds
+
+    def initialize(timeout_seconds:, elapsed_seconds:)
+      @elapsed_seconds = elapsed_seconds.to_f
+      super("OpenAI operation exceeded #{(timeout_seconds.to_f * 1000).round}ms deadline")
+    end
+  end
+
   MAX_RETRIES = 3
   MAX_RETRY_DELAY = 60 # seconds
   RETRY_DELAY = 2 # seconds
@@ -31,7 +40,12 @@ class OpenaiClient
     Net::OpenTimeout,
   ].freeze
 
-  def call(context, model: nil, reasoning_effort: nil, event_kind: nil)
+  def call(context, model: nil, reasoning_effort: nil, event_kind: nil, timeout: nil)
+    timeout = timeout.to_f if timeout.present?
+    timeout = nil unless timeout&.positive?
+    started_at = monotonic_time
+    deadline = started_at + timeout if timeout
+
     messages = if context.is_a?(Array)
                  context
                else
@@ -49,8 +63,8 @@ class OpenaiClient
     body[:reasoning_effort] = reasoning_effort if reasoning_effort.present?
     body = body.to_json
 
-    with_retry do
-      response = self.class.client.post('chat/completions', body)
+    with_retry(deadline:, timeout:, started_at:) do |remaining|
+      response = post(body, remaining:)
 
       raise_on_error!(response, model:, event_kind:) unless response.success?
 
@@ -67,6 +81,25 @@ class OpenaiClient
   end
 
 private
+
+  def post(body, remaining:)
+    return self.class.client.post('chat/completions', body) unless remaining
+
+    timeout, open_timeout = transport_timeouts(remaining)
+
+    self.class.client.post('chat/completions', body) do |request|
+      request.options.timeout = timeout
+      request.options.open_timeout = open_timeout
+    end
+  end
+
+  def transport_timeouts(remaining)
+    timeout = TradeTariffBackend.openai_api_timeout.to_f
+    open_timeout = TradeTariffBackend.openai_api_open_timeout.to_f
+    scale = [remaining / (timeout + open_timeout), 1.0].min
+
+    [timeout * scale, open_timeout * scale]
+  end
 
   def raise_on_error!(response, model: nil, event_kind: nil)
     ai_usage = usage_metadata(response.body, model:, event_kind:)
@@ -90,15 +123,31 @@ private
     AiUsage.metadata_for(model:, event_kind:, usage:)
   end
 
-  def with_retry
+  def with_retry(deadline:, timeout:, started_at:)
     attempts = 0
 
     begin
       attempts += 1
-      yield
+      remaining = remaining_time(deadline)
+      raise_deadline!(timeout:, started_at:) if deadline && remaining <= 0
+
+      result = yield remaining
+      raise_deadline!(timeout:, started_at:) if deadline && remaining_time(deadline) <= 0
+
+      result
     rescue *RETRYABLE_ERRORS => e
+      raise_deadline!(timeout:, started_at:) if deadline && remaining_time(deadline) <= 0
+
       if attempts < MAX_RETRIES
         delay = calculate_retry_delay(attempts, e)
+
+        if deadline
+          remaining = remaining_time(deadline)
+          if delay >= remaining
+            raise_deadline!(timeout:, started_at:)
+          end
+        end
+
         Rails.logger.warn "OpenaiClient: #{e.class} on attempt #{attempts}, retrying in #{delay}s..."
         Kernel.sleep delay
         retry
@@ -107,6 +156,21 @@ private
         raise
       end
     end
+  end
+
+  def remaining_time(deadline)
+    deadline && deadline - monotonic_time
+  end
+
+  def raise_deadline!(timeout:, started_at:)
+    raise DeadlineExceeded.new(
+      timeout_seconds: timeout,
+      elapsed_seconds: monotonic_time - started_at,
+    )
+  end
+
+  def monotonic_time
+    Process.clock_gettime(Process::CLOCK_MONOTONIC)
   end
 
   def calculate_retry_delay(attempts, error)
@@ -120,9 +184,9 @@ private
   end
 
   class << self
-    def call(context, model: nil, reasoning_effort: nil, event_kind: nil)
+    def call(context, model: nil, reasoning_effort: nil, event_kind: nil, timeout: nil)
       instrument do
-        new.call(context, model: model, reasoning_effort: reasoning_effort, event_kind:)
+        new.call(context, model: model, reasoning_effort: reasoning_effort, event_kind:, timeout:)
       end
     end
 

--- a/app/lib/search/instrumentation/query_events.rb
+++ b/app/lib/search/instrumentation/query_events.rb
@@ -40,6 +40,18 @@ module Search
         instrument('query_expansion_decided', request_id:, search_type: 'interactive', query:, expand:, reason:, result_count:, max_score:)
       end
 
+      def query_expansion_timed_out(request_id:, timeout_ms:, elapsed_ms:, model:, fallback_outcome:)
+        instrument(
+          'query_expansion_timed_out',
+          request_id:,
+          search_type: 'interactive',
+          timeout_ms:,
+          elapsed_ms:,
+          model:,
+          fallback_outcome:,
+        )
+      end
+
       def duplicate_question_guard_checked(request_id:, attempt_number:, allowed:, duplicate:, suspicious:, signals:, reason:, iteration: nil, effective_query: nil, duplicate_of_question: nil, duplicate_of_answer: nil)
         reason_payload = truncate_reason_payload(reason)
 

--- a/app/lib/search/logger.rb
+++ b/app/lib/search/logger.rb
@@ -51,6 +51,18 @@ module Search
       }, event)
     end
 
+    def query_expansion_timed_out(event)
+      info log_entry({
+        event: 'query_expansion_timed_out',
+        request_id: event.payload[:request_id],
+        search_type: event.payload[:search_type],
+        timeout_ms: event.payload[:timeout_ms],
+        elapsed_ms: event.payload[:elapsed_ms],
+        model: event.payload[:model],
+        fallback_outcome: event.payload[:fallback_outcome],
+      }, event)
+    end
+
     def api_call_completed(event)
       data = {
         event: 'api_call_completed',

--- a/app/services/expand_search_query_service.rb
+++ b/app/services/expand_search_query_service.rb
@@ -1,6 +1,8 @@
 class ExpandSearchQueryService
   NUMERIC_CODE_PATTERN = /\A\d+\z/
   CACHE_TTL = 7.days
+  EXPANSION_TIMEOUT_SECONDS = 5.0
+  EXPANSION_TIMEOUT_MS = (EXPANSION_TIMEOUT_SECONDS * 1000).to_i
 
   Result = Data.define(:expanded_query, :reason)
 
@@ -50,6 +52,7 @@ private
         model: configured_model,
         reasoning_effort: configured_reasoning_effort,
         event_kind: 'search_query_expansion',
+        timeout: EXPANSION_TIMEOUT_SECONDS,
       )
     end
 
@@ -60,6 +63,15 @@ private
     else
       unchanged_result
     end
+  rescue OpenaiClient::DeadlineExceeded => e
+    Search::Instrumentation.query_expansion_timed_out(
+      request_id:,
+      timeout_ms: EXPANSION_TIMEOUT_MS,
+      elapsed_ms: (e.elapsed_seconds * 1000).round(2),
+      model: configured_model,
+      fallback_outcome: 'original_query',
+    )
+    unchanged_result
   rescue StandardError => e
     Search::Instrumentation.search_failed(
       request_id:,

--- a/docs/architecture/search-and-indexing.md
+++ b/docs/architecture/search-and-indexing.md
@@ -47,3 +47,33 @@ Relevant code paths include:
 - `app/workers/goods_nomenclature_reconciliation_worker.rb`
 
 Guided classification search can also attach bounded chapter- and section-note evidence to retrieved candidates. [Tariff knowledge notes](../tariff-knowledge-notes.md) documents extraction, graph edges, compressed-note materialisation and deduplication, prompt selection, and request-ID diagnostics.
+
+## Query Expansion Deadline
+
+Uncached guided-search query expansion has a fixed five-second operation-specific deadline.
+
+The deadline covers the OpenAI connection, response wait, retry backoff, and all retry attempts. Each attempt receives only the operation's remaining budget. When the deadline expires, expansion returns the original query and conditional search retains its preliminary retrieval. No background work continues, so a late response cannot populate the expansion cache or start another retrieval.
+
+Expected deadline fallback emits `query_expansion_timed_out` rather than `search_failed`. Its structured fields are `request_id`, `search_type`, `timeout_ms`, `elapsed_ms`, `model`, and `fallback_outcome`; the event does not contain the query. `fallback_outcome` is `original_query`, which is the direct result of the expansion service. Conditional search can then retain its preliminary retrieval. Use expansion-specific `api_call_completed` events as the uncached-attempt denominator and `query_expansion_timed_out` as the timeout numerator. End-to-end latency remains available as `total_duration_ms` on `search_completed`.
+
+Example CloudWatch Logs Insights queries for rollout monitoring:
+
+```text
+filter service = "search"
+  and (event = "query_expansion_timed_out"
+       or (event = "api_call_completed" and operation = "search_query_expansion"))
+| fields if(event = "query_expansion_timed_out", 1, 0) as timeout,
+         if(event = "api_call_completed", 1, 0) as uncached_expansion
+| stats sum(timeout) as timeouts,
+        sum(uncached_expansion) as uncached_expansions,
+        100.0 * sum(timeout) / sum(uncached_expansion) as timeout_rate_pct
+```
+
+```text
+filter service = "search" and event = "search_completed" and search_type = "interactive"
+| stats pct(total_duration_ms, 50) as p50_ms,
+        pct(total_duration_ms, 95) as p95_ms,
+        pct(total_duration_ms, 99) as p99_ms
+```
+
+Validate the behaviour in staging before production. Record the timeout count/rate, end-to-end p50/p95/p99, and a sample of the preliminary-result quality.

--- a/spec/lib/openai_client_spec.rb
+++ b/spec/lib/openai_client_spec.rb
@@ -297,6 +297,101 @@ RSpec.describe OpenaiClient do
         expect { client.call('test') }.to raise_error(OpenaiClient::ApiError)
       end
     end
+
+    context 'with an operation timeout' do
+      let(:connection) { instance_double(Faraday::Connection) }
+      let(:response) { instance_double(Faraday::Response, success?: true, body: response_body) }
+      let(:operation_state) { { now: 0.0, request_timeouts: [] } }
+
+      before do
+        allow(described_class).to receive(:client).and_return(connection)
+        allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC) { operation_state[:now] }
+        allow(Kernel).to receive(:sleep) { |delay| operation_state[:now] += delay }
+      end
+
+      it 'caps the combined transport timeouts to the budget' do
+        allow(connection).to receive(:post) do |_path, _body, &configure|
+          options = Faraday::RequestOptions.new
+          configure.call(instance_double(Faraday::Request, options:))
+          operation_state[:request_timeouts] << [options.timeout, options.open_timeout]
+          response
+        end
+
+        client.call('test', timeout: 5)
+
+        expect(operation_state[:request_timeouts]).to eq([[3.75, 1.25]])
+        expect(operation_state[:request_timeouts].first.sum).to eq(5.0)
+      end
+
+      it 'retries within the remaining budget' do
+        attempts = 0
+        allow(connection).to receive(:post) do |_path, _body, &configure|
+          attempts += 1
+          options = Faraday::RequestOptions.new
+          configure.call(instance_double(Faraday::Request, options:))
+          operation_state[:request_timeouts] << options.timeout
+          raise Faraday::SSLError, 'transient' if attempts == 1
+
+          response
+        end
+
+        result = client.call('test', timeout: 5)
+
+        expect(result).to eq('capital' => 'Paris')
+        expect(operation_state[:request_timeouts]).to eq([3.75, 2.25])
+      end
+
+      it 'stops when retry backoff exhausts the budget' do
+        allow(connection).to receive(:post) do |_path, _body, &configure|
+          options = Faraday::RequestOptions.new
+          configure.call(instance_double(Faraday::Request, options:))
+          operation_state[:request_timeouts] << options.timeout
+          raise Faraday::SSLError, 'transient'
+        end
+
+        expect { client.call('test', timeout: 1) }
+          .to raise_error(OpenaiClient::DeadlineExceeded) { |error|
+            expect(error.elapsed_seconds).to eq(0.0)
+            expect(error.message).to include('1000ms deadline')
+          }
+
+        expect(operation_state[:request_timeouts]).to eq([0.75])
+        expect(Kernel).not_to have_received(:sleep)
+      end
+
+      it 'converts transport expiry into a deadline error' do
+        allow(connection).to receive(:post) do |_path, _body, &configure|
+          options = Faraday::RequestOptions.new
+          configure.call(instance_double(Faraday::Request, options:))
+          operation_state[:request_timeouts] << options.timeout
+          operation_state[:now] = 5.0
+          raise Faraday::TimeoutError, 'execution expired'
+        end
+
+        expect { client.call('test', timeout: 5) }
+          .to raise_error(OpenaiClient::DeadlineExceeded)
+
+        expect(operation_state[:request_timeouts]).to eq([3.75])
+        expect(Kernel).not_to have_received(:sleep)
+      end
+
+      it 'rejects a response that completes after the operation deadline' do
+        allow(connection).to receive(:post) do |_path, _body, &configure|
+          options = Faraday::RequestOptions.new
+          configure.call(instance_double(Faraday::Request, options:))
+          operation_state[:request_timeouts] << options.timeout
+          operation_state[:now] = 5.01
+          response
+        end
+
+        expect { client.call('test', timeout: 5) }
+          .to raise_error(OpenaiClient::DeadlineExceeded) { |error|
+            expect(error.elapsed_seconds).to eq(5.01)
+          }
+
+        expect(operation_state[:request_timeouts]).to eq([3.75])
+      end
+    end
   end
 
   describe '.call' do

--- a/spec/lib/search/instrumentation_spec.rb
+++ b/spec/lib/search/instrumentation_spec.rb
@@ -237,6 +237,30 @@ RSpec.describe Search::Instrumentation do
     end
   end
 
+  describe '.query_expansion_timed_out' do
+    it 'instruments the timeout without a query' do
+      allow(ActiveSupport::Notifications).to receive(:instrument)
+
+      described_class.query_expansion_timed_out(
+        request_id: 'req-1',
+        timeout_ms: 5000,
+        elapsed_ms: 5010.0,
+        model: 'gpt-4.1-mini-2025-04-14',
+        fallback_outcome: 'preliminary_results',
+      )
+
+      expect(ActiveSupport::Notifications).to have_received(:instrument).with(
+        'query_expansion_timed_out.search',
+        request_id: 'req-1',
+        search_type: 'interactive',
+        timeout_ms: 5000,
+        elapsed_ms: 5010.0,
+        model: 'gpt-4.1-mini-2025-04-14',
+        fallback_outcome: 'preliminary_results',
+      )
+    end
+  end
+
   describe '.api_call' do
     it 'instruments the api_call_completed event and returns the result' do
       allow(ActiveSupport::Notifications).to receive(:instrument)

--- a/spec/lib/search/logger_spec.rb
+++ b/spec/lib/search/logger_spec.rb
@@ -172,6 +172,40 @@ RSpec.describe Search::Logger do
     end
   end
 
+  describe '#query_expansion_timed_out' do
+    let(:payload) do
+      {
+        request_id: 'req-1',
+        timeout_ms: 5000,
+        elapsed_ms: 5010.0,
+        model: 'gpt-4.1-mini-2025-04-14',
+        fallback_outcome: 'preliminary_results',
+      }
+    end
+
+    it_behaves_like 'a search log entry', :query_expansion_timed_out, 'query_expansion_timed_out',
+                    { request_id: 'req-1',
+                      timeout_ms: 5000,
+                      elapsed_ms: 5010.0,
+                      model: 'gpt-4.1-mini-2025-04-14',
+                      fallback_outcome: 'preliminary_results' }
+
+    it 'logs safe timeout fields' do
+      logger_instance.query_expansion_timed_out(build_event('query_expansion_timed_out', payload))
+
+      json = parsed_log_output
+      expect(json).to include(
+        'event' => 'query_expansion_timed_out',
+        'request_id' => 'req-1',
+        'timeout_ms' => 5000,
+        'elapsed_ms' => 5010.0,
+        'model' => 'gpt-4.1-mini-2025-04-14',
+        'fallback_outcome' => 'preliminary_results',
+      )
+      expect(json).not_to have_key('query')
+    end
+  end
+
   describe '#api_call_completed' do
     let(:payload) do
       { request_id: 'req-1', model: 'gpt-4', duration_ms: 2500.0, response_type: 'answers', attempt_number: 1, operation: 'interactive_search' }

--- a/spec/requests/api/internal/search_controller_spec.rb
+++ b/spec/requests/api/internal/search_controller_spec.rb
@@ -124,6 +124,52 @@ RSpec.describe Api::Internal::SearchController, :internal do
       end
     end
 
+    context 'when query expansion times out' do
+      before do
+        index = Search::GoodsNomenclatureIndex.new
+
+        TradeTariffBackend.search_client.index_by_name(
+          index.name,
+          98_765,
+          {
+            goods_nomenclature_sid: 98_765,
+            goods_nomenclature_item_id: '8479899790',
+            producline_suffix: '80',
+            goods_nomenclature_class: 'Commodity',
+            description: 'slow expansion widget',
+            formatted_description: 'Slow expansion widget',
+            full_description: 'Slow expansion widget',
+            heading_description: 'Machines and mechanical appliances',
+            declarable: true,
+            validity_start_date: Time.zone.today.iso8601,
+          },
+        )
+        TradeTariffBackend.search_client.indices.refresh(index: 'tariff-test-*')
+
+        allow(AdminConfiguration).to receive(:enabled?).with('expand_search_enabled').and_return(true)
+        allow(AdminConfiguration).to receive(:enabled?).with('expand_search_when_needed_enabled').and_return(true)
+        allow(AdminConfiguration).to receive(:integer_value).and_call_original
+        allow(AdminConfiguration).to receive(:integer_value).with('expand_search_min_results').and_return(5)
+        allow(AdminConfiguration).to receive(:integer_value).with('expand_search_min_score').and_return(5)
+        allow(ExpandSearchQueryService).to receive(:call).and_call_original
+        allow(OpenaiClient).to receive(:call).and_raise(
+          OpenaiClient::DeadlineExceeded.new(timeout_seconds: 5, elapsed_seconds: 5),
+        )
+        allow(Search::Instrumentation).to receive(:search_failed)
+        allow(TradeTariffBackend.search_client).to receive(:search).and_call_original
+      end
+
+      it 'returns the preliminary results successfully' do
+        post api_search_path(format: :json), params: { q: 'slow expansion widget', request_id: 'timeout-request' }
+
+        payload = JSON.parse(response.body)
+        expect(response).to have_http_status(:ok)
+        expect(payload.dig('data', 0, 'attributes', 'goods_nomenclature_item_id')).to eq('8479899790')
+        expect(TradeTariffBackend.search_client).to have_received(:search).once
+        expect(Search::Instrumentation).not_to have_received(:search_failed)
+      end
+    end
+
     context 'when exact match via padded numeric code' do
       before do
         chapter = create(:chapter, :with_description,

--- a/spec/services/api/internal/search_service_spec.rb
+++ b/spec/services/api/internal/search_service_spec.rb
@@ -790,6 +790,20 @@ RSpec.describe Api::Internal::SearchService do
         expect(TradeTariffBackend.search_client).to have_received(:search).twice
         expect(result[:data].first[:attributes][:goods_nomenclature_item_id]).to eq('3304990000')
       end
+
+      context 'when expansion returns the original query' do
+        before do
+          allow(ExpandSearchQueryService).to receive(:call)
+            .and_return(ExpandSearchQueryService::Result.new(expanded_query: 'CBD oil', reason: nil))
+        end
+
+        it 'retains the preliminary retrieval' do
+          result = described_class.new(q: 'CBD oil').call
+
+          expect(TradeTariffBackend.search_client).to have_received(:search).once
+          expect(result[:data]).to be_empty
+        end
+      end
     end
 
     context 'when answer-based query refinement is enabled' do

--- a/spec/services/expand_search_query_service_spec.rb
+++ b/spec/services/expand_search_query_service_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe ExpandSearchQueryService do
           model: 'gpt-4.1-mini-2025-04-14',
           reasoning_effort: nil,
           event_kind: 'search_query_expansion',
+          timeout: 5.0,
         )
       end
 
@@ -169,6 +170,41 @@ RSpec.describe ExpandSearchQueryService do
         )
       end
     end
+
+    context 'when the expansion deadline expires' do
+      let(:query) { 'laptop' }
+      let(:deadline_error) do
+        OpenaiClient::DeadlineExceeded.new(timeout_seconds: 5, elapsed_seconds: 5.01)
+      end
+
+      before do
+        allow(OpenaiClient).to receive(:call).and_raise(deadline_error)
+        allow(Search::Instrumentation).to receive(:query_expansion_timed_out)
+        allow(Search::Instrumentation).to receive(:search_failed)
+      end
+
+      it 'falls back to the original query' do
+        expect(result.expanded_query).to eq('laptop')
+      end
+
+      it 'emits timeout telemetry' do
+        result
+
+        expect(Search::Instrumentation).to have_received(:query_expansion_timed_out).with(
+          request_id: 'request-123',
+          timeout_ms: 5000,
+          elapsed_ms: 5010.0,
+          model: 'gpt-4.1-mini-2025-04-14',
+          fallback_outcome: 'original_query',
+        )
+      end
+
+      it 'does not emit search_failed' do
+        result
+
+        expect(Search::Instrumentation).not_to have_received(:search_failed)
+      end
+    end
   end
 
   describe 'AdminConfiguration integration' do
@@ -196,6 +232,7 @@ RSpec.describe ExpandSearchQueryService do
           model: 'gpt-4.1-mini-2025-04-14',
           reasoning_effort: nil,
           event_kind: 'search_query_expansion',
+          timeout: 5.0,
         )
       end
     end
@@ -215,6 +252,7 @@ RSpec.describe ExpandSearchQueryService do
           model: 'gpt-4.1-mini-2025-04-14',
           reasoning_effort: nil,
           event_kind: 'search_query_expansion',
+          timeout: 5.0,
         )
       end
     end
@@ -290,6 +328,24 @@ RSpec.describe ExpandSearchQueryService do
       end
 
       it 'does not cache the failure' do
+        described_class.call(query)
+
+        allow(OpenaiClient).to receive(:call).and_return(ai_response)
+
+        described_class.call(query)
+
+        expect(OpenaiClient).to have_received(:call).twice
+      end
+    end
+
+    context 'when the expansion deadline expires' do
+      before do
+        allow(OpenaiClient).to receive(:call).and_raise(
+          OpenaiClient::DeadlineExceeded.new(timeout_seconds: 5, elapsed_seconds: 5),
+        )
+      end
+
+      it 'does not cache the fallback' do
         described_class.call(query)
 
         allow(OpenaiClient).to receive(:call).and_return(ai_response)


### PR DESCRIPTION
## What:

- [x] Add a fixed five-second deadline for uncached query expansion
- [x] Cap OpenAI connection, response and retry/backoff work to one shared monotonic budget
- [x] Retain preliminary retrieval results when expansion reaches the deadline
- [x] Emit safe `query_expansion_timed_out` telemetry without reporting `search_failed`
- [x] Document CloudWatch timeout-rate and end-to-end p50/p95/p99 queries
- [x] Cover transport, retry, cache, service and internal request behaviour
- [ ] Record timeout rate, latency percentiles and sampled fallback quality in staging

```mermaid
flowchart TD
    QUERY[Internal search query] --> PRELIMINARY[Preliminary retrieval]
    PRELIMINARY --> DECISION{Expand query?}
    DECISION -->|No| RETURN_PRELIMINARY[Return preliminary results]
    DECISION -->|Yes| EXPANSION[OpenAI expansion]
    EXPANSION -->|Within budget| FINAL[Final retrieval]
    EXPANSION -->|Deadline| RETURN_PRELIMINARY
    FINAL --> RETURN_FINAL[Return expanded results]

    classDef box stroke:#6366f1,stroke-width:2px
    class QUERY,PRELIMINARY,DECISION,RETURN_PRELIMINARY,EXPANSION,FINAL,RETURN_FINAL box
```

Verification: 368 focused examples, 0 failures. RuboCop inspected 10 changed Ruby/spec files with no offenses. Debride and the pre-commit hooks pass.

## Why:

The latency pilot measured query expansion at 2.59s p50, 6.50s p95 and 21.10s maximum. The slow tail currently holds the full internal-search request open.

A five-second operation deadline leaves normal calls alone but stops expansion owning the request tail. Faraday receives only the remaining budget on each attempt, and retry backoff cannot extend it. Deadline expiry returns the unchanged query, so the existing conditional-search path keeps the preliminary results without another retrieval or an error response.

## Ticket:

[AI-1080](https://transformuk.atlassian.net/browse/AI-1080)

## Risk:
**Risk level:** 🟢

**Reason for rating:** The change is a bounded fallback applied only to query expansion. It retains existing preliminary results and changes no API contract, search index or other AI operation.
