### PR TITLE
[HMRC-2296] Refactor check database backup freshness script

### DIFF
--- a/bin/check-database-backup-freshness
+++ b/bin/check-database-backup-freshness
@@ -218,6 +218,7 @@ check_archive_for_epoch() {
   local candidate
   local offset
   local status
+  local archive_epoch
 
   for offset in 0 -86400; do
     candidate=$(archive_key_for_epoch "$latest_epoch" "$offset")
@@ -225,7 +226,13 @@ check_archive_for_epoch() {
     archive_key=$candidate
 
     if archive_last_modified=$(head_object_last_modified "$candidate"); then
-      if [ "$(epoch_for_timestamp "$archive_last_modified")" -lt "$latest_epoch" ]; then
+      # errexit does not apply inside an if condition, so an unparseable timestamp fails silently.
+      if ! archive_epoch=$(epoch_for_timestamp "$archive_last_modified") || [ -z "$archive_epoch" ]; then
+        echo "Unable to parse archive LastModified '$archive_last_modified' for $candidate." >&2
+        return 2
+      fi
+
+      if [ "$archive_epoch" -lt "$latest_epoch" ]; then
         freshness_ok=0
         reasons+=("archive key $candidate is older than latest key $LATEST_KEY")
       fi

--- a/bin/check-database-backup-freshness
+++ b/bin/check-database-backup-freshness
@@ -86,11 +86,6 @@ format_duration() {
   local minutes
   local seconds
 
-  if [ "$total_seconds" = "unknown" ]; then
-    echo "unknown"
-    return
-  fi
-
   days=$((total_seconds / 86400))
   hours=$(((total_seconds % 86400) / 3600))
   minutes=$(((total_seconds % 3600) / 60))
@@ -185,16 +180,12 @@ head_object_last_modified() {
 }
 
 epoch_for_timestamp() {
-  local timestamp=$1
-  local timestamp_without_colon_offset
-
-  if date -d "$timestamp" +%s >/dev/null 2>&1; then
-    date -d "$timestamp" +%s
-    return
-  fi
-
-  timestamp_without_colon_offset=$(echo "$timestamp" | sed -E 's/([+-][0-9]{2}):([0-9]{2})$/\1\2/')
-  date -j -f "%Y-%m-%dT%H:%M:%S%z" "$timestamp_without_colon_offset" +%s
+  # Turns an S3 timestamp like "2026-07-28T02:14:33+00:00" into a Unix epoch
+  # so we can subtract to work out how old a backup is
+  #
+  # Use ruby here to enfore a consistent date parsing across all OS's
+  # instead of rely on os's `date` which has variations in flags and naming between OS's
+  ruby -rtime -e 'print Time.parse(ARGV[0]).to_i' "$1"
 }
 
 archive_key_for_epoch() {
@@ -216,6 +207,43 @@ archive_key_for_epoch() {
   echo "$(TZ="$BACKUP_ARCHIVE_TIME_ZONE" date -r "$archive_epoch" +"%Y/%m/%d")/tariff-merged-${ENVIRONMENT}.sql.gz"
 }
 
+# Looks for the archive copy of the latest backup, trying the upload completion
+# date first and then the day before, because a backup that crosses midnight
+# archives under the earlier date. Sets archive_key, archive_last_modified,
+# freshness_ok and reasons. Returns non-zero only when S3 fails for a reason
+# other than the object being absent.
+check_archive_for_epoch() {
+  local latest_epoch=$1
+  local candidate_keys=()
+  local candidate
+  local offset
+  local status
+
+  for offset in 0 -86400; do
+    candidate=$(archive_key_for_epoch "$latest_epoch" "$offset")
+    candidate_keys+=("$candidate")
+    archive_key=$candidate
+
+    if archive_last_modified=$(head_object_last_modified "$candidate"); then
+      if [ "$(epoch_for_timestamp "$archive_last_modified")" -lt "$latest_epoch" ]; then
+        freshness_ok=0
+        reasons+=("archive key $candidate is older than latest key $LATEST_KEY")
+      fi
+
+      return 0
+    else
+      # $? here is the status of the condition. Read it inside the else branch:
+      # after a plain if/fi with no else, $? is the status of the if itself.
+      status=$?
+
+      [ "$status" -eq 1 ] || return "$status"
+    fi
+  done
+
+  freshness_ok=0
+  reasons+=("archive keys ${candidate_keys[0]} and ${candidate_keys[1]} are missing")
+}
+
 reasons=()
 freshness_ok=1
 now_epoch=$(date +%s)
@@ -229,43 +257,7 @@ if latest_last_modified=$(head_object_last_modified "$LATEST_KEY"); then
     reasons+=("latest object is ${latest_age_seconds}s old, over threshold ${BACKUP_FRESHNESS_THRESHOLD_SECONDS}s")
   fi
 
-  archive_key=$(archive_key_for_epoch "$latest_epoch")
-
-  if archive_last_modified=$(head_object_last_modified "$archive_key"); then
-    archive_epoch=$(epoch_for_timestamp "$archive_last_modified")
-
-    if [ "$archive_epoch" -lt "$latest_epoch" ]; then
-      freshness_ok=0
-      reasons+=("archive key $archive_key is older than latest key $LATEST_KEY")
-    fi
-  else
-    status=$?
-
-    if [ "$status" -eq 1 ]; then
-      expected_archive_key=$archive_key
-      archive_key=$(archive_key_for_epoch "$latest_epoch" -86400)
-
-      if archive_last_modified=$(head_object_last_modified "$archive_key"); then
-        archive_epoch=$(epoch_for_timestamp "$archive_last_modified")
-
-        if [ "$archive_epoch" -lt "$latest_epoch" ]; then
-          freshness_ok=0
-          reasons+=("archive key $archive_key is older than latest key $LATEST_KEY")
-        fi
-      else
-        status=$?
-
-        if [ "$status" -eq 1 ]; then
-          freshness_ok=0
-          reasons+=("archive keys $expected_archive_key and $archive_key are missing")
-        else
-          exit "$status"
-        fi
-      fi
-    else
-      exit "$status"
-    fi
-  fi
+  check_archive_for_epoch "$latest_epoch" || exit $?
 else
   status=$?
 

--- a/spec/bin/check_database_backup_freshness_spec.rb
+++ b/spec/bin/check_database_backup_freshness_spec.rb
@@ -1,0 +1,186 @@
+# frozen_string_literal: true
+
+require 'active_support/time'
+require 'date'
+require 'open3'
+require 'tmpdir'
+
+RSpec.describe 'bin/check-database-backup-freshness' do # rubocop:disable RSpec/DescribeClass
+  let(:script_path) { File.expand_path('../../bin/check-database-backup-freshness', __dir__) }
+  let(:tempdir) { Dir.mktmpdir }
+  # The script derives the archive key from the backup's Europe/London date.
+  let(:london_zone) { Time.find_zone!('Europe/London') }
+  let(:latest_epoch) { london_zone.now.to_i - 60 }
+
+  def write_executable(path, contents)
+    File.write(path, contents)
+    File.chmod(0o755, path)
+  end
+
+  def run_check(tempdir, env_overrides = {}, args = ['--publish'])
+    env = {
+      'PATH' => "#{tempdir}/bin:#{ENV.fetch('PATH')}",
+      'TMPDIR' => tempdir,
+      'ENVIRONMENT' => 'development',
+      'S3_BUCKET' => 'trade-tariff-database-backups-test',
+    }.merge(env_overrides)
+
+    Open3.capture3(env, script_path, *args, chdir: File.expand_path('../..', __dir__))
+  end
+
+  def command_log(tempdir)
+    File.readlines("#{tempdir}/commands.log", chomp: true)
+  end
+
+  def archive_keys_requested(tempdir)
+    command_log(tempdir).grep(/head-object/).filter_map { |line| line[%r{--key (\S+/\S+)}, 1] }
+  end
+
+  def touch_flag(name)
+    FileUtils.touch("#{tempdir}/#{name}")
+  end
+
+  def london_date(epoch)
+    london_zone.at(epoch).strftime('%Y/%m/%d')
+  end
+
+  def aws_timestamp(epoch)
+    london_zone.at(epoch).utc.strftime('%Y-%m-%dT%H:%M:%S+00:00')
+  end
+
+  # Archive candidates are date prefixed (2026/07/29/...), the latest key is not,
+  # so the stub tells them apart by looking for a slash in the requested key.
+  def install_command_stubs
+    write_executable "#{tempdir}/bin/aws", <<~'BASH'
+      #!/usr/bin/env bash
+      set -euo pipefail
+      echo "aws $*" >> "$TMPDIR/commands.log"
+
+      if [[ "$1 $2" != "s3api head-object" ]]; then
+        exit 0
+      fi
+
+      key=''
+      args=("$@")
+      for ((i = 0; i < ${#args[@]}; i++)); do
+        if [[ "${args[$i]}" == "--key" ]]; then
+          key="${args[$((i + 1))]}"
+        fi
+      done
+
+      not_found() {
+        echo "An error occurred (404) when calling the HeadObject operation: Not Found" >&2
+        exit 254
+      }
+
+      if [[ "$key" != */* ]]; then
+        if [[ -f "$TMPDIR/latest_head_error" ]]; then
+          echo "An error occurred (AccessDenied) when calling the HeadObject operation" >&2
+          exit 5
+        fi
+
+        if [[ -f "$TMPDIR/latest_missing" ]]; then
+          not_found
+        fi
+
+        cat "$TMPDIR/latest_last_modified"
+        exit 0
+      fi
+
+      attempts_file="$TMPDIR/archive-attempts"
+      attempts=0
+      [[ -f "$attempts_file" ]] && attempts=$(cat "$attempts_file")
+      attempts=$((attempts + 1))
+      echo "$attempts" > "$attempts_file"
+
+      if [[ -f "$TMPDIR/archive_missing_all" ]]; then
+        not_found
+      fi
+
+      if [[ -f "$TMPDIR/archive_previous_day" && "$attempts" -eq 1 ]]; then
+        not_found
+      fi
+
+      if [[ -f "$TMPDIR/archive_unparseable" ]]; then
+        echo "not-a-timestamp"
+        exit 0
+      fi
+
+      cat "$TMPDIR/archive_last_modified"
+      exit 0
+    BASH
+  end
+
+  before do
+    FileUtils.mkdir_p("#{tempdir}/bin")
+    FileUtils.touch("#{tempdir}/commands.log")
+    File.write("#{tempdir}/latest_last_modified", aws_timestamp(latest_epoch))
+    File.write("#{tempdir}/archive_last_modified", aws_timestamp(latest_epoch + 10))
+    install_command_stubs
+  end
+
+  after do
+    FileUtils.remove_entry(tempdir)
+  end
+
+  it 'passes and publishes 1 when the archive exists under the upload completion date' do
+    stdout, stderr, status = run_check(tempdir)
+
+    expect(status).to be_success, stderr
+    expect(stdout).to include('Status: PASS')
+    expect(archive_keys_requested(tempdir)).to eq(
+      ["#{london_date(latest_epoch)}/tariff-merged-development.sql.gz"],
+    )
+    expect(command_log(tempdir).grep(/cloudwatch put-metric-data/).first).to include('--value 1')
+  end
+
+  it 'falls back to the previous day when a backup crosses midnight' do
+    touch_flag 'archive_previous_day'
+
+    stdout, stderr, status = run_check(tempdir)
+
+    expect(status).to be_success, stderr
+    expect(stdout).to include('Status: PASS')
+
+    same_day, previous_day = archive_keys_requested(tempdir)
+    expect(previous_day).to eq(
+      "#{london_date(latest_epoch - 86_400)}/tariff-merged-development.sql.gz",
+    )
+    expect(Date.parse(previous_day[%r{\A\d{4}/\d{2}/\d{2}}])).to eq(
+      Date.parse(same_day[%r{\A\d{4}/\d{2}/\d{2}}]) - 1,
+    )
+    expect(command_log(tempdir).grep(/cloudwatch put-metric-data/).first).to include('--value 1')
+  end
+
+  it 'fails and publishes 0 when both archive candidates are missing' do
+    touch_flag 'archive_missing_all'
+
+    stdout, stderr, status = run_check(tempdir)
+
+    expect(status).to be_success, stderr
+    expect(stdout).to include('Status: FAIL')
+    expect(stdout).to include('are missing')
+    expect(archive_keys_requested(tempdir).count).to eq(2)
+    expect(command_log(tempdir).grep(/cloudwatch put-metric-data/).first).to include('--value 0')
+  end
+
+  it 'exits without publishing when an archive timestamp cannot be parsed' do
+    touch_flag 'archive_unparseable'
+
+    _stdout, stderr, status = run_check(tempdir)
+
+    expect(status.exitstatus).to eq(2)
+    expect(stderr).to include('Unable to parse archive LastModified')
+    expect(command_log(tempdir).grep(/cloudwatch put-metric-data/)).to be_empty
+  end
+
+  it 'exits without publishing when S3 fails for a reason other than a missing object' do
+    touch_flag 'latest_head_error'
+
+    _stdout, stderr, status = run_check(tempdir)
+
+    expect(status.exitstatus).to eq(5)
+    expect(stderr).to include('Unable to inspect s3://trade-tariff-database-backups-test/')
+    expect(command_log(tempdir).grep(/cloudwatch put-metric-data/)).to be_empty
+  end
+end


### PR DESCRIPTION
## What:

Refactors timestamp conversion to use ruby instead of `date`

## Why:

Date has variations in flags and naming between OSs. What works fine on mac doesn't always work on alpine where this is being deployed. Farming this out to ruby ensures consistency in date conversion on all OSs.

## Ticket:
[HMRC-2296](https://transformuk.atlassian.net/browse/HMRC-2296)

## Risk:
🟢

**Reason for rating:**
Only changes a utility script, no changes to daily ops of service