### PR TITLE
AI-1092: Fix search experiment token totals

### DIFF
--- a/spec/terraform/search_experiment_dashboard_spec.rb
+++ b/spec/terraform/search_experiment_dashboard_spec.rb
@@ -54,8 +54,8 @@ RSpec.describe 'search experiment dashboard Terraform' do
     expect(module_main_tf).to include('| filter ispresent(total_cost_usd)')
     expect(module_main_tf).to include('stats sum(total_cost_usd) as total_cost_usd by ai_operation, model')
     expect(module_main_tf).to include('AI Token Totals by Operation')
-    expect(module_main_tf).to include('sum(input_tokens) as input_tokens')
-    expect(module_main_tf).to include('sum(output_tokens) as output_tokens')
+    expect(module_main_tf).to include('sum(input_tokens) as input_token_total')
+    expect(module_main_tf).to include('sum(output_tokens) as output_token_total')
     expect(module_main_tf).to include('Unknown Pricing Events')
     expect(module_main_tf).to include('not pricing_known or not ispresent(total_cost_usd)')
     expect(module_main_tf).not_to include('pricing_known = true')
@@ -68,8 +68,9 @@ RSpec.describe 'search experiment dashboard Terraform' do
 
     expect(token_widget).not_to include('view   = "bar"')
     expect(token_widget).to include(
-      'stats sum(input_tokens) as input_tokens, sum(output_tokens) as output_tokens, sum(total_tokens) as total_tokens by ai_operation, model',
+      'stats sum(input_tokens) as input_token_total, sum(output_tokens) as output_token_total, sum(total_tokens) as token_total by ai_operation, model',
     )
+    expect(token_widget).to include('| sort token_total desc')
   end
 
   it 'summarises the UAT period and exposes the behaviour needed for diagnosis' do

--- a/terraform/modules/search_experiment_dashboard/main.tf
+++ b/terraform/modules/search_experiment_dashboard/main.tf
@@ -264,8 +264,8 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
               ${local.source}
               | ${local.ai_cost_filter}
               | fields if(ispresent(operation), operation, event_kind) as ai_operation
-              | stats sum(input_tokens) as input_tokens, sum(output_tokens) as output_tokens, sum(total_tokens) as total_tokens by ai_operation, model
-              | sort total_tokens desc
+              | stats sum(input_tokens) as input_token_total, sum(output_tokens) as output_token_total, sum(total_tokens) as token_total by ai_operation, model
+              | sort token_total desc
             EOT
           }
         },


### PR DESCRIPTION
## What:

- [x] Give SearchExperiment token aggregates distinct result aliases
- [x] Sort the widget by the renamed total-token aggregate
- [x] Add regression coverage for the dashboard query

## Why:

CloudWatch Logs Insights returned only the `ai_operation` and `model` grouping fields because the aggregate aliases reused the source token field names. Distinct aliases avoid that collision and expose input, output, and total token counts in the dashboard table.

Verified against the production `trstd-trdr` logs in the CloudWatch widget editor. The corrected query returned populated totals, including 3,085,197 input tokens, 423,972 output tokens, and 3,509,169 total tokens for `interactive_search` over the editor's one-week range.

## Ticket:

[AI-1092](https://transformuk.atlassian.net/browse/AI-1092)

## Risk:

**Risk level:** 🟢

**Reason for rating:**

Read-only CloudWatch dashboard query change. It does not alter application behaviour or recreate AWS resources.