### PR TITLE
Clarify search response dashboard labels

### DIFF
--- a/spec/terraform/search_experiment_dashboard_spec.rb
+++ b/spec/terraform/search_experiment_dashboard_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'search experiment dashboard Terraform' do
   it 'covers experiment usage, performance, outcomes, questions, searches, and AI costs' do
     expect(module_main_tf).to include('UAT Period Totals')
     expect(module_main_tf).to include('E2E Latency in seconds (p50/p90/p99)')
-    expect(module_main_tf).to include('Final Result Types')
+    expect(module_main_tf).to include('Search Response Types')
     expect(module_main_tf).to include('Questions per Search')
     expect(module_main_tf).to include('Top Search Terms')
     expect(module_main_tf).to include('Total AI Cost by Operation')
@@ -278,16 +278,16 @@ RSpec.describe 'search experiment dashboard Terraform' do
     expect(module_main_tf).to include('| fields event_payload.details.questions[0].question as question,')
   end
 
-  it 'labels every outcome in the result-type pie chart' do
-    final_result_types_query = widget_query('Final Result Types')
+  it 'uses plain-language labels for every search response type' do
+    search_response_types_query = widget_query('Search Response Types')
 
-    expect(final_result_types_query).to include(
-      'case(ispresent(final_result_type), final_result_type, result_count = 0, "no_results", "results_without_questions") as final_result_category',
+    expect(search_response_types_query).to include(
+      'case(final_result_type = "answers", "suggested results", final_result_type = "questions", "questions", final_result_type = "error", "errors", result_count = 0, "no results", "results without questions") as search_response_type',
     )
-    expect(final_result_types_query).to include(
-      'stats count(*) as searches by final_result_category',
+    expect(search_response_types_query).to include(
+      'stats count(*) as completed_searches by search_response_type',
     )
-    expect(final_result_types_query).not_to include('searches by final_result_type')
+    expect(module_main_tf).not_to include('Final Result Types')
   end
 
   it 'is discoverable from the search overview dashboard' do

--- a/terraform/modules/search_experiment_dashboard/main.tf
+++ b/terraform/modules/search_experiment_dashboard/main.tf
@@ -315,14 +315,14 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
           width  = 8
           height = 6
           properties = {
-            title  = "Final Result Types"
+            title  = "Search Response Types"
             region = var.region
             view   = "pie"
             query  = <<-EOT
               ${local.source}
               | ${local.search_filter} and event = "search_completed"
-              | fields case(ispresent(final_result_type), final_result_type, result_count = 0, "no_results", "results_without_questions") as final_result_category
-              | stats count(*) as searches by final_result_category
+              | fields case(final_result_type = "answers", "suggested results", final_result_type = "questions", "questions", final_result_type = "error", "errors", result_count = 0, "no results", "results without questions") as search_response_type
+              | stats count(*) as completed_searches by search_response_type
             EOT
           }
         },


### PR DESCRIPTION
## What:

- [x] Rename the widget from `Final Result Types` to `Search Response Types`
- [x] Replace internal response names with plain-language chart labels
- [x] Cover the widget title and labels in the dashboard spec
- [x] Verify the dashboard spec (24 examples, 0 failures), RuboCop, Terraform formatting, Terraform validation, and pre-commit checks

## Why:

The previous title made the chart look like the final outcome of a whole search journey, while the `answers` label could be mistaken for answers given by the user. The widget actually counts what each completed search response returned. The new wording makes that clear.

## Ticket:

N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:**

This only changes labels on a read-only CloudWatch dashboard. It does not change search behaviour or the data being counted.