### PR TITLE
Count guided search browser sessions

### DIFF
--- a/spec/terraform/search_experiment_dashboard_spec.rb
+++ b/spec/terraform/search_experiment_dashboard_spec.rb
@@ -36,7 +36,8 @@ RSpec.describe 'search experiment dashboard Terraform' do
 
   it 'explains how to interpret and investigate the production UAT cohort' do
     expect(module_main_tf).to include('Production UAT')
-    expect(module_main_tf).to include('Requests are counted, not unique users')
+    expect(module_main_tf).to include('Requests and distinct guided-search browser sessions are reported separately.')
+    expect(module_main_tf).to include('One browser session can contain multiple requests.')
     expect(module_main_tf).to include('Set the dashboard time range to the UAT window')
     expect(module_main_tf).to include('copy the request ID into admin search diagnostics')
     expect(module_main_tf).to include('Recent UAT Events')
@@ -77,6 +78,11 @@ RSpec.describe 'search experiment dashboard Terraform' do
     expect(module_main_tf).to include('Selected Results')
     expect(module_main_tf).to include('goods_nomenclature_item_id')
     expect(module_main_tf).to include('Top Zero-Result Terms')
+  end
+
+  it 'reports distinct guided-search browser sessions alongside request totals' do
+    expect(module_main_tf).to include('event = "guided_search.journey" and ispresent(browser_session_id)')
+    expect(module_main_tf).to include('count_distinct(browser_session_id) as distinct_browser_sessions')
   end
 
   it 'shows provider latency by operation so slow requests can be diagnosed' do

--- a/terraform/modules/search_experiment_dashboard/README.md
+++ b/terraform/modules/search_experiment_dashboard/README.md
@@ -1,6 +1,6 @@
 # search_experiment_dashboard
 
-CloudWatch Logs Insights dashboard for reviewing a labelled production-UAT search cohort. It summarises request outcomes, latency, AI usage and cost, search behaviour, and request IDs for diagnostic follow-up.
+CloudWatch Logs Insights dashboard for reviewing a labelled production-UAT search cohort. It summarises distinct observed guided-search browser sessions, request outcomes, latency, AI usage and cost, search behaviour, and request IDs for diagnostic follow-up.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/terraform/modules/search_experiment_dashboard/main.tf
+++ b/terraform/modules/search_experiment_dashboard/main.tf
@@ -36,7 +36,7 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
           properties = {
             markdown = join("\n", [
               "## Trade Tariff Search Production UAT",
-              "All widgets are scoped to the experiment label selected above. Requests are counted, not unique users.",
+              "All widgets are scoped to the experiment label selected above. Requests and distinct guided-search browser sessions are reported separately. One browser session can contain multiple requests.",
               "**Start here:** Set the dashboard time range to the UAT window, then review volume, reliability, latency, outcomes, questions, search terms, and costs.",
               "**Investigate:** copy the request ID into admin search diagnostics to reconstruct an individual request.",
               "**Related:** [Search Overview](${local.search_dashboard_url}) | [Search Operations](${local.search_operations_dashboard_url}) | [Search Quality](${local.search_quality_dashboard_url})",
@@ -57,8 +57,11 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
             view   = "bar"
             query  = <<-EOT
               ${local.source}
-              | ${local.search_filter} and event in ["search_completed", "search_failed", "result_selected"]
-              | stats sum(if(event = "search_completed", 1, 0)) as completed_requests,
+              | ${local.experiment_filter}
+              | filter (service = "search" and event in ["search_completed", "search_failed", "result_selected"])
+                  or (event = "guided_search.journey" and ispresent(browser_session_id))
+              | stats count_distinct(browser_session_id) as distinct_browser_sessions,
+                  sum(if(event = "search_completed", 1, 0)) as completed_requests,
                   sum(if(event = "search_failed", 1, 0)) as hard_failures,
                   sum(if(event = "search_completed" and final_result_type = "error", 1, 0)) as error_outcomes,
                   sum(if(event = "search_completed" and result_count = 0, 1, 0)) as zero_result_requests,


### PR DESCRIPTION
## What:

- [x] Count distinct observed guided-search browser sessions in the experiment dashboard’s UAT period totals
- [x] Preserve the existing request, failure, outcome, zero-result and selection totals
- [x] Keep `request_id` as the diagnostic correlation key and avoid displaying raw pseudonymous session IDs
- [x] Document that one browser session can contain multiple search requests
- [x] Verify all 17 Terraform specs, Terraform formatting, validation, TFLint, RuboCop and secret scanning

## Why:

Request counts show search volume but cannot show how many browser sessions produced that activity. The frontend journey logs include a session-cookie-scoped, HMAC-pseudonymised `browser_session_id`, so the experiment dashboard can report distinct observed browser sessions alongside requests without changing backend request plumbing.

This is deliberately described as browser sessions rather than unique users: multiple requests and tabs can share a session, and a new session cookie creates a new identifier.

## Ticket:

N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:** Read-only CloudWatch dashboard observability only. No application plumbing, API behaviour, resources or permissions change.