### PR TITLE
Simplify search experiment latency charts

### DIFF
--- a/spec/terraform/search_experiment_dashboard_spec.rb
+++ b/spec/terraform/search_experiment_dashboard_spec.rb
@@ -117,10 +117,16 @@ RSpec.describe 'search experiment dashboard Terraform' do
     expect(recent_uat_events_query).not_to include('browser_session_id')
   end
 
-  it 'shows provider latency by operation so slow requests can be diagnosed' do
+  it 'shows overall provider latency percentiles as a comparable time series' do
     expect(module_main_tf).to include('AI API Latency (p50/p90/p99)')
     expect(module_main_tf).to include('pct(duration_ms, 50) as p50')
-    expect(module_main_tf).to include('by operation, bin(1h)')
+    expect(widget_query('AI API Latency (p50/p90/p99)')).to include('by bin(1h)')
+    expect(widget_query('AI API Latency (p50/p90/p99)')).not_to include('by operation, bin(1h)')
+  end
+
+  it 'renders latency percentiles together instead of splitting them into dimension panes' do
+    expect(widget_query('E2E Latency (p50/p90/p99)')).to include('by bin(1h)')
+    expect(widget_query('E2E Latency (p50/p90/p99)')).not_to include('by search_type, bin(1h)')
   end
 
   it 'uses renderable hourly request volume series' do

--- a/terraform/modules/search_experiment_dashboard/main.tf
+++ b/terraform/modules/search_experiment_dashboard/main.tf
@@ -101,7 +101,7 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
             query  = <<-EOT
               ${local.source}
               | ${local.search_filter} and event = "search_completed"
-              | stats pct(total_duration_ms, 50) as p50, pct(total_duration_ms, 90) as p90, pct(total_duration_ms, 99) as p99 by search_type, bin(1h)
+              | stats pct(total_duration_ms, 50) as p50, pct(total_duration_ms, 90) as p90, pct(total_duration_ms, 99) as p99 by bin(1h)
             EOT
           }
         },
@@ -180,7 +180,7 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
             query  = <<-EOT
               ${local.source}
               | ${local.search_filter} and event = "api_call_completed"
-              | stats pct(duration_ms, 50) as p50, pct(duration_ms, 90) as p90, pct(duration_ms, 99) as p99 by operation, bin(1h)
+              | stats pct(duration_ms, 50) as p50, pct(duration_ms, 90) as p90, pct(duration_ms, 99) as p99 by bin(1h)
             EOT
           }
         },


### PR DESCRIPTION
## What:

- [x] Render E2E p50/p90/p99 as three comparable hourly lines
- [x] Render AI API p50/p90/p99 as three comparable hourly lines
- [x] Remove search-type and operation dimensions that split each percentile into cramped mini-panels
- [x] Add widget-scoped regression coverage

## Why:

CloudWatch split both latency widgets into multiple narrow panes, making the percentile trends difficult to read. Cohort-level hourly percentiles produce one useful chart per widget. Search-type and operation details remain available in Recent UAT Events and the linked operations dashboard.

## Ticket:

N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:** Read-only CloudWatch dashboard presentation only. No application plumbing, APIs, resources, permissions or user journeys change.