### PR TITLE
Disable search analytics snapshot retries

### DIFF
--- a/app/workers/search_analytics_snapshot_worker.rb
+++ b/app/workers/search_analytics_snapshot_worker.rb
@@ -3,7 +3,7 @@
 class SearchAnalyticsSnapshotWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: :within_1_day, retry: true
+  sidekiq_options queue: :within_1_day, retry: false
 
   def perform(periods = SearchAnalytics::SnapshotRefresh::PERIODS)
     SearchAnalytics::SnapshotRefresh.new(periods:).call

--- a/spec/workers/search_analytics_snapshot_worker_spec.rb
+++ b/spec/workers/search_analytics_snapshot_worker_spec.rb
@@ -3,6 +3,10 @@ RSpec.describe SearchAnalyticsSnapshotWorker, type: :worker do
     expect(described_class.sidekiq_options['queue']).to eq(:within_1_day)
   end
 
+  it 'does not retry failures' do
+    expect(described_class.sidekiq_options['retry']).to be(false)
+  end
+
   describe '#perform' do
     it 'delegates to the snapshot refresh service' do
       refresh = instance_double(SearchAnalytics::SnapshotRefresh, call: true)


### PR DESCRIPTION
## What:

- [x] Disable retries for failed search analytics snapshot jobs
- [x] Cover the Sidekiq retry configuration with a worker spec

## Why:

A failed snapshot job currently inherits Sidekiq’s default of 25 retries. Snapshot failures should stop after the initial attempt instead of repeatedly rerunning the refresh.

## Ticket:

N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:**
This is a small, isolated Sidekiq configuration change for a scheduled analytics job, covered by its worker spec. It does not affect tariff data or public APIs.