### PR TITLE
Count search queries once per request

### DIFF
--- a/spec/terraform/search_experiment_dashboard_spec.rb
+++ b/spec/terraform/search_experiment_dashboard_spec.rb
@@ -3,6 +3,7 @@
 RSpec.describe 'search experiment dashboard Terraform' do
   let(:dashboards_tf) { Rails.root.join('terraform/dashboards.tf').read }
   let(:module_main_tf) { Rails.root.join('terraform/modules/search_experiment_dashboard/main.tf').read }
+  let(:operations_dashboard_tf) { Rails.root.join('terraform/modules/search_operations_dashboard/main.tf').read }
   let(:search_dashboard_tf) { Rails.root.join('terraform/modules/search_dashboard/main.tf').read }
 
   it 'wires the search experiment dashboard into the dashboard stack' do
@@ -207,6 +208,27 @@ RSpec.describe 'search experiment dashboard Terraform' do
     )
   end
 
+  it 'counts started searches once per request' do
+    top_search_terms_query = widget_query('Top Search Terms')
+
+    expect(top_search_terms_query).to include(
+      'stats count_distinct(request_id) as searches by query, search_type',
+    )
+    expect(top_search_terms_query).not_to include('stats count(*) as searches')
+  end
+
+  it 'lists each recent started search once' do
+    recent_searches_query = operations_widget_query('Recent Searches')
+
+    expect(recent_searches_query).to include(
+      'stats latest(@timestamp) as latest_timestamp, latest(query) as query,',
+    )
+    expect(recent_searches_query).to include('by request_id')
+    expect(recent_searches_query).to include(
+      'display latest_timestamp, query, request_source, search_type, request_id',
+    )
+  end
+
   it 'uses frontend journey events for guided-search result selections' do
     selected_results_query = widget_query('Selected Results')
 
@@ -284,6 +306,13 @@ RSpec.describe 'search experiment dashboard Terraform' do
     module_main_tf.match(/properties = \{\n\s+title\s+= "#{Regexp.escape(title)}".*?\n\s+EOT/m).then do |match|
       expect(match).to be_present
       match[0]
+    end
+  end
+
+  def operations_widget_query(title)
+    operations_dashboard_tf.match(/title\s+= "#{Regexp.escape(title)}".*?query\s+= <<-EOT\n(.*?)\n\s+EOT/m).then do |match|
+      expect(match).to be_present
+      match[1]
     end
   end
 end

--- a/terraform/modules/search_experiment_dashboard/main.tf
+++ b/terraform/modules/search_experiment_dashboard/main.tf
@@ -375,7 +375,7 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
             query  = <<-EOT
               ${local.source}
               | ${local.search_filter} and event = "search_started"
-              | stats count(*) as searches by query, search_type
+              | stats count_distinct(request_id) as searches by query, search_type
               | sort searches desc
               | limit 30
             EOT

--- a/terraform/modules/search_operations_dashboard/main.tf
+++ b/terraform/modules/search_operations_dashboard/main.tf
@@ -255,8 +255,11 @@ resource "aws_cloudwatch_dashboard" "search_operations" {
             query  = <<-EOT
               ${local.source}
               | ${local.service_filter} and event = "search_started"
-              | fields @timestamp, query, request_source, search_type, request_id
-              | sort @timestamp desc
+              | stats latest(@timestamp) as latest_timestamp, latest(query) as query,
+                  latest(request_source) as request_source, latest(search_type) as search_type
+                by request_id
+              | display latest_timestamp, query, request_source, search_type, request_id
+              | sort latest_timestamp desc
               | limit 30
             EOT
           }


### PR DESCRIPTION
## What:

- [x] Count experiment dashboard search terms once per `request_id`
- [x] Collapse operations dashboard recent searches to one row per `request_id`
- [x] Add regression coverage for both dashboard queries
- [x] Verify 32 Terraform specs, RuboCop, Terraform formatting and validation

## Why:

Guided search emits `search_started` for each question round using the same `request_id`. The experiment dashboard used `count(*)`, so one search journey increased the Top Search Terms count several times. Counting distinct request IDs measures the original query once per journey, while grouping Recent Searches removes the same duplicate rows from the operations dashboard.

## Ticket:

N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:**

Read-only CloudWatch dashboard query changes with regression coverage. They do not alter application behaviour or recreate AWS resources.