### PR TITLE
Harden guided search experiment telemetry

### DIFF
--- a/spec/terraform/search_experiment_dashboard_spec.rb
+++ b/spec/terraform/search_experiment_dashboard_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'search experiment dashboard Terraform' do
 
   it 'explains how to interpret and investigate the production UAT cohort' do
     expect(module_main_tf).to include('Production UAT')
-    expect(module_main_tf).to include('Requests and distinct guided-search browser sessions are reported separately.')
+    expect(module_main_tf).to include('Requests and estimated distinct guided-search browser sessions are reported separately.')
     expect(module_main_tf).to include('One browser session can contain multiple requests.')
     expect(module_main_tf).to include('Set the dashboard time range to the UAT window')
     expect(module_main_tf).to include('copy the request ID into admin search diagnostics')
@@ -64,12 +64,14 @@ RSpec.describe 'search experiment dashboard Terraform' do
   end
 
   it 'summarises the UAT period and exposes the behaviour needed for diagnosis' do
+    uat_period_totals_query = widget_query('UAT Period Totals')
+
     expect(module_main_tf).to include('UAT Period Totals')
-    expect(module_main_tf).to include('as completed_requests')
-    expect(module_main_tf).to include('as hard_failures')
-    expect(module_main_tf).to include('as error_outcomes')
-    expect(module_main_tf).to include('as zero_result_requests')
-    expect(module_main_tf).to include('as selections')
+    expect(uat_period_totals_query).to include('sum(if(event = "search_completed", 1, 0)) as completed_requests')
+    expect(uat_period_totals_query).to include('sum(if(event = "search_failed", 1, 0)) as hard_failures')
+    expect(uat_period_totals_query).to include('sum(if(event = "search_completed" and final_result_type = "error", 1, 0)) as error_outcomes')
+    expect(uat_period_totals_query).to include('sum(if(event = "search_completed" and result_count = 0, 1, 0)) as zero_result_requests')
+    expect(uat_period_totals_query).to include('sum(if(event = "guided_search.journey" and outcome = "result_selected", 1, 0)) as selections')
     expect(module_main_tf).to include('Questions and Answers')
     expect(module_main_tf).to include('event in ["question_returned", "answer_returned"]')
     expect(module_main_tf).to include('details.questions.0.question as question')
@@ -80,9 +82,39 @@ RSpec.describe 'search experiment dashboard Terraform' do
     expect(module_main_tf).to include('Top Zero-Result Terms')
   end
 
-  it 'reports distinct guided-search browser sessions alongside request totals' do
-    expect(module_main_tf).to include('event = "guided_search.journey" and ispresent(browser_session_id)')
-    expect(module_main_tf).to include('count_distinct(browser_session_id) as distinct_browser_sessions')
+  it 'reports estimated browser sessions from valid v1 guided-search events' do
+    uat_period_totals_query = widget_query('UAT Period Totals')
+
+    expect(uat_period_totals_query).to include('${local.experiment_filter}')
+    expect(uat_period_totals_query).to include('service = "search" and event in ["search_completed", "search_failed"]')
+    expect(uat_period_totals_query).to include(
+      'case(event = "guided_search.journey" and schema_version = 1 and browser_session_id like /^v1:[0-9a-f]{64}$/, browser_session_id) as guided_search_browser_session_id',
+    )
+    expect(uat_period_totals_query).to include('or ispresent(guided_search_browser_session_id)')
+    expect(uat_period_totals_query).to include(
+      'count_distinct(guided_search_browser_session_id) as estimated_browser_sessions',
+    )
+  end
+
+  it 'uses frontend journey events for guided-search result selections' do
+    selected_results_query = widget_query('Selected Results')
+
+    expect(selected_results_query).to include('${local.experiment_filter}')
+    expect(selected_results_query).to include(
+      'event = "guided_search.journey" and schema_version = 1 and outcome = "result_selected"',
+    )
+    expect(selected_results_query).to include('browser_session_id like /^v1:[0-9a-f]{64}$/')
+    expect(selected_results_query).to include('stats count(*) as selections by goods_nomenclature_item_id, confidence')
+    expect(selected_results_query).not_to include('${local.search_filter}')
+  end
+
+  it 'shows journey diagnostics without exposing browser session identifiers' do
+    recent_uat_events_query = widget_query('Recent UAT Events')
+
+    expect(recent_uat_events_query).to include(
+      'outcome, destination, result_rank, confidence, used_dont_know, client_elapsed_ms, client_navigation_ms',
+    )
+    expect(recent_uat_events_query).not_to include('browser_session_id')
   end
 
   it 'shows provider latency by operation so slow requests can be diagnosed' do
@@ -99,6 +131,7 @@ RSpec.describe 'search experiment dashboard Terraform' do
   end
 
   it 'gives detailed diagnostics enough horizontal space' do
+    expect(module_main_tf).to match(/width\s+= 8\n\s+height\s+= 6\n\s+properties = \{\n\s+title\s+= "UAT Period Totals"/)
     expect(module_main_tf).to match(/width\s+= 12\n\s+height\s+= 6\n\s+properties = \{\n\s+title\s+= "Total AI Cost by Operation"/)
     expect(module_main_tf).to match(/width\s+= 12\n\s+height\s+= 6\n\s+properties = \{\n\s+title\s+= "AI Token Totals by Operation"/)
     expect(module_main_tf).to match(/width\s+= 16\n\s+height\s+= 6\n\s+properties = \{\n\s+title\s+= "AI API Latency \(p50\/p90\/p99\)"/)
@@ -114,5 +147,12 @@ RSpec.describe 'search experiment dashboard Terraform' do
   it 'is discoverable from the search overview dashboard' do
     expect(search_dashboard_tf).to include('Search Experiments')
     expect(search_dashboard_tf).to include('SearchExperiment-${var.environment}')
+  end
+
+  def widget_query(title)
+    module_main_tf.match(/title\s+= "#{Regexp.escape(title)}".*?query\s+= <<-EOT\n(.*?)\n\s+EOT/m).then do |match|
+      expect(match).to be_present
+      match[1]
+    end
   end
 end

--- a/terraform/modules/search_experiment_dashboard/README.md
+++ b/terraform/modules/search_experiment_dashboard/README.md
@@ -1,6 +1,6 @@
 # search_experiment_dashboard
 
-CloudWatch Logs Insights dashboard for reviewing a labelled production-UAT search cohort. It summarises distinct observed guided-search browser sessions, request outcomes, latency, AI usage and cost, search behaviour, and request IDs for diagnostic follow-up.
+CloudWatch Logs Insights dashboard for reviewing a labelled production-UAT search cohort. It consumes version 1 `guided_search.journey` events to summarise estimated distinct observed browser sessions and guided-search selections alongside request outcomes, latency, AI usage and cost, search behaviour, and request IDs for diagnostic follow-up.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/terraform/modules/search_experiment_dashboard/main.tf
+++ b/terraform/modules/search_experiment_dashboard/main.tf
@@ -36,7 +36,7 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
           properties = {
             markdown = join("\n", [
               "## Trade Tariff Search Production UAT",
-              "All widgets are scoped to the experiment label selected above. Requests and distinct guided-search browser sessions are reported separately. One browser session can contain multiple requests.",
+              "All widgets are scoped to the experiment label selected above. Requests and estimated distinct guided-search browser sessions are reported separately. One browser session can contain multiple requests. CloudWatch may approximate high-cardinality counts.",
               "**Start here:** Set the dashboard time range to the UAT window, then review volume, reliability, latency, outcomes, questions, search terms, and costs.",
               "**Investigate:** copy the request ID into admin search diagnostics to reconstruct an individual request.",
               "**Related:** [Search Overview](${local.search_dashboard_url}) | [Search Operations](${local.search_operations_dashboard_url}) | [Search Quality](${local.search_quality_dashboard_url})",
@@ -49,7 +49,7 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
           type   = "log"
           x      = 0
           y      = 2
-          width  = 6
+          width  = 8
           height = 6
           properties = {
             title  = "UAT Period Totals"
@@ -58,22 +58,23 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
             query  = <<-EOT
               ${local.source}
               | ${local.experiment_filter}
-              | filter (service = "search" and event in ["search_completed", "search_failed", "result_selected"])
-                  or (event = "guided_search.journey" and ispresent(browser_session_id))
-              | stats count_distinct(browser_session_id) as distinct_browser_sessions,
+              | fields case(event = "guided_search.journey" and schema_version = 1 and browser_session_id like /^v1:[0-9a-f]{64}$/, browser_session_id) as guided_search_browser_session_id
+              | filter (service = "search" and event in ["search_completed", "search_failed"])
+                  or ispresent(guided_search_browser_session_id)
+              | stats count_distinct(guided_search_browser_session_id) as estimated_browser_sessions,
                   sum(if(event = "search_completed", 1, 0)) as completed_requests,
                   sum(if(event = "search_failed", 1, 0)) as hard_failures,
                   sum(if(event = "search_completed" and final_result_type = "error", 1, 0)) as error_outcomes,
                   sum(if(event = "search_completed" and result_count = 0, 1, 0)) as zero_result_requests,
-                  sum(if(event = "result_selected", 1, 0)) as selections
+                  sum(if(event = "guided_search.journey" and outcome = "result_selected", 1, 0)) as selections
             EOT
           }
         },
         {
           type   = "log"
-          x      = 6
+          x      = 8
           y      = 2
-          width  = 9
+          width  = 8
           height = 6
           properties = {
             title  = "Hourly Request Volume"
@@ -89,9 +90,9 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
         },
         {
           type   = "log"
-          x      = 15
+          x      = 16
           y      = 2
-          width  = 9
+          width  = 8
           height = 6
           properties = {
             title  = "E2E Latency (p50/p90/p99)"
@@ -334,8 +335,9 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
             region = var.region
             query  = <<-EOT
               ${local.source}
-              | ${local.search_filter} and event = "result_selected"
-              | stats count(*) as selections by goods_nomenclature_item_id, goods_nomenclature_class
+              | ${local.experiment_filter} and event = "guided_search.journey" and schema_version = 1 and outcome = "result_selected"
+              | filter browser_session_id like /^v1:[0-9a-f]{64}$/
+              | stats count(*) as selections by goods_nomenclature_item_id, confidence
               | sort selections desc
               | limit 30
             EOT
@@ -355,7 +357,7 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
             query  = <<-EOT
               ${local.source}
               | ${local.experiment_filter}
-              | fields @timestamp, request_id, service, event, event_kind, search_type, query, effective_query, question_count, answer_count, total_questions, result_count, results_type, final_result_type, total_duration_ms, duration_ms, operation, model, total_tokens, total_cost_usd, error_message, details
+              | fields @timestamp, request_id, service, event, schema_version, outcome, destination, result_rank, confidence, used_dont_know, client_elapsed_ms, client_navigation_ms, event_kind, search_type, query, effective_query, question_count, option_count, answer_count, total_questions, result_count, results_type, final_result_type, total_duration_ms, duration_ms, operation, model, total_tokens, total_cost_usd, error_message, details
               | sort @timestamp desc
               | limit 100
             EOT


### PR DESCRIPTION
## What:

- [x] Count browser sessions only from valid version 1 guided-search journey events
- [x] Label the high-cardinality session total as an estimate
- [x] Count guided-search selections from experiment-labelled frontend journey events
- [x] Show bounded journey outcome, result and timing fields without displaying session identifiers
- [x] Widen the UAT totals widget and strengthen widget-scoped regression coverage
- [x] Verify all 19 Terraform specs, Terraform validation, TFLint, RuboCop and secret scanning

## Why:

The experiment dashboard consumes a versioned frontend log contract. Constraining the query to valid version 1 session identifiers prevents malformed or future event schemas from inflating the session estimate.

Guided-search result clicks are recorded as frontend `guided_search.journey` events with `outcome = "result_selected"`. Using those events fixes experiment selection totals without changing backend request plumbing. The detailed event table exposes the new bounded journey fields while keeping the pseudonymous browser-session identifier aggregate-only.

## Ticket:

N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:** Read-only CloudWatch dashboard observability only. No application plumbing, APIs, resources, permissions or user journeys change.