### PR TITLE
AI-1080: Add a versioned query-expansion strategy

### DIFF
--- a/app/lib/admin_configuration_seeder.rb
+++ b/app/lib/admin_configuration_seeder.rb
@@ -15,7 +15,7 @@ module_function
     config = AdminConfiguration.where(name: attrs[:name]).first
     return create_config(attrs) unless config
 
-    patch_config_type(config, attrs)
+    patch_config(config, attrs)
   end
 
   def create_config(attrs)
@@ -24,16 +24,22 @@ module_function
     1
   end
 
-  def patch_config_type(config, attrs)
-    if config.config_type == attrs[:config_type]
-      return refresh_nested_options(config, attrs) if config.config_type == 'nested_options'
+  def patch_config(config, attrs)
+    if config.config_type != attrs[:config_type]
+      config.update(config_type: attrs[:config_type], value: attrs[:value], description: attrs[:description])
+      output "  patched: #{attrs[:name]} (config type)"
+      return 1
+    end
 
+    return refresh_nested_options(config, attrs) if config.config_type == 'nested_options'
+
+    if config.description == attrs[:description]
       output "  skip: #{attrs[:name]} (already exists)"
       return 0
     end
 
-    config.update(config_type: attrs[:config_type], value: attrs[:value])
-    output "  patched: #{attrs[:name]} (config type)"
+    config.update(description: attrs[:description])
+    output "  patched: #{attrs[:name]} (description)"
     1
   end
 

--- a/app/lib/admin_configuration_seeder.rb
+++ b/app/lib/admin_configuration_seeder.rb
@@ -33,13 +33,19 @@ module_function
 
     return refresh_nested_options(config, attrs) if config.config_type == 'nested_options'
 
-    if config.description == attrs[:description]
+    updates = {}
+    updates[:description] = attrs[:description] if config.description != attrs[:description]
+
+    refreshed_value = refresh_options(config.value, attrs[:value])
+    updates[:value] = refreshed_value if config.value != refreshed_value
+
+    if updates.empty?
       output "  skip: #{attrs[:name]} (already exists)"
       return 0
     end
 
-    config.update(description: attrs[:description])
-    output "  patched: #{attrs[:name]} (description)"
+    config.update(updates)
+    output "  patched: #{attrs[:name]} (definition)"
     1
   end
 
@@ -50,6 +56,15 @@ module_function
     config.update(value: Sequel.pg_jsonb_wrap(value))
     output "  patched: #{attrs[:name]} (options)"
     1
+  end
+
+  def refresh_options(current_value, seeded_value)
+    return current_value unless seeded_value.is_a?(Hash) && seeded_value.key?('options')
+
+    current = current_value.respond_to?(:to_hash) ? current_value.to_hash : {}
+    selected = current.fetch('selected', seeded_value['selected'])
+
+    Sequel.pg_jsonb_wrap(current.merge('selected' => selected, 'options' => seeded_value['options']))
   end
 
   def patch_retrieval_method

--- a/app/lib/admin_configuration_seeder/config_registry.rb
+++ b/app/lib/admin_configuration_seeder/config_registry.rb
@@ -13,7 +13,8 @@ module AdminConfigurationSeeder
     def materialize_config(definition)
       attrs = definition.transform_keys(&:to_sym)
       value = config_value(attrs)
-      attrs.except(:default, :string_default, :prompt, :nested_option, :chapter_options, :retrieval_method_options)
+      attrs.except(:default, :string_default, :prompt, :nested_option, :chapter_options, :retrieval_method_options,
+                   :expansion_decider_options)
            .merge(value:)
     end
 
@@ -24,6 +25,7 @@ module AdminConfigurationSeeder
       return nested_option_value(attrs[:nested_option]) if attrs[:nested_option]
       return chapter_options_value if attrs[:chapter_options]
       return retrieval_method_value if attrs[:retrieval_method_options]
+      return expansion_decider_value if attrs[:expansion_decider_options]
 
       attrs[:value]
     end
@@ -67,6 +69,16 @@ module AdminConfigurationSeeder
           { 'key' => 'opensearch', 'label' => 'OpenSearch (text search)' },
           { 'key' => 'vector', 'label' => 'pgvector (cosine similarity)' },
           { 'key' => 'hybrid', 'label' => 'Hybrid (text + vector with RRF fusion)' },
+        ],
+      }
+    end
+
+    def expansion_decider_value
+      {
+        'selected' => AdminConfiguration.default_for('expand_search_decider'),
+        'options' => [
+          { 'key' => 'v1', 'label' => 'V1: casing and retrieval evidence' },
+          { 'key' => 'v2', 'label' => 'V2: targeted synonyms and retrieval evidence' },
         ],
       }
     end

--- a/app/lib/admin_configuration_seeder/configs.yml
+++ b/app/lib/admin_configuration_seeder/configs.yml
@@ -8,7 +8,7 @@
   default: expand_search_enabled
 - name: expand_search_decider
   config_type: options
-  description: "Guided-search expansion strategy. V1 selects AI expansion from casing and retrieval evidence. V2 applies targeted lexical synonyms and selects AI expansion from retrieval evidence without using casing."
+  description: "Guided-search expansion strategy. V1 selects AI expansion from casing and retrieval evidence. V2 applies targeted retrieval synonyms and selects AI expansion from retrieval evidence without using casing."
   expansion_decider_options: true
 - name: expand_search_when_needed_enabled
   config_type: boolean

--- a/app/lib/admin_configuration_seeder/configs.yml
+++ b/app/lib/admin_configuration_seeder/configs.yml
@@ -6,9 +6,13 @@
   config_type: boolean
   description: Allow guided search to use AI to translate eligible queries into tariff terminology before retrieval.
   default: expand_search_enabled
+- name: expand_search_decider
+  config_type: options
+  description: "Guided-search expansion strategy. V1 selects AI expansion from casing and retrieval evidence. V2 applies targeted lexical synonyms and selects AI expansion from retrieval evidence without using casing."
+  expansion_decider_options: true
 - name: expand_search_when_needed_enabled
   config_type: boolean
-  description: "When AI expansion is enabled, run an unexpanded retrieval first and expand only for uppercase acronym-like terms, queries with no significant tagged words, too few results, or a low top score. Disable to expand every eligible query."
+  description: "When AI expansion is enabled, run a preliminary retrieval first and use the selected expansion strategy to decide from casing and/or retrieval evidence. Retrieval evidence includes no significant tagged words, too few results, or a low top score. Disable to expand every eligible query."
   default: expand_search_when_needed_enabled
 - name: expand_search_min_results
   config_type: integer

--- a/app/lib/search/instrumentation/query_events.rb
+++ b/app/lib/search/instrumentation/query_events.rb
@@ -36,8 +36,18 @@ module Search
         result
       end
 
-      def query_expansion_decided(request_id:, query:, expand:, reason:, result_count:, max_score:)
-        instrument('query_expansion_decided', request_id:, search_type: 'interactive', query:, expand:, reason:, result_count:, max_score:)
+      def query_expansion_decided(request_id:, query:, expand:, reason:, decider_version:, result_count:, max_score:)
+        instrument(
+          'query_expansion_decided',
+          request_id:,
+          search_type: 'interactive',
+          query:,
+          expand:,
+          reason:,
+          decider_version:,
+          result_count:,
+          max_score:,
+        )
       end
 
       def query_expansion_timed_out(request_id:, timeout_ms:, elapsed_ms:, model:, fallback_outcome:)

--- a/app/lib/search/logger.rb
+++ b/app/lib/search/logger.rb
@@ -46,6 +46,7 @@ module Search
         query: event.payload[:query],
         expand: event.payload[:expand],
         reason: event.payload[:reason],
+        decider_version: event.payload[:decider_version],
         result_count: event.payload[:result_count],
         max_score: event.payload[:max_score],
       }, event)

--- a/app/models/admin_configuration.rb
+++ b/app/models/admin_configuration.rb
@@ -113,6 +113,7 @@ class AdminConfiguration < Sequel::Model(Sequel[:admin_configurations].qualify(:
       },
     },
     'expand_search_enabled' => true,
+    'expand_search_decider' => 'v1',
     'expand_search_min_results' => 5,
     'expand_search_min_score' => 5,
     'expand_search_when_needed_enabled' => true,

--- a/app/services/api/internal/search_service.rb
+++ b/app/services/api/internal/search_service.rb
@@ -198,8 +198,9 @@ module Api
       end
 
       def vector_short_list(search_expanded_query)
+        search_retrieval_query = retrieval_query_with_synonyms(search_expanded_query)
         goods_nomenclatures = VectorRetrievalService.call(
-          query: search_expanded_query,
+          query: search_retrieval_query,
           limit: opensearch_result_limit,
           filter_prefixes: filter_prefixes,
           request_id: request_id,
@@ -207,7 +208,7 @@ module Api
         ::Search::Instrumentation.retrieval_results_returned(
           request_id: request_id,
           query: q,
-          effective_query: search_expanded_query,
+          effective_query: search_retrieval_query,
           search_type: 'interactive',
           retrieval_method: 'vector',
           stage: 'returned',
@@ -226,9 +227,9 @@ module Api
       end
 
       def opensearch_short_list(search_expanded_query)
-        search_lexical_query = lexical_query(search_expanded_query)
+        search_retrieval_query = retrieval_query_with_synonyms(search_expanded_query)
         result = OpensearchRetrievalService.call(
-          query: q, expanded_query: search_lexical_query,
+          query: q, expanded_query: search_retrieval_query,
           as_of: as_of, request_id: request_id, limit: opensearch_result_limit,
           filter_prefixes: filter_prefixes
         )
@@ -254,10 +255,10 @@ module Api
       end
 
       def hybrid_short_list(search_expanded_query)
-        search_lexical_query = lexical_query(search_expanded_query)
+        search_retrieval_query = retrieval_query_with_synonyms(search_expanded_query)
         result = HybridRetrievalService.call(
           query: q, expanded_query: search_expanded_query,
-          lexical_query: search_lexical_query,
+          retrieval_query: search_retrieval_query,
           as_of: as_of, request_id: request_id, limit: opensearch_result_limit,
           filter_prefixes: filter_prefixes, iteration: search_iteration,
           search_type: 'interactive'
@@ -297,14 +298,14 @@ module Api
           AdminConfiguration.enabled?('expand_search_when_needed_enabled')
       end
 
-      def lexical_query(search_expanded_query)
+      def retrieval_query_with_synonyms(search_expanded_query)
         return search_expanded_query unless expansion_decider_version == 'v2'
 
         ::Search::SynonymExpander.call(search_expanded_query)
       end
 
       def expansion_decider_version
-        @expansion_decider_version ||= AdminConfiguration.option_value('expand_search_decider')
+        @expansion_decider_version ||= SearchExpansionDecisionService.decider_version
       end
 
       def normalised_query

--- a/app/services/api/internal/search_service.rb
+++ b/app/services/api/internal/search_service.rb
@@ -226,8 +226,9 @@ module Api
       end
 
       def opensearch_short_list(search_expanded_query)
+        search_lexical_query = lexical_query(search_expanded_query)
         result = OpensearchRetrievalService.call(
-          query: q, expanded_query: search_expanded_query,
+          query: q, expanded_query: search_lexical_query,
           as_of: as_of, request_id: request_id, limit: opensearch_result_limit,
           filter_prefixes: filter_prefixes
         )
@@ -246,15 +247,17 @@ module Api
         RetrievalResult.new(
           goods_nomenclatures: result.results,
           max_score: result.results.map(&:score).compact.max,
-          expanded_query: result.expanded_query,
+          expanded_query: search_expanded_query,
           results_type: 'opensearch',
           decision_results: result.results,
         )
       end
 
       def hybrid_short_list(search_expanded_query)
+        search_lexical_query = lexical_query(search_expanded_query)
         result = HybridRetrievalService.call(
           query: q, expanded_query: search_expanded_query,
+          lexical_query: search_lexical_query,
           as_of: as_of, request_id: request_id, limit: opensearch_result_limit,
           filter_prefixes: filter_prefixes, iteration: search_iteration,
           search_type: 'interactive'
@@ -292,6 +295,16 @@ module Api
         expanded_query.blank? &&
           AdminConfiguration.enabled?('expand_search_enabled') &&
           AdminConfiguration.enabled?('expand_search_when_needed_enabled')
+      end
+
+      def lexical_query(search_expanded_query)
+        return search_expanded_query unless expansion_decider_version == 'v2'
+
+        ::Search::SynonymExpander.call(search_expanded_query)
+      end
+
+      def expansion_decider_version
+        @expansion_decider_version ||= AdminConfiguration.option_value('expand_search_decider')
       end
 
       def normalised_query
@@ -356,6 +369,7 @@ module Api
           interactive_search_duplicate_question_guard_enabled: AdminConfiguration.enabled?('interactive_search_duplicate_question_guard_enabled'),
           interactive_search_max_questions: AdminConfiguration.integer_value('interactive_search_max_questions'),
           expand_search_enabled: AdminConfiguration.enabled?('expand_search_enabled'),
+          expand_search_decider: expansion_decider_version,
           expand_search_when_needed_enabled: AdminConfiguration.enabled?('expand_search_when_needed_enabled'),
           expand_search_min_results: AdminConfiguration.integer_value('expand_search_min_results'),
           expand_search_min_score: AdminConfiguration.integer_value('expand_search_min_score'),

--- a/app/services/api/internal/search_service.rb
+++ b/app/services/api/internal/search_service.rb
@@ -299,6 +299,7 @@ module Api
       end
 
       def retrieval_query_with_synonyms(search_expanded_query)
+        return search_expanded_query unless AdminConfiguration.enabled?('expand_search_enabled')
         return search_expanded_query unless expansion_decider_version == 'v2'
 
         ::Search::SynonymExpander.call(search_expanded_query)

--- a/app/services/hybrid_retrieval_service.rb
+++ b/app/services/hybrid_retrieval_service.rb
@@ -3,14 +3,14 @@ class HybridRetrievalService
   LegResult = Data.define(:value, :error)
   Result = Data.define(:results, :expanded_query, :source_results)
 
-  def self.call(query:, as_of:, expanded_query: nil, lexical_query: nil, request_id: nil, limit: 30, filter_prefixes: [], iteration: nil, search_type: 'interactive')
-    new(query:, as_of:, expanded_query:, lexical_query:, request_id:, limit:, filter_prefixes:, iteration:, search_type:).call
+  def self.call(query:, as_of:, expanded_query: nil, retrieval_query: nil, request_id: nil, limit: 30, filter_prefixes: [], iteration: nil, search_type: 'interactive')
+    new(query:, as_of:, expanded_query:, retrieval_query:, request_id:, limit:, filter_prefixes:, iteration:, search_type:).call
   end
 
-  def initialize(query:, as_of:, expanded_query: nil, lexical_query: nil, request_id: nil, limit: 30, filter_prefixes: [], iteration: nil, search_type: 'interactive')
+  def initialize(query:, as_of:, expanded_query: nil, retrieval_query: nil, request_id: nil, limit: 30, filter_prefixes: [], iteration: nil, search_type: 'interactive')
     @query = query
     @expanded_query = expanded_query.presence || query
-    @lexical_query = lexical_query.presence || @expanded_query
+    @retrieval_query = retrieval_query.presence || @expanded_query
     @as_of = as_of
     @request_id = request_id
     @limit = limit
@@ -84,7 +84,7 @@ private
     Search::Instrumentation.retrieval_results_returned(
       request_id: @request_id,
       query: @query,
-      effective_query: effective_query_for(leg),
+      effective_query: @retrieval_query,
       search_type: @search_type,
       retrieval_method: 'hybrid',
       stage: 'before_rrf',
@@ -109,7 +109,7 @@ private
   def opensearch_args
     args = {
       query: @query,
-      expanded_query: @lexical_query,
+      expanded_query: @retrieval_query,
       as_of: @as_of,
       request_id: @request_id,
       limit: @limit,
@@ -119,13 +119,9 @@ private
   end
 
   def vector_args
-    args = { query: @expanded_query, limit: @limit, request_id: @request_id }
+    args = { query: @retrieval_query, limit: @limit, request_id: @request_id }
     args[:filter_prefixes] = @filter_prefixes if @filter_prefixes.present?
     args
-  end
-
-  def effective_query_for(leg)
-    leg == :opensearch ? @lexical_query : @expanded_query
   end
 
   def rrf_merge(opensearch_items, vector_items)

--- a/app/services/hybrid_retrieval_service.rb
+++ b/app/services/hybrid_retrieval_service.rb
@@ -3,13 +3,14 @@ class HybridRetrievalService
   LegResult = Data.define(:value, :error)
   Result = Data.define(:results, :expanded_query, :source_results)
 
-  def self.call(query:, as_of:, expanded_query: nil, request_id: nil, limit: 30, filter_prefixes: [], iteration: nil, search_type: 'interactive')
-    new(query:, as_of:, expanded_query:, request_id:, limit:, filter_prefixes:, iteration:, search_type:).call
+  def self.call(query:, as_of:, expanded_query: nil, lexical_query: nil, request_id: nil, limit: 30, filter_prefixes: [], iteration: nil, search_type: 'interactive')
+    new(query:, as_of:, expanded_query:, lexical_query:, request_id:, limit:, filter_prefixes:, iteration:, search_type:).call
   end
 
-  def initialize(query:, as_of:, expanded_query: nil, request_id: nil, limit: 30, filter_prefixes: [], iteration: nil, search_type: 'interactive')
+  def initialize(query:, as_of:, expanded_query: nil, lexical_query: nil, request_id: nil, limit: 30, filter_prefixes: [], iteration: nil, search_type: 'interactive')
     @query = query
     @expanded_query = expanded_query.presence || query
+    @lexical_query = lexical_query.presence || @expanded_query
     @as_of = as_of
     @request_id = request_id
     @limit = limit
@@ -83,7 +84,7 @@ private
     Search::Instrumentation.retrieval_results_returned(
       request_id: @request_id,
       query: @query,
-      effective_query: @expanded_query,
+      effective_query: effective_query_for(leg),
       search_type: @search_type,
       retrieval_method: 'hybrid',
       stage: 'before_rrf',
@@ -108,7 +109,7 @@ private
   def opensearch_args
     args = {
       query: @query,
-      expanded_query: @expanded_query,
+      expanded_query: @lexical_query,
       as_of: @as_of,
       request_id: @request_id,
       limit: @limit,
@@ -121,6 +122,10 @@ private
     args = { query: @expanded_query, limit: @limit, request_id: @request_id }
     args[:filter_prefixes] = @filter_prefixes if @filter_prefixes.present?
     args
+  end
+
+  def effective_query_for(leg)
+    leg == :opensearch ? @lexical_query : @expanded_query
   end
 
   def rrf_merge(opensearch_items, vector_items)

--- a/app/services/search/expansion_deciders/base.rb
+++ b/app/services/search/expansion_deciders/base.rb
@@ -1,0 +1,55 @@
+module Search
+  module ExpansionDeciders
+    class Base
+      NOISE_TAGS = Search::GoodsNomenclatureQuery::NOISE_TAGS
+
+      def self.call(query:, results:, max_score:)
+        new(query:, results:, max_score:).call
+      end
+
+      def initialize(query:, results:, max_score:)
+        @query = query.to_s
+        @results = Array(results)
+        @max_score = max_score
+      end
+
+      def call
+        return 'no_significant_word_parts' if no_significant_word_parts?
+        return 'low_result_count' if low_result_count?
+        return 'low_max_score' if low_max_score?
+
+        'sufficient_results'
+      end
+
+    private
+
+      attr_reader :query, :results, :max_score
+
+      def no_significant_word_parts?
+        tagged_words = tag_words
+        return false if tagged_words.empty?
+
+        tagged_words.none? { |_word, tag| tag.present? && !NOISE_TAGS.include?(tag) }
+      end
+
+      def tag_words
+        Search::GoodsNomenclatureQuery.tagger.get_readable(query).split.filter_map do |token|
+          word, tag = token.split('/')
+          next if word.blank? || word.match?(/\A\W+\z/)
+
+          [word, tag&.downcase]
+        end
+      end
+
+      def low_result_count?
+        results.size < AdminConfiguration.integer_value('expand_search_min_results')
+      end
+
+      def low_max_score?
+        return false if max_score.nil?
+
+        max_score < AdminConfiguration.integer_value('expand_search_min_score')
+      end
+    end
+  end
+end

--- a/app/services/search/expansion_deciders/casing_and_evidence.rb
+++ b/app/services/search/expansion_deciders/casing_and_evidence.rb
@@ -1,0 +1,13 @@
+module Search
+  module ExpansionDeciders
+    class CasingAndEvidence < Base
+      NON_WORD_TOKEN_PATTERN = /\b[A-Z]{2,6}\b/
+
+      def call
+        return 'non_word_token' if query.scan(NON_WORD_TOKEN_PATTERN).any?
+
+        super
+      end
+    end
+  end
+end

--- a/app/services/search/expansion_deciders/evidence_only.rb
+++ b/app/services/search/expansion_deciders/evidence_only.rb
@@ -1,0 +1,6 @@
+module Search
+  module ExpansionDeciders
+    class EvidenceOnly < Base
+    end
+  end
+end

--- a/app/services/search/synonym_expander.rb
+++ b/app/services/search/synonym_expander.rb
@@ -3,6 +3,7 @@ module Search
     InvalidRule = Class.new(StandardError)
     Rule = Data.define(:term, :alternatives)
     DEFAULT_RULES_PATH = Rails.root.join('config/search_synonyms.txt').freeze
+    RULES_MUTEX = Mutex.new
 
     class << self
       def call(query, rules_path: DEFAULT_RULES_PATH)
@@ -12,8 +13,10 @@ module Search
     private
 
       def rules_for(path)
-        @rules_by_path ||= {}
-        @rules_by_path[path.to_s] ||= parse(path)
+        RULES_MUTEX.synchronize do
+          @rules_by_path ||= {}
+          @rules_by_path[path.to_s] ||= parse(path)
+        end
       end
 
       def parse(path)

--- a/app/services/search/synonym_expander.rb
+++ b/app/services/search/synonym_expander.rb
@@ -1,0 +1,96 @@
+module Search
+  class SynonymExpander
+    InvalidRule = Class.new(StandardError)
+    Rule = Data.define(:term, :alternatives)
+    DEFAULT_RULES_PATH = Rails.root.join('config/search_synonyms.txt').freeze
+
+    class << self
+      def call(query, rules_path: DEFAULT_RULES_PATH)
+        new(rules: rules_for(rules_path)).call(query)
+      end
+
+    private
+
+      def rules_for(path)
+        @rules_by_path ||= {}
+        @rules_by_path[path.to_s] ||= parse(path)
+      end
+
+      def parse(path)
+        path.each_line.with_index(1).flat_map do |line, line_number|
+          parse_line(line, line_number)
+        end
+      end
+
+      def parse_line(line, line_number)
+        line = line.strip
+        return [] if line.blank? || line.start_with?('#')
+
+        return parse_directional_rule(line, line_number) if line.include?('=>')
+
+        parse_equivalent_rule(line, line_number)
+      end
+
+      def parse_directional_rule(line, line_number)
+        sides = line.split('=>', -1)
+        invalid_rule!(line_number) unless sides.size == 2
+
+        left = terms(sides.first)
+        right = terms(sides.last)
+        invalid_rule!(line_number) if left.empty? || right.empty?
+
+        left.map { |term| Rule.new(term:, alternatives: right) }
+      end
+
+      def parse_equivalent_rule(line, line_number)
+        equivalents = terms(line)
+        invalid_rule!(line_number) if equivalents.size < 2
+
+        equivalents.map do |term|
+          Rule.new(term:, alternatives: equivalents.reject { |candidate| same_term?(candidate, term) })
+        end
+      end
+
+      def terms(value)
+        value.split(',').map(&:strip).compact_blank
+      end
+
+      def same_term?(left, right)
+        left.casecmp?(right)
+      end
+
+      def invalid_rule!(line_number)
+        raise InvalidRule, "Invalid synonym rule on line #{line_number}"
+      end
+    end
+
+    def initialize(rules:)
+      @rules = rules
+    end
+
+    def call(query)
+      query = query.to_s.squish
+      return query if query.blank?
+
+      alternatives = matching_rules(query)
+        .flat_map(&:alternatives)
+        .reject { |alternative| term_present?(query, alternative) }
+        .uniq(&:downcase)
+
+      [query, *alternatives].join(' ')
+    end
+
+  private
+
+    attr_reader :rules
+
+    def matching_rules(query)
+      rules.select { |rule| term_present?(query, rule.term) }
+    end
+
+    def term_present?(query, term)
+      flexible_term = Regexp.escape(term).gsub('\\ ', '\\s+')
+      query.match?(/(?<![[:alnum:]])#{flexible_term}(?![[:alnum:]])/i)
+    end
+  end
+end

--- a/app/services/search_expansion_decision_service.rb
+++ b/app/services/search_expansion_decision_service.rb
@@ -14,6 +14,11 @@ class SearchExpansionDecisionService
     new(query:, results:, request_id:).call
   end
 
+  def self.decider_version
+    configured_version = AdminConfiguration.option_value('expand_search_decider')
+    DECIDERS.key?(configured_version) ? configured_version : 'v1'
+  end
+
   def initialize(query:, results: nil, request_id: nil)
     @query = query.to_s
     @results = Array(results)
@@ -57,8 +62,7 @@ private
   end
 
   def decider_version
-    configured_version = AdminConfiguration.option_value('expand_search_decider')
-    DECIDERS.key?(configured_version) ? configured_version : 'v1'
+    self.class.decider_version
   end
 
   def result(expand, reason)

--- a/app/services/search_expansion_decision_service.rb
+++ b/app/services/search_expansion_decision_service.rb
@@ -1,6 +1,8 @@
 class SearchExpansionDecisionService
-  NOISE_TAGS = Search::GoodsNomenclatureQuery::NOISE_TAGS
-  NON_WORD_TOKEN_PATTERN = /\b[A-Z]{2,6}\b/
+  DECIDERS = {
+    'v1' => Search::ExpansionDeciders::CasingAndEvidence,
+    'v2' => Search::ExpansionDeciders::EvidenceOnly,
+  }.freeze
 
   Result = Data.define(:expand, :reason, :result_count, :max_score) do
     def expand?
@@ -26,6 +28,7 @@ class SearchExpansionDecisionService
       query: query,
       expand: decision.expand?,
       reason: decision.reason,
+      decider_version:,
       result_count: decision.result_count,
       max_score: decision.max_score,
     )
@@ -40,46 +43,22 @@ private
   def expansion_decision
     return result(false, 'disabled') unless AdminConfiguration.enabled?('expand_search_enabled')
     return result(true, 'always_enabled') unless AdminConfiguration.enabled?('expand_search_when_needed_enabled')
-    return result(true, 'non_word_token') if non_word_token?
-    return result(true, 'no_significant_word_parts') if no_significant_word_parts?
-    return result(true, 'low_result_count') if low_result_count?
-    return result(true, 'low_max_score') if low_max_score?
 
-    result(false, 'sufficient_results')
-  end
-
-  def non_word_token?
-    query.scan(NON_WORD_TOKEN_PATTERN).any?
-  end
-
-  def no_significant_word_parts?
-    tagged_words = tag_words
-    return false if tagged_words.empty?
-
-    tagged_words.none? { |_word, tag| tag.present? && !NOISE_TAGS.include?(tag) }
-  end
-
-  def tag_words
-    Search::GoodsNomenclatureQuery.tagger.get_readable(query).split.filter_map do |token|
-      word, tag = token.split('/')
-      next if word.blank? || word.match?(/\A\W+\z/)
-
-      [word, tag&.downcase]
-    end
-  end
-
-  def low_result_count?
-    results.size < AdminConfiguration.integer_value('expand_search_min_results')
-  end
-
-  def low_max_score?
-    return false if max_score.nil?
-
-    max_score < AdminConfiguration.integer_value('expand_search_min_score')
+    reason = decider.call(query:, results:, max_score:)
+    result(reason != 'sufficient_results', reason)
   end
 
   def max_score
     @max_score ||= results.filter_map { |result| result.score&.to_f }.max
+  end
+
+  def decider
+    DECIDERS.fetch(decider_version)
+  end
+
+  def decider_version
+    configured_version = AdminConfiguration.option_value('expand_search_decider')
+    DECIDERS.key?(configured_version) ? configured_version : 'v1'
   end
 
   def result(expand, reason)

--- a/config/search_synonyms.txt
+++ b/config/search_synonyms.txt
@@ -1,14 +1,14 @@
-# Guided-search lexical synonyms
+# Guided-search retrieval synonyms
 #
 # Keep rules contextual. Broad acronym rules can dilute search relevance.
 # The original phrase is retained and alternatives are appended for OpenSearch
-# only. Vector retrieval continues to use the unmodified semantic query.
+# and vector retrieval. Interactive questioning keeps the semantic query.
 #
 # Equivalent rule:
 #   term, equivalent term
 #
 # Directional rule:
-#   input phrase => input phrase, lexical alternative
+#   input phrase => input phrase, synonym alternative
 
 ABV => ABV, alcohol by volume
 HEPA filter => HEPA filter, high efficiency particulate air filter

--- a/config/search_synonyms.txt
+++ b/config/search_synonyms.txt
@@ -1,0 +1,20 @@
+# Guided-search lexical synonyms
+#
+# Keep rules contextual. Broad acronym rules can dilute search relevance.
+# The original phrase is retained and alternatives are appended for OpenSearch
+# only. Vector retrieval continues to use the unmodified semantic query.
+#
+# Equivalent rule:
+#   term, equivalent term
+#
+# Directional rule:
+#   input phrase => input phrase, lexical alternative
+
+ABV => ABV, alcohol by volume
+HEPA filter => HEPA filter, high efficiency particulate air filter
+HDMI cable => HDMI cable, high definition multimedia interface cable
+LED lamp => LED lamp, light emitting diode lamp
+RFID reader => RFID reader, radio frequency identification reader
+RFID tag => RFID tag, radio frequency identification tag
+USB cable => USB cable, universal serial bus cable
+USB connector => USB connector, universal serial bus connector

--- a/config/search_synonyms.txt
+++ b/config/search_synonyms.txt
@@ -18,3 +18,17 @@ RFID reader => RFID reader, radio frequency identification reader
 RFID tag => RFID tag, radio frequency identification tag
 USB cable => USB cable, universal serial bus cable
 USB connector => USB connector, universal serial bus connector
+
+# Reviewed spelling and trade terminology
+vacum cleaner => vacum cleaner, vacuum cleaner
+vermeil ring => vermeil ring, gold plated silver ring
+vermeil necklace => vermeil necklace, gold plated silver necklace
+
+# Reviewed product and professional terminology from FPO declarations
+Invisalign system => Invisalign system, clear dental aligner
+ClearCorrect => ClearCorrect, clear dental aligner
+Vivera => Vivera, orthodontic retainer, orthopaedic appliance
+PTCA dilatation => PTCA dilatation, percutaneous transluminal coronary angioplasty catheter
+Cricut Joy Xtra => Cricut Joy Xtra, electronic cutting machine
+Denon Perl => Denon Perl, wireless earbuds
+Ledger Flex => Ledger Flex, hardware wallet

--- a/docs/architecture/search-and-indexing.md
+++ b/docs/architecture/search-and-indexing.md
@@ -97,3 +97,23 @@ filter service = "search" and event = "search_completed" and search_type = "inte
 ```
 
 Validate the behaviour in staging before production. Record the timeout count/rate, end-to-end p50/p95/p99, and a sample of the preliminary-result quality.
+
+## Query Expansion Strategies
+
+The `expand_search_decider` admin configuration selects the conditional-expansion strategy:
+
+- `v1` is the default. It preserves the existing behaviour, selecting AI expansion for uppercase acronym-like tokens as well as weak retrieval evidence.
+- `v2` applies the targeted rules in `config/search_synonyms.txt` to the OpenSearch query and selects AI expansion from retrieval evidence without treating casing as a signal.
+
+Selecting `v2` does not disable AI expansion. Queries with no significant tagged words, too few preliminary results, or a low top score continue through the normal AI-expansion path and retain the five-second deadline.
+
+In hybrid retrieval, mechanical synonyms affect only the lexical OpenSearch leg. The vector leg and interactive-search context retain the original query, or the AI-expanded semantic query when evidence-based expansion runs. This prevents generic words from a synonym’s full form from shifting the query embedding.
+
+The synonym file accepts equivalent rules and directional rules:
+
+```text
+term, equivalent term
+input phrase => input phrase, lexical alternative
+```
+
+Rules are matched case-insensitively against complete terms or phrases. Keep mappings contextual: prefer `HEPA filter` or `USB connector` to broad rules for `HEPA` or `USB`.

--- a/docs/architecture/search-and-indexing.md
+++ b/docs/architecture/search-and-indexing.md
@@ -103,11 +103,11 @@ Validate the behaviour in staging before production. Record the timeout count/ra
 The `expand_search_decider` admin configuration selects the conditional-expansion strategy:
 
 - `v1` is the default. It preserves the existing behaviour, selecting AI expansion for uppercase acronym-like tokens as well as weak retrieval evidence.
-- `v2` applies the targeted rules in `config/search_synonyms.txt` to the OpenSearch query and selects AI expansion from retrieval evidence without treating casing as a signal.
+- `v2` applies the targeted rules in `config/search_synonyms.txt` to retrieval queries and selects AI expansion from retrieval evidence without treating casing as a signal.
 
 Selecting `v2` does not disable AI expansion. Queries with no significant tagged words, too few preliminary results, or a low top score continue through the normal AI-expansion path and retain the five-second deadline.
 
-In hybrid retrieval, mechanical synonyms affect only the lexical OpenSearch leg. The vector leg and interactive-search context retain the original query, or the AI-expanded semantic query when evidence-based expansion runs. This prevents generic words from a synonym’s full form from shifting the query embedding.
+Mechanical synonyms are applied to both OpenSearch and vector retrieval. The interactive-search context retains the original query, or the AI-expanded semantic query when evidence-based expansion runs. Per-leg retrieval telemetry records the effective synonym-expanded query.
 
 The synonym file accepts equivalent rules and directional rules:
 

--- a/spec/fixtures/files/invalid_search_synonyms.txt
+++ b/spec/fixtures/files/invalid_search_synonyms.txt
@@ -1,0 +1,1 @@
+HEPA filter =>

--- a/spec/fixtures/files/search_synonyms.txt
+++ b/spec/fixtures/files/search_synonyms.txt
@@ -1,0 +1,8 @@
+# Directional phrase
+HEPA filter => HEPA filter, high efficiency particulate air filter
+
+# Equivalent terms
+TV, television
+
+# Identity rules are harmless
+LED => LED

--- a/spec/lib/search/instrumentation_spec.rb
+++ b/spec/lib/search/instrumentation_spec.rb
@@ -220,6 +220,7 @@ RSpec.describe Search::Instrumentation do
         query: 'CBD oil',
         expand: true,
         reason: 'non_word_token',
+        decider_version: 'v1',
         result_count: 3,
         max_score: 4.5,
       )
@@ -231,6 +232,7 @@ RSpec.describe Search::Instrumentation do
         query: 'CBD oil',
         expand: true,
         reason: 'non_word_token',
+        decider_version: 'v1',
         result_count: 3,
         max_score: 4.5,
       )

--- a/spec/lib/search/logger_spec.rb
+++ b/spec/lib/search/logger_spec.rb
@@ -147,6 +147,7 @@ RSpec.describe Search::Logger do
         query: 'CBD oil',
         expand: true,
         reason: 'non_word_token',
+        decider_version: 'v1',
         result_count: 3,
         max_score: 4.5,
       }
@@ -157,6 +158,7 @@ RSpec.describe Search::Logger do
                       query: 'CBD oil',
                       expand: true,
                       reason: 'non_word_token',
+                      decider_version: 'v1',
                       result_count: 3,
                       max_score: 4.5 }
 
@@ -167,6 +169,7 @@ RSpec.describe Search::Logger do
       expect(json['query']).to eq('CBD oil')
       expect(json['expand']).to be(true)
       expect(json['reason']).to eq('non_word_token')
+      expect(json['decider_version']).to eq('v1')
       expect(json['result_count']).to eq(3)
       expect(json['max_score']).to eq(4.5)
     end

--- a/spec/lib/tasks/admin_configurations_rake_spec.rb
+++ b/spec/lib/tasks/admin_configurations_rake_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe 'admin_configurations:seed' do
     Rake::Task['admin_configurations:seed'].reenable
   end
 
-  it 'creates all 51 admin configurations', :aggregate_failures do
-    expect { seed }.to change(AdminConfiguration, :count).by(51)
+  it 'creates all 52 admin configurations', :aggregate_failures do
+    expect { seed }.to change(AdminConfiguration, :count).by(52)
 
     names = AdminConfiguration.order(:name).select_map(:name)
     expect(names).to eq(%w[
@@ -483,7 +483,7 @@ RSpec.describe 'admin_configurations:seed' do
   it 'patches existing configurations when their type changes' do
     create(:admin_configuration, name: 'description_intercept_templates', config_type: 'string', value: 'legacy')
 
-    expect { seed }.to change(AdminConfiguration, :count).by(50)
+    expect { seed }.to change(AdminConfiguration, :count).by(51)
     expect(AdminConfiguration.where(name: 'description_intercept_templates').first.config_type).to eq('object_template')
   end
 

--- a/spec/lib/tasks/admin_configurations_rake_spec.rb
+++ b/spec/lib/tasks/admin_configurations_rake_spec.rb
@@ -502,4 +502,28 @@ RSpec.describe 'admin_configurations:seed' do
     expect(config.description).to include('selected expansion strategy')
     expect(config.value).to be(false)
   end
+
+  it 'refreshes options without replacing an existing selected value' do
+    config = create(
+      :admin_configuration,
+      name: 'expand_search_decider',
+      config_type: 'options',
+      description: 'Legacy description',
+      value: {
+        'selected' => 'v2',
+        'options' => [{ 'key' => 'v1', 'label' => 'Legacy V1' }],
+      },
+    )
+    AdminConfiguration.where(id: config.id)
+      .update(value: Sequel.pg_jsonb_wrap('selected' => 'v2'))
+
+    seed
+
+    config = AdminConfiguration.where(name: 'expand_search_decider').first
+    expect(config.value['selected']).to eq('v2')
+    expect(config.value['options']).to eq([
+      { 'key' => 'v1', 'label' => 'V1: casing and retrieval evidence' },
+      { 'key' => 'v2', 'label' => 'V2: targeted synonyms and retrieval evidence' },
+    ])
+  end
 end

--- a/spec/lib/tasks/admin_configurations_rake_spec.rb
+++ b/spec/lib/tasks/admin_configurations_rake_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe 'admin_configurations:seed' do
       description_intercept_templates
       expand_model
       expand_query_context
+      expand_search_decider
       expand_search_enabled
       expand_search_min_results
       expand_search_min_score
@@ -215,10 +216,18 @@ RSpec.describe 'admin_configurations:seed' do
   it 'seeds conditional expansion controls', :aggregate_failures do
     seed
 
+    decider = AdminConfiguration.where(name: 'expand_search_decider').first
+    expect(decider.config_type).to eq('options')
+    expect(decider.value['selected']).to eq('v1')
+    expect(decider.value['options']).to eq([
+      { 'key' => 'v1', 'label' => 'V1: casing and retrieval evidence' },
+      { 'key' => 'v2', 'label' => 'V2: targeted synonyms and retrieval evidence' },
+    ])
+
     enabled = AdminConfiguration.where(name: 'expand_search_when_needed_enabled').first
     expect(enabled.config_type).to eq('boolean')
     expect(enabled.description).to include('When AI expansion is enabled')
-    expect(enabled.description).to include('acronym-like terms')
+    expect(enabled.description).to include('selected expansion strategy')
     expect(enabled.description).to include('no significant tagged words')
     expect(enabled.description).to include('too few results')
     expect(enabled.value).to be true
@@ -476,5 +485,21 @@ RSpec.describe 'admin_configurations:seed' do
 
     expect { seed }.to change(AdminConfiguration, :count).by(50)
     expect(AdminConfiguration.where(name: 'description_intercept_templates').first.config_type).to eq('object_template')
+  end
+
+  it 'refreshes descriptions without replacing an existing selected value' do
+    create(
+      :admin_configuration,
+      :boolean,
+      name: 'expand_search_when_needed_enabled',
+      description: 'Legacy description',
+      value: false,
+    )
+
+    seed
+
+    config = AdminConfiguration.where(name: 'expand_search_when_needed_enabled').first
+    expect(config.description).to include('selected expansion strategy')
+    expect(config.value).to be(false)
   end
 end

--- a/spec/models/admin_configuration_spec.rb
+++ b/spec/models/admin_configuration_spec.rb
@@ -493,6 +493,7 @@ RSpec.describe AdminConfiguration do
       expect(described_class.default_for('opensearch_result_limit')).to eq(50)
       expect(described_class.default_for('input_sanitiser_max_length')).to eq(1000)
       expect(described_class.default_for('expand_search_enabled')).to be(true)
+      expect(described_class.default_for('expand_search_decider')).to eq('v1')
       expect(described_class.default_for('expand_search_when_needed_enabled')).to be(true)
       expect(described_class.default_for('refine_search_with_answers_enabled')).to be(true)
     end
@@ -596,6 +597,7 @@ RSpec.describe AdminConfiguration do
     context 'when config record is missing' do
       it 'returns the default value' do
         expect(described_class.option_value('search_model')).to eq('gpt-5.4')
+        expect(described_class.option_value('expand_search_decider')).to eq('v1')
       end
     end
 

--- a/spec/services/api/internal/search_service_spec.rb
+++ b/spec/services/api/internal/search_service_spec.rb
@@ -64,6 +64,7 @@ RSpec.describe Api::Internal::SearchService do
         query: 'multimeter leads',
         skip_question: nil,
         configuration: hash_including(
+          expand_search_decider: 'v1',
           interactive_search_duplicate_question_guard_enabled: true,
           hybrid_query_guardrail_enabled: false,
           hybrid_query_guardrail_threshold: 32,
@@ -797,6 +798,37 @@ RSpec.describe Api::Internal::SearchService do
         expect(result[:data].first[:attributes][:goods_nomenclature_item_id]).to eq('3304990000')
       end
 
+      it 'uses lexical synonyms before retaining evidence-based AI fallback with the v2 decider' do
+        allow(AdminConfiguration).to receive(:option_value).with('expand_search_decider').and_return('v2')
+        allow(Search::SynonymExpander).to receive(:call) do |query|
+          query == 'CBD oil' ? 'CBD oil cannabidiol' : query
+        end
+        allow(Search::GoodsNomenclatureQuery).to receive(:new).and_call_original
+
+        described_class.new(q: 'CBD oil').call
+
+        expect(Search::GoodsNomenclatureQuery).to have_received(:new).with(
+          'CBD oil',
+          anything,
+          hash_including(expanded_query: 'CBD oil cannabidiol'),
+        )
+        expect(ExpandSearchQueryService).to have_received(:call).with('CBD oil', request_id: a_kind_of(String))
+        expect(Search::GoodsNomenclatureQuery).to have_received(:new).with(
+          'CBD oil',
+          anything,
+          hash_including(expanded_query: 'cannabidiol oil'),
+        )
+      end
+
+      it 'does not apply lexical synonyms with the v1 decider' do
+        allow(AdminConfiguration).to receive(:option_value).with('expand_search_decider').and_return('v1')
+        allow(Search::SynonymExpander).to receive(:call)
+
+        described_class.new(q: 'CBD oil').call
+
+        expect(Search::SynonymExpander).not_to have_received(:call)
+      end
+
       context 'when expansion returns the original query' do
         before do
           allow(ExpandSearchQueryService).to receive(:call)
@@ -1406,6 +1438,28 @@ RSpec.describe Api::Internal::SearchService do
               max_score: 250.0,
             ),
           )
+        end
+
+        context 'with the v2 decider' do
+          before do
+            allow(AdminConfiguration).to receive(:option_value).with('expand_search_decider').and_return('v2')
+            allow(Search::SynonymExpander).to receive(:call)
+              .with('horses')
+              .and_return('horses equines')
+          end
+
+          it 'passes targeted synonyms to the lexical leg without changing the semantic query' do
+            described_class.new(q: 'horses').call
+
+            expect(HybridRetrievalService).to have_received(:call).with(
+              hash_including(
+                query: 'horses',
+                expanded_query: 'horses',
+                lexical_query: 'horses equines',
+              ),
+            )
+            expect(ExpandSearchQueryService).not_to have_received(:call)
+          end
         end
 
         context 'when source retrieval results contain duplicate goods nomenclatures' do

--- a/spec/services/api/internal/search_service_spec.rb
+++ b/spec/services/api/internal/search_service_spec.rb
@@ -735,6 +735,15 @@ RSpec.describe Api::Internal::SearchService do
 
         expect(ExpandSearchQueryService).not_to have_received(:call)
       end
+
+      it 'does not apply retrieval synonyms with the v2 decider' do
+        allow(AdminConfiguration).to receive(:option_value).with('expand_search_decider').and_return('v2')
+        allow(Search::SynonymExpander).to receive(:call)
+
+        described_class.new(q: 'laptop').call
+
+        expect(Search::SynonymExpander).not_to have_received(:call)
+      end
     end
 
     context 'when expand_search_enabled is true' do

--- a/spec/services/api/internal/search_service_spec.rb
+++ b/spec/services/api/internal/search_service_spec.rb
@@ -77,6 +77,18 @@ RSpec.describe Api::Internal::SearchService do
       expect(captured_configuration.fetch(:hybrid_query_guardrail_enabled)).to be(false)
     end
 
+    it 'reports the effective decider when the configured version is invalid' do
+      allow(AdminConfiguration).to receive(:option_value).with('expand_search_decider').and_return('unknown')
+      allow(Search::Instrumentation).to receive(:interactive_configuration_used)
+      allow(TradeTariffBackend.search_client).to receive(:search).and_return({ 'hits' => { 'hits' => [] } })
+
+      described_class.new(q: 'multimeter leads').call
+
+      expect(Search::Instrumentation).to have_received(:interactive_configuration_used).with(
+        hash_including(configuration: hash_including(expand_search_decider: 'v1')),
+      )
+    end
+
     context 'when exact match via search_reference suggestion' do
       let!(:heading) do
         create(:heading, :with_description,
@@ -798,7 +810,7 @@ RSpec.describe Api::Internal::SearchService do
         expect(result[:data].first[:attributes][:goods_nomenclature_item_id]).to eq('3304990000')
       end
 
-      it 'uses lexical synonyms before retaining evidence-based AI fallback with the v2 decider' do
+      it 'uses retrieval synonyms before retaining evidence-based AI fallback with the v2 decider' do
         allow(AdminConfiguration).to receive(:option_value).with('expand_search_decider').and_return('v2')
         allow(Search::SynonymExpander).to receive(:call) do |query|
           query == 'CBD oil' ? 'CBD oil cannabidiol' : query
@@ -820,7 +832,7 @@ RSpec.describe Api::Internal::SearchService do
         )
       end
 
-      it 'does not apply lexical synonyms with the v1 decider' do
+      it 'does not apply retrieval synonyms with the v1 decider' do
         allow(AdminConfiguration).to receive(:option_value).with('expand_search_decider').and_return('v1')
         allow(Search::SynonymExpander).to receive(:call)
 
@@ -1306,6 +1318,22 @@ RSpec.describe Api::Internal::SearchService do
         )
       end
 
+      it 'applies v2 synonyms to vector retrieval while preserving the semantic query' do
+        allow(AdminConfiguration).to receive(:option_value).with('expand_search_decider').and_return('v2')
+        allow(Search::SynonymExpander).to receive(:call)
+          .with('pure-bred breeding horses')
+          .and_return('pure-bred breeding horses equines')
+
+        described_class.new(q: 'horses').call
+
+        expect(VectorRetrievalService).to have_received(:call).with(
+          hash_including(query: 'pure-bred breeding horses equines'),
+        )
+        expect(InteractiveSearchService).to have_received(:call).with(
+          hash_including(expanded_query: 'pure-bred breeding horses'),
+        )
+      end
+
       it 'does not call OpenSearch' do
         allow(TradeTariffBackend.search_client).to receive(:search)
 
@@ -1448,14 +1476,14 @@ RSpec.describe Api::Internal::SearchService do
               .and_return('horses equines')
           end
 
-          it 'passes targeted synonyms to the lexical leg without changing the semantic query' do
+          it 'passes targeted synonyms to both retrieval legs without changing the semantic query' do
             described_class.new(q: 'horses').call
 
             expect(HybridRetrievalService).to have_received(:call).with(
               hash_including(
                 query: 'horses',
                 expanded_query: 'horses',
-                lexical_query: 'horses equines',
+                retrieval_query: 'horses equines',
               ),
             )
             expect(ExpandSearchQueryService).not_to have_received(:call)

--- a/spec/services/hybrid_retrieval_service_spec.rb
+++ b/spec/services/hybrid_retrieval_service_spec.rb
@@ -76,6 +76,30 @@ RSpec.describe HybridRetrievalService do
       )
     end
 
+    it 'uses a separate lexical query for OpenSearch while preserving the semantic vector query' do
+      as_of = Time.zone.today
+      lexical_query = 'HEPA filter high efficiency particulate air filter'
+
+      result = described_class.call(
+        query: 'HEPA filter',
+        expanded_query: 'HEPA filter',
+        lexical_query: lexical_query,
+        as_of: as_of,
+      )
+
+      expect(OpensearchRetrievalService).to have_received(:call).with(
+        query: 'HEPA filter', expanded_query: lexical_query, as_of: as_of, request_id: nil, limit: 30,
+      )
+      expect(VectorRetrievalService).to have_received(:call).with(query: 'HEPA filter', limit: 30, request_id: nil)
+      expect(result.expanded_query).to eq('HEPA filter')
+      expect(Search::Instrumentation).to have_received(:retrieval_results_returned).with(
+        hash_including(stage: 'before_rrf', leg: :opensearch, effective_query: lexical_query),
+      )
+      expect(Search::Instrumentation).to have_received(:retrieval_results_returned).with(
+        hash_including(stage: 'before_rrf', leg: :vector, effective_query: 'HEPA filter'),
+      )
+    end
+
     it 'passes filter prefixes to both retrieval legs' do
       as_of = Time.zone.today
 

--- a/spec/services/hybrid_retrieval_service_spec.rb
+++ b/spec/services/hybrid_retrieval_service_spec.rb
@@ -76,27 +76,27 @@ RSpec.describe HybridRetrievalService do
       )
     end
 
-    it 'uses a separate lexical query for OpenSearch while preserving the semantic vector query' do
+    it 'uses the synonym-expanded query for both retrieval legs while preserving the semantic query' do
       as_of = Time.zone.today
-      lexical_query = 'HEPA filter high efficiency particulate air filter'
+      retrieval_query = 'HEPA filter high efficiency particulate air filter'
 
       result = described_class.call(
         query: 'HEPA filter',
         expanded_query: 'HEPA filter',
-        lexical_query: lexical_query,
+        retrieval_query: retrieval_query,
         as_of: as_of,
       )
 
       expect(OpensearchRetrievalService).to have_received(:call).with(
-        query: 'HEPA filter', expanded_query: lexical_query, as_of: as_of, request_id: nil, limit: 30,
+        query: 'HEPA filter', expanded_query: retrieval_query, as_of: as_of, request_id: nil, limit: 30,
       )
-      expect(VectorRetrievalService).to have_received(:call).with(query: 'HEPA filter', limit: 30, request_id: nil)
+      expect(VectorRetrievalService).to have_received(:call).with(query: retrieval_query, limit: 30, request_id: nil)
       expect(result.expanded_query).to eq('HEPA filter')
       expect(Search::Instrumentation).to have_received(:retrieval_results_returned).with(
-        hash_including(stage: 'before_rrf', leg: :opensearch, effective_query: lexical_query),
+        hash_including(stage: 'before_rrf', leg: :opensearch, effective_query: retrieval_query),
       )
       expect(Search::Instrumentation).to have_received(:retrieval_results_returned).with(
-        hash_including(stage: 'before_rrf', leg: :vector, effective_query: 'HEPA filter'),
+        hash_including(stage: 'before_rrf', leg: :vector, effective_query: retrieval_query),
       )
     end
 

--- a/spec/services/hybrid_retrieval_service_spec.rb
+++ b/spec/services/hybrid_retrieval_service_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe HybridRetrievalService do
       expect(OpensearchRetrievalService).to have_received(:call).with(
         query: 'HEPA filter', expanded_query: retrieval_query, as_of: as_of, request_id: nil, limit: 30,
       )
-      expect(VectorRetrievalService).to have_received(:call).with(query: retrieval_query, limit: 30, request_id: nil)
+      expect(VectorRetrievalService).to have_received(:call_with_diagnostics).with(query: retrieval_query, limit: 30, request_id: nil)
       expect(result.expanded_query).to eq('HEPA filter')
       expect(Search::Instrumentation).to have_received(:retrieval_results_returned).with(
         hash_including(stage: 'before_rrf', leg: :opensearch, effective_query: retrieval_query),

--- a/spec/services/search/synonym_expander_spec.rb
+++ b/spec/services/search/synonym_expander_spec.rb
@@ -48,4 +48,42 @@ RSpec.describe Search::SynonymExpander do
     expect(described_class.call('replacement HEPA filter'))
       .to eq('replacement HEPA filter high efficiency particulate air filter')
   end
+
+  it 'parses each rules file once when requests initialise it concurrently' do
+    source_class = Class.new do
+      attr_reader :reads
+
+      def initialize(path)
+        @path = path
+        @reads = 0
+        @mutex = Mutex.new
+      end
+
+      def to_s
+        'concurrent-search-synonyms'
+      end
+
+      def each_line
+        @mutex.synchronize { @reads += 1 }
+        sleep(0.01)
+        @path.each_line
+      end
+    end
+    rules_source = source_class.new(rules_path)
+    ready = Queue.new
+    start = Queue.new
+
+    threads = Array.new(8) do
+      Thread.new do
+        ready << true
+        start.pop
+        described_class.call('HEPA filter', rules_path: rules_source)
+      end
+    end
+    8.times { ready.pop }
+    8.times { start << true }
+
+    expect(threads.map(&:value)).to all(include('high efficiency particulate air filter'))
+    expect(rules_source.reads).to eq(1)
+  end
 end

--- a/spec/services/search/synonym_expander_spec.rb
+++ b/spec/services/search/synonym_expander_spec.rb
@@ -1,0 +1,51 @@
+RSpec.describe Search::SynonymExpander do
+  let(:rules_path) { Rails.root.join('spec/fixtures/files/search_synonyms.txt') }
+
+  it 'appends directional alternatives while preserving the original phrase' do
+    query = 'Replacement HEPA filter unit'
+
+    expect(described_class.call(query, rules_path:)).to eq('Replacement HEPA filter unit high efficiency particulate air filter')
+  end
+
+  it 'matches phrases case-insensitively' do
+    query = 'replacement hepa FILTER'
+
+    expect(described_class.call(query, rules_path:)).to eq('replacement hepa FILTER high efficiency particulate air filter')
+  end
+
+  it 'expands equivalent terms in either direction' do
+    expect(described_class.call('TV stand', rules_path:)).to eq('TV stand television')
+    expect(described_class.call('television stand', rules_path:)).to eq('television stand TV')
+  end
+
+  it 'matches only complete terms' do
+    query = 'preHEPA filter unit'
+
+    expect(described_class.call(query, rules_path:)).to eq(query)
+  end
+
+  it 'does not append an alternative already present in the query' do
+    query = 'HEPA filter high efficiency particulate air filter'
+
+    expect(described_class.call(query, rules_path:)).to eq(query)
+  end
+
+  it 'treats identity mappings as no-ops' do
+    query = 'LED screen'
+
+    expect(described_class.call(query, rules_path:)).to eq(query)
+  end
+
+  it 'rejects malformed directional rules with their line number' do
+    invalid_rules_path = Rails.root.join('spec/fixtures/files/invalid_search_synonyms.txt')
+
+    expect {
+      described_class.call('HEPA filter', rules_path: invalid_rules_path)
+    }.to raise_error(described_class::InvalidRule, /line 1/)
+  end
+
+  it 'loads the production rules file by default' do
+    expect(described_class.call('replacement HEPA filter'))
+      .to eq('replacement HEPA filter high efficiency particulate air filter')
+  end
+end

--- a/spec/services/search/synonym_expander_spec.rb
+++ b/spec/services/search/synonym_expander_spec.rb
@@ -49,6 +49,35 @@ RSpec.describe Search::SynonymExpander do
       .to eq('replacement HEPA filter high efficiency particulate air filter')
   end
 
+  describe 'reviewed production rules' do
+    {
+      'robotic vacum cleaner with mop function' =>
+        'robotic vacum cleaner with mop function vacuum cleaner',
+      'vermeil ring' =>
+        'vermeil ring gold plated silver ring',
+      'vermeil necklace' =>
+        'vermeil necklace gold plated silver necklace',
+      'Invisalign system comprehensive' =>
+        'Invisalign system comprehensive clear dental aligner',
+      'ClearCorrect aligner' =>
+        'ClearCorrect aligner clear dental aligner',
+      'Vivera retainers' =>
+        'Vivera retainers orthodontic retainer orthopaedic appliance',
+      'PTCA dilatation catheter' =>
+        'PTCA dilatation catheter percutaneous transluminal coronary angioplasty catheter',
+      'Cricut Joy Xtra' =>
+        'Cricut Joy Xtra electronic cutting machine',
+      'Denon Perl' =>
+        'Denon Perl wireless earbuds',
+      'Ledger Flex' =>
+        'Ledger Flex hardware wallet',
+    }.each do |query, expanded_query|
+      it "expands #{query}" do
+        expect(described_class.call(query)).to eq(expanded_query)
+      end
+    end
+  end
+
   it 'parses each rules file once when requests initialise it concurrently' do
     source_class = Class.new do
       attr_reader :reads

--- a/spec/services/search_expansion_decision_service_spec.rb
+++ b/spec/services/search_expansion_decision_service_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe SearchExpansionDecisionService do
   before do
     allow(AdminConfiguration).to receive(:enabled?).and_call_original
     allow(AdminConfiguration).to receive(:integer_value).and_call_original
+    allow(AdminConfiguration).to receive(:option_value).and_call_original
     allow(Search::Instrumentation).to receive(:query_expansion_decided).and_call_original
   end
 
@@ -50,6 +51,35 @@ RSpec.describe SearchExpansionDecisionService do
     end
 
     it 'expands acronym-like query tokens' do
+      allow(AdminConfiguration).to receive(:option_value).with('expand_search_decider').and_return('v1')
+
+      result = described_class.call(query: 'CBD oil', results: results, request_id: 'req-1')
+
+      expect(result.expand?).to be(true)
+      expect(result.reason).to eq('non_word_token')
+    end
+
+    it 'does not use casing as an expansion reason with the v2 decider' do
+      allow(AdminConfiguration).to receive(:option_value).with('expand_search_decider').and_return('v2')
+
+      result = described_class.call(query: 'CBD oil', results: results, request_id: 'req-1')
+
+      expect(result.expand?).to be(false)
+      expect(result.reason).to eq('sufficient_results')
+    end
+
+    it 'still expands weak uppercase queries with the v2 decider' do
+      allow(AdminConfiguration).to receive(:option_value).with('expand_search_decider').and_return('v2')
+
+      result = described_class.call(query: 'CBD oil', results: [build_result(score: 12.5)], request_id: 'req-1')
+
+      expect(result.expand?).to be(true)
+      expect(result.reason).to eq('low_result_count')
+    end
+
+    it 'falls back to the v1 decider for an unknown configured version' do
+      allow(AdminConfiguration).to receive(:option_value).with('expand_search_decider').and_return('unknown')
+
       result = described_class.call(query: 'CBD oil', results: results, request_id: 'req-1')
 
       expect(result.expand?).to be(true)
@@ -98,6 +128,7 @@ RSpec.describe SearchExpansionDecisionService do
         query: 'laptop',
         expand: false,
         reason: 'sufficient_results',
+        decider_version: 'v1',
         result_count: 5,
         max_score: 12.5,
       )


### PR DESCRIPTION
## What:

- [x] Add an admin-selectable `v1` and `v2` query-expansion decider.
- [x] Keep `v1` as the seeded default, preserving current production behaviour.
- [x] Make `v2` apply contextual synonyms to OpenSearch and vector retrieval, then decide AI expansion from retrieval evidence without using casing.
- [x] Keep the original or AI-expanded semantic query for interactive questioning.
- [x] Record the effective decider and each hybrid leg's effective retrieval query for comparison.
- [x] Fall back consistently to `v1` when a stored decider value is invalid.
- [x] Keep all AI and synonym expansion behind the existing `expand_search_enabled` master switch.
- [x] Add reviewed contextual rules for `vacum cleaner`, vermeil rings/necklaces, Invisalign, ClearCorrect, Vivera, PTCA dilatation, Cricut Joy Xtra, Denon Perl, and Ledger Flex.
- [x] Cover every new production rule in `Search::SynonymExpander` specs.

```mermaid
flowchart TD
    INPUT[Semantic query]
    SYNONYMS[Targeted synonyms]
    RETRIEVAL[Retrieval query]
    OPENSEARCH[OpenSearch leg]
    VECTOR[Vector leg]
    FUSION[Hybrid results]
    EVIDENCE{Retrieval strong?}
    AI[AI expansion]
    INTERACTIVE[Interactive questions]

    INPUT --> SYNONYMS
    SYNONYMS --> RETRIEVAL
    RETRIEVAL --> OPENSEARCH
    RETRIEVAL --> VECTOR
    OPENSEARCH --> FUSION
    VECTOR --> FUSION
    FUSION --> EVIDENCE
    EVIDENCE -->|Yes| INTERACTIVE
    EVIDENCE -->|No| AI
    AI --> SYNONYMS
    INPUT -. semantic context .-> INTERACTIVE
```

## Why:

Uppercase text currently selects AI expansion even when retrieval is already strong. The versioned strategy lets us test targeted mechanical synonyms across both retrieval methods before applying the existing result-count, score, and significant-word heuristics. AI expansion remains the fallback for weak retrieval, with its existing five-second deadline.

The synonym review used the AI-1080 ticket and reports, the guided-search test spreadsheet, tariff descriptions/self-texts/labels, official product or terminology sources, and 23,237,753 FPO rows across 14 monthly files. The FPO funnel contained 7,930,223 normalised descriptions, 27,931 recurring phrase gaps, and 3,134 candidate phrases whose vocabulary was absent from the dominant heading's search text.

FPO commodity codes were not used as evaluation labels. They are often incorrectly selected and can be wrong at chapter or heading level. Code frequency and concentration were used only to triage a very large vocabulary dataset and find recurring declaration language worth reviewing. The rules themselves were accepted from the meaning of the declaration text, its gap from current tariff search language, official product or terminology sources, and manual inspection of the resulting searches.

The seven FPO-derived rules occur across 10,138 normalised description variants representing 81,834 declaration events. Those figures describe corpus coverage, not classification accuracy or search relevance. The spreadsheet and vermeil rules occur across another 113 reviewed variants.

Broad alternatives were excluded where the language or returned results were ambiguous, including generic `vermeil`, `Invisalign`, `Cricut Joy`, `ski goggles`, `tote`, `DMF`, and `CSC`. Those need more context, exclusions, or a richer rule format rather than a flat synonym entry.

Deployment does not activate the new behaviour. The seeded default remains `v1`; administrators must explicitly select experimental `v2`. The existing `expand_search_enabled` switch disables both AI and synonym expansion, and selecting `v1` is the strategy rollback.

## Ticket:

https://transformuk.atlassian.net/browse/AI-1080

## Risk:

**Risk level:** 🟢

**Reason for rating:** Deployment keeps the existing `v1` behaviour. The experimental `v2` strategy is off by default, requires explicit selection for evaluation, remains behind the existing master switch, and can be rolled back immediately by selecting `v1`.