### PR TITLE
Allow replication task reads for TARIC and CDS

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,3 +1,11 @@
+locals {
+  production_replication_object_prefixes = [
+    "data/exchange_rates",
+    "data/taric",
+    "data/cds",
+  ]
+}
+
 data "aws_iam_policy_document" "task" {
   statement {
     effect    = "Allow"
@@ -51,11 +59,14 @@ data "aws_iam_policy_document" "task" {
       "s3:ListBucket",
       "s3:GetObject",
     ]
-    # NOTE: READONLY access to production exchange rates for replication
-    resources = [
-      "arn:aws:s3:::trade-tariff-persistence-382373577178",
-      "arn:aws:s3:::trade-tariff-persistence-382373577178/data/exchange_rates/*",
-    ]
+    # NOTE: READONLY access to production data files for replication
+    resources = concat(
+      ["arn:aws:s3:::trade-tariff-persistence-382373577178"],
+      [
+        for prefix in local.production_replication_object_prefixes :
+        "arn:aws:s3:::trade-tariff-persistence-382373577178/${prefix}/*"
+      ],
+    )
   }
 
   statement {
@@ -104,4 +115,15 @@ data "aws_iam_policy_document" "task" {
 resource "aws_iam_policy" "task" {
   name   = "backend-task-role-policy"
   policy = data.aws_iam_policy_document.task.json
+}
+
+check "production_replication_object_prefixes" {
+  assert {
+    condition = toset(local.production_replication_object_prefixes) == toset([
+      "data/exchange_rates",
+      "data/taric",
+      "data/cds",
+    ])
+    error_message = "Production replication read access must cover exchange rate, TARIC, and CDS objects."
+  }
 }


### PR DESCRIPTION
## What:

- [x] Extend the backend job task role's read-only production persistence access to `data/taric/*` and `data/cds/*`
- [x] Keep the existing `data/exchange_rates/*` access
- [x] Assert that replication read access covers all three data prefixes
- [x] Run Terraform validation, tflint, pre-commit and the Terraform specs

## Why:

Cross-account `CopyObject` needs the caller's identity policy and the source bucket policy to allow `s3:GetObject`. The task role only allowed production exchange-rate objects, so TARIC copies failed with `AccessDenied` and CDS copies would fail for the same reason.

The production bucket policy needs to be deployed before this development task-role change is exercised.

## Ticket:

N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:** Adds read-only access to two narrowly scoped production persistence prefixes. It grants no production write/delete capability and does not recreate resources.