### PR TITLE
Validate Search Analytics CloudWatch queries in development

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,3 +5,6 @@ needs-deployment:
       - "db/**"
       - "Dockerfile"
       - "terraform/**"
+      - "app/services/search_analytics/**"
+      - "app/workers/search_analytics_snapshot_worker.rb"
+      - "lib/tasks/search_analytics.rake"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -8,3 +8,5 @@ needs-deployment:
       - "app/services/search_analytics/**"
       - "app/workers/search_analytics_snapshot_worker.rb"
       - "lib/tasks/search_analytics.rake"
+      - ".github/labeler.yml"
+      - ".github/workflows/deploy-to-development.yml"

--- a/.github/workflows/deploy-to-development.yml
+++ b/.github/workflows/deploy-to-development.yml
@@ -43,7 +43,10 @@ jobs:
   validate-cloudwatch-queries:
     if: >
       github.event_name == 'workflow_dispatch' ||
-      contains(github.event.pull_request.labels.*.name, 'needs-deployment')
+      (
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        contains(github.event.pull_request.labels.*.name, 'needs-deployment')
+      )
     needs: deploy
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy-to-development.yml
+++ b/.github/workflows/deploy-to-development.yml
@@ -39,3 +39,32 @@ jobs:
         with:
           service-names: backend-uk backend-xi worker-uk worker-xi
           environment: development
+
+  validate-cloudwatch-queries:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'needs-deployment')
+    needs: deploy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7.0.0
+
+      - uses: ruby/setup-ruby@v1.319.0
+        with:
+          bundler-cache: true
+
+      - id: environment-config
+        uses: trade-tariff/trade-tariff-tools/.github/actions/configure-environment@main
+        with:
+          app-name: tariff-backend
+          environment: development
+
+      - uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-region: eu-west-2
+          role-to-assume: ${{ steps.environment-config.outputs.deploy-role-arn }}
+
+      - name: Validate CloudWatch queries
+        env:
+          CLOUDWATCH_QUERY_VALIDATION_LOG_GROUP: ${{ steps.environment-config.outputs.log-group }}
+        run: bundle exec rake search_analytics:validate_cloudwatch_queries

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,15 +57,3 @@ repos:
     rev: main
     hooks:
       - id: debride
-
-  - repo: local
-    hooks:
-      - id: cloudwatch-query-specs
-        name: cloudwatch query specs
-        entry: bundle exec rspec
-        language: system
-        pass_filenames: false
-        files: ^(app/services/search_analytics/cloudwatch_(snapshot_query|query_validator)\.rb|lib/tasks/search_analytics\.rake|spec/services/search_analytics/cloudwatch_(snapshot_query|query_validator)_spec\.rb)$
-        args:
-          - spec/services/search_analytics/cloudwatch_snapshot_query_spec.rb
-          - spec/services/search_analytics/cloudwatch_query_validator_spec.rb

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,3 +57,15 @@ repos:
     rev: main
     hooks:
       - id: debride
+
+  - repo: local
+    hooks:
+      - id: cloudwatch-query-specs
+        name: cloudwatch query specs
+        entry: bundle exec rspec
+        language: system
+        pass_filenames: false
+        files: ^(app/services/search_analytics/cloudwatch_(snapshot_query|query_validator)\.rb|lib/tasks/search_analytics\.rake|spec/services/search_analytics/cloudwatch_(snapshot_query|query_validator)_spec\.rb)$
+        args:
+          - spec/services/search_analytics/cloudwatch_snapshot_query_spec.rb
+          - spec/services/search_analytics/cloudwatch_query_validator_spec.rb

--- a/app/services/search_analytics/cloudwatch_query_validator.rb
+++ b/app/services/search_analytics/cloudwatch_query_validator.rb
@@ -3,9 +3,9 @@
 module SearchAnalytics
   class CloudwatchQueryValidator
     LOOKBACK = 5.minutes
-    QUERY_MAX_POLLS = 60
-    QUERY_POLL_INTERVAL_SECONDS = 1
-    TERMINAL_FAILURE_STATUSES = %w[Failed Cancelled Timeout Unknown].freeze
+    QUERY_MAX_POLLS = CloudwatchSnapshotQuery::QUERY_MAX_POLLS
+    QUERY_POLL_INTERVAL_SECONDS = CloudwatchSnapshotQuery::QUERY_POLL_INTERVAL_SECONDS
+    TERMINAL_FAILURE_STATUSES = CloudwatchSnapshotQuery::TERMINAL_FAILURE_STATUSES
     ValidationError = Class.new(StandardError)
     QueryError = Class.new(StandardError)
 
@@ -67,12 +67,12 @@ module SearchAnalytics
         status = client.get_query_results(query_id:).status
         return if status == 'Complete'
 
-        raise QueryError, "CloudWatch query #{status}" if TERMINAL_FAILURE_STATUSES.include?(status)
+        raise QueryError, "CloudWatch query #{status} (query ID: #{query_id})" if TERMINAL_FAILURE_STATUSES.include?(status)
 
         Kernel.sleep QUERY_POLL_INTERVAL_SECONDS
       end
 
-      raise QueryError, 'CloudWatch query timed out while polling'
+      raise QueryError, "CloudWatch query timed out while polling (query ID: #{query_id})"
     end
 
     def compile_error_message(error)

--- a/app/services/search_analytics/cloudwatch_query_validator.rb
+++ b/app/services/search_analytics/cloudwatch_query_validator.rb
@@ -63,13 +63,13 @@ module SearchAnalytics
     end
 
     def await_completion(query_id)
-      QUERY_MAX_POLLS.times do
+      QUERY_MAX_POLLS.times do |poll|
         status = client.get_query_results(query_id:).status
-        return if status == 'Complete'
+        return true if status == 'Complete'
 
         raise QueryError, "CloudWatch query #{status} (query ID: #{query_id})" if TERMINAL_FAILURE_STATUSES.include?(status)
 
-        Kernel.sleep QUERY_POLL_INTERVAL_SECONDS
+        Kernel.sleep QUERY_POLL_INTERVAL_SECONDS unless poll == QUERY_MAX_POLLS - 1
       end
 
       raise QueryError, "CloudWatch query timed out while polling (query ID: #{query_id})"

--- a/app/services/search_analytics/cloudwatch_query_validator.rb
+++ b/app/services/search_analytics/cloudwatch_query_validator.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module SearchAnalytics
+  class CloudwatchQueryValidator
+    LOOKBACK = 5.minutes
+    QUERY_MAX_POLLS = 60
+    QUERY_POLL_INTERVAL_SECONDS = 1
+    TERMINAL_FAILURE_STATUSES = %w[Failed Cancelled Timeout Unknown].freeze
+    ValidationError = Class.new(StandardError)
+    QueryError = Class.new(StandardError)
+
+    def self.call(log_group_name:, client: Aws::CloudWatchLogs::Client.new, now: Time.current, output: $stdout)
+      new(log_group_name:, client:, now:, output:).call
+    end
+
+    def initialize(log_group_name:, client:, now:, output:)
+      @log_group_name = log_group_name
+      @client = client
+      @now = now
+      @output = output
+    end
+
+    def call
+      failures = []
+
+      distinct_queries.each do |query_string, references|
+        validate_query(query_string)
+        output.puts("Validated #{references.join(', ')}")
+      rescue Aws::CloudWatchLogs::Errors::MalformedQueryException => e
+        failures << "#{references.join(', ')}: #{compile_error_message(e)}"
+      rescue QueryError => e
+        failures << "#{references.join(', ')}: #{e.message}"
+      end
+
+      raise ValidationError, failures.join("\n") if failures.any?
+
+      output.puts("Validated #{distinct_queries.size} distinct CloudWatch queries")
+      true
+    end
+
+  private
+
+    attr_reader :log_group_name, :client, :now, :output
+
+    def distinct_queries
+      @distinct_queries ||= SnapshotRefresh::PERIODS.each_with_object(Hash.new { |hash, query| hash[query] = [] }) do |period, queries|
+        CloudwatchSnapshotQuery.query_definitions(period:).each do |name, query_string|
+          queries[query_string] << "#{period}/#{name}"
+        end
+      end
+    end
+
+    def validate_query(query_string)
+      query_id = client.start_query(
+        log_group_name:,
+        start_time: (now - LOOKBACK).to_i,
+        end_time: now.to_i,
+        query_language: 'CWLI',
+        query_string:,
+      ).query_id
+
+      await_completion(query_id)
+    end
+
+    def await_completion(query_id)
+      QUERY_MAX_POLLS.times do
+        status = client.get_query_results(query_id:).status
+        return if status == 'Complete'
+
+        raise QueryError, "CloudWatch query #{status}" if TERMINAL_FAILURE_STATUSES.include?(status)
+
+        Kernel.sleep QUERY_POLL_INTERVAL_SECONDS
+      end
+
+      raise QueryError, 'CloudWatch query timed out while polling'
+    end
+
+    def compile_error_message(error)
+      compile_error = error.query_compile_error
+      return error.message unless compile_error
+
+      location = compile_error.location
+      return compile_error.message unless location
+
+      "#{compile_error.message} (characters #{location.start_char_offset}-#{location.end_char_offset})"
+    end
+  end
+end

--- a/app/services/search_analytics/cloudwatch_snapshot_query.rb
+++ b/app/services/search_analytics/cloudwatch_snapshot_query.rb
@@ -11,6 +11,24 @@ module SearchAnalytics
       'classic' => %w[classic],
       'internal' => %w[interactive internal],
     }.freeze
+    AGGREGATED_COST_FIELDS = %w[
+      input_cost_usd
+      cached_input_cost_usd
+      output_cost_usd
+      embedding_cost_usd
+      total_cost_usd
+      average_cost_usd
+      p50_cost_usd
+      p90_cost_usd
+      assisted_searches
+      input_tokens
+      cached_input_tokens
+      output_tokens
+      total_tokens
+      calls
+      priced_calls
+      unpriced_calls
+    ].index_by { |field| "aggregated_#{field}" }.freeze
     VIEWS = %w[all classic internal].freeze
     REQUEST_SOURCES = %w[frontend backend_only unknown].freeze
     QueryError = Class.new(StandardError)
@@ -106,7 +124,7 @@ module SearchAnalytics
     def normalise_field(field)
       return '@timestamp' if field.to_s.start_with?('bin(')
 
-      field
+      AGGREGATED_COST_FIELDS.fetch(field, field)
     end
 
     def bucket_expression = period.bucket_size == 'hour' ? 'bin(1h)' : 'bin(1d)'
@@ -186,13 +204,13 @@ module SearchAnalytics
         | stats sum(known_cost_usd) as request_cost_usd,
             sum(priced) as request_priced_calls,
             sum(unpriced) as request_unpriced_calls by request_id
-        | stats sum(request_cost_usd) as total_cost_usd,
-            avg(request_cost_usd) as average_cost_usd,
-            pct(request_cost_usd, 50) as p50_cost_usd,
-            pct(request_cost_usd, 90) as p90_cost_usd,
-            count(*) as assisted_searches,
-            sum(request_priced_calls) as priced_calls,
-            sum(request_unpriced_calls) as unpriced_calls
+        | stats sum(request_cost_usd) as aggregated_total_cost_usd,
+            avg(request_cost_usd) as aggregated_average_cost_usd,
+            pct(request_cost_usd, 50) as aggregated_p50_cost_usd,
+            pct(request_cost_usd, 90) as aggregated_p90_cost_usd,
+            count(*) as aggregated_assisted_searches,
+            sum(request_priced_calls) as aggregated_priced_calls,
+            sum(request_unpriced_calls) as aggregated_unpriced_calls
       QUERY
     end
 
@@ -202,24 +220,24 @@ module SearchAnalytics
         | #{log_stream_filter}
         | #{search_ai_cost_filter}
         | fields if(pricing_known = true and service = "search", input_cost_usd, 0) as model_input_cost_usd
-        | fields if(pricing_known = true and service = "search", cached_input_cost_usd, 0) as cached_input_cost_usd
+        | fields if(pricing_known = true and service = "search", cached_input_cost_usd, 0) as model_cached_input_cost_usd
         | fields if(pricing_known = true and service = "search", output_cost_usd, 0) as model_output_cost_usd
-        | fields if(pricing_known = true and service = "ai_usage", total_cost_usd, 0) as embedding_cost_usd
+        | fields if(pricing_known = true and service = "ai_usage", total_cost_usd, 0) as model_embedding_cost_usd
         | fields if(pricing_known = true and ispresent(total_cost_usd), total_cost_usd, 0) as known_cost_usd
         | fields if(pricing_known = true and ispresent(total_cost_usd), 1, 0) as priced_call
         | fields if(pricing_known = true and ispresent(total_cost_usd), 0, 1) as unpriced_call
-        | stats sum(model_input_cost_usd) as input_cost_usd,
-            sum(cached_input_cost_usd) as cached_input_cost_usd,
-            sum(model_output_cost_usd) as output_cost_usd,
-            sum(embedding_cost_usd) as embedding_cost_usd,
-            sum(known_cost_usd) as total_cost_usd,
-            sum(input_tokens) as input_tokens,
-            sum(cached_input_tokens) as cached_input_tokens,
-            sum(output_tokens) as output_tokens,
-            sum(total_tokens) as total_tokens,
-            count(*) as calls,
-            sum(priced_call) as priced_calls,
-            sum(unpriced_call) as unpriced_calls by #{bucket_expression}, event_kind
+        | stats sum(model_input_cost_usd) as aggregated_input_cost_usd,
+            sum(model_cached_input_cost_usd) as aggregated_cached_input_cost_usd,
+            sum(model_output_cost_usd) as aggregated_output_cost_usd,
+            sum(model_embedding_cost_usd) as aggregated_embedding_cost_usd,
+            sum(known_cost_usd) as aggregated_total_cost_usd,
+            sum(input_tokens) as aggregated_input_tokens,
+            sum(cached_input_tokens) as aggregated_cached_input_tokens,
+            sum(output_tokens) as aggregated_output_tokens,
+            sum(total_tokens) as aggregated_total_tokens,
+            count(*) as aggregated_calls,
+            sum(priced_call) as aggregated_priced_calls,
+            sum(unpriced_call) as aggregated_unpriced_calls by #{bucket_expression}, event_kind
       QUERY
     end
 

--- a/app/services/search_analytics/cloudwatch_snapshot_query.rb
+++ b/app/services/search_analytics/cloudwatch_snapshot_query.rb
@@ -17,6 +17,8 @@ module SearchAnalytics
 
     def self.call(period:, client: self.client, now: Time.current) = new(period:, client:, now:).call
 
+    def self.query_definitions(period:) = new(period:, client: nil).query_definitions
+
     def self.client = @client ||= Aws::CloudWatchLogs::Client.new
 
     def initialize(period:, client: self.class.client, now: Time.current)
@@ -26,19 +28,23 @@ module SearchAnalytics
     end
 
     def call
+      queries = query_definitions
       aggregate = Aggregate.new(
         period:,
-        volume_rows: run_query(volume_query),
-        zero_result_rows: run_query(zero_result_query),
-        summary_all_latency_rows: run_query(summary_all_latency_query),
-        summary_view_latency_rows: run_query(summary_view_latency_query),
-        source_all_latency_rows: run_query(source_all_latency_query),
-        source_view_latency_rows: run_query(source_view_latency_query),
-        ai_cost_summary_rows: run_query(ai_cost_summary_query),
-        ai_cost_trend_rows: run_query(ai_cost_trend_query),
-        selection_rows: selection_queries.flat_map { |view, query| run_query(query).map { |row| row.merge('selectable_search_type' => view) } },
-        selection_trend_rows: selection_trend_queries.flat_map { |view, query| run_query(query).map { |row| row.merge('selectable_search_type' => view) } },
-        improvement_term_rows: improvement_term_queries.flat_map { |term_type, query| run_query(query).map { |row| row.merge('term_type' => term_type) } },
+        volume_rows: run_query(queries.fetch('volume')),
+        zero_result_rows: run_query(queries.fetch('zero_results')),
+        summary_all_latency_rows: run_query(queries.fetch('summary_all_latency')),
+        summary_view_latency_rows: run_query(queries.fetch('summary_view_latency')),
+        source_all_latency_rows: run_query(queries.fetch('source_all_latency')),
+        source_view_latency_rows: run_query(queries.fetch('source_view_latency')),
+        ai_cost_summary_rows: run_query(queries.fetch('ai_cost_summary')),
+        ai_cost_trend_rows: run_query(queries.fetch('ai_cost_trend')),
+        selection_rows: %w[classic internal].flat_map { |view| run_query(queries.fetch("#{view}_selections")).map { |row| row.merge('selectable_search_type' => view) } },
+        selection_trend_rows: %w[classic internal].flat_map { |view| run_query(queries.fetch("#{view}_selection_trend")).map { |row| row.merge('selectable_search_type' => view) } },
+        improvement_term_rows: {
+          'search_terms' => 'search_term_improvements',
+          'item_ids' => 'item_id_improvements',
+        }.flat_map { |term_type, name| run_query(queries.fetch(name)).map { |row| row.merge('term_type' => term_type) } },
       )
 
       VIEWS.index_with { |view| aggregate.payload_for(view) }
@@ -46,6 +52,25 @@ module SearchAnalytics
       raise
     rescue StandardError => e
       raise QueryError, e.message
+    end
+
+    def query_definitions
+      {
+        'volume' => volume_query,
+        'zero_results' => zero_result_query,
+        'summary_all_latency' => summary_all_latency_query,
+        'summary_view_latency' => summary_view_latency_query,
+        'source_all_latency' => source_all_latency_query,
+        'source_view_latency' => source_view_latency_query,
+        'ai_cost_summary' => ai_cost_summary_query,
+        'ai_cost_trend' => ai_cost_trend_query,
+        'classic_selections' => selection_queries.fetch('classic'),
+        'internal_selections' => selection_queries.fetch('internal'),
+        'classic_selection_trend' => selection_trend_queries.fetch('classic'),
+        'internal_selection_trend' => selection_trend_queries.fetch('internal'),
+        'search_term_improvements' => improvement_term_queries.fetch('search_terms'),
+        'item_id_improvements' => improvement_term_queries.fetch('item_ids'),
+      }
     end
 
   private

--- a/lib/tasks/search_analytics.rake
+++ b/lib/tasks/search_analytics.rake
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+namespace :search_analytics do
+  desc 'Validate generated CloudWatch Logs Insights queries in AWS'
+  task validate_cloudwatch_queries: :environment do
+    SearchAnalytics::CloudwatchQueryValidator.call(
+      log_group_name: ENV.fetch('CLOUDWATCH_QUERY_VALIDATION_LOG_GROUP'),
+    )
+  end
+end

--- a/lib/tasks/search_analytics.rake
+++ b/lib/tasks/search_analytics.rake
@@ -2,9 +2,14 @@
 
 namespace :search_analytics do
   desc 'Validate generated CloudWatch Logs Insights queries in AWS'
-  task validate_cloudwatch_queries: :environment do
+  # This CI task deliberately avoids booting the database-backed Rails environment.
+  task :validate_cloudwatch_queries do # rubocop:disable Rails/RakeEnvironment
+    %w[period cloudwatch_snapshot_query snapshot_refresh cloudwatch_query_validator].each do |service|
+      require Rails.root.join("app/services/search_analytics/#{service}")
+    end
+
     SearchAnalytics::CloudwatchQueryValidator.call(
       log_group_name: ENV.fetch('CLOUDWATCH_QUERY_VALIDATION_LOG_GROUP'),
     )
-  end
+  end # rubocop:enable Rails/RakeEnvironment
 end

--- a/spec/lib/tasks/search_analytics_rake_spec.rb
+++ b/spec/lib/tasks/search_analytics_rake_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe 'search analytics rake tasks' do
+  describe 'search_analytics:validate_cloudwatch_queries' do
+    subject(:task) { Rake::Task['search_analytics:validate_cloudwatch_queries'] }
+
+    it 'runs without booting the Rails environment' do
+      expect(task.prerequisites).not_to include('environment')
+    end
+  end
+end

--- a/spec/services/search_analytics/cloudwatch_query_validator_spec.rb
+++ b/spec/services/search_analytics/cloudwatch_query_validator_spec.rb
@@ -24,6 +24,11 @@ RSpec.describe SearchAnalytics::CloudwatchQueryValidator do
     )
   end
 
+  it 'uses the snapshot query polling policy' do
+    expect(described_class::QUERY_MAX_POLLS).to eq(SearchAnalytics::CloudwatchSnapshotQuery::QUERY_MAX_POLLS)
+    expect(described_class::QUERY_POLL_INTERVAL_SECONDS).to eq(SearchAnalytics::CloudwatchSnapshotQuery::QUERY_POLL_INTERVAL_SECONDS)
+  end
+
   it 'executes every distinct generated query against development AWS' do
     expect(validate).to be(true)
     expect(SearchAnalytics::CloudwatchSnapshotQuery).to have_received(:query_definitions).with(period: '24h')
@@ -67,9 +72,24 @@ RSpec.describe SearchAnalytics::CloudwatchQueryValidator do
 
     expect { validate }.to raise_error(
       described_class::ValidationError,
-      a_string_including('24h/volume: CloudWatch query Failed'),
+      a_string_including('24h/volume: CloudWatch query Failed (query ID: query-id)'),
     )
     expect(client).to have_received(:start_query).twice
+  end
+
+  it 'reports a timeout after the configured polling limit' do
+    stub_const("#{described_class}::QUERY_MAX_POLLS", 2)
+    allow(Kernel).to receive(:sleep)
+    allow(client).to receive(:get_query_results).and_return(
+      instance_double(Aws::CloudWatchLogs::Types::GetQueryResultsResponse, status: 'Running'),
+    )
+
+    expect { validate }.to raise_error(
+      described_class::ValidationError,
+      a_string_including('CloudWatch query timed out while polling (query ID: query-id)'),
+    )
+    expect(client).to have_received(:get_query_results).exactly(4).times
+    expect(Kernel).to have_received(:sleep).exactly(4).times
   end
 
   it 'includes AWS compile details for malformed queries' do

--- a/spec/services/search_analytics/cloudwatch_query_validator_spec.rb
+++ b/spec/services/search_analytics/cloudwatch_query_validator_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe SearchAnalytics::CloudwatchQueryValidator do
       a_string_including('CloudWatch query timed out while polling (query ID: query-id)'),
     )
     expect(client).to have_received(:get_query_results).exactly(4).times
-    expect(Kernel).to have_received(:sleep).exactly(4).times
+    expect(Kernel).to have_received(:sleep).exactly(2).times
   end
 
   it 'includes AWS compile details for malformed queries' do

--- a/spec/services/search_analytics/cloudwatch_query_validator_spec.rb
+++ b/spec/services/search_analytics/cloudwatch_query_validator_spec.rb
@@ -1,0 +1,93 @@
+RSpec.describe SearchAnalytics::CloudwatchQueryValidator do
+  subject(:validate) do
+    described_class.call(
+      log_group_name: 'platform-logs-development',
+      client:,
+      now:,
+      output:,
+    )
+  end
+
+  let(:client) { instance_double(Aws::CloudWatchLogs::Client) }
+  let(:now) { Time.zone.parse('2026-07-23 10:00:00 UTC') }
+  let(:output) { StringIO.new }
+
+  before do
+    allow(SearchAnalytics::CloudwatchSnapshotQuery).to receive(:query_definitions).and_return(
+      { 'volume' => 'fields event | stats count(*)' },
+      { 'volume' => 'fields event | stats count(*) by bin(1d)' },
+      { 'volume' => 'fields event | stats count(*) by bin(1d)' },
+    )
+    allow(client).to receive_messages(
+      start_query: instance_double(Aws::CloudWatchLogs::Types::StartQueryResponse, query_id: 'query-id'),
+      get_query_results: instance_double(Aws::CloudWatchLogs::Types::GetQueryResultsResponse, status: 'Complete'),
+    )
+  end
+
+  it 'executes every distinct generated query against development AWS' do
+    expect(validate).to be(true)
+    expect(SearchAnalytics::CloudwatchSnapshotQuery).to have_received(:query_definitions).with(period: '24h')
+    expect(SearchAnalytics::CloudwatchSnapshotQuery).to have_received(:query_definitions).with(period: '7d')
+    expect(SearchAnalytics::CloudwatchSnapshotQuery).to have_received(:query_definitions).with(period: '30d')
+    expect(client).to have_received(:start_query).with(
+      log_group_name: 'platform-logs-development',
+      start_time: (now - 5.minutes).to_i,
+      end_time: now.to_i,
+      query_language: 'CWLI',
+      query_string: 'fields event | stats count(*)',
+    ).once
+    expect(client).to have_received(:start_query).with(
+      log_group_name: 'platform-logs-development',
+      start_time: (now - 5.minutes).to_i,
+      end_time: now.to_i,
+      query_language: 'CWLI',
+      query_string: 'fields event | stats count(*) by bin(1d)',
+    ).once
+    expect(output.string).to include('Validated 2 distinct CloudWatch queries')
+  end
+
+  it 'polls until AWS completes the query' do
+    allow(Kernel).to receive(:sleep)
+    allow(client).to receive(:get_query_results).and_return(
+      instance_double(Aws::CloudWatchLogs::Types::GetQueryResultsResponse, status: 'Running'),
+      instance_double(Aws::CloudWatchLogs::Types::GetQueryResultsResponse, status: 'Complete'),
+    )
+
+    validate
+
+    expect(client).to have_received(:get_query_results).exactly(3).times
+    expect(Kernel).to have_received(:sleep).once
+  end
+
+  it 'reports terminal query failures and continues validating' do
+    allow(client).to receive(:get_query_results).and_return(
+      instance_double(Aws::CloudWatchLogs::Types::GetQueryResultsResponse, status: 'Failed'),
+      instance_double(Aws::CloudWatchLogs::Types::GetQueryResultsResponse, status: 'Complete'),
+    )
+
+    expect { validate }.to raise_error(
+      described_class::ValidationError,
+      a_string_including('24h/volume: CloudWatch query Failed'),
+    )
+    expect(client).to have_received(:start_query).twice
+  end
+
+  it 'includes AWS compile details for malformed queries' do
+    compile_error = Aws::CloudWatchLogs::Types::QueryCompileError.new(
+      message: 'unexpected symbol',
+      location: Aws::CloudWatchLogs::Types::QueryCompileErrorLocation.new(
+        start_char_offset: 12,
+        end_char_offset: 18,
+      ),
+    )
+    malformed_query = Aws::CloudWatchLogs::Errors::MalformedQueryException.allocate
+
+    allow(malformed_query).to receive(:query_compile_error).and_return(compile_error)
+    allow(client).to receive(:start_query).and_raise(malformed_query)
+
+    expect { validate }.to raise_error(
+      described_class::ValidationError,
+      a_string_including('unexpected symbol (characters 12-18)'),
+    )
+  end
+end

--- a/spec/services/search_analytics/cloudwatch_snapshot_query_spec.rb
+++ b/spec/services/search_analytics/cloudwatch_snapshot_query_spec.rb
@@ -59,47 +59,47 @@ RSpec.describe SearchAnalytics::CloudwatchSnapshotQuery do
       ),
       complete_response(
         result_row(
-          'total_cost_usd' => '0.0102',
-          'average_cost_usd' => '0.0051',
-          'p50_cost_usd' => '0.0048',
-          'p90_cost_usd' => '0.0075',
-          'assisted_searches' => '2',
-          'priced_calls' => '4',
-          'unpriced_calls' => '1',
+          'aggregated_total_cost_usd' => '0.0102',
+          'aggregated_average_cost_usd' => '0.0051',
+          'aggregated_p50_cost_usd' => '0.0048',
+          'aggregated_p90_cost_usd' => '0.0075',
+          'aggregated_assisted_searches' => '2',
+          'aggregated_priced_calls' => '4',
+          'aggregated_unpriced_calls' => '1',
         ),
       ),
       complete_response(
         result_row(
           '@timestamp' => '2026-06-10 09:00:00.000',
           'event_kind' => 'interactive_search',
-          'input_cost_usd' => '0.004',
-          'cached_input_cost_usd' => '0.0002',
-          'output_cost_usd' => '0.006',
-          'embedding_cost_usd' => '0',
-          'total_cost_usd' => '0.01',
-          'input_tokens' => '2000',
-          'cached_input_tokens' => '400',
-          'output_tokens' => '500',
-          'total_tokens' => '2500',
-          'calls' => '4',
-          'priced_calls' => '3',
-          'unpriced_calls' => '1',
+          'aggregated_input_cost_usd' => '0.004',
+          'aggregated_cached_input_cost_usd' => '0.0002',
+          'aggregated_output_cost_usd' => '0.006',
+          'aggregated_embedding_cost_usd' => '0',
+          'aggregated_total_cost_usd' => '0.01',
+          'aggregated_input_tokens' => '2000',
+          'aggregated_cached_input_tokens' => '400',
+          'aggregated_output_tokens' => '500',
+          'aggregated_total_tokens' => '2500',
+          'aggregated_calls' => '4',
+          'aggregated_priced_calls' => '3',
+          'aggregated_unpriced_calls' => '1',
         ),
         result_row(
           '@timestamp' => '2026-06-10 09:00:00.000',
           'event_kind' => 'vector_search_query_embedding',
-          'input_cost_usd' => '0',
-          'cached_input_cost_usd' => '0',
-          'output_cost_usd' => '0',
-          'embedding_cost_usd' => '0.0002',
-          'total_cost_usd' => '0.0002',
-          'input_tokens' => '10000',
-          'cached_input_tokens' => '0',
-          'output_tokens' => '0',
-          'total_tokens' => '10000',
-          'calls' => '1',
-          'priced_calls' => '1',
-          'unpriced_calls' => '0',
+          'aggregated_input_cost_usd' => '0',
+          'aggregated_cached_input_cost_usd' => '0',
+          'aggregated_output_cost_usd' => '0',
+          'aggregated_embedding_cost_usd' => '0.0002',
+          'aggregated_total_cost_usd' => '0.0002',
+          'aggregated_input_tokens' => '10000',
+          'aggregated_cached_input_tokens' => '0',
+          'aggregated_output_tokens' => '0',
+          'aggregated_total_tokens' => '10000',
+          'aggregated_calls' => '1',
+          'aggregated_priced_calls' => '1',
+          'aggregated_unpriced_calls' => '0',
         ),
       ),
       complete_response(
@@ -204,7 +204,11 @@ RSpec.describe SearchAnalytics::CloudwatchSnapshotQuery do
     )
     expect(client).to have_received(:start_query).with(
       hash_including(
-        query_string: a_string_including('stats sum(request_cost_usd) as total_cost_usd'),
+        query_string: a_string_including(
+          'stats sum(request_cost_usd) as aggregated_total_cost_usd',
+          'avg(request_cost_usd) as aggregated_average_cost_usd',
+          'count(*) as aggregated_assisted_searches',
+        ),
       ),
     ).once
     expect(client).to have_received(:start_query).with(
@@ -214,7 +218,11 @@ RSpec.describe SearchAnalytics::CloudwatchSnapshotQuery do
     ).twice
     expect(client).to have_received(:start_query).with(
       hash_including(
-        query_string: a_string_including('sum(embedding_cost_usd) as embedding_cost_usd'),
+        query_string: a_string_including(
+          'as model_embedding_cost_usd',
+          'sum(model_embedding_cost_usd) as aggregated_embedding_cost_usd',
+          'sum(known_cost_usd) as aggregated_total_cost_usd',
+        ),
       ),
     ).once
     expect(client).to have_received(:start_query).with(

--- a/spec/services/search_analytics/cloudwatch_snapshot_query_spec.rb
+++ b/spec/services/search_analytics/cloudwatch_snapshot_query_spec.rb
@@ -120,6 +120,30 @@ RSpec.describe SearchAnalytics::CloudwatchSnapshotQuery do
     )
   end
 
+  describe '.query_definitions' do
+    subject(:definitions) { described_class.query_definitions(period: '24h') }
+
+    it 'returns every named query executed by the snapshot' do
+      expect(definitions.keys).to contain_exactly(
+        'volume',
+        'zero_results',
+        'summary_all_latency',
+        'summary_view_latency',
+        'source_all_latency',
+        'source_view_latency',
+        'ai_cost_summary',
+        'ai_cost_trend',
+        'classic_selections',
+        'internal_selections',
+        'classic_selection_trend',
+        'internal_selection_trend',
+        'search_term_improvements',
+        'item_id_improvements',
+      )
+      expect(definitions.values).to all(be_a(String).and(be_present))
+    end
+  end
+
   it 'uses aggregate CloudWatch stats queries for the period window' do
     payloads
 


### PR DESCRIPTION
## What:

- [x] Expose the exact named CloudWatch query catalogue used by Search Analytics snapshots
- [x] Add a Rake task that executes each distinct generated query against development AWS and waits for completion
- [x] Run the task after a successful `needs-deployment` deployment for trusted same-repository branches
- [x] Auto-label Search Analytics query and validation workflow changes for development deployment
- [x] Add focused offline specs to the normal CI test suite
- [x] Avoid CloudWatch alias collisions while normalising results back to the existing snapshot schema

## Why:

CloudWatch Logs Insights can reject syntactically valid-looking aggregate queries at execution time, including alias reuse across consecutive `stats` stages. Executing all 42 generated definitions as 19 distinct queries against `platform-logs-development` catches that failure class before merge without requiring AWS or LocalStack during ordinary local development.

The validator shares the runtime snapshot polling configuration, reports CloudWatch query IDs on failures, and uses a bounded five-minute development log window without printing query results.

## Ticket:

N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:** This adds development-only validation and changes only internal CloudWatch query aliases, normalising their results back to the existing snapshot payload. The AWS integration reads a bounded five-minute development log window and does not print query results.