### PR TITLE
Clarify latency units across CloudWatch dashboards

### DIFF
--- a/spec/terraform/dashboard_latency_units_spec.rb
+++ b/spec/terraform/dashboard_latency_units_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe 'CloudWatch dashboard latency units' do

--- a/spec/terraform/dashboard_latency_units_spec.rb
+++ b/spec/terraform/dashboard_latency_units_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe 'CloudWatch dashboard latency units' do
+  dashboard_files = Dir[Rails.root.join('terraform/modules/*_dashboard/main.tf')].freeze
+
+  latency_widgets = dashboard_files.flat_map do |path|
+    File.read(path).scan(
+      /title\s+= "([^"]+)"(?:(?!title\s+=).)*?query\s+= <<-EOT\n(.*?)\n\s+EOT/m,
+    ).filter_map do |title, query|
+      [path, title, query] if query.match?(/\| stats .*duration_ms/)
+    end
+  end
+
+  it 'converts every aggregated millisecond duration to a human-scale unit' do
+    aggregate_expressions = latency_widgets.flat_map do |_path, _title, query|
+      query.scan(/\b(?:pct|avg|max|min|median)\(([^)]*duration_ms[^)]*)\)/).flatten
+    end
+
+    expect(aggregate_expressions).not_to be_empty
+    expect(aggregate_expressions).to all(match(%r{/ (?:1000|60000)}))
+  end
+
+  it 'states the unit in every latency or duration chart title' do
+    titles = latency_widgets.map { |_path, title, _query| title }
+
+    expect(titles).to all(match(/\b(?:seconds|minutes)\b/))
+    expect(titles.join("\n")).not_to match(/\((?:ms|s|min)\)/)
+  end
+
+  it 'states the unit in every aggregated latency or duration series name' do
+    queries = latency_widgets.map { |_path, _title, query| query }
+
+    expect(queries).to all(match(/\bas \w+_(?:seconds|minutes)\b/))
+    expect(queries.join("\n")).not_to match(/\bas (?:p50|p90|p99|max|avg|avg_ms|avg_duration_ms)\b/)
+  end
+end

--- a/spec/terraform/search_experiment_dashboard_spec.rb
+++ b/spec/terraform/search_experiment_dashboard_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'search experiment dashboard Terraform' do
 
   it 'covers experiment usage, performance, outcomes, questions, searches, and AI costs' do
     expect(module_main_tf).to include('UAT Period Totals')
-    expect(module_main_tf).to include('E2E Latency (p50/p90/p99)')
+    expect(module_main_tf).to include('E2E Latency in seconds (p50/p90/p99)')
     expect(module_main_tf).to include('Final Result Types')
     expect(module_main_tf).to include('Questions per Search')
     expect(module_main_tf).to include('Top Search Terms')
@@ -118,15 +118,15 @@ RSpec.describe 'search experiment dashboard Terraform' do
   end
 
   it 'shows overall provider latency percentiles as a comparable time series' do
-    expect(module_main_tf).to include('AI API Latency (p50/p90/p99)')
-    expect(module_main_tf).to include('pct(duration_ms, 50) as p50')
-    expect(widget_query('AI API Latency (p50/p90/p99)')).to include('by bin(1h)')
-    expect(widget_query('AI API Latency (p50/p90/p99)')).not_to include('by operation, bin(1h)')
+    expect(module_main_tf).to include('AI API Latency in seconds (p50/p90/p99)')
+    expect(module_main_tf).to include('pct(duration_ms / 1000, 50) as p50_seconds')
+    expect(widget_query('AI API Latency in seconds (p50/p90/p99)')).to include('by bin(1h)')
+    expect(widget_query('AI API Latency in seconds (p50/p90/p99)')).not_to include('by operation, bin(1h)')
   end
 
   it 'renders latency percentiles together instead of splitting them into dimension panes' do
-    expect(widget_query('E2E Latency (p50/p90/p99)')).to include('by bin(1h)')
-    expect(widget_query('E2E Latency (p50/p90/p99)')).not_to include('by search_type, bin(1h)')
+    expect(widget_query('E2E Latency in seconds (p50/p90/p99)')).to include('by bin(1h)')
+    expect(widget_query('E2E Latency in seconds (p50/p90/p99)')).not_to include('by search_type, bin(1h)')
   end
 
   it 'uses renderable hourly request volume series' do
@@ -140,7 +140,7 @@ RSpec.describe 'search experiment dashboard Terraform' do
     expect(module_main_tf).to match(/width\s+= 8\n\s+height\s+= 6\n\s+properties = \{\n\s+title\s+= "UAT Period Totals"/)
     expect(module_main_tf).to match(/width\s+= 12\n\s+height\s+= 6\n\s+properties = \{\n\s+title\s+= "Total AI Cost by Operation"/)
     expect(module_main_tf).to match(/width\s+= 12\n\s+height\s+= 6\n\s+properties = \{\n\s+title\s+= "AI Token Totals by Operation"/)
-    expect(module_main_tf).to match(/width\s+= 16\n\s+height\s+= 6\n\s+properties = \{\n\s+title\s+= "AI API Latency \(p50\/p90\/p99\)"/)
+    expect(module_main_tf).to match(/width\s+= 16\n\s+height\s+= 6\n\s+properties = \{\n\s+title\s+= "AI API Latency in seconds \(p50\/p90\/p99\)"/)
     expect(module_main_tf).to match(/width\s+= 24\n\s+height\s+= 6\n\s+properties = \{\n\s+title\s+= "Questions and Answers"/)
     expect(module_main_tf).to include('| fields details.questions.0.question as question,')
   end

--- a/terraform/modules/label_generator_dashboard/main.tf
+++ b/terraform/modules/label_generator_dashboard/main.tf
@@ -59,13 +59,13 @@ resource "aws_cloudwatch_dashboard" "label_generator" {
           width  = 6
           height = 6
           properties = {
-            title  = "API Latency (p50/p90)"
+            title  = "API Latency in seconds (p50/p90)"
             region = var.region
             view   = "timeSeries"
             query  = <<-EOT
               ${local.source}
               | ${local.service_filter} and event = "api_call_completed"
-              | stats pct(duration_ms, 50) as p50, pct(duration_ms, 90) as p90 by bin(1h)
+              | stats pct(duration_ms / 1000, 50) as p50_seconds, pct(duration_ms / 1000, 90) as p90_seconds by bin(1h)
             EOT
           }
         },
@@ -114,13 +114,13 @@ resource "aws_cloudwatch_dashboard" "label_generator" {
           width  = 12
           height = 6
           properties = {
-            title  = "Page Processing Percentiles (ms)"
+            title  = "Page Processing in seconds (p50/p90/p99)"
             region = var.region
             view   = "timeSeries"
             query  = <<-EOT
               ${local.source}
               | ${local.service_filter} and event = "page_completed"
-              | stats pct(duration_ms, 50) as p50, pct(duration_ms, 90) as p90, pct(duration_ms, 99) as p99 by bin(1h)
+              | stats pct(duration_ms / 1000, 50) as p50_seconds, pct(duration_ms / 1000, 90) as p90_seconds, pct(duration_ms / 1000, 99) as p99_seconds by bin(1h)
             EOT
           }
         },
@@ -131,13 +131,13 @@ resource "aws_cloudwatch_dashboard" "label_generator" {
           width  = 12
           height = 6
           properties = {
-            title  = "API Latency Percentiles (ms)"
+            title  = "API Latency in seconds (p50/p90/p99)"
             region = var.region
             view   = "timeSeries"
             query  = <<-EOT
               ${local.source}
               | ${local.service_filter} and event = "api_call_completed"
-              | stats pct(duration_ms, 50) as p50, pct(duration_ms, 90) as p90, pct(duration_ms, 99) as p99 by bin(1h)
+              | stats pct(duration_ms / 1000, 50) as p50_seconds, pct(duration_ms / 1000, 90) as p90_seconds, pct(duration_ms / 1000, 99) as p99_seconds by bin(1h)
             EOT
           }
         }

--- a/terraform/modules/search_dashboard/main.tf
+++ b/terraform/modules/search_dashboard/main.tf
@@ -112,13 +112,13 @@ resource "aws_cloudwatch_dashboard" "search" {
           width  = 8
           height = 6
           properties = {
-            title  = "E2E Latency (p50/p90)"
+            title  = "E2E Latency in seconds (p50/p90)"
             region = var.region
             view   = "timeSeries"
             query  = <<-EOT
               ${local.source}
               | ${local.service_filter} and event = "search_completed"
-              | stats pct(total_duration_ms, 50) as p50, pct(total_duration_ms, 90) as p90 by bin(1d)
+              | stats pct(total_duration_ms / 1000, 50) as p50_seconds, pct(total_duration_ms / 1000, 90) as p90_seconds by bin(1d)
             EOT
           }
         },
@@ -129,13 +129,13 @@ resource "aws_cloudwatch_dashboard" "search" {
           width  = 8
           height = 6
           properties = {
-            title  = "AI API Latency (p50/p90)"
+            title  = "AI API Latency in seconds (p50/p90)"
             region = var.region
             view   = "timeSeries"
             query  = <<-EOT
               ${local.source}
               | ${local.service_filter} and event = "api_call_completed"
-              | stats pct(duration_ms, 50) as p50, pct(duration_ms, 90) as p90 by bin(1d)
+              | stats pct(duration_ms / 1000, 50) as p50_seconds, pct(duration_ms / 1000, 90) as p90_seconds by bin(1d)
             EOT
           }
         },

--- a/terraform/modules/search_experiment_dashboard/main.tf
+++ b/terraform/modules/search_experiment_dashboard/main.tf
@@ -95,13 +95,13 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
           width  = 8
           height = 6
           properties = {
-            title  = "E2E Latency (p50/p90/p99)"
+            title  = "E2E Latency in seconds (p50/p90/p99)"
             region = var.region
             view   = "timeSeries"
             query  = <<-EOT
               ${local.source}
               | ${local.search_filter} and event = "search_completed"
-              | stats pct(total_duration_ms, 50) as p50, pct(total_duration_ms, 90) as p90, pct(total_duration_ms, 99) as p99 by bin(1h)
+              | stats pct(total_duration_ms / 1000, 50) as p50_seconds, pct(total_duration_ms / 1000, 90) as p90_seconds, pct(total_duration_ms / 1000, 99) as p99_seconds by bin(1h)
             EOT
           }
         },
@@ -174,13 +174,13 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
           width  = 16
           height = 6
           properties = {
-            title  = "AI API Latency (p50/p90/p99)"
+            title  = "AI API Latency in seconds (p50/p90/p99)"
             region = var.region
             view   = "timeSeries"
             query  = <<-EOT
               ${local.source}
               | ${local.search_filter} and event = "api_call_completed"
-              | stats pct(duration_ms, 50) as p50, pct(duration_ms, 90) as p90, pct(duration_ms, 99) as p99 by bin(1h)
+              | stats pct(duration_ms / 1000, 50) as p50_seconds, pct(duration_ms / 1000, 90) as p90_seconds, pct(duration_ms / 1000, 99) as p99_seconds by bin(1h)
             EOT
           }
         },

--- a/terraform/modules/search_operations_dashboard/main.tf
+++ b/terraform/modules/search_operations_dashboard/main.tf
@@ -55,13 +55,13 @@ resource "aws_cloudwatch_dashboard" "search_operations" {
           width  = 6
           height = 6
           properties = {
-            title  = "E2E Latency (p50/p90/p99)"
+            title  = "E2E Latency in seconds (p50/p90/p99)"
             region = var.region
             view   = "timeSeries"
             query  = <<-EOT
               ${local.source}
               | ${local.service_filter} and event = "search_completed"
-              | stats pct(total_duration_ms, 50) as p50, pct(total_duration_ms, 90) as p90, pct(total_duration_ms, 99) as p99 by bin(1h)
+              | stats pct(total_duration_ms / 1000, 50) as p50_seconds, pct(total_duration_ms / 1000, 90) as p90_seconds, pct(total_duration_ms / 1000, 99) as p99_seconds by bin(1h)
             EOT
           }
         },
@@ -72,13 +72,13 @@ resource "aws_cloudwatch_dashboard" "search_operations" {
           width  = 6
           height = 6
           properties = {
-            title  = "AI API Latency (p50/p90/p99)"
+            title  = "AI API Latency in seconds (p50/p90/p99)"
             region = var.region
             view   = "timeSeries"
             query  = <<-EOT
               ${local.source}
               | ${local.service_filter} and event = "api_call_completed"
-              | stats pct(duration_ms, 50) as p50, pct(duration_ms, 90) as p90, pct(duration_ms, 99) as p99 by bin(1h)
+              | stats pct(duration_ms / 1000, 50) as p50_seconds, pct(duration_ms / 1000, 90) as p90_seconds, pct(duration_ms / 1000, 99) as p99_seconds by bin(1h)
             EOT
           }
         },
@@ -108,13 +108,13 @@ resource "aws_cloudwatch_dashboard" "search_operations" {
           width  = 8
           height = 6
           properties = {
-            title  = "Query Expansion Volume"
+            title  = "Query Expansion Volume and Average Duration in seconds"
             region = var.region
             view   = "timeSeries"
             query  = <<-EOT
               ${local.source}
               | ${local.service_filter} and event = "query_expanded"
-              | stats count(*) as expansions, avg(duration_ms) as avg_duration_ms by bin(1h)
+              | stats count(*) as expansions, avg(duration_ms / 1000) as avg_duration_seconds by bin(1h)
             EOT
           }
         },
@@ -161,13 +161,13 @@ resource "aws_cloudwatch_dashboard" "search_operations" {
           width  = 8
           height = 6
           properties = {
-            title  = "Hybrid Leg Latency (p50/p90)"
+            title  = "Hybrid Leg Latency in seconds (p50/p90)"
             region = var.region
             view   = "timeSeries"
             query  = <<-EOT
               ${local.source}
               | ${local.service_filter} and event = "retrieval_leg_completed"
-              | stats pct(duration_ms, 50) as p50, pct(duration_ms, 90) as p90 by leg, bin(1h)
+              | stats pct(duration_ms / 1000, 50) as p50_seconds, pct(duration_ms / 1000, 90) as p90_seconds by leg, bin(1h)
             EOT
           }
         },
@@ -214,12 +214,12 @@ resource "aws_cloudwatch_dashboard" "search_operations" {
           width  = 8
           height = 6
           properties = {
-            title  = "Query Expansion Detail"
+            title  = "Query Expansion Detail in seconds"
             region = var.region
             query  = <<-EOT
               ${local.source}
               | ${local.service_filter} and event = "query_expanded"
-              | stats count(*) as expansions, avg(duration_ms) as avg_ms by reason
+              | stats count(*) as expansions, avg(duration_ms / 1000) as avg_seconds by reason
               | sort expansions desc
             EOT
           }
@@ -270,13 +270,13 @@ resource "aws_cloudwatch_dashboard" "search_operations" {
           width  = 8
           height = 6
           properties = {
-            title  = "Duplicate Guard AI Latency"
+            title  = "Duplicate Guard AI Latency in seconds"
             region = var.region
             view   = "timeSeries"
             query  = <<-EOT
               ${local.source}
               | ${local.service_filter} and event = "api_call_completed" and operation in ["duplicate_question_validator", "duplicate_question_retry"]
-              | stats pct(duration_ms, 50) as p50, pct(duration_ms, 90) as p90, pct(duration_ms, 99) as p99 by operation, bin(1h)
+              | stats pct(duration_ms / 1000, 50) as p50_seconds, pct(duration_ms / 1000, 90) as p90_seconds, pct(duration_ms / 1000, 99) as p99_seconds by operation, bin(1h)
             EOT
           }
         },

--- a/terraform/modules/self_text_generator_dashboard/main.tf
+++ b/terraform/modules/self_text_generator_dashboard/main.tf
@@ -58,13 +58,13 @@ resource "aws_cloudwatch_dashboard" "self_text_generator" {
           width  = 6
           height = 6
           properties = {
-            title  = "API Latency (p50/p90) (min)"
+            title  = "API Latency in minutes (p50/p90)"
             region = var.region
             view   = "timeSeries"
             query  = <<-EOT
               ${local.source}
               | ${local.service_filter} and event = "api_call_completed"
-              | stats pct(duration_ms / 60000, 50) as p50, pct(duration_ms / 60000, 90) as p90 by bin(1h)
+              | stats pct(duration_ms / 60000, 50) as p50_minutes, pct(duration_ms / 60000, 90) as p90_minutes by bin(1h)
             EOT
           }
         },
@@ -113,13 +113,13 @@ resource "aws_cloudwatch_dashboard" "self_text_generator" {
           width  = 12
           height = 6
           properties = {
-            title  = "Chapter Processing Percentiles (min)"
+            title  = "Chapter Processing in minutes (p50/p90/p99)"
             region = var.region
             view   = "timeSeries"
             query  = <<-EOT
               ${local.source}
               | ${local.service_filter} and event = "chapter_completed" and not ispresent(exception)
-              | stats pct(duration_ms / 60000, 50) as p50, pct(duration_ms / 60000, 90) as p90, pct(duration_ms / 60000, 99) as p99 by bin(1h)
+              | stats pct(duration_ms / 60000, 50) as p50_minutes, pct(duration_ms / 60000, 90) as p90_minutes, pct(duration_ms / 60000, 99) as p99_minutes by bin(1h)
             EOT
           }
         },
@@ -130,13 +130,13 @@ resource "aws_cloudwatch_dashboard" "self_text_generator" {
           width  = 12
           height = 6
           properties = {
-            title  = "API Latency Percentiles (min)"
+            title  = "API Latency in minutes (p50/p90/p99)"
             region = var.region
             view   = "timeSeries"
             query  = <<-EOT
               ${local.source}
               | ${local.service_filter} and event = "api_call_completed"
-              | stats pct(duration_ms / 60000, 50) as p50, pct(duration_ms / 60000, 90) as p90, pct(duration_ms / 60000, 99) as p99 by bin(1h)
+              | stats pct(duration_ms / 60000, 50) as p50_minutes, pct(duration_ms / 60000, 90) as p90_minutes, pct(duration_ms / 60000, 99) as p99_minutes by bin(1h)
             EOT
           }
         }
@@ -249,13 +249,13 @@ resource "aws_cloudwatch_dashboard" "self_text_generator" {
           width  = 8
           height = 6
           properties = {
-            title  = "Embedding API Latency (p50/p90) (s)"
+            title  = "Embedding API Latency in seconds (p50/p90)"
             region = var.region
             view   = "timeSeries"
             query  = <<-EOT
               ${local.source}
               | ${local.service_filter} and event = "embedding_api_call_completed"
-              | stats pct(duration_ms / 1000, 50) as p50, pct(duration_ms / 1000, 90) as p90 by bin(1h)
+              | stats pct(duration_ms / 1000, 50) as p50_seconds, pct(duration_ms / 1000, 90) as p90_seconds by bin(1h)
             EOT
           }
         },

--- a/terraform/modules/tariff_note_pipeline_dashboard/main.tf
+++ b/terraform/modules/tariff_note_pipeline_dashboard/main.tf
@@ -73,13 +73,13 @@ resource "aws_cloudwatch_dashboard" "tariff_note_pipeline" {
           width  = 6
           height = 6
           properties = {
-            title  = "Duration: Run p50/p90/p99 (ms)"
+            title  = "Run Duration in seconds (p50/p90/p99)"
             region = var.region
             view   = "timeSeries"
             query  = <<-EOT
               ${local.source}
               | ${local.service_filter} and event = "import_run_completed"
-              | stats pct(duration_ms, 50) as p50, pct(duration_ms, 90) as p90, pct(duration_ms, 99) as p99 by bin(1h)
+              | stats pct(duration_ms / 1000, 50) as p50_seconds, pct(duration_ms / 1000, 90) as p90_seconds, pct(duration_ms / 1000, 99) as p99_seconds by bin(1h)
             EOT
           }
         },
@@ -112,13 +112,13 @@ resource "aws_cloudwatch_dashboard" "tariff_note_pipeline" {
           width  = 8
           height = 6
           properties = {
-            title  = "Fetch Duration p50/p90/p99 (ms)"
+            title  = "Fetch Duration in seconds (p50/p90/p99)"
             region = var.region
             view   = "timeSeries"
             query  = <<-EOT
               ${local.source}
               | ${local.service_filter} and event = "document_fetched"
-              | stats pct(duration_ms, 50) as p50, pct(duration_ms, 90) as p90, pct(duration_ms, 99) as p99 by bin(1h)
+              | stats pct(duration_ms / 1000, 50) as p50_seconds, pct(duration_ms / 1000, 90) as p90_seconds, pct(duration_ms / 1000, 99) as p99_seconds by bin(1h)
             EOT
           }
         },
@@ -129,13 +129,13 @@ resource "aws_cloudwatch_dashboard" "tariff_note_pipeline" {
           width  = 8
           height = 6
           properties = {
-            title  = "Parse Duration p50/p90/p99 (ms)"
+            title  = "Parse Duration in seconds (p50/p90/p99)"
             region = var.region
             view   = "timeSeries"
             query  = <<-EOT
               ${local.source}
               | ${local.service_filter} and event = "document_parsed"
-              | stats pct(duration_ms, 50) as p50, pct(duration_ms, 90) as p90, pct(duration_ms, 99) as p99 by bin(1h)
+              | stats pct(duration_ms / 1000, 50) as p50_seconds, pct(duration_ms / 1000, 90) as p90_seconds, pct(duration_ms / 1000, 99) as p99_seconds by bin(1h)
             EOT
           }
         },
@@ -146,13 +146,13 @@ resource "aws_cloudwatch_dashboard" "tariff_note_pipeline" {
           width  = 8
           height = 6
           properties = {
-            title  = "Document Import Duration p50/p90/p99 (ms)"
+            title  = "Document Import Duration in seconds (p50/p90/p99)"
             region = var.region
             view   = "timeSeries"
             query  = <<-EOT
               ${local.source}
               | ${local.service_filter} and event = "document_imported"
-              | stats pct(duration_ms, 50) as p50, pct(duration_ms, 90) as p90, pct(duration_ms, 99) as p99 by bin(1h)
+              | stats pct(duration_ms / 1000, 50) as p50_seconds, pct(duration_ms / 1000, 90) as p90_seconds, pct(duration_ms / 1000, 99) as p99_seconds by bin(1h)
             EOT
           }
         }

--- a/terraform/modules/tariff_sync_dashboard/main.tf
+++ b/terraform/modules/tariff_sync_dashboard/main.tf
@@ -95,13 +95,13 @@ resource "aws_cloudwatch_dashboard" "tariff_sync" {
           width  = 6
           height = 6
           properties = {
-            title  = "Apply Duration (ms)"
+            title  = "Apply Duration in seconds"
             region = var.region
             view   = "timeSeries"
             query  = <<-EOT
               ${local.source}
               | ${local.service_filter} and event = "apply_completed"
-              | stats max(duration_ms) as max, avg(duration_ms) as avg by bin(1d)
+              | stats max(duration_ms / 1000) as max_seconds, avg(duration_ms / 1000) as avg_seconds by bin(1d)
             EOT
           }
         }
@@ -116,13 +116,13 @@ resource "aws_cloudwatch_dashboard" "tariff_sync" {
           width  = 8
           height = 6
           properties = {
-            title  = "Download Duration (ms)"
+            title  = "Download Duration in seconds"
             region = var.region
             view   = "timeSeries"
             query  = <<-EOT
               ${local.source}
               | ${local.service_filter} and event = "download_completed"
-              | stats max(duration_ms) as max, avg(duration_ms) as avg by bin(1d)
+              | stats max(duration_ms / 1000) as max_seconds, avg(duration_ms / 1000) as avg_seconds by bin(1d)
             EOT
           }
         },
@@ -133,13 +133,13 @@ resource "aws_cloudwatch_dashboard" "tariff_sync" {
           width  = 8
           height = 6
           properties = {
-            title  = "File Import Duration (ms)"
+            title  = "File Import Duration in seconds"
             region = var.region
             view   = "timeSeries"
             query  = <<-EOT
               ${local.source}
               | ${local.service_filter} and event = "file_import_completed"
-              | stats max(duration_ms) as max, avg(duration_ms) as avg by bin(1d)
+              | stats max(duration_ms / 1000) as max_seconds, avg(duration_ms / 1000) as avg_seconds by bin(1d)
             EOT
           }
         },


### PR DESCRIPTION
## What:

- [x] Convert raw millisecond aggregates to seconds across short-running dashboard latency and duration charts
- [x] Keep long-running self-text generation charts in minutes
- [x] Add explicit units to chart titles and series names
- [x] Preserve raw millisecond fields in diagnostic event tables
- [x] Add a cross-dashboard regression contract covering 24 duration widgets in seven modules
- [x] Verify all 23 Terraform specs, Terraform validation, formatting, TFLint, RuboCop and secret scanning

## Why:

CloudWatch abbreviated millisecond values such as 8,090 ms to 8.09k without showing a unit, making latency charts difficult to interpret. Human-scale values and explicit labels make the axes and legends immediately understandable while preserving the underlying telemetry.

## Ticket:

N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:** Read-only CloudWatch dashboard presentation and regression coverage only. No application plumbing, APIs, resources, permissions or user journeys change.