### PR TITLE
AI-1070: Fix experiment dashboard queries

### DIFF
--- a/spec/terraform/search_experiment_dashboard_spec.rb
+++ b/spec/terraform/search_experiment_dashboard_spec.rb
@@ -44,17 +44,21 @@ RSpec.describe 'search experiment dashboard Terraform' do
   end
 
   it 'separates period cost and token totals and exposes incomplete pricing' do
+    expect(module_main_tf).to include('event in [\\"api_call_completed\\", \\"embedding_api_call_completed\\"]')
     expect(module_main_tf).to include('service = \\"ai_usage\\" and event = \\"embedding_api_call_completed\\"')
     expect(module_main_tf).to include('event_kind = \\"vector_search_query_embedding\\"')
     expect(module_main_tf).to include('if(ispresent(operation), operation, event_kind) as ai_operation')
     expect(module_main_tf).to include('Total AI Cost by Operation')
-    expect(module_main_tf).to include('filter pricing_known = true and ispresent(total_cost_usd)')
+    expect(module_main_tf).to include('| filter pricing_known')
+    expect(module_main_tf).to include('| filter ispresent(total_cost_usd)')
     expect(module_main_tf).to include('stats sum(total_cost_usd) as total_cost_usd by ai_operation, model')
     expect(module_main_tf).to include('AI Token Totals by Operation')
     expect(module_main_tf).to include('sum(input_tokens) as input_tokens')
     expect(module_main_tf).to include('sum(output_tokens) as output_tokens')
     expect(module_main_tf).to include('Unknown Pricing Events')
-    expect(module_main_tf).to include('pricing_known = false or not ispresent(total_cost_usd)')
+    expect(module_main_tf).to include('not pricing_known or not ispresent(total_cost_usd)')
+    expect(module_main_tf).not_to include('pricing_known = true')
+    expect(module_main_tf).not_to include('pricing_known = false')
     expect(module_main_tf).not_to include('AI Tokens and Cost')
   end
 
@@ -67,6 +71,9 @@ RSpec.describe 'search experiment dashboard Terraform' do
     expect(module_main_tf).to include('as selections')
     expect(module_main_tf).to include('Questions and Answers')
     expect(module_main_tf).to include('event in ["question_returned", "answer_returned"]')
+    expect(module_main_tf).to include('details.questions.0.question as question')
+    expect(module_main_tf).to include('details.answers.0.commodity_code as top_commodity_code')
+    expect(module_main_tf).to include('details.answers.0.confidence as top_confidence')
     expect(module_main_tf).to include('Selected Results')
     expect(module_main_tf).to include('goods_nomenclature_item_id')
     expect(module_main_tf).to include('Top Zero-Result Terms')
@@ -76,6 +83,13 @@ RSpec.describe 'search experiment dashboard Terraform' do
     expect(module_main_tf).to include('AI API Latency (p50/p90/p99)')
     expect(module_main_tf).to include('pct(duration_ms, 50) as p50')
     expect(module_main_tf).to include('by operation, bin(1h)')
+  end
+
+  it 'uses renderable hourly request volume series' do
+    expect(module_main_tf).to include('sum(if(event = "search_completed", 1, 0)) as completed_requests')
+    expect(module_main_tf).to include('sum(if(event = "search_failed", 1, 0)) as failed_requests')
+    expect(module_main_tf).to include('as failed_requests by search_type, bin(1h)')
+    expect(module_main_tf).not_to include('stats count(*) as searches by event, search_type, bin(1h)')
   end
 
   it 'uses a single outcome dimension for the result-type pie chart' do

--- a/terraform/modules/search_experiment_dashboard/main.tf
+++ b/terraform/modules/search_experiment_dashboard/main.tf
@@ -3,7 +3,7 @@ locals {
   source            = "SOURCE '${var.log_group_name}'"
   experiment_filter = "filter experiment = \"EXPERIMENT_LABEL\""
   search_filter     = "${local.experiment_filter} and service = \"search\""
-  ai_cost_filter    = "${local.experiment_filter} and ((service = \"search\" and event = \"api_call_completed\") or (service = \"ai_usage\" and event = \"embedding_api_call_completed\" and event_kind = \"vector_search_query_embedding\"))"
+  ai_cost_filter    = "filter event in [\"api_call_completed\", \"embedding_api_call_completed\"]\n              | ${local.experiment_filter} and ((service = \"search\" and event = \"api_call_completed\") or (service = \"ai_usage\" and event = \"embedding_api_call_completed\" and event_kind = \"vector_search_query_embedding\"))"
 
   search_dashboard_url            = "https://${var.region}.console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=Search-${var.environment}"
   search_operations_dashboard_url = "https://${var.region}.console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=SearchOperations-${var.environment}"
@@ -79,7 +79,8 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
             query  = <<-EOT
               ${local.source}
               | ${local.search_filter} and event in ["search_completed", "search_failed"]
-              | stats count(*) as searches by event, search_type, bin(1h)
+              | stats sum(if(event = "search_completed", 1, 0)) as completed_requests,
+                  sum(if(event = "search_failed", 1, 0)) as failed_requests by search_type, bin(1h)
             EOT
           }
         },
@@ -114,7 +115,8 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
               ${local.source}
               | ${local.ai_cost_filter}
               | fields if(ispresent(operation), operation, event_kind) as ai_operation
-              | filter pricing_known = true and ispresent(total_cost_usd)
+              | filter pricing_known
+              | filter ispresent(total_cost_usd)
               | stats sum(total_cost_usd) as total_cost_usd by ai_operation, model
               | sort total_cost_usd desc
             EOT
@@ -154,7 +156,7 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
               ${local.source}
               | ${local.ai_cost_filter}
               | fields if(ispresent(operation), operation, event_kind) as ai_operation
-              | filter pricing_known = false or not ispresent(total_cost_usd)
+              | filter not pricing_known or not ispresent(total_cost_usd)
               | stats count(*) as events, sum(total_tokens) as total_tokens, sum(total_cost_usd) as partial_cost_usd by ai_operation, model
               | sort events desc, partial_cost_usd desc, total_tokens desc
               | limit 50
@@ -264,7 +266,14 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
             query  = <<-EOT
               ${local.source}
               | ${local.search_filter} and event in ["question_returned", "answer_returned"]
-              | fields @timestamp, request_id, event, effective_query, question_count, answer_count, confidence_levels, attempt_number, iteration, details
+              | fields event,
+                  details.questions.0.question as question,
+                  details.answers.0.commodity_code as top_commodity_code,
+                  details.answers.0.confidence as top_confidence,
+                  answer_count,
+                  effective_query,
+                  request_id,
+                  @timestamp
               | sort @timestamp desc
               | limit 50
             EOT


### PR DESCRIPTION
## What:
- Make Hourly Request Volume return renderable completed and failed time series.
- Restore Total AI Cost by Operation by handling CloudWatch boolean fields correctly.
- Surface question text and top answer details directly in the Questions and Answers table.
- Prefilter AI events using the indexed event field, reducing the tested 24-hour production query scan from about 4.2 GB to about 60 MB without changing totals.
- Add regression coverage for the corrected query contracts.

## Why:
The production UAT dashboard had an unrenderable volume widget, an empty cost widget despite known costs, and diagnostic Q&A data hidden inside nested details. These query-only changes make the dashboard usable for the trstd-trdr experiment.

Live production Logs Insights validation returned 25 hourly search events, USD 0.476638 in known AI costs across three operations, and readable question and answer rows. Terraform validation, Terraform specs, RuboCop, tflint, and repository hooks pass.

## Ticket:
[AI-1070](https://transformuk.atlassian.net/browse/AI-1070)

## Risk:
**Risk level:** 🟢

**Reason for rating:**
This only changes read-only CloudWatch dashboard queries and their regression spec. It does not change application behaviour, stored data, deployment workflow, or AWS permissions.