### PR TITLE
Make database replication atomic and restartable

### DIFF
--- a/bin/after.sql
+++ b/bin/after.sql
@@ -230,7 +230,11 @@ BEGIN
     RAISE NOTICE 'Total runtime: %', formatted_duration;
     RAISE NOTICE 'Successfully refreshed: % views', success_count;
     RAISE NOTICE 'Failed refreshes: % views', failure_count;
-    RAISE NOTICE 'Success rate: %', round((success_count::numeric / total_views * 100), 1) || '%';
+    RAISE NOTICE 'Success rate: %',
+        CASE
+            WHEN total_views = 0 THEN 'N/A'
+            ELSE round((success_count::numeric / total_views * 100), 1) || '%'
+        END;
 
     IF failure_count > 0 THEN
         RAISE NOTICE 'Failed views: %', array_to_string(failed_views, ', ');

--- a/bin/backup-database
+++ b/bin/backup-database
@@ -29,12 +29,14 @@ today="s3://$S3_BUCKET/$(date +"%Y/%m/%d")/tariff-merged-${ENVIRONMENT}.sql.gz"
     --no-acl            \
     --no-owner          \
     --clean             \
+    --if-exists         \
     --verbose | \
     sed -e '/^REFRESH MATERIALIZED VIEW/d' \
         -e 's/^SET client_min_messages = warning;$/SET client_min_messages = notice;/' \
         -e '/^\\restrict /d' \
         -e '/^\\unrestrict /d' \
         -e 's/^DROP SCHEMA \(.*\);$/DROP SCHEMA IF EXISTS \1 CASCADE;/'
+  printf '\n-- TRADE_TARIFF_POST_RESTORE_START\n'
   cat "$(dirname "$0")/after.sql"
 } |
   gzip |

--- a/bin/db-replicate
+++ b/bin/db-replicate
@@ -18,6 +18,8 @@ declare -A ACCOUNT_IDS=(
 RETRY_MAX_ATTEMPTS=${RETRY_MAX_ATTEMPTS:-6}
 RETRY_INITIAL_DELAY_SECONDS=${RETRY_INITIAL_DELAY_SECONDS:-5}
 SERVICES_STOPPED=false
+RESTORE_PHASE=before_restore
+REPLICATION_LOCK_PID=
 
 require_env() {
     local missing=false
@@ -160,11 +162,52 @@ set_desired_count_for_service_to() {
         set_desired_count_for_service_to_once "$service" "$desired_count"
 }
 
-restart_stopped_services_on_failure() {
+release_replication_lock() {
+    if [ -n "$REPLICATION_LOCK_PID" ]; then
+        kill "$REPLICATION_LOCK_PID" 2>/dev/null || true
+        wait "$REPLICATION_LOCK_PID" 2>/dev/null || true
+        REPLICATION_LOCK_PID=
+    fi
+}
+
+acquire_replication_lock() {
+    local acquired
+    local lock_query
+
+    lock_query="SELECT pg_try_advisory_lock(hashtextextended('trade-tariff-database-replication', 0));"
+
+    coproc REPLICATION_LOCK {
+        psql -X -qAt "$DATABASE_URL"
+    }
+
+    printf '%s\n' "$lock_query" >&"${REPLICATION_LOCK[1]}"
+
+    if ! IFS= read -r acquired <&"${REPLICATION_LOCK[0]}"; then
+        echo "Failed to acquire the database replication lock." >&2
+        release_replication_lock
+        return 1
+    fi
+
+    if [ "$acquired" != "t" ]; then
+        echo "Another database replication is already running." >&2
+        release_replication_lock
+        return 1
+    fi
+}
+
+cleanup_on_exit() {
     local status=$?
 
+    trap - EXIT
+    release_replication_lock
+
     if [ "$status" -ne 0 ] && [ "$SERVICES_STOPPED" = true ]; then
-        echo "Replication failed. Starting stopped services before exiting." >&2
+        if [ "$RESTORE_PHASE" = "post_restore" ]; then
+            echo "Post-restore maintenance failed after the core database committed. Leaving services stopped." >&2
+            exit "$status"
+        fi
+
+        echo "Replication failed before post-restore maintenance committed. Starting stopped services before exiting." >&2
 
         if ! start_services; then
             echo "Failed to restart all stopped services after replication failure." >&2
@@ -174,7 +217,7 @@ restart_stopped_services_on_failure() {
     exit "$status"
 }
 
-trap restart_stopped_services_on_failure EXIT
+trap cleanup_on_exit EXIT
 
 stop_services() {
   local desired_count
@@ -209,10 +252,41 @@ download_database_dump_once() {
     "$DB_DUMP_SERVER""$RESTORE_FILE"
 }
 
-restore_database_dump_once() {
+stream_core_database_dump() {
   local dump_file=$1
 
-  gzip -dc "$dump_file" | psql --single-transaction -v ON_ERROR_STOP=1 "$DATABASE_URL"
+  gzip -dc "$dump_file" |
+    awk '
+      /^-- TRADE_TARIFF_POST_RESTORE_START$/ {
+        post_restore = 1
+        next
+      }
+
+      !post_restore && /^VACUUM FULL ANALYZE;$/ {
+        post_restore = 1
+      }
+
+      !post_restore &&
+      /^DROP EVENT TRIGGER / &&
+      !/^DROP EVENT TRIGGER IF EXISTS / {
+        sub(/^DROP EVENT TRIGGER /, "DROP EVENT TRIGGER IF EXISTS ")
+      }
+
+      !post_restore {
+        print
+      }
+    '
+}
+
+restore_core_database_dump() {
+  local dump_file=$1
+
+  stream_core_database_dump "$dump_file" |
+    psql --single-transaction -v ON_ERROR_STOP=1 "$DATABASE_URL"
+}
+
+run_post_restore_maintenance() {
+  psql -v ON_ERROR_STOP=1 "$DATABASE_URL" < "$(dirname "$0")/after.sql"
 }
 
 cleanup_dump_file() {
@@ -234,13 +308,25 @@ restore_database() {
     return "$status"
   }
 
-  retry_command "Restore database" restore_database_dump_once "$dump_file" || {
+  RESTORE_PHASE=core_restore
+
+  restore_core_database_dump "$dump_file" || {
     status=$?
     cleanup_dump_file "$dump_file" || \
       echo "Failed to remove temporary database dump $dump_file." >&2
     return "$status"
   }
 
+  RESTORE_PHASE=post_restore
+
+  run_post_restore_maintenance || {
+    status=$?
+    cleanup_dump_file "$dump_file" || \
+      echo "Failed to remove temporary database dump $dump_file." >&2
+    return "$status"
+  }
+
+  RESTORE_PHASE=ready
   cleanup_dump_file "$dump_file"
 }
 
@@ -296,6 +382,9 @@ sync_delta_files() {
   retry_command "Sync cds delta files from $1 to $2" \
     aws s3 sync "$source_bucket/data/cds/" "$target_bucket/data/cds/"
 }
+
+echo "Acquiring database replication lock"
+acquire_replication_lock
 
 echo "Stopping services $SERVICES"
 stop_services

--- a/spec/bin/database_replication_integration_spec.rb
+++ b/spec/bin/database_replication_integration_spec.rb
@@ -1,0 +1,312 @@
+# frozen_string_literal: true
+
+require 'open3'
+require 'securerandom'
+require 'tmpdir'
+require 'zlib'
+
+RSpec.describe 'database replication with PostgreSQL' do
+  attr_reader :backup_script,
+              :command_log,
+              :database_user,
+              :dump_file,
+              :real_psql,
+              :replicate_script,
+              :target_database,
+              :tempdir
+
+  def run_command(*command, stdin_data: '')
+    stdout, stderr, status = Open3.capture3(*command, stdin_data:)
+    raise "#{command.join(' ')} failed:\n#{stdout}\n#{stderr}" unless status.success?
+
+    stdout
+  end
+
+  def psql(database, sql)
+    run_command('psql', '-X', '--username', database_user, '-v', 'ON_ERROR_STOP=1', '-q', database, '-c', sql)
+  end
+
+  def query(database, sql)
+    run_command('psql', '-X', '--username', database_user, '-Atq', database, '-c', sql).strip
+  end
+
+  def write_executable(name, contents)
+    path = File.join(tempdir, 'bin', name)
+    File.write(path, contents)
+    File.chmod(0o755, path)
+  end
+
+  def create_target_database
+    run_command('createdb', '--username', database_user, target_database)
+
+    psql(target_database, <<~SQL)
+      CREATE TABLE restore_probe(value text);
+      INSERT INTO restore_probe VALUES ('old');
+      CREATE MATERIALIZED VIEW restore_probe_view AS
+        SELECT value FROM restore_probe;
+      CREATE FUNCTION noop_event_trigger() RETURNS event_trigger
+        LANGUAGE plpgsql AS $$ BEGIN END; $$;
+      CREATE EVENT TRIGGER reassign_owned
+        ON ddl_command_end EXECUTE FUNCTION noop_event_trigger();
+    SQL
+  end
+
+  def build_dump(sql_transform: nil, include_materialized_view: true)
+    materialized_view_drop_sql = 'DROP MATERIALIZED VIEW restore_probe_view;' if include_materialized_view
+    materialized_view_create_sql = if include_materialized_view
+                                     <<~SQL
+                                       CREATE MATERIALIZED VIEW restore_probe_view AS
+                                         SELECT value FROM restore_probe WITH NO DATA;
+                                     SQL
+                                   end
+
+    dump = <<~SQL
+      SET client_min_messages = warning;
+
+      DROP EVENT TRIGGER reassign_owned;
+      #{materialized_view_drop_sql}
+      DROP TABLE restore_probe;
+      DROP FUNCTION noop_event_trigger();
+
+      CREATE TABLE restore_probe(value text);
+      INSERT INTO restore_probe VALUES ('new');
+      #{materialized_view_create_sql}
+      CREATE FUNCTION noop_event_trigger() RETURNS event_trigger
+        LANGUAGE plpgsql AS $$ BEGIN END; $$;
+      CREATE EVENT TRIGGER reassign_owned
+        ON ddl_command_end EXECUTE FUNCTION noop_event_trigger();
+    SQL
+    dump = sql_transform.call(dump) if sql_transform
+    dump += Rails.root.join('bin/after.sql').read
+
+    Zlib::GzipWriter.open(dump_file) { |gzip| gzip.write(dump) }
+  end
+
+  def install_replication_boundary_stubs
+    FileUtils.mkdir_p(File.join(tempdir, 'bin'))
+    FileUtils.touch(command_log)
+
+    write_executable('aws', <<~'BASH')
+      #!/usr/bin/env bash
+      set -euo pipefail
+      echo "aws $*" >> "$TMPDIR/commands.log"
+
+      if [[ "$1 $2" == "ecs describe-services" ]]; then
+        echo 1
+      fi
+    BASH
+
+    write_executable('curl', <<~'BASH')
+      #!/usr/bin/env bash
+      set -euo pipefail
+      echo "curl $*" >> "$TMPDIR/commands.log"
+
+      while [[ $# -gt 0 ]]; do
+        if [[ "$1" == "--output" ]]; then
+          cp "$DUMP_FIXTURE" "$2"
+          exit 0
+        fi
+        shift
+      done
+
+      exit 1
+    BASH
+
+    write_executable('psql', <<~'BASH')
+      #!/usr/bin/env bash
+      set -euo pipefail
+      echo "psql $*" >> "$TMPDIR/commands.log"
+      exec "$REAL_PSQL" "$@"
+    BASH
+  end
+
+  def run_replication
+    env = {
+      'PATH' => "#{tempdir}/bin:#{ENV.fetch('PATH')}",
+      'TMPDIR' => tempdir,
+      'REAL_PSQL' => real_psql,
+      'DUMP_FIXTURE' => dump_file,
+      'ENVIRONMENT' => 'development',
+      'CLUSTER_NAME' => 'test-cluster',
+      'SERVICES' => 'backend-web backend-worker',
+      'DB_DUMP_USER' => 'dump-user',
+      'DB_DUMP_PASSWORD' => 'dump-password',
+      'DB_DUMP_SERVER' => 'https://dumps.example.test',
+      'RESTORE_FILE' => '/tariff.sql.gz',
+      'DATABASE_URL' => target_database,
+      'PGUSER' => database_user,
+      'RETRY_MAX_ATTEMPTS' => '2',
+      'RETRY_INITIAL_DELAY_SECONDS' => '1',
+    }
+
+    Open3.capture3(env, replicate_script, chdir: Rails.root.to_s)
+  end
+
+  before do
+    @replicate_script = Rails.root.join('bin/db-replicate').to_s
+    @backup_script = Rails.root.join('bin/backup-database').to_s
+    @target_database = "replication_target_#{SecureRandom.hex(6)}"
+    @tempdir = Dir.mktmpdir
+    @command_log = File.join(tempdir, 'commands.log')
+    @dump_file = File.join(tempdir, 'production.sql.gz')
+    @database_user = [ENV['PGUSER'], ENV['DB_USER'], ENV['USER'], 'postgres']
+                       .compact
+                       .uniq
+                       .find do |candidate|
+      _stdout, _stderr, status = Open3.capture3(
+        'psql',
+        '-X',
+        '--username',
+        candidate,
+        '-d',
+        'postgres',
+        '-Atqc',
+        'SELECT 1',
+      )
+      status.success?
+    end
+    @real_psql = ENV.fetch('PATH')
+                      .split(File::PATH_SEPARATOR)
+                      .map { |directory| File.join(directory, 'psql') }
+                      .find { |path| File.executable?(path) }
+
+    create_target_database
+  end
+
+  after do
+    run_command('dropdb', '--username', database_user, '--if-exists', '--force', target_database)
+    FileUtils.remove_entry(tempdir)
+  end
+
+  it 'restores a legacy production-shaped dump and completes post-restore maintenance' do
+    psql(target_database, 'DROP EVENT TRIGGER reassign_owned')
+    build_dump
+    install_replication_boundary_stubs
+
+    _stdout, stderr, status = run_replication
+
+    expect(status).to be_success, stderr
+    expect(query(target_database, 'TABLE restore_probe')).to eq('new')
+    expect(query(target_database, 'TABLE restore_probe_view')).to eq('new')
+    expect(query(target_database, <<~SQL)).to eq('1')
+      SELECT count(*) FROM pg_event_trigger WHERE evtname = 'reassign_owned'
+    SQL
+    expect(query(target_database, <<~SQL)).to eq('t')
+      SELECT pg_try_advisory_lock(
+        hashtextextended('trade-tariff-database-replication', 0)
+      )
+    SQL
+  end
+
+  it 'completes post-restore maintenance when there are no materialized views' do
+    psql(target_database, 'DROP MATERIALIZED VIEW restore_probe_view')
+    build_dump(include_materialized_view: false)
+    install_replication_boundary_stubs
+
+    _stdout, stderr, status = run_replication
+
+    expect(status).to be_success, stderr
+    expect(query(target_database, 'TABLE restore_probe')).to eq('new')
+  end
+
+  it 'rolls back destructive statements and does not retry a deterministic SQL failure' do
+    build_dump(
+      sql_transform: lambda { |dump|
+        dump.sub(
+          "DROP EVENT TRIGGER reassign_owned;\n",
+          "DROP EVENT TRIGGER reassign_owned;\nSELECT 1 / 0;\n",
+        )
+      },
+    )
+    install_replication_boundary_stubs
+
+    _stdout, _stderr, status = run_replication
+
+    expect(status).not_to be_success
+    expect(query(target_database, 'TABLE restore_probe')).to eq('old')
+    expect(query(target_database, <<~SQL)).to eq('1')
+      SELECT count(*) FROM pg_event_trigger WHERE evtname = 'reassign_owned'
+    SQL
+    core_restores = File.readlines(command_log).grep(/psql --single-transaction/)
+    expect(core_restores.length).to eq(1)
+    expect(File.readlines(command_log).grep(/aws ecs update-service .*--desired-count 1/).length).to eq(2)
+  end
+
+  it 'does not mutate services or the target when another replication holds the lock' do
+    build_dump
+    install_replication_boundary_stubs
+
+    Open3.popen3(
+      real_psql,
+      '-X',
+      '--username',
+      database_user,
+      '-qAt',
+      target_database,
+    ) do |stdin, stdout, _stderr, wait_thread|
+      stdin.puts <<~SQL
+        SELECT pg_try_advisory_lock(
+          hashtextextended('trade-tariff-database-replication', 0)
+        );
+      SQL
+      stdin.flush
+      expect(stdout.gets&.strip).to eq('t')
+
+      _replication_stdout, replication_stderr, status = run_replication
+
+      expect(status).not_to be_success
+      expect(replication_stderr).to include('Another database replication is already running')
+      expect(File.readlines(command_log).grep(/aws ecs/)).to be_empty
+      expect(query(target_database, 'TABLE restore_probe')).to eq('old')
+
+      stdin.close
+      Process.kill('TERM', wait_thread.pid) if wait_thread.alive?
+    end
+  end
+
+  it 'emits a restartable dump with an explicit maintenance boundary' do
+    FileUtils.mkdir_p(File.join(tempdir, 'bin'))
+
+    write_executable('pg_dump', <<~'BASH')
+      #!/usr/bin/env bash
+      set -euo pipefail
+
+      if [[ " $* " != *" --if-exists "* ]]; then
+        echo "missing --if-exists" >&2
+        exit 42
+      fi
+
+      printf 'DROP EVENT TRIGGER IF EXISTS reassign_owned;\n'
+    BASH
+
+    write_executable('gzip', <<~'BASH')
+      #!/usr/bin/env bash
+      exec cat
+    BASH
+
+    write_executable('aws', <<~'BASH')
+      #!/usr/bin/env bash
+      set -euo pipefail
+
+      if [[ "$1 $2 $3" == "s3 cp -" ]]; then
+        cat > "$TMPDIR/uploaded.sql"
+      fi
+    BASH
+
+    env = {
+      'PATH' => "#{tempdir}/bin:#{ENV.fetch('PATH')}",
+      'TMPDIR' => tempdir,
+      'ENVIRONMENT' => 'production',
+      'S3_BUCKET' => 'test-backups',
+      'DATABASE_URL' => target_database,
+      'PGUSER' => database_user,
+    }
+
+    _stdout, stderr, status = Open3.capture3(env, backup_script, chdir: Rails.root.to_s)
+    uploaded_dump = File.read(File.join(tempdir, 'uploaded.sql'))
+
+    expect(status).to be_success, stderr
+    expect(uploaded_dump).to include('DROP EVENT TRIGGER IF EXISTS reassign_owned;')
+    expect(uploaded_dump).to include("-- TRADE_TARIFF_POST_RESTORE_START\n")
+  end
+end

--- a/spec/bin/db_replicate_spec.rb
+++ b/spec/bin/db_replicate_spec.rb
@@ -168,7 +168,11 @@ RSpec.describe 'bin/db-replicate' do
         fi
       done
 
-      printf 'dump' > "$output_file"
+      {
+        printf 'CREATE TABLE restored_table(id integer);\n'
+        printf '%s\n' '-- TRADE_TARIFF_POST_RESTORE_START'
+        printf 'VACUUM FULL ANALYZE;\n'
+      } > "$output_file"
     BASH
 
     write_executable "#{tempdir}/bin/gzip", <<~'BASH'
@@ -196,35 +200,37 @@ RSpec.describe 'bin/db-replicate' do
       #!/usr/bin/env bash
       set -euo pipefail
       echo "psql $*" >> "$TMPDIR/commands.log"
-      cat > /dev/null
 
-      if [[ -f "$TMPDIR/simulate_sql_error" ]]; then
-        if [[ "$*" == *"ON_ERROR_STOP=1"* ]]; then
-          echo "simulated SQL error" >&2
-          exit 42
+      if [[ "$*" == *"-qAt"* ]]; then
+        IFS= read -r lock_query
+        echo "lock-query $lock_query" >> "$TMPDIR/commands.log"
+
+        if [[ -f "$TMPDIR/replication_lock_unavailable" ]]; then
+          printf 'f\n'
+        else
+          printf 't\n'
         fi
 
-        echo "simulated SQL error ignored" >&2
+        cat > /dev/null
         exit 0
       fi
 
-      if [[ -f "$TMPDIR/always_fail_psql" ]]; then
-        echo "permanent psql failure" >&2
-        exit 42
-      fi
+      if [[ "$*" == *"--single-transaction"* ]]; then
+        cat > "$TMPDIR/core-restore.sql"
 
-      if [[ -f "$TMPDIR/fail_psql_once" ]]; then
-        attempts_file="$TMPDIR/psql-attempts"
-        attempts=0
-        [[ -f "$attempts_file" ]] && attempts=$(cat "$attempts_file")
-        attempts=$((attempts + 1))
-        echo "$attempts" > "$attempts_file"
+        if [[ -f "$TMPDIR/always_fail_core_restore" ]]; then
+          echo "permanent core restore failure" >&2
+          exit 42
+        fi
+      else
+        cat > "$TMPDIR/post-restore.sql"
 
-        if [[ "$attempts" -eq 1 ]]; then
-          echo "temporary psql failure" >&2
+        if [[ -f "$TMPDIR/always_fail_post_restore" ]]; then
+          echo "permanent post-restore failure" >&2
           exit 42
         fi
       fi
+
     BASH
 
     write_executable "#{tempdir}/bin/sleep", <<~'BASH'
@@ -300,15 +306,41 @@ RSpec.describe 'bin/db-replicate' do
     expect(command_log(tempdir)).to include('sleep 5')
   end
 
-  it 'retries transient database restore failures' do
+  it 'restores the core dump once in a transaction and runs maintenance separately' do
     install_successful_command_stubs
-    touch_flag 'fail_psql_once'
 
     _stdout, stderr, status = run_replicate(tempdir)
 
     expect(status).to be_success, stderr
-    expect(command_log(tempdir).grep(/psql --single-transaction -v ON_ERROR_STOP=1 postgres:\/\/database.example.test\/tariff/).count).to eq(2)
-    expect(command_log(tempdir)).to include('sleep 5')
+    expect(command_log(tempdir).grep(
+      %r{\Apsql --single-transaction -v ON_ERROR_STOP=1 postgres://database\.example\.test/tariff\z},
+    ).count).to eq(1)
+    expect(File.read("#{tempdir}/core-restore.sql")).to include('CREATE TABLE restored_table')
+    expect(File.read("#{tempdir}/core-restore.sql")).not_to include('VACUUM FULL ANALYZE')
+    expect(File.read("#{tempdir}/post-restore.sql")).to include('VACUUM FULL ANALYZE')
+  end
+
+  it 'acquires the replication lock before changing service desired counts' do
+    install_successful_command_stubs
+
+    _stdout, stderr, status = run_replicate(tempdir)
+
+    expect(status).to be_success, stderr
+    commands = command_log(tempdir)
+    expect(commands.index { |command| command.start_with?('lock-query SELECT pg_try_advisory_lock') })
+      .to be < commands.index { |command| command.match?(/aws ecs update-service/) }
+  end
+
+  it 'exits without changing services when another replication holds the lock' do
+    install_successful_command_stubs
+    touch_flag 'replication_lock_unavailable'
+
+    _stdout, stderr, status = run_replicate(tempdir)
+
+    expect(status).not_to be_success
+    expect(stderr).to include('Another database replication is already running')
+    expect(command_log(tempdir).grep(/aws ecs/)).to be_empty
+    expect(command_log(tempdir).grep(/curl/)).to be_empty
   end
 
   it 'retries transient database download failures' do
@@ -322,15 +354,15 @@ RSpec.describe 'bin/db-replicate' do
     expect(command_log(tempdir)).to include('sleep 5')
   end
 
-  it 'retries transient database decompression failures' do
+  it 'does not retry database decompression failures' do
     install_successful_command_stubs
     touch_flag 'fail_gzip_once'
 
     _stdout, stderr, status = run_replicate(tempdir)
 
-    expect(status).to be_success, stderr
-    expect(command_log(tempdir).grep(/gzip -dc/).count).to eq(2)
-    expect(command_log(tempdir)).to include('sleep 5')
+    expect(status).not_to be_success
+    expect(command_log(tempdir).grep(/gzip -dc/).count).to eq(1)
+    expect(stderr).not_to include('Retrying')
   end
 
   it 'retries transient service restart failures' do
@@ -427,33 +459,46 @@ RSpec.describe 'bin/db-replicate' do
     expect(command_log(tempdir).grep(/aws ecs update-service .*backend-web.*--desired-count 2/).count).to be >= 1
   end
 
-  it 'fails restore when psql reports a SQL error' do
+  it 'fails the core restore once when psql reports a SQL error' do
     install_successful_command_stubs
-    touch_flag 'simulate_sql_error'
+    touch_flag 'always_fail_core_restore'
 
     _stdout, stderr, status = run_replicate(tempdir, 'RETRY_MAX_ATTEMPTS' => '2')
 
     expect(status).not_to be_success
-    expect(stderr).to include('Restore database failed after 2 attempts')
-    expect(command_log(tempdir).grep(/psql --single-transaction -v ON_ERROR_STOP=1/).count).to eq(2)
+    expect(stderr).to include('permanent core restore failure')
+    expect(command_log(tempdir).grep(/psql --single-transaction -v ON_ERROR_STOP=1/).count).to eq(1)
     expect(command_log(tempdir).grep(/aws s3 sync/)).to be_empty
   end
 
-  it 'restarts stopped services when database restore ultimately fails' do
+  it 'restarts stopped services when the transactional core restore fails' do
     install_successful_command_stubs
-    touch_flag 'always_fail_psql'
+    touch_flag 'always_fail_core_restore'
 
-    _stdout, stderr, status = run_replicate(tempdir)
+    _stdout, _stderr, status = run_replicate(tempdir)
 
     expect(status).not_to be_success
-    expect(stderr).to include('Restore database failed after')
-    expect(command_log(tempdir).grep(/psql --single-transaction -v ON_ERROR_STOP=1 postgres:\/\/database.example.test\/tariff/).count).to eq(6)
-    expect(command_log(tempdir).grep(/^sleep /)).to include('sleep 5', 'sleep 10', 'sleep 20', 'sleep 40', 'sleep 80')
+    expect(command_log(tempdir).grep(
+      %r{\Apsql --single-transaction -v ON_ERROR_STOP=1 postgres://database\.example\.test/tariff\z},
+    ).count).to eq(1)
     expect(command_log(tempdir).grep(/aws ecs update-service .*backend-web.*--desired-count 2/).count).to eq(1)
     expect(command_log(tempdir).grep(/aws ecs update-service .*backend-worker.*--desired-count 1/).count).to eq(1)
     expect(command_log(tempdir).grep(/aws s3 sync/)).to be_empty
     expect(command_log(tempdir)).to include("rm -f #{tempdir}/database-dump.sql.gz")
     expect(File.exist?("#{tempdir}/database-dump.sql.gz")).to be(false)
+  end
+
+  it 'leaves services stopped when post-restore maintenance fails after the core commits' do
+    install_successful_command_stubs
+    touch_flag 'always_fail_post_restore'
+
+    _stdout, stderr, status = run_replicate(tempdir)
+
+    expect(status).not_to be_success
+    expect(stderr).to include('Post-restore maintenance failed after the core database committed')
+    expect(command_log(tempdir).grep(/aws ecs update-service .*--desired-count 2/)).to be_empty
+    expect(command_log(tempdir).grep(/aws ecs update-service .*--desired-count 1/)).to be_empty
+    expect(command_log(tempdir).grep(/aws s3 sync/)).to be_empty
   end
 
   it 'removes the temporary dump file when database download ultimately fails' do


### PR DESCRIPTION
## What:

<img width="2082" height="1062" alt="image" src="https://github.com/user-attachments/assets/20e94189-32ec-46ae-901e-03ad0885fe21" />


- [x] Restore the core `pg_dump` in one transaction with `ON_ERROR_STOP`.
- [x] Run `VACUUM FULL ANALYZE` and materialized-view refreshes after the core transaction commits.
- [x] Stop retrying deterministic SQL restores while retaining bounded retries for downloads and ECS operations.
- [x] Acquire a PostgreSQL advisory lock before changing service desired counts.
- [x] Make new dumps restartable with `--if-exists` and support the current legacy dump when `reassign_owned` is already missing.
- [x] Keep services stopped when maintenance fails after the core restore commits.
- [x] Cover a production-shaped restore with real PostgreSQL integration tests.

```mermaid
flowchart TD
    LOCK[Acquire replication lock] --> STOP[Stop target services]
    STOP --> CORE[Restore core atomically]
    CORE -->|Failure| ROLLBACK[Rollback and restart services]
    CORE -->|Committed| MAINT[Vacuum and refresh views]
    MAINT -->|Failure| HOLD[Leave services stopped]
    MAINT -->|Success| START[Restart services]

    classDef box stroke:#6366f1,stroke-width:2px
    class LOCK,STOP,CORE,ROLLBACK,MAINT,HOLD,START box
```

Local verification: 31 examples, 0 failures; RuboCop, ShellCheck, Bash syntax and repository hooks pass.

## Why:

The database dump contains destructive `pg_dump --clean` statements followed by `VACUUM FULL ANALYZE`. Running the whole stream with `--single-transaction` made PostgreSQL reject the vacuum. Removing the transaction allowed the vacuum to run, but committed each destructive statement immediately.

Two replication tasks then overlapped in development. One dropped the `reassign_owned` event trigger before failing; the other task and every automatic retry then failed because that trigger no longer existed. The retries repeated deterministic SQL against an increasingly partial database and both tasks also owned the same ECS desired-count recovery.

The core dump is now atomic and attempted once. Maintenance runs separately because vacuum cannot run inside a transaction. A database advisory lock prevents concurrent tasks before they touch ECS, and phase-aware recovery only restarts services when the database is known to be safe. The integration tests reproduce the missing-trigger state with a small production-shaped SQL stream in real PostgreSQL and verify the complete restore and materialized-view refresh.

The tests also exposed a separate divide-by-zero in the materialized-view summary when no views exist; that path now reports `N/A`.

## Ticket:

N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:** The restore, concurrency and service-recovery behaviour only applies to lower-environment database replication; production targets remain explicitly rejected. The production backup path only emits restartable `DROP ... IF EXISTS` statements and an SQL comment marking the maintenance boundary, without restoring into or otherwise mutating the live database. Both the legacy production-dump shape and the new dump shape are covered against real PostgreSQL.
