### PR TITLE
BAU: Run search analytics snapshots on Saturdays

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -46,7 +46,7 @@
       cron: "0 18 * * *"
       description: "Populates search suggestions which are used in the frontend"
     SearchAnalyticsSnapshotWorker:
-      cron: "0 4 * * *"
+      cron: "0 4 * * 6"
       queue: within_1_day
       description: "Refreshes cached aggregate search analytics snapshots"
     ReportWorker:

--- a/spec/config/sidekiq_schedule_spec.rb
+++ b/spec/config/sidekiq_schedule_spec.rb
@@ -42,14 +42,14 @@ RSpec.describe 'config/sidekiq.yml' do
     )
   end
 
-  it 'schedules search analytics snapshot refreshes for each backend service' do
+  it 'schedules search analytics snapshot refreshes on Saturdays for each backend service' do
     uk_schedule = sidekiq_schedule(environment: 'production', service: 'uk')
     xi_schedule = sidekiq_schedule(environment: 'production', service: 'xi')
 
     [uk_schedule, xi_schedule].each do |schedule|
       expect(schedule).to include(
         'SearchAnalyticsSnapshotWorker' => include(
-          'cron' => '0 4 * * *',
+          'cron' => '0 4 * * 6',
           'queue' => 'within_1_day',
           'description' => 'Refreshes cached aggregate search analytics snapshots',
         ),


### PR DESCRIPTION
## What:

- [x] Run `SearchAnalyticsSnapshotWorker` at 04:00 every Saturday instead of daily.
- [x] Update the Sidekiq schedule spec for both UK and XI services.

## Why:

Daily search analytics snapshots are no longer required. A Saturday refresh keeps the cached analytics on the required weekly cadence and avoids running the CloudWatch snapshot queries on the other six days.

## Ticket:

N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:**
Small Sidekiq scheduler configuration change for cached search analytics snapshots. It does not alter tariff data, public APIs, search indexing, sync behaviour, or trader-facing regulatory content.