### PR TITLE
Preserve the latest backup when dump generation fails

### DIFF
--- a/bin/backup-database
+++ b/bin/backup-database
@@ -22,26 +22,35 @@ fi
 
 latest="s3://$S3_BUCKET/tariff-merged-${ENVIRONMENT}.sql.gz"
 today="s3://$S3_BUCKET/$(date +"%Y/%m/%d")/tariff-merged-${ENVIRONMENT}.sql.gz"
+staging="${latest}.$$.uploading"
+
+cleanup_staging() {
+  aws s3 rm "$staging" > /dev/null 2>&1 || true
+}
+
+trap cleanup_staging EXIT
 
 # NOTE: This streams line-by-line without spiking memory usage or using a file.
+pg_dump "$DATABASE_URL" \
+  --no-acl            \
+  --no-owner          \
+  --clean             \
+  --if-exists         \
+  --verbose | \
+  sed -E -e '/^REFRESH MATERIALIZED VIEW/d' \
+      -e 's/^SET client_min_messages = warning;$/SET client_min_messages = notice;/' \
+      -e '/^\\restrict /d' \
+      -e '/^\\unrestrict /d' \
+      -e 's/^DROP SCHEMA (IF EXISTS )?(.*);$/DROP SCHEMA IF EXISTS \2 CASCADE;/' | \
 {
-  pg_dump "$DATABASE_URL" \
-    --no-acl            \
-    --no-owner          \
-    --clean             \
-    --if-exists         \
-    --verbose | \
-    sed -E -e '/^REFRESH MATERIALIZED VIEW/d' \
-        -e 's/^SET client_min_messages = warning;$/SET client_min_messages = notice;/' \
-        -e '/^\\restrict /d' \
-        -e '/^\\unrestrict /d' \
-        -e 's/^DROP SCHEMA (IF EXISTS )?(.*);$/DROP SCHEMA IF EXISTS \2 CASCADE;/'
+  cat
   printf '\n-- TRADE_TARIFF_POST_RESTORE_START\n'
   cat "$(dirname "$0")/after.sql"
 } |
   gzip |
-  aws s3 cp - "$latest" || exit 2
+  aws s3 cp - "$staging" || exit 2
 
+aws s3 cp "$staging" "$latest" || exit 2
 aws s3 cp "$latest" "$today" || exit 3
 
 ENDED=$(date +"%Y-%m-%d %H:%M:%S")

--- a/spec/bin/database_replication_integration_spec.rb
+++ b/spec/bin/database_replication_integration_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe 'database replication with PostgreSQL' do
               :command_log,
               :database_user,
               :dump_file,
+              :pg_dump_container,
               :real_pg_dump,
               :real_psql,
               :replicate_script,
@@ -149,6 +150,11 @@ RSpec.describe 'database replication with PostgreSQL' do
     write_executable('pg_dump', <<~'BASH')
       #!/usr/bin/env bash
       set -euo pipefail
+
+      if [[ -n "${PG_DUMP_CONTAINER:-}" ]]; then
+        exec docker exec --env "PGUSER=$PGUSER" "$PG_DUMP_CONTAINER" pg_dump "$@"
+      fi
+
       exec "$REAL_PG_DUMP" "$@"
     BASH
 
@@ -164,6 +170,7 @@ RSpec.describe 'database replication with PostgreSQL' do
     env = {
       'PATH' => "#{tempdir}/bin:#{ENV.fetch('PATH')}",
       'DUMP_FIXTURE' => dump_file,
+      'PG_DUMP_CONTAINER' => pg_dump_container.to_s,
       'REAL_PG_DUMP' => real_pg_dump,
       'ENVIRONMENT' => 'production',
       'S3_BUCKET' => 'test-backups',
@@ -205,6 +212,18 @@ RSpec.describe 'database replication with PostgreSQL' do
                        .split(File::PATH_SEPARATOR)
                        .map { |directory| File.join(directory, 'pg_dump') }
                        .find { |path| File.executable?(path) }
+    server_major = query('postgres', 'SHOW server_version_num').to_i / 10_000
+    client_major = run_command(real_pg_dump, '--version')[/\d+/].to_i
+    @pg_dump_container = if server_major != client_major
+                           run_command(
+                             'docker',
+                             'ps',
+                             '--filter',
+                             'publish=5432',
+                             '--format',
+                             '{{.ID}}',
+                           ).lines.first&.strip
+                         end
 
     create_target_database
   end
@@ -386,5 +405,44 @@ RSpec.describe 'database replication with PostgreSQL' do
     expect(uploaded_dump).to include('DROP SCHEMA IF EXISTS xi CASCADE;')
     expect(uploaded_dump).not_to include('IF EXISTS IF EXISTS')
     expect(uploaded_dump).to include("-- TRADE_TARIFF_POST_RESTORE_START\n")
+  end
+
+  it 'does not replace the latest backup when pg_dump fails' do
+    FileUtils.mkdir_p(File.join(tempdir, 'bin'))
+
+    write_executable('pg_dump', <<~'BASH')
+      #!/usr/bin/env bash
+      printf '%s\n' '-- incomplete dump'
+      exit 42
+    BASH
+
+    write_executable('gzip', <<~'BASH')
+      #!/usr/bin/env bash
+      exec cat
+    BASH
+
+    write_executable('aws', <<~'BASH')
+      #!/usr/bin/env bash
+      set -euo pipefail
+      echo "$*" >> "$TMPDIR/aws-commands.log"
+      cat > /dev/null
+    BASH
+
+    env = {
+      'PATH' => "#{tempdir}/bin:#{ENV.fetch('PATH')}",
+      'TMPDIR' => tempdir,
+      'ENVIRONMENT' => 'production',
+      'S3_BUCKET' => 'test-backups',
+      'DATABASE_URL' => target_database,
+      'PGUSER' => database_user,
+    }
+
+    _stdout, _stderr, status = Open3.capture3(env, backup_script, chdir: Rails.root.to_s)
+    aws_commands = File.readlines(File.join(tempdir, 'aws-commands.log'), chomp: true)
+
+    expect(status.exitstatus).to eq(2)
+    expect(aws_commands).not_to include(
+      's3 cp - s3://test-backups/tariff-merged-production.sql.gz',
+    )
   end
 end

--- a/spec/bin/database_replication_integration_spec.rb
+++ b/spec/bin/database_replication_integration_spec.rb
@@ -309,6 +309,9 @@ RSpec.describe 'database replication with PostgreSQL' do
 
       _stdout, backup_stderr, backup_status = run_backup(source_database)
       expect(backup_status).to be_success, backup_stderr
+      backup_sql = Zlib::GzipReader.open(dump_file, &:read)
+      expect(backup_sql).to include('COPY public.restore_probe')
+      expect(backup_sql).to include("from-backup\n")
 
       install_replication_boundary_stubs
       _stdout, replication_stderr, replication_status = run_replication

--- a/spec/bin/database_replication_integration_spec.rb
+++ b/spec/bin/database_replication_integration_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe 'database replication with PostgreSQL' do
     Open3.capture3(env, replicate_script, chdir: Rails.root.to_s)
   end
 
-  def run_backup
+  def run_backup(source_database)
     FileUtils.mkdir_p(File.join(tempdir, 'bin'))
 
     write_executable('aws', <<~'BASH')
@@ -159,7 +159,7 @@ RSpec.describe 'database replication with PostgreSQL' do
       'DUMP_FIXTURE' => dump_file,
       'ENVIRONMENT' => 'production',
       'S3_BUCKET' => 'test-backups',
-      'DATABASE_URL' => target_database,
+      'DATABASE_URL' => source_database,
       'PGUSER' => database_user,
     }
 
@@ -289,28 +289,37 @@ RSpec.describe 'database replication with PostgreSQL' do
   end
 
   it 'restores a dump produced by the real backup pipeline' do
-    psql(target_database, <<~SQL)
-      CREATE SCHEMA xi;
-      CREATE TABLE xi.restore_probe(value text);
-      INSERT INTO xi.restore_probe VALUES ('from-backup');
-    SQL
+    source_database = "replication_source_#{SecureRandom.hex(6)}"
+    run_command('createdb', '--username', database_user, source_database)
 
-    _stdout, backup_stderr, backup_status = run_backup
-    expect(backup_status).to be_success, backup_stderr
+    begin
+      psql(source_database, <<~SQL)
+        CREATE TABLE restore_probe(value text);
+        INSERT INTO restore_probe VALUES ('from-backup');
+        CREATE MATERIALIZED VIEW restore_probe_view AS
+          SELECT value FROM restore_probe;
+        CREATE SCHEMA xi;
+        CREATE TABLE xi.restore_probe(value text);
+        INSERT INTO xi.restore_probe VALUES ('from-backup');
+        CREATE FUNCTION noop_event_trigger() RETURNS event_trigger
+          LANGUAGE plpgsql AS $$ BEGIN END; $$;
+        CREATE EVENT TRIGGER reassign_owned
+          ON ddl_command_end EXECUTE FUNCTION noop_event_trigger();
+      SQL
 
-    psql(target_database, <<~SQL)
-      UPDATE restore_probe SET value = 'changed-after-backup';
-      UPDATE xi.restore_probe SET value = 'changed-after-backup';
-      REFRESH MATERIALIZED VIEW restore_probe_view;
-    SQL
-    install_replication_boundary_stubs
+      _stdout, backup_stderr, backup_status = run_backup(source_database)
+      expect(backup_status).to be_success, backup_stderr
 
-    _stdout, replication_stderr, replication_status = run_replication
+      install_replication_boundary_stubs
+      _stdout, replication_stderr, replication_status = run_replication
 
-    expect(replication_status).to be_success, replication_stderr
-    expect(query(target_database, 'TABLE restore_probe')).to eq('old')
-    expect(query(target_database, 'TABLE xi.restore_probe')).to eq('from-backup')
-    expect(query(target_database, 'TABLE restore_probe_view')).to eq('old')
+      expect(replication_status).to be_success, replication_stderr
+      expect(query(target_database, 'TABLE restore_probe')).to eq('from-backup')
+      expect(query(target_database, 'TABLE xi.restore_probe')).to eq('from-backup')
+      expect(query(target_database, 'TABLE restore_probe_view')).to eq('from-backup')
+    ensure
+      run_command('dropdb', '--username', database_user, '--if-exists', '--force', source_database)
+    end
   end
 
   it 'emits a restartable dump with an explicit maintenance boundary' do

--- a/spec/bin/database_replication_integration_spec.rb
+++ b/spec/bin/database_replication_integration_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe 'database replication with PostgreSQL' do
               :command_log,
               :database_user,
               :dump_file,
+              :real_pg_dump,
               :real_psql,
               :replicate_script,
               :target_database,
@@ -145,6 +146,12 @@ RSpec.describe 'database replication with PostgreSQL' do
   def run_backup(source_database)
     FileUtils.mkdir_p(File.join(tempdir, 'bin'))
 
+    write_executable('pg_dump', <<~'BASH')
+      #!/usr/bin/env bash
+      set -euo pipefail
+      exec "$REAL_PG_DUMP" "$@"
+    BASH
+
     write_executable('aws', <<~'BASH')
       #!/usr/bin/env bash
       set -euo pipefail
@@ -157,6 +164,7 @@ RSpec.describe 'database replication with PostgreSQL' do
     env = {
       'PATH' => "#{tempdir}/bin:#{ENV.fetch('PATH')}",
       'DUMP_FIXTURE' => dump_file,
+      'REAL_PG_DUMP' => real_pg_dump,
       'ENVIRONMENT' => 'production',
       'S3_BUCKET' => 'test-backups',
       'DATABASE_URL' => source_database,
@@ -193,6 +201,10 @@ RSpec.describe 'database replication with PostgreSQL' do
                       .split(File::PATH_SEPARATOR)
                       .map { |directory| File.join(directory, 'psql') }
                       .find { |path| File.executable?(path) }
+    @real_pg_dump = ENV.fetch('PATH')
+                       .split(File::PATH_SEPARATOR)
+                       .map { |directory| File.join(directory, 'pg_dump') }
+                       .find { |path| File.executable?(path) }
 
     create_target_database
   end

--- a/spec/bin/database_replication_integration_spec.rb
+++ b/spec/bin/database_replication_integration_spec.rb
@@ -319,10 +319,12 @@ RSpec.describe 'database replication with PostgreSQL' do
           ON ddl_command_end EXECUTE FUNCTION noop_event_trigger();
       SQL
 
+      expect(query(source_database, 'TABLE restore_probe')).to eq('from-backup')
+
       _stdout, backup_stderr, backup_status = run_backup(source_database)
       expect(backup_status).to be_success, backup_stderr
       backup_sql = Zlib::GzipReader.open(dump_file, &:read)
-      expect(backup_sql).to include('COPY public.restore_probe')
+      expect(backup_sql).to include('COPY public.restore_probe'), backup_stderr
       expect(backup_sql).to include("from-backup\n")
 
       install_replication_boundary_stubs

--- a/spec/bin/database_replication_integration_spec.rb
+++ b/spec/bin/database_replication_integration_spec.rb
@@ -142,6 +142,30 @@ RSpec.describe 'database replication with PostgreSQL' do
     Open3.capture3(env, replicate_script, chdir: Rails.root.to_s)
   end
 
+  def run_backup
+    FileUtils.mkdir_p(File.join(tempdir, 'bin'))
+
+    write_executable('aws', <<~'BASH')
+      #!/usr/bin/env bash
+      set -euo pipefail
+
+      if [[ "$1 $2 $3" == "s3 cp -" ]]; then
+        cat > "$DUMP_FIXTURE"
+      fi
+    BASH
+
+    env = {
+      'PATH' => "#{tempdir}/bin:#{ENV.fetch('PATH')}",
+      'DUMP_FIXTURE' => dump_file,
+      'ENVIRONMENT' => 'production',
+      'S3_BUCKET' => 'test-backups',
+      'DATABASE_URL' => target_database,
+      'PGUSER' => database_user,
+    }
+
+    Open3.capture3(env, backup_script, chdir: Rails.root.to_s)
+  end
+
   before do
     @replicate_script = Rails.root.join('bin/db-replicate').to_s
     @backup_script = Rails.root.join('bin/backup-database').to_s
@@ -262,6 +286,31 @@ RSpec.describe 'database replication with PostgreSQL' do
       stdin.close
       Process.kill('TERM', wait_thread.pid) if wait_thread.alive?
     end
+  end
+
+  it 'restores a dump produced by the real backup pipeline' do
+    psql(target_database, <<~SQL)
+      CREATE SCHEMA xi;
+      CREATE TABLE xi.restore_probe(value text);
+      INSERT INTO xi.restore_probe VALUES ('from-backup');
+    SQL
+
+    _stdout, backup_stderr, backup_status = run_backup
+    expect(backup_status).to be_success, backup_stderr
+
+    psql(target_database, <<~SQL)
+      UPDATE restore_probe SET value = 'changed-after-backup';
+      UPDATE xi.restore_probe SET value = 'changed-after-backup';
+      REFRESH MATERIALIZED VIEW restore_probe_view;
+    SQL
+    install_replication_boundary_stubs
+
+    _stdout, replication_stderr, replication_status = run_replication
+
+    expect(replication_status).to be_success, replication_stderr
+    expect(query(target_database, 'TABLE restore_probe')).to eq('old')
+    expect(query(target_database, 'TABLE xi.restore_probe')).to eq('from-backup')
+    expect(query(target_database, 'TABLE restore_probe_view')).to eq('old')
   end
 
   it 'emits a restartable dump with an explicit maintenance boundary' do


### PR DESCRIPTION
## What:

- [x] Generate a compressed backup with the real `pg_dump` pipeline
- [x] Restore that artifact into a separate target through `bin/db-replicate`
- [x] Verify public data, XI data and materialized views are recovered
- [x] Propagate `pg_dump` failures instead of masking them with appended maintenance SQL
- [x] Upload to a staging key and promote only a complete dump to `latest`

## Why:

The backup generator and replication consumer were covered with separate synthetic fixtures, so CI did not prove that SQL emitted by `bin/backup-database` could be restored by `bin/db-replicate`.

The round-trip test exposed a second production safety issue. If `pg_dump` failed, the grouped pipeline continued with `after.sql`, returned success, and uploaded that maintenance-only artifact over the last good backup. The script now keeps `pg_dump` in the top-level `pipefail` pipeline and streams to a unique staging object. It promotes the object to `latest` only after the complete pipeline succeeds, then removes staging.

The integration test mirrors the production topology with separate source and target PostgreSQL databases. It generates the compressed artifact with a server-compatible real `pg_dump`, restores it through `db-replicate`, and verifies restored public data, XI data, and a materialized view. A failure regression proves an incomplete dump returns exit 2 and never replaces `latest`.

Local verification: 7 integration examples, 0 failures. RuboCop, ShellCheck, pre-commit, and pre-push hooks pass.

## Ticket:

N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:** The change is isolated to the backup publication path. Successful dumps retain the same `latest` and dated outputs; failed dumps now leave the previous `latest` untouched. The staging object is uniquely named and removed on exit.
