### PR TITLE
Conditionally index public ATaRs

### DIFF
--- a/app/indexes/search/goods_nomenclature_index.rb
+++ b/app/indexes/search/goods_nomenclature_index.rb
@@ -60,8 +60,12 @@ module Search
         { ancestors: %i[goods_nomenclature_descriptions search_references] },
         { heading: [:goods_nomenclature_descriptions] },
       ]
-      associations << :public_atar_rulings if AdminConfiguration.enabled?('search_atars_enabled')
+      associations << :public_atar_rulings if search_atars_enabled?
       associations
+    end
+
+    def serialize_record(record)
+      serializer.new(record, include_atars: search_atars_enabled?).as_json
     end
 
     def dataset_page(page_number)
@@ -79,6 +83,14 @@ module Search
       TimeMachine.now do
         (dataset.with_leaf_column.count / page_size.to_f).ceil
       end
+    end
+
+  private
+
+    def search_atars_enabled?
+      return @search_atars_enabled if defined?(@search_atars_enabled)
+
+      @search_atars_enabled = AdminConfiguration.enabled?('search_atars_enabled')
     end
   end
 end

--- a/app/indexes/search/goods_nomenclature_index.rb
+++ b/app/indexes/search/goods_nomenclature_index.rb
@@ -51,16 +51,17 @@ module Search
     end
 
     def eager_load
-      [
+      associations = [
         :goods_nomenclature_indents,
         :goods_nomenclature_descriptions,
         :goods_nomenclature_label,
         :goods_nomenclature_self_text,
-        :public_atar_rulings,
         :search_references,
         { ancestors: %i[goods_nomenclature_descriptions search_references] },
         { heading: [:goods_nomenclature_descriptions] },
       ]
+      associations << :public_atar_rulings if AdminConfiguration.enabled?('search_atars_enabled')
+      associations
     end
 
     def dataset_page(page_number)

--- a/app/lib/admin_configuration_seeder/configs.yml
+++ b/app/lib/admin_configuration_seeder/configs.yml
@@ -150,6 +150,10 @@
   config_type: markdown
   description: System prompt sent to the AI model during interactive search
   prompt: search_context
+- name: search_atars_enabled
+  config_type: boolean
+  description: Include public ATAR keywords and derived facts in OpenSearch retrieval and composite search embeddings.
+  default: search_atars_enabled
 - name: search_labels_enabled
   config_type: boolean
   description: Search label-enriched index fields during the OpenSearch retrieval leg, including OpenSearch within hybrid retrieval.

--- a/app/models/admin_configuration.rb
+++ b/app/models/admin_configuration.rb
@@ -116,6 +116,7 @@ class AdminConfiguration < Sequel::Model(Sequel[:admin_configurations].qualify(:
     'expand_search_min_results' => 5,
     'expand_search_min_score' => 5,
     'expand_search_when_needed_enabled' => true,
+    'search_atars_enabled' => false,
     'search_compressed_notes_enabled' => false,
     'search_general_rules_enabled' => false,
     'expand_model' => NESTED_OPTION_DEFAULTS['expand_model'][:selected],

--- a/app/queries/search/goods_nomenclature_query.rb
+++ b/app/queries/search/goods_nomenclature_query.rb
@@ -126,9 +126,9 @@ module Search
       fields = %w[
         search_references^5
         description^3
-        atar_keywords^2
         ancestor_descriptions
       ]
+      fields << 'atar_keywords^2' if AdminConfiguration.enabled?('search_atars_enabled')
 
       if SearchLabels.enabled?
         fields += %w[

--- a/app/queries/search/goods_nomenclature_query.rb
+++ b/app/queries/search/goods_nomenclature_query.rb
@@ -123,23 +123,25 @@ module Search
     end
 
     def search_fields
-      fields = %w[
-        search_references^5
-        description^3
-        ancestor_descriptions
-      ]
-      fields << 'atar_keywords^2' if AdminConfiguration.enabled?('search_atars_enabled')
-
-      if SearchLabels.enabled?
-        fields += %w[
-          labels.known_brands^2
-          labels.colloquial_terms^2
-          labels.synonyms^1.5
-          labels.description
+      @search_fields ||= begin
+        fields = %w[
+          search_references^5
+          description^3
+          ancestor_descriptions
         ]
-      end
+        fields << 'atar_keywords^2' if AdminConfiguration.enabled?('search_atars_enabled')
 
-      fields
+        if SearchLabels.enabled?
+          fields += %w[
+            labels.known_brands^2
+            labels.colloquial_terms^2
+            labels.synonyms^1.5
+            labels.description
+          ]
+        end
+
+        fields
+      end
     end
 
     def hidden_goods_nomenclature_filter

--- a/app/serializers/search/goods_nomenclature_serializer.rb
+++ b/app/serializers/search/goods_nomenclature_serializer.rb
@@ -1,5 +1,10 @@
 module Search
   class GoodsNomenclatureSerializer < ::Serializer
+    def initialize(record, include_atars: AdminConfiguration.enabled?('search_atars_enabled'))
+      @include_atars = include_atars
+      super(record)
+    end
+
     def serializable_hash(_opts = {})
       {
         # Presentational fields
@@ -78,10 +83,12 @@ module Search
     end
 
     def atar_keywords_part
-      return unless AdminConfiguration.enabled?('search_atars_enabled')
+      return unless include_atars
 
       keywords = public_atar_rulings.flat_map(&:search_terms).compact_blank.uniq
       keywords.presence
     end
+
+    attr_reader :include_atars
   end
 end

--- a/app/serializers/search/goods_nomenclature_serializer.rb
+++ b/app/serializers/search/goods_nomenclature_serializer.rb
@@ -78,6 +78,8 @@ module Search
     end
 
     def atar_keywords_part
+      return unless AdminConfiguration.enabled?('search_atars_enabled')
+
       keywords = public_atar_rulings.flat_map(&:search_terms).compact_blank.uniq
       keywords.presence
     end

--- a/app/services/composite_search_text_builder.rb
+++ b/app/services/composite_search_text_builder.rb
@@ -29,14 +29,19 @@ class CompositeSearchTextBuilder
       .where(goods_nomenclature_sid: sids)
       .as_hash(:goods_nomenclature_sid)
 
-    atar_keywords_by_item_id = TariffKnowledge::PublicAtarRuling
-      .actual
-      .where(goods_nomenclature_item_id: goods_nomenclature_item_ids)
-      .select(:goods_nomenclature_item_id, :keywords, :derived_facts)
-      .order(:goods_nomenclature_item_id, :ref)
-      .all
-      .group_by(&:goods_nomenclature_item_id)
-      .transform_values { |rulings| rulings.flat_map(&:search_terms).compact_blank.uniq }
+    atar_keywords_by_item_id =
+      if AdminConfiguration.enabled?('search_atars_enabled')
+        TariffKnowledge::PublicAtarRuling
+          .actual
+          .where(goods_nomenclature_item_id: goods_nomenclature_item_ids)
+          .select(:goods_nomenclature_item_id, :keywords, :derived_facts)
+          .order(:goods_nomenclature_item_id, :ref)
+          .all
+          .group_by(&:goods_nomenclature_item_id)
+          .transform_values { |rulings| rulings.flat_map(&:search_terms).compact_blank.uniq }
+      else
+        {}
+      end
 
     gns_by_sid = GoodsNomenclature
       .where(goods_nomenclature_sid: sids)

--- a/app/services/tariff_knowledge/public_atar_search_refresh.rb
+++ b/app/services/tariff_knowledge/public_atar_search_refresh.rb
@@ -10,7 +10,11 @@ module TariffKnowledge
 
     def call
       return [] if goods_nomenclature_item_ids.empty?
-      return [] unless AdminConfiguration.enabled?('search_atars_enabled')
+
+      unless AdminConfiguration.enabled?('search_atars_enabled')
+        log_disabled
+        return []
+      end
 
       sids = []
       goods_nomenclature_item_ids.each_slice(BATCH_SIZE) do |item_id_batch|
@@ -31,10 +35,14 @@ module TariffKnowledge
 
     attr_reader :goods_nomenclature_item_ids
 
+    def log_disabled
+      count = goods_nomenclature_item_ids.size
+      item_id_label = count == 1 ? 'item ID' : 'item IDs'
+      Rails.logger.info("Skipping public ATAR search refresh because search_atars_enabled is disabled (#{count} changed #{item_id_label})")
+    end
+
     def matching_goods_nomenclatures(item_ids)
       TimeMachine.now do
-        index = Search::GoodsNomenclatureIndex.new
-
         GoodsNomenclature
           .actual
           .with_leaf_column
@@ -45,12 +53,15 @@ module TariffKnowledge
     end
 
     def bulk_reindex(goods_nomenclatures)
-      index = Search::GoodsNomenclatureIndex.new
       TradeTariffBackend.search_client.bulk(
         {
           body: goods_nomenclatures.map { |goods_nomenclature| bulk_operation(index, goods_nomenclature) },
         }.merge(TradeTariffBackend.search_client.search_operation_options),
       )
+    end
+
+    def index
+      @index ||= Search::GoodsNomenclatureIndex.new
     end
 
     def bulk_operation(index, goods_nomenclature)

--- a/app/services/tariff_knowledge/public_atar_search_refresh.rb
+++ b/app/services/tariff_knowledge/public_atar_search_refresh.rb
@@ -10,6 +10,7 @@ module TariffKnowledge
 
     def call
       return [] if goods_nomenclature_item_ids.empty?
+      return [] unless AdminConfiguration.enabled?('search_atars_enabled')
 
       sids = []
       goods_nomenclature_item_ids.each_slice(BATCH_SIZE) do |item_id_batch|

--- a/docs/architecture/search-and-indexing.md
+++ b/docs/architecture/search-and-indexing.md
@@ -35,6 +35,13 @@ The higher-level `tariff:reindex` task delegates to `TradeTariffBackend.reindex`
 
 Generated self-texts, labels, and embeddings support search quality. The lifecycle is documented in [Generated classification content lifecycle](../generated-classification-content-lifecycle.md).
 
+Public ATAR keywords and derived facts are excluded from OpenSearch documents, OpenSearch queries, and composite search embeddings unless the `search_atars_enabled` admin configuration is enabled. The setting defaults to `false`. After changing it, rebuild both search representations so stored documents and embeddings match the configured value:
+
+```sh
+bin/rake opensearch:search:recreate_all
+bin/rake search_embeddings:generate
+```
+
 Relevant code paths include:
 
 - `app/services/generate_self_text/`

--- a/docs/architecture/search-and-indexing.md
+++ b/docs/architecture/search-and-indexing.md
@@ -38,7 +38,9 @@ Generated self-texts, labels, and embeddings support search quality. The lifecyc
 Public ATAR keywords and derived facts are excluded from OpenSearch documents, OpenSearch queries, and composite search embeddings unless the `search_atars_enabled` admin configuration is enabled. The setting defaults to `false`. After changing it, rebuild both search representations so stored documents and embeddings match the configured value:
 
 ```sh
-bin/rake opensearch:search:recreate_all
+# Wait at least 150 seconds after changing the setting so the production
+# admin-configuration cache has expired.
+INDEX=Search::GoodsNomenclatureIndex bin/rake opensearch:search:recreate
 bin/rake search_embeddings:generate
 ```
 

--- a/spec/indexes/search/goods_nomenclature_index_spec.rb
+++ b/spec/indexes/search/goods_nomenclature_index_spec.rb
@@ -51,9 +51,16 @@ RSpec.describe Search::GoodsNomenclatureIndex do
         :goods_nomenclature_indents,
         :goods_nomenclature_descriptions,
         :goods_nomenclature_label,
-        :public_atar_rulings,
         :search_references,
       )
+      expect(associations).not_to include(:public_atar_rulings)
+    end
+
+    it 'includes public ATAR rulings when ATaR search is enabled' do
+      allow(AdminConfiguration).to receive(:enabled?).and_call_original
+      allow(AdminConfiguration).to receive(:enabled?).with('search_atars_enabled').and_return(true)
+
+      expect(instance.eager_load.flatten).to include(:public_atar_rulings)
     end
 
     it 'includes ancestors with descriptions' do

--- a/spec/indexes/search/goods_nomenclature_index_spec.rb
+++ b/spec/indexes/search/goods_nomenclature_index_spec.rb
@@ -63,11 +63,52 @@ RSpec.describe Search::GoodsNomenclatureIndex do
       expect(instance.eager_load.flatten).to include(:public_atar_rulings)
     end
 
+    it 'resolves the ATaR configuration once per index instance' do
+      allow(AdminConfiguration).to receive(:enabled?).and_call_original
+      allow(AdminConfiguration).to receive(:enabled?).with('search_atars_enabled').and_return(false)
+
+      2.times { instance.eager_load }
+
+      expect(AdminConfiguration).to have_received(:enabled?).with('search_atars_enabled').once
+    end
+
     it 'includes ancestors with descriptions' do
       ancestor_config = instance.eager_load.find { |e| e.is_a?(Hash) && e.key?(:ancestors) }
 
       expect(ancestor_config).to be_present
       expect(ancestor_config[:ancestors]).to include(:goods_nomenclature_descriptions)
+    end
+  end
+
+  describe '#serialize_record' do
+    let(:record) { instance_double(GoodsNomenclature) }
+    let(:serializer) { instance_double(Search::GoodsNomenclatureSerializer, as_json: {}) }
+
+    before do
+      allow(AdminConfiguration).to receive(:enabled?).and_call_original
+    end
+
+    it 'disables ATaR serialization by default' do
+      allow(Search::GoodsNomenclatureSerializer).to receive(:new)
+        .with(record, include_atars: false)
+        .and_return(serializer)
+
+      instance.serialize_record(record)
+
+      expect(Search::GoodsNomenclatureSerializer).to have_received(:new)
+        .with(record, include_atars: false)
+    end
+
+    it 'enables ATaR serialization when configured' do
+      allow(AdminConfiguration).to receive(:enabled?).with('search_atars_enabled').and_return(true)
+      allow(Search::GoodsNomenclatureSerializer).to receive(:new)
+        .with(record, include_atars: true)
+        .and_return(serializer)
+
+      instance.serialize_record(record)
+
+      expect(Search::GoodsNomenclatureSerializer).to have_received(:new)
+        .with(record, include_atars: true)
     end
   end
 end

--- a/spec/lib/tasks/admin_configurations_rake_spec.rb
+++ b/spec/lib/tasks/admin_configurations_rake_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe 'admin_configurations:seed' do
     Rake::Task['admin_configurations:seed'].reenable
   end
 
-  it 'creates all 48 admin configurations', :aggregate_failures do
-    expect { seed }.to change(AdminConfiguration, :count).by(48)
+  it 'creates all 49 admin configurations', :aggregate_failures do
+    expect { seed }.to change(AdminConfiguration, :count).by(49)
 
     names = AdminConfiguration.order(:name).select_map(:name)
     expect(names).to eq(%w[
@@ -45,6 +45,7 @@ RSpec.describe 'admin_configurations:seed' do
       refine_search_with_answers_enabled
       retrieval_method
       rrf_k
+      search_atars_enabled
       search_compressed_notes_enabled
       search_context
       search_general_rules_enabled
@@ -247,6 +248,16 @@ RSpec.describe 'admin_configurations:seed' do
     expect(config.value).to be(AdminConfiguration.default_for('search_labels_enabled'))
   end
 
+  it 'seeds search_atars_enabled as a boolean config defaulting to false', :aggregate_failures do
+    seed
+
+    config = AdminConfiguration.where(name: 'search_atars_enabled').first
+    expect(config.config_type).to eq('boolean')
+    expect(config.area).to eq('classification')
+    expect(config.value).to be(AdminConfiguration.default_for('search_atars_enabled'))
+    expect(config.value).to be false
+  end
+
   it 'seeds expand_search_enabled as a boolean config', :aggregate_failures do
     seed
 
@@ -402,7 +413,7 @@ RSpec.describe 'admin_configurations:seed' do
   it 'patches existing configurations when their type changes' do
     create(:admin_configuration, name: 'description_intercept_templates', config_type: 'string', value: 'legacy')
 
-    expect { seed }.to change(AdminConfiguration, :count).by(47)
+    expect { seed }.to change(AdminConfiguration, :count).by(48)
     expect(AdminConfiguration.where(name: 'description_intercept_templates').first.config_type).to eq('object_template')
   end
 end

--- a/spec/models/goods_nomenclature_self_text_spec.rb
+++ b/spec/models/goods_nomenclature_self_text_spec.rb
@@ -377,6 +377,31 @@ RSpec.describe GoodsNomenclatureSelfText do
       expect(record.reload.search_text).to include('ATAR keywords: cotton sheets')
     end
 
+    it 'removes public ATAR keywords after ATaR search is disabled' do
+      search_atars_enabled = true
+      allow(AdminConfiguration).to receive(:enabled?).and_call_original
+      allow(AdminConfiguration).to receive(:enabled?).with('search_atars_enabled') { search_atars_enabled }
+
+      commodity = create(:commodity, :with_description, :declarable, goods_nomenclature_item_id: '6302100000')
+      record = create(:goods_nomenclature_self_text,
+                      goods_nomenclature: commodity,
+                      goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
+                      self_text: 'Bed linen')
+      create(:tariff_knowledge_public_atar_ruling,
+             commodity_code: '630210',
+             goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
+             keywords: Sequel.pg_array(['cotton sheets'], :text))
+
+      described_class.regenerate_search_embeddings([record.goods_nomenclature_sid])
+      expect(record.reload.search_text).to include('ATAR keywords: cotton sheets')
+
+      search_atars_enabled = false
+      described_class.regenerate_search_embeddings([record.goods_nomenclature_sid])
+
+      expect(embedding_service).to have_received(:embed_batch).twice
+      expect(record.reload.search_text).not_to include('ATAR keywords:')
+    end
+
     it 're-embeds when search_embedding is nil even if search_text matches' do
       record = create(:goods_nomenclature_self_text, self_text: 'Widgets for manufacturing')
 

--- a/spec/models/goods_nomenclature_self_text_spec.rb
+++ b/spec/models/goods_nomenclature_self_text_spec.rb
@@ -332,7 +332,31 @@ RSpec.describe GoodsNomenclatureSelfText do
       expect(embedding_service).to have_received(:embed_batch).twice
     end
 
-    it 're-embeds when public ATAR keywords change the composite search text' do
+    it 'does not re-embed when public ATAR keywords change while ATaR search is disabled' do
+      commodity = create(:commodity, :with_description, :declarable, goods_nomenclature_item_id: '6302100000')
+      record = create(:goods_nomenclature_self_text,
+                      goods_nomenclature: commodity,
+                      goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
+                      self_text: 'Bed linen')
+
+      described_class.regenerate_search_embeddings([record.goods_nomenclature_sid])
+      expect(embedding_service).to have_received(:embed_batch).once
+
+      create(:tariff_knowledge_public_atar_ruling,
+             commodity_code: '630210',
+             goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
+             keywords: Sequel.pg_array(['cotton sheets'], :text))
+
+      described_class.regenerate_search_embeddings([record.goods_nomenclature_sid])
+
+      expect(embedding_service).to have_received(:embed_batch).once
+      expect(record.reload.search_text).not_to include('ATAR keywords:')
+    end
+
+    it 're-embeds when public ATAR keywords change while ATaR search is enabled' do
+      allow(AdminConfiguration).to receive(:enabled?).and_call_original
+      allow(AdminConfiguration).to receive(:enabled?).with('search_atars_enabled').and_return(true)
+
       commodity = create(:commodity, :with_description, :declarable, goods_nomenclature_item_id: '6302100000')
       record = create(:goods_nomenclature_self_text,
                       goods_nomenclature: commodity,

--- a/spec/queries/search/goods_nomenclature_query_spec.rb
+++ b/spec/queries/search/goods_nomenclature_query_spec.rb
@@ -52,7 +52,14 @@ RSpec.describe Search::GoodsNomenclatureQuery do
           expect(multi_match[:fields]).to include('ancestor_descriptions')
         end
 
-        it 'searches public ATAR keywords' do
+        it 'does not search public ATAR keywords by default' do
+          expect(multi_match[:fields]).not_to include('atar_keywords^2')
+        end
+
+        it 'searches public ATAR keywords when ATaR search is enabled' do
+          allow(AdminConfiguration).to receive(:enabled?).and_call_original
+          allow(AdminConfiguration).to receive(:enabled?).with('search_atars_enabled').and_return(true)
+
           expect(multi_match[:fields]).to include('atar_keywords^2')
         end
       end

--- a/spec/queries/search/goods_nomenclature_query_spec.rb
+++ b/spec/queries/search/goods_nomenclature_query_spec.rb
@@ -123,6 +123,16 @@ RSpec.describe Search::GoodsNomenclatureQuery do
       it 'has no must clauses in the inner bool' do
         expect(pos_clause.dig(:bool, :must)).to be_nil
       end
+
+      it 'resolves the ATaR configuration once per query' do
+        allow(AdminConfiguration).to receive(:enabled?).and_call_original
+        allow(Search::GoodsNomenclatureIndex).to receive(:new)
+          .and_return(instance_double(Search::GoodsNomenclatureIndex, name: 'goods-nomenclatures-test'))
+
+        query
+
+        expect(AdminConfiguration).to have_received(:enabled?).with('search_atars_enabled').once
+      end
     end
 
     context 'with noun + noun query (steel pipe)' do

--- a/spec/serializers/search/goods_nomenclature_serializer_spec.rb
+++ b/spec/serializers/search/goods_nomenclature_serializer_spec.rb
@@ -99,20 +99,31 @@ RSpec.describe Search::GoodsNomenclatureSerializer do
         commodity.reload
       end
 
-      it 'includes unique nonblank ATAR keywords and derived facts for OpenSearch' do
-        expect(result[:atar_keywords]).to eq(['riding horses', 'show ponies', 'equestrian sports'])
+      it 'omits ATAR search terms by default' do
+        expect(result).not_to have_key(:atar_keywords)
       end
 
-      it 'includes derived facts when no official keywords are present' do
-        TariffKnowledge::PublicAtarRuling.dataset.delete
-        create(:tariff_knowledge_public_atar_ruling,
-               commodity_code: '0101210000',
-               goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
-               keywords: Sequel.pg_array([], :text),
-               derived_facts: Sequel.pg_array(['equestrian sports'], :text))
-        commodity.reload
+      context 'when ATaR search is enabled' do
+        before do
+          allow(AdminConfiguration).to receive(:enabled?).and_call_original
+          allow(AdminConfiguration).to receive(:enabled?).with('search_atars_enabled').and_return(true)
+        end
 
-        expect(result[:atar_keywords]).to eq(['equestrian sports'])
+        it 'includes unique nonblank ATAR keywords and derived facts for OpenSearch' do
+          expect(result[:atar_keywords]).to eq(['riding horses', 'show ponies', 'equestrian sports'])
+        end
+
+        it 'includes derived facts when no official keywords are present' do
+          TariffKnowledge::PublicAtarRuling.dataset.delete
+          create(:tariff_knowledge_public_atar_ruling,
+                 commodity_code: '0101210000',
+                 goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
+                 keywords: Sequel.pg_array([], :text),
+                 derived_facts: Sequel.pg_array(['equestrian sports'], :text))
+          commodity.reload
+
+          expect(result[:atar_keywords]).to eq(['equestrian sports'])
+        end
       end
     end
 

--- a/spec/services/composite_search_text_builder_spec.rb
+++ b/spec/services/composite_search_text_builder_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe CompositeSearchTextBuilder do
       expect(result[commodity.goods_nomenclature_sid]).to include('References: fridges')
     end
 
-    it 'includes public ATAR keywords for the matching goods nomenclature item id' do
+    it 'omits public ATAR search terms by default' do
       commodity = create(:commodity, :with_description, :declarable,
                          goods_nomenclature_item_id: '6302100000')
       self_text = create(:goods_nomenclature_self_text,
@@ -223,50 +223,75 @@ RSpec.describe CompositeSearchTextBuilder do
 
       result = described_class.batch([self_text])
 
-      expect(result[commodity.goods_nomenclature_sid]).to include('ATAR keywords: cotton sheets, bed linen, hotel bedding')
+      expect(result[commodity.goods_nomenclature_sid]).not_to include('ATAR keywords:')
     end
 
-    it 'includes public ATAR derived facts when no official keywords are present' do
-      commodity = create(:commodity, :with_description, :declarable,
-                         goods_nomenclature_item_id: '6302100000')
-      self_text = create(:goods_nomenclature_self_text,
-                         goods_nomenclature_sid: commodity.goods_nomenclature_sid,
-                         goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
-                         self_text: 'Bed linen commodity')
-      create(:tariff_knowledge_public_atar_ruling,
-             commodity_code: '630210',
-             goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
-             keywords: Sequel.pg_array([], :text),
-             derived_facts: Sequel.pg_array(['hotel bedding'], :text))
+    context 'when ATaR search is enabled' do
+      before do
+        allow(AdminConfiguration).to receive(:enabled?).and_call_original
+        allow(AdminConfiguration).to receive(:enabled?).with('search_atars_enabled').and_return(true)
+      end
 
-      result = described_class.batch([self_text])
+      it 'includes public ATAR keywords for the matching goods nomenclature item id' do
+        commodity = create(:commodity, :with_description, :declarable,
+                           goods_nomenclature_item_id: '6302100000')
+        self_text = create(:goods_nomenclature_self_text,
+                           goods_nomenclature_sid: commodity.goods_nomenclature_sid,
+                           goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
+                           self_text: 'Bed linen commodity')
+        create(:tariff_knowledge_public_atar_ruling,
+               commodity_code: '630210',
+               goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
+               keywords: Sequel.pg_array(['cotton sheets', 'bed linen'], :text),
+               derived_facts: Sequel.pg_array(['hotel bedding', 'bed linen'], :text))
 
-      expect(result[commodity.goods_nomenclature_sid]).to include('ATAR keywords: hotel bedding')
-    end
+        result = described_class.batch([self_text])
 
-    it 'orders public ATAR search terms by ruling reference' do
-      commodity = create(:commodity, :with_description, :declarable,
-                         goods_nomenclature_item_id: '6302100000')
-      self_text = create(:goods_nomenclature_self_text,
-                         goods_nomenclature_sid: commodity.goods_nomenclature_sid,
-                         goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
-                         self_text: 'Bed linen commodity')
-      create(:tariff_knowledge_public_atar_ruling,
-             ref: '600015804',
-             commodity_code: '630210',
-             goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
-             keywords: Sequel.pg_array(['later keyword'], :text),
-             derived_facts: Sequel.pg_array(['later fact'], :text))
-      create(:tariff_knowledge_public_atar_ruling,
-             ref: '600004365',
-             commodity_code: '630210',
-             goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
-             keywords: Sequel.pg_array(['earlier keyword'], :text),
-             derived_facts: Sequel.pg_array(['earlier fact'], :text))
+        expect(result[commodity.goods_nomenclature_sid]).to include('ATAR keywords: cotton sheets, bed linen, hotel bedding')
+      end
 
-      result = described_class.batch([self_text])
+      it 'includes public ATAR derived facts when no official keywords are present' do
+        commodity = create(:commodity, :with_description, :declarable,
+                           goods_nomenclature_item_id: '6302100000')
+        self_text = create(:goods_nomenclature_self_text,
+                           goods_nomenclature_sid: commodity.goods_nomenclature_sid,
+                           goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
+                           self_text: 'Bed linen commodity')
+        create(:tariff_knowledge_public_atar_ruling,
+               commodity_code: '630210',
+               goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
+               keywords: Sequel.pg_array([], :text),
+               derived_facts: Sequel.pg_array(['hotel bedding'], :text))
 
-      expect(result[commodity.goods_nomenclature_sid]).to include('ATAR keywords: earlier keyword, earlier fact, later keyword, later fact')
+        result = described_class.batch([self_text])
+
+        expect(result[commodity.goods_nomenclature_sid]).to include('ATAR keywords: hotel bedding')
+      end
+
+      it 'orders public ATAR search terms by ruling reference' do
+        commodity = create(:commodity, :with_description, :declarable,
+                           goods_nomenclature_item_id: '6302100000')
+        self_text = create(:goods_nomenclature_self_text,
+                           goods_nomenclature_sid: commodity.goods_nomenclature_sid,
+                           goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
+                           self_text: 'Bed linen commodity')
+        create(:tariff_knowledge_public_atar_ruling,
+               ref: '600015804',
+               commodity_code: '630210',
+               goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
+               keywords: Sequel.pg_array(['later keyword'], :text),
+               derived_facts: Sequel.pg_array(['later fact'], :text))
+        create(:tariff_knowledge_public_atar_ruling,
+               ref: '600004365',
+               commodity_code: '630210',
+               goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
+               keywords: Sequel.pg_array(['earlier keyword'], :text),
+               derived_facts: Sequel.pg_array(['earlier fact'], :text))
+
+        result = described_class.batch([self_text])
+
+        expect(result[commodity.goods_nomenclature_sid]).to include('ATAR keywords: earlier keyword, earlier fact, later keyword, later fact')
+      end
     end
   end
 end

--- a/spec/services/tariff_knowledge/public_atar_search_refresh_spec.rb
+++ b/spec/services/tariff_knowledge/public_atar_search_refresh_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe TariffKnowledge::PublicAtarSearchRefresh do
     context 'when ATaR search is disabled' do
       before do
         allow(AdminConfiguration).to receive(:enabled?).with('search_atars_enabled').and_return(false)
+        allow(Rails.logger).to receive(:info)
       end
 
       it 'skips OpenSearch and embedding refreshes' do
@@ -59,6 +60,9 @@ RSpec.describe TariffKnowledge::PublicAtarSearchRefresh do
         expect(result).to eq([])
         expect(search_client).not_to have_received(:bulk)
         expect(ScoreLabelBatchWorker).not_to have_received(:perform_async)
+        expect(Rails.logger).to have_received(:info).with(
+          'Skipping public ATAR search refresh because search_atars_enabled is disabled (1 changed item ID)',
+        )
       end
     end
   end

--- a/spec/services/tariff_knowledge/public_atar_search_refresh_spec.rb
+++ b/spec/services/tariff_knowledge/public_atar_search_refresh_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe TariffKnowledge::PublicAtarSearchRefresh do
     before do
       allow(TradeTariffBackend).to receive(:search_client).and_return(search_client)
       allow(ScoreLabelBatchWorker).to receive(:perform_async)
+      allow(AdminConfiguration).to receive(:enabled?).and_call_original
+      allow(AdminConfiguration).to receive(:enabled?).with('search_atars_enabled').and_return(true)
     end
 
     it 'indexes matching goods nomenclatures and queues embedding regeneration' do
@@ -42,6 +44,22 @@ RSpec.describe TariffKnowledge::PublicAtarSearchRefresh do
       expect(result).to eq([commodity.goods_nomenclature_sid])
       expect(search_client).to have_received(:bulk).once
       expect(ScoreLabelBatchWorker).to have_received(:perform_async).with([commodity.goods_nomenclature_sid])
+    end
+
+    context 'when ATaR search is disabled' do
+      before do
+        allow(AdminConfiguration).to receive(:enabled?).with('search_atars_enabled').and_return(false)
+      end
+
+      it 'skips OpenSearch and embedding refreshes' do
+        commodity = create(:commodity, :with_description, :declarable, goods_nomenclature_item_id: '6302100000')
+
+        result = described_class.call([commodity.goods_nomenclature_item_id])
+
+        expect(result).to eq([])
+        expect(search_client).not_to have_received(:bulk)
+        expect(ScoreLabelBatchWorker).not_to have_received(:perform_async)
+      end
     end
   end
 end


### PR DESCRIPTION
## What:

- [x] Add a `search_atars_enabled` admin configuration that defaults to `false`
- [x] Exclude public ATaR terms from OpenSearch documents, OpenSearch queries, and composite search embeddings while disabled
- [x] Skip incremental OpenSearch and embedding refresh work for ATaR imports while disabled
- [x] Preserve the OpenSearch mapping so the setting can be enabled without another deployment
- [x] Avoid repeated configuration lookups in OpenSearch indexing and query hot paths
- [x] Document the required targeted OpenSearch and embedding rebuild commands
- [x] Cover disabled, enabled, and enabled-to-disabled behaviour with focused RSpec examples

## Why:

Public ATaR search terms were being added to OpenSearch documents and composite embeddings unconditionally, although this enrichment is not used by a live journey. This makes the enrichment opt-in through admin configuration and avoids the associated indexing and embedding work by default.

After deployment, wait at least 150 seconds for the production admin-configuration cache to expire, then rebuild the affected OpenSearch index and composite embeddings so stored search data reflects the disabled default:

```sh
INDEX=Search::GoodsNomenclatureIndex bin/rake opensearch:search:recreate
bin/rake search_embeddings:generate
```

Verified after review fixes with 306 affected search/ATaR examples, RuboCop, and repository commit/push hooks. Nine independent review passes covered robustness, performance, instrumentation/logging, security, test coverage, idiomatic implementation, algorithm/data-structure efficiency, SOLID principles, and maintainability.

## Ticket:

N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:** This disables an unused search enrichment through a new admin configuration with a safe false default. It does not change a live user journey, the OpenSearch mapping, or an API contract.