### PR TITLE
AI-1092: Fix search experiment dashboard queries

### DIFF
--- a/spec/terraform/search_experiment_dashboard_spec.rb
+++ b/spec/terraform/search_experiment_dashboard_spec.rb
@@ -170,10 +170,13 @@ RSpec.describe 'search experiment dashboard Terraform' do
       'case(outcome = "dont_know" or (outcome = "page_visible" and destination = "question"), request_id) as question_request_id',
     )
     expect(dont_know_query).to include(
-      'count_distinct(dont_know_request_id) * 100 / count_distinct(question_request_id) as request_usage_rate_percent',
+      'requests_using_dont_know * 100 / requests_shown_questions as request_usage_rate_percent',
     )
-    expect(dont_know_query).not_to include(
-      'fields dont_know_uses, requests_using_dont_know, requests_shown_questions,',
+    expect(dont_know_query).to include(
+      'filter requests_shown_questions > 0',
+    )
+    expect(dont_know_query).to include(
+      'display dont_know_uses, requests_using_dont_know, requests_shown_questions, request_usage_rate_percent',
     )
   end
 

--- a/spec/terraform/search_experiment_dashboard_spec.rb
+++ b/spec/terraform/search_experiment_dashboard_spec.rb
@@ -63,6 +63,15 @@ RSpec.describe 'search experiment dashboard Terraform' do
     expect(module_main_tf).not_to include('AI Tokens and Cost')
   end
 
+  it 'shows token totals as one readable table' do
+    token_widget = widget_definition('AI Token Totals by Operation')
+
+    expect(token_widget).not_to include('view   = "bar"')
+    expect(token_widget).to include(
+      'stats sum(input_tokens) as input_tokens, sum(output_tokens) as output_tokens, sum(total_tokens) as total_tokens by ai_operation, model',
+    )
+  end
+
   it 'summarises the UAT period and exposes the behaviour needed for diagnosis' do
     uat_period_totals_query = widget_query('UAT Period Totals')
 
@@ -264,6 +273,13 @@ RSpec.describe 'search experiment dashboard Terraform' do
     module_main_tf.match(/title\s+= "#{Regexp.escape(title)}".*?query\s+= <<-EOT\n(.*?)\n\s+EOT/m).then do |match|
       expect(match).to be_present
       match[1]
+    end
+  end
+
+  def widget_definition(title)
+    module_main_tf.match(/properties = \{\n\s+title\s+= "#{Regexp.escape(title)}".*?\n\s+EOT/m).then do |match|
+      expect(match).to be_present
+      match[0]
     end
   end
 end

--- a/spec/terraform/search_experiment_dashboard_spec.rb
+++ b/spec/terraform/search_experiment_dashboard_spec.rb
@@ -161,7 +161,10 @@ RSpec.describe 'search experiment dashboard Terraform' do
       'case(outcome = "dont_know" or (outcome = "page_visible" and destination = "question"), request_id) as question_request_id',
     )
     expect(dont_know_query).to include(
-      'requests_using_dont_know * 100 / requests_shown_questions as request_usage_rate_percent',
+      'count_distinct(dont_know_request_id) * 100 / count_distinct(question_request_id) as request_usage_rate_percent',
+    )
+    expect(dont_know_query).not_to include(
+      'fields dont_know_uses, requests_using_dont_know, requests_shown_questions,',
     )
   end
 
@@ -240,9 +243,16 @@ RSpec.describe 'search experiment dashboard Terraform' do
     expect(module_main_tf).to include('| fields event_payload.details.questions[0].question as question,')
   end
 
-  it 'uses a single outcome dimension for the result-type pie chart' do
-    expect(module_main_tf).to include('stats count(*) as searches by final_result_type')
-    expect(module_main_tf).not_to include('by search_type, results_type, final_result_type')
+  it 'labels every outcome in the result-type pie chart' do
+    final_result_types_query = widget_query('Final Result Types')
+
+    expect(final_result_types_query).to include(
+      'case(ispresent(final_result_type), final_result_type, result_count = 0, "no_results", "results_without_questions") as final_result_category',
+    )
+    expect(final_result_types_query).to include(
+      'stats count(*) as searches by final_result_category',
+    )
+    expect(final_result_types_query).not_to include('searches by final_result_type')
   end
 
   it 'is discoverable from the search overview dashboard' do

--- a/terraform/modules/search_experiment_dashboard/README.md
+++ b/terraform/modules/search_experiment_dashboard/README.md
@@ -4,6 +4,8 @@ CloudWatch Logs Insights dashboard for reviewing a labelled production-UAT searc
 
 The “I don’t know” request usage rate compares distinct requests that used the option with distinct requests known to have shown a question. An “I don’t know” interaction itself is treated as proof that its request showed a question, so best-effort browser events and dashboard time-window boundaries cannot produce a rate above 100%.
 
+The final-result pie chart keeps the recorded `questions`, `answers`, and `error` outcomes. Completed searches without a recorded final result type are labelled `no_results` when they returned nothing and `results_without_questions` otherwise, rather than appearing as an unnamed category.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/terraform/modules/search_experiment_dashboard/main.tf
+++ b/terraform/modules/search_experiment_dashboard/main.tf
@@ -259,7 +259,6 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
           properties = {
             title  = "AI Token Totals by Operation"
             region = var.region
-            view   = "bar"
             query  = <<-EOT
               ${local.source}
               | ${local.ai_cost_filter}

--- a/terraform/modules/search_experiment_dashboard/main.tf
+++ b/terraform/modules/search_experiment_dashboard/main.tf
@@ -182,9 +182,10 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
                   case(outcome = "dont_know" or (outcome = "page_visible" and destination = "question"), request_id) as question_request_id
               | stats sum(if(outcome = "dont_know", 1, 0)) as dont_know_uses,
                   count_distinct(dont_know_request_id) as requests_using_dont_know,
-                  count_distinct(question_request_id) as requests_shown_questions,
-                  count_distinct(dont_know_request_id) * 100 / count_distinct(question_request_id) as request_usage_rate_percent
+                  count_distinct(question_request_id) as requests_shown_questions
               | filter requests_shown_questions > 0
+              | fields requests_using_dont_know * 100 / requests_shown_questions as request_usage_rate_percent
+              | display dont_know_uses, requests_using_dont_know, requests_shown_questions, request_usage_rate_percent
             EOT
           }
         },

--- a/terraform/modules/search_experiment_dashboard/main.tf
+++ b/terraform/modules/search_experiment_dashboard/main.tf
@@ -182,10 +182,9 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
                   case(outcome = "dont_know" or (outcome = "page_visible" and destination = "question"), request_id) as question_request_id
               | stats sum(if(outcome = "dont_know", 1, 0)) as dont_know_uses,
                   count_distinct(dont_know_request_id) as requests_using_dont_know,
-                  count_distinct(question_request_id) as requests_shown_questions
+                  count_distinct(question_request_id) as requests_shown_questions,
+                  count_distinct(dont_know_request_id) * 100 / count_distinct(question_request_id) as request_usage_rate_percent
               | filter requests_shown_questions > 0
-              | fields dont_know_uses, requests_using_dont_know, requests_shown_questions,
-                  requests_using_dont_know * 100 / requests_shown_questions as request_usage_rate_percent
             EOT
           }
         },
@@ -322,7 +321,8 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
             query  = <<-EOT
               ${local.source}
               | ${local.search_filter} and event = "search_completed"
-              | stats count(*) as searches by final_result_type
+              | fields case(ispresent(final_result_type), final_result_type, result_count = 0, "no_results", "results_without_questions") as final_result_category
+              | stats count(*) as searches by final_result_category
             EOT
           }
         },


### PR DESCRIPTION
## What:

- calculate the “I don’t know” request usage rate within the existing Logs Insights aggregation
- label completed searches without `final_result_type` as `no_results` or `results_without_questions`
- show AI input, output, and total token counts in one readable operation/model table instead of three cramped bar-chart panes
- add regression coverage and document the fallback result categories

## Why:

The production Search Experiment dashboard currently has confusing/broken widgets:

- “I Don’t Know Usage” fails because the query redefines the `dont_know_uses` ephemeral field after `stats`
- “Final Result Types” shows an unnamed `---` category when `search_completed` events do not contain `final_result_type`
- “AI Token Totals by Operation” renders three tiny charts with no useful visible values

This keeps the dashboard read-only and does not change search event plumbing, request IDs, browser session IDs, APIs, permissions, or runtime application behaviour.

## Ticket:

[AI-1092](https://transformuk.atlassian.net/browse/AI-1092)

## Risk:

**Risk level:** 🟢

**Reason for rating:**
Read-only CloudWatch dashboard query, presentation, test, and documentation changes. No resource replacement, permissions change, API change, or user-journey change.

## Verification:

- `bundle exec rspec spec/terraform` — 30 examples, 0 failures
- `bundle exec rubocop spec/terraform/search_experiment_dashboard_spec.rb` — no offences
- `terraform -chdir=terraform fmt -check -recursive`
- `terraform -chdir=terraform validate` — configuration valid
- commit hooks: RuboCop, Terraform formatting/validation, TFLint and security checks passed