### PR TITLE
AI-1092 Expose guided search journey outcomes

### DIFF
--- a/spec/terraform/search_experiment_dashboard_spec.rb
+++ b/spec/terraform/search_experiment_dashboard_spec.rb
@@ -72,9 +72,9 @@ RSpec.describe 'search experiment dashboard Terraform' do
     expect(uat_period_totals_query).to include('sum(if(event = "search_completed" and final_result_type = "error", 1, 0)) as error_outcomes')
     expect(uat_period_totals_query).to include('sum(if(event = "search_completed" and result_count = 0, 1, 0)) as zero_result_requests')
     expect(uat_period_totals_query).to include('sum(if(event = "guided_search.journey" and outcome = "result_selected", 1, 0)) as selections')
-    expect(module_main_tf).to include('Questions and Answers')
+    expect(module_main_tf).to include('Questions and Answer Options')
     expect(module_main_tf).to include('event in ["question_returned", "answer_returned"]')
-    expect(module_main_tf).to include('details.questions.0.question as question')
+    expect(module_main_tf).to include('event_payload.details.questions[0].question as question')
     expect(module_main_tf).to include('details.answers.0.commodity_code as top_commodity_code')
     expect(module_main_tf).to include('details.answers.0.confidence as top_confidence')
     expect(module_main_tf).to include('Selected Results')
@@ -93,6 +93,98 @@ RSpec.describe 'search experiment dashboard Terraform' do
     expect(uat_period_totals_query).to include('or ispresent(guided_search_browser_session_id)')
     expect(uat_period_totals_query).to include(
       'count_distinct(guided_search_browser_session_id) as estimated_browser_sessions',
+    )
+  end
+
+  it 'makes estimated browser sessions directly visible without exposing identifiers' do
+    unique_sessions_query = widget_query('Estimated Unique Browser Sessions')
+
+    expect(module_main_tf).to match(
+      /title\s+= "Estimated Unique Browser Sessions"\n\s+region = var\.region\n\s+query\s+= <<-EOT/,
+    )
+    expect(unique_sessions_query).to include('${local.experiment_filter}')
+    expect(unique_sessions_query).to include(
+      'event = "guided_search.journey" and schema_version = 1',
+    )
+    expect(unique_sessions_query).to include('browser_session_id like /^v1:[0-9a-f]{64}$/')
+    expect(unique_sessions_query).to include(
+      'count_distinct(browser_session_id) as estimated_browser_sessions',
+    )
+    expect(unique_sessions_query).not_to include('| fields browser_session_id')
+  end
+
+  it 'breaks browser-confirmed page destinations down by views, requests, and sessions' do
+    destinations_query = widget_query('Guided Search Page Destinations')
+
+    expect(destinations_query).to include('outcome = "page_visible"')
+    expect(destinations_query).to include('browser_session_id like /^v1:[0-9a-f]{64}$/')
+    expect(destinations_query).to include(
+      'stats count(*) as page_views, count_distinct(request_id) as distinct_requests,',
+    )
+    expect(destinations_query).to include(
+      'count_distinct(browser_session_id) as estimated_browser_sessions by destination',
+    )
+  end
+
+  it 'combines frontend journey errors and backend search failures by outcome' do
+    errors_query = widget_query('Guided Search Errors and Fallbacks')
+
+    expect(errors_query).to include(
+      'event = "guided_search.journey" and schema_version = 1 and outcome in ["input_error", "backend_error", "no_results", "unknown_results", "blocking_guidance"]',
+    )
+    expect(errors_query).to include('service = "search" and event = "search_failed"')
+    expect(errors_query).to include(
+      'service = "search" and event = "search_completed" and final_result_type = "error"',
+    )
+    expect(errors_query).to include(
+      'stats count(*) as events, count_distinct(request_id) as distinct_requests by error_or_fallback',
+    )
+  end
+
+  it 'reports dont-know usage and rate against displayed questions' do
+    dont_know_query = widget_query("I Don't Know Usage")
+
+    expect(dont_know_query).to include('outcome in ["page_visible", "dont_know"]')
+    expect(dont_know_query).to include(
+      'sum(if(outcome = "dont_know", 1, 0)) as dont_know_uses',
+    )
+    expect(dont_know_query).to include(
+      'count_distinct(dont_know_request_id) as requests_using_dont_know',
+    )
+    expect(dont_know_query).to include(
+      'count_distinct(question_request_id) as requests_shown_questions',
+    )
+    expect(dont_know_query).to include(
+      'if(outcome = "dont_know" or (outcome = "page_visible" and destination = "question"), request_id) as question_request_id',
+    )
+    expect(dont_know_query).to include(
+      'requests_using_dont_know * 100 / requests_shown_questions as request_usage_rate_percent',
+    )
+  end
+
+  it 'shows client journey timings in explicitly labelled seconds' do
+    navigation_query = widget_query('Client Navigation Time in seconds by Destination (p50/p90/p99)')
+    question_query = widget_query('Question Response Time in seconds (p50/p90/p99)')
+
+    expect(navigation_query).to include('outcome = "page_visible"')
+    expect(navigation_query).to include(
+      'pct(client_navigation_ms / 1000, 50) as p50_seconds',
+    )
+    expect(navigation_query).to include('by destination')
+    expect(question_query).to include('ispresent(client_elapsed_ms)')
+    expect(question_query).to include(
+      'pct(client_elapsed_ms / 1000, 50) as p50_seconds',
+    )
+    expect(question_query).not_to include('by question_count')
+  end
+
+  it 'shows the answer options returned with each question' do
+    questions_query = widget_query('Questions and Answer Options')
+
+    expect(questions_query).to include('jsonParse(@message) as event_payload')
+    expect(questions_query).to include('event_payload.details.questions[0].question as question')
+    expect(questions_query).to include(
+      'jsonStringify(event_payload.details.questions[0].options) as answer_options',
     )
   end
 
@@ -141,8 +233,8 @@ RSpec.describe 'search experiment dashboard Terraform' do
     expect(module_main_tf).to match(/width\s+= 12\n\s+height\s+= 6\n\s+properties = \{\n\s+title\s+= "Total AI Cost by Operation"/)
     expect(module_main_tf).to match(/width\s+= 12\n\s+height\s+= 6\n\s+properties = \{\n\s+title\s+= "AI Token Totals by Operation"/)
     expect(module_main_tf).to match(/width\s+= 16\n\s+height\s+= 6\n\s+properties = \{\n\s+title\s+= "AI API Latency in seconds \(p50\/p90\/p99\)"/)
-    expect(module_main_tf).to match(/width\s+= 24\n\s+height\s+= 6\n\s+properties = \{\n\s+title\s+= "Questions and Answers"/)
-    expect(module_main_tf).to include('| fields details.questions.0.question as question,')
+    expect(module_main_tf).to match(/width\s+= 24\n\s+height\s+= 6\n\s+properties = \{\n\s+title\s+= "Questions and Answer Options"/)
+    expect(module_main_tf).to include('| fields event_payload.details.questions[0].question as question,')
   end
 
   it 'uses a single outcome dimension for the result-type pie chart' do

--- a/spec/terraform/search_experiment_dashboard_spec.rb
+++ b/spec/terraform/search_experiment_dashboard_spec.rb
@@ -155,7 +155,10 @@ RSpec.describe 'search experiment dashboard Terraform' do
       'count_distinct(question_request_id) as requests_shown_questions',
     )
     expect(dont_know_query).to include(
-      'if(outcome = "dont_know" or (outcome = "page_visible" and destination = "question"), request_id) as question_request_id',
+      'case(outcome = "dont_know", request_id) as dont_know_request_id',
+    )
+    expect(dont_know_query).to include(
+      'case(outcome = "dont_know" or (outcome = "page_visible" and destination = "question"), request_id) as question_request_id',
     )
     expect(dont_know_query).to include(
       'requests_using_dont_know * 100 / requests_shown_questions as request_usage_rate_percent',

--- a/spec/unit/changes_table_populator/measure_created_or_updated_spec.rb
+++ b/spec/unit/changes_table_populator/measure_created_or_updated_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ChangesTablePopulator::MeasureCreatedOrUpdated do
         db[:measures_oplog].delete
       end
 
-      it 'doesn\'t extract changes' do
+      it_with_refresh_materialized_view 'doesn\'t extract changes' do
         expect { described_class.populate }.not_to change(Change, :count)
       end
     end

--- a/terraform/modules/search_experiment_dashboard/README.md
+++ b/terraform/modules/search_experiment_dashboard/README.md
@@ -1,6 +1,8 @@
 # search_experiment_dashboard
 
-CloudWatch Logs Insights dashboard for reviewing a labelled production-UAT search cohort. It consumes version 1 `guided_search.journey` events to summarise estimated distinct observed browser sessions and guided-search selections alongside request outcomes, latency, AI usage and cost, search behaviour, and request IDs for diagnostic follow-up.
+CloudWatch Logs Insights dashboard for reviewing a labelled production-UAT search cohort. It consumes version 1 `guided_search.journey` events to summarise estimated distinct observed browser sessions, browser-confirmed page destinations, frontend errors and fallbacks, “I don’t know” usage, client journey timing, and guided-search selections alongside request outcomes, latency, AI usage and cost, search behaviour, and request IDs for diagnostic follow-up.
+
+The “I don’t know” request usage rate compares distinct requests that used the option with distinct requests known to have shown a question. An “I don’t know” interaction itself is treated as proof that its request showed a question, so best-effort browser events and dashboard time-window boundaries cannot produce a rate above 100%.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/terraform/modules/search_experiment_dashboard/main.tf
+++ b/terraform/modules/search_experiment_dashboard/main.tf
@@ -178,8 +178,8 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
             query  = <<-EOT
               ${local.source}
               | ${local.experiment_filter} and event = "guided_search.journey" and schema_version = 1 and outcome in ["page_visible", "dont_know"]
-              | fields if(outcome = "dont_know", request_id) as dont_know_request_id,
-                  if(outcome = "dont_know" or (outcome = "page_visible" and destination = "question"), request_id) as question_request_id
+              | fields case(outcome = "dont_know", request_id) as dont_know_request_id,
+                  case(outcome = "dont_know" or (outcome = "page_visible" and destination = "question"), request_id) as question_request_id
               | stats sum(if(outcome = "dont_know", 1, 0)) as dont_know_uses,
                   count_distinct(dont_know_request_id) as requests_using_dont_know,
                   count_distinct(question_request_id) as requests_shown_questions

--- a/terraform/modules/search_experiment_dashboard/main.tf
+++ b/terraform/modules/search_experiment_dashboard/main.tf
@@ -111,6 +111,129 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
           type   = "log"
           x      = 0
           y      = 8
+          width  = 6
+          height = 6
+          properties = {
+            title  = "Estimated Unique Browser Sessions"
+            region = var.region
+            query  = <<-EOT
+              ${local.source}
+              | ${local.experiment_filter} and event = "guided_search.journey" and schema_version = 1
+              | filter browser_session_id like /^v1:[0-9a-f]{64}$/
+              | stats count_distinct(browser_session_id) as estimated_browser_sessions
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 6
+          y      = 8
+          width  = 10
+          height = 6
+          properties = {
+            title  = "Guided Search Page Destinations"
+            region = var.region
+            query  = <<-EOT
+              ${local.source}
+              | ${local.experiment_filter} and event = "guided_search.journey" and schema_version = 1 and outcome = "page_visible"
+              | filter browser_session_id like /^v1:[0-9a-f]{64}$/
+              | stats count(*) as page_views, count_distinct(request_id) as distinct_requests,
+                  count_distinct(browser_session_id) as estimated_browser_sessions by destination
+              | sort page_views desc
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 16
+          y      = 8
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Guided Search Errors and Fallbacks"
+            region = var.region
+            query  = <<-EOT
+              ${local.source}
+              | ${local.experiment_filter}
+              | filter (event = "guided_search.journey" and schema_version = 1 and outcome in ["input_error", "backend_error", "no_results", "unknown_results", "blocking_guidance"])
+                  or (service = "search" and event = "search_failed")
+                  or (service = "search" and event = "search_completed" and final_result_type = "error")
+              | fields if(event = "guided_search.journey", outcome, if(event = "search_failed", "search_failed", "error_result")) as error_or_fallback
+              | stats count(*) as events, count_distinct(request_id) as distinct_requests by error_or_fallback
+              | sort events desc
+            EOT
+          }
+        },
+      ],
+      [
+        {
+          type   = "log"
+          x      = 0
+          y      = 14
+          width  = 8
+          height = 6
+          properties = {
+            title  = "I Don't Know Usage"
+            region = var.region
+            query  = <<-EOT
+              ${local.source}
+              | ${local.experiment_filter} and event = "guided_search.journey" and schema_version = 1 and outcome in ["page_visible", "dont_know"]
+              | fields if(outcome = "dont_know", request_id) as dont_know_request_id,
+                  if(outcome = "dont_know" or (outcome = "page_visible" and destination = "question"), request_id) as question_request_id
+              | stats sum(if(outcome = "dont_know", 1, 0)) as dont_know_uses,
+                  count_distinct(dont_know_request_id) as requests_using_dont_know,
+                  count_distinct(question_request_id) as requests_shown_questions
+              | filter requests_shown_questions > 0
+              | fields dont_know_uses, requests_using_dont_know, requests_shown_questions,
+                  requests_using_dont_know * 100 / requests_shown_questions as request_usage_rate_percent
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 8
+          y      = 14
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Client Navigation Time in seconds by Destination (p50/p90/p99)"
+            region = var.region
+            query  = <<-EOT
+              ${local.source}
+              | ${local.experiment_filter} and event = "guided_search.journey" and schema_version = 1 and outcome = "page_visible"
+              | filter ispresent(client_navigation_ms)
+              | stats pct(client_navigation_ms / 1000, 50) as p50_seconds,
+                  pct(client_navigation_ms / 1000, 90) as p90_seconds,
+                  pct(client_navigation_ms / 1000, 99) as p99_seconds by destination
+              | sort p90_seconds desc
+            EOT
+          }
+        },
+        {
+          type   = "log"
+          x      = 16
+          y      = 14
+          width  = 8
+          height = 6
+          properties = {
+            title  = "Question Response Time in seconds (p50/p90/p99)"
+            region = var.region
+            query  = <<-EOT
+              ${local.source}
+              | ${local.experiment_filter} and event = "guided_search.journey" and schema_version = 1
+              | filter ispresent(client_elapsed_ms)
+              | stats pct(client_elapsed_ms / 1000, 50) as p50_seconds,
+                  pct(client_elapsed_ms / 1000, 90) as p90_seconds,
+                  pct(client_elapsed_ms / 1000, 99) as p99_seconds
+            EOT
+          }
+        },
+      ],
+      [
+        {
+          type   = "log"
+          x      = 0
+          y      = 20
           width  = 12
           height = 6
           properties = {
@@ -131,7 +254,7 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
         {
           type   = "log"
           x      = 12
-          y      = 8
+          y      = 20
           width  = 12
           height = 6
           properties = {
@@ -150,7 +273,7 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
         {
           type   = "log"
           x      = 0
-          y      = 14
+          y      = 26
           width  = 8
           height = 6
           properties = {
@@ -170,7 +293,7 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
         {
           type   = "log"
           x      = 8
-          y      = 14
+          y      = 26
           width  = 16
           height = 6
           properties = {
@@ -189,7 +312,7 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
         {
           type   = "log"
           x      = 0
-          y      = 20
+          y      = 32
           width  = 8
           height = 6
           properties = {
@@ -206,7 +329,7 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
         {
           type   = "log"
           x      = 8
-          y      = 20
+          y      = 32
           width  = 8
           height = 6
           properties = {
@@ -224,7 +347,7 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
         {
           type   = "log"
           x      = 16
-          y      = 20
+          y      = 32
           width  = 8
           height = 6
           properties = {
@@ -243,7 +366,7 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
         {
           type   = "log"
           x      = 0
-          y      = 26
+          y      = 38
           width  = 12
           height = 6
           properties = {
@@ -261,7 +384,7 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
         {
           type   = "log"
           x      = 12
-          y      = 26
+          y      = 38
           width  = 12
           height = 6
           properties = {
@@ -282,16 +405,18 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
         {
           type   = "log"
           x      = 0
-          y      = 32
+          y      = 44
           width  = 24
           height = 6
           properties = {
-            title  = "Questions and Answers"
+            title  = "Questions and Answer Options"
             region = var.region
             query  = <<-EOT
               ${local.source}
               | ${local.search_filter} and event in ["question_returned", "answer_returned"]
-              | fields details.questions.0.question as question,
+              | fields jsonParse(@message) as event_payload
+              | fields event_payload.details.questions[0].question as question,
+                  jsonStringify(event_payload.details.questions[0].options) as answer_options,
                   details.answers.0.commodity_code as top_commodity_code,
                   details.answers.0.confidence as top_confidence,
                   answer_count,
@@ -299,6 +424,7 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
                   effective_query,
                   request_id,
                   @timestamp
+              | display @timestamp, request_id, event, effective_query, question, answer_options, top_commodity_code, top_confidence, answer_count
               | sort @timestamp desc
               | limit 50
             EOT
@@ -309,7 +435,7 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
         {
           type   = "log"
           x      = 0
-          y      = 38
+          y      = 50
           width  = 12
           height = 6
           properties = {
@@ -327,7 +453,7 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
         {
           type   = "log"
           x      = 12
-          y      = 38
+          y      = 50
           width  = 12
           height = 6
           properties = {
@@ -348,7 +474,7 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
         {
           type   = "log"
           x      = 0
-          y      = 44
+          y      = 56
           width  = 24
           height = 8
           properties = {


### PR DESCRIPTION
## What:

- [x] Add a dedicated estimated unique browser-session total
- [x] Break browser-confirmed page destinations down by views, requests and sessions
- [x] Summarise guided-search errors and fallback outcomes
- [x] Report “I don’t know” uses, distinct requests and a bounded request usage rate
- [x] Show navigation and question-response percentiles in seconds
- [x] Display the answer options returned with each question
- [x] Keep browser-session identifiers inside aggregate queries only
- [x] Cover the dashboard contract with Terraform specs
- [x] Refresh the materialized measure view in the existing empty-database test so the full CI suite is isolated
- [x] Verify 42 focused specs, RuboCop, Terraform formatting and Terraform validation
- [x] Complete an independent review with no remaining findings

```mermaid
flowchart TD
    FRONTEND[Frontend journey events]
    BACKEND[Backend search events]
    LOGS[Platform logs]
    JOURNEY[Journey widgets]
    DIAGNOSTICS[Diagnostic tables]

    FRONTEND --> LOGS
    BACKEND --> LOGS
    LOGS --> JOURNEY
    LOGS --> DIAGNOSTICS

    classDef box stroke:#6366f1,stroke-width:2px
    class FRONTEND,BACKEND,LOGS,JOURNEY,DIAGNOSTICS box
```

## Why:

The experiment dashboard had the underlying guided-search events but did not make the user journey visible. Browser sessions were buried inside a crowded totals widget, destinations and frontend outcomes were available only in raw events, and client timings remained unaggregated.

These read-only widgets make it possible to review how many browser sessions used guided search, which pages users reached, where searches ended in an error or fallback, how often “I don’t know” was used, and how long browser transitions and question responses took.

## Ticket:

[AI-1092: Make guided-search experiment dashboards explain journey outcomes and latency](https://transformuk.atlassian.net/browse/AI-1092)

## Risk:
**Risk level:** 🟢

**Reason for rating:**

This is a read-only CloudWatch dashboard and test change. It does not change search behaviour, APIs, event plumbing, data storage or permissions.
