### PR TITLE
perf: eliminate 30-min daily DB pressure from compressed note refresh

### DIFF
--- a/app/services/tariff_knowledge/compressed_note_generator.rb
+++ b/app/services/tariff_knowledge/compressed_note_generator.rb
@@ -10,6 +10,11 @@ module TariffKnowledge
 
     def call
       nodes = declarable_nodes
+      existing_notes = CompressedNote
+        .by_sids(nodes.map(&:goods_nomenclature_sid))
+        .all
+        .index_by(&:goods_nomenclature_sid)
+
       apply_edges = apply_edges_for_declarable_nodes(nodes)
       evidence_by_node_id = evidence_by_declarable_node_id(nodes, apply_edges)
       block_evidence_by_node_id = block_evidence_by_declarable_node_id(nodes, apply_edges)
@@ -21,6 +26,7 @@ module TariffKnowledge
           evidence_by_node_id.fetch(declarable_node.id, []),
           block_evidence_by_node_id.fetch(declarable_node.id, []),
           contained_fragment_key_lookup,
+          existing_notes[declarable_node.goods_nomenclature_sid],
         )
       end
     end
@@ -35,8 +41,8 @@ module TariffKnowledge
           .all
     end
 
-    def generate_for(declarable_node, evidence, block_evidence, contained_fragment_keys_by_block_node_id)
-      return mark_existing_note_stale(declarable_node) if evidence.empty? && block_evidence.empty?
+    def generate_for(declarable_node, evidence, block_evidence, contained_fragment_keys_by_block_node_id, existing_note)
+      return mark_existing_note_stale(existing_note) if evidence.empty? && block_evidence.empty?
 
       content = evidence.any? ? content_for(declarable_node, evidence) : block_content_for(block_evidence)
       attributes = {
@@ -56,7 +62,7 @@ module TariffKnowledge
         expired: false,
       }
 
-      upsert_note(declarable_node, attributes)
+      upsert_note(declarable_node, attributes, existing_note)
     end
 
     def apply_edges_for_declarable_nodes(declarable_nodes)
@@ -335,19 +341,18 @@ module TariffKnowledge
       end
     end
 
-    def upsert_note(declarable_node, attributes)
-      note = CompressedNote[declarable_node.goods_nomenclature_sid]
-      return mark_note_stale_if_context_changed(note, attributes[:context_hash]) if note&.manually_edited
+    def upsert_note(declarable_node, attributes, existing_note)
+      return mark_note_stale_if_context_changed(existing_note, attributes[:context_hash]) if existing_note&.manually_edited
 
-      if note
-        note.update(attributes)
+      if existing_note
+        existing_note.update(attributes)
       else
         CompressedNote.create(attributes.merge(goods_nomenclature_sid: declarable_node.goods_nomenclature_sid))
       end
     end
 
-    def mark_existing_note_stale(declarable_node)
-      CompressedNote[declarable_node.goods_nomenclature_sid]&.mark_stale!
+    def mark_existing_note_stale(existing_note)
+      existing_note&.mark_stale!
       nil
     end
 

--- a/app/services/tariff_knowledge/compressed_note_generator.rb
+++ b/app/services/tariff_knowledge/compressed_note_generator.rb
@@ -345,7 +345,7 @@ module TariffKnowledge
       return mark_note_stale_if_context_changed(existing_note, attributes[:context_hash]) if existing_note&.manually_edited
 
       if existing_note
-        existing_note.update(attributes)
+        existing_note.this.where(manually_edited: false).update(attributes)
       else
         CompressedNote.create(attributes.merge(goods_nomenclature_sid: declarable_node.goods_nomenclature_sid))
       end

--- a/app/services/tariff_knowledge/compressed_note_refresh.rb
+++ b/app/services/tariff_knowledge/compressed_note_refresh.rb
@@ -3,7 +3,7 @@ module TariffKnowledge
     BATCH_SIZE = 500
     FINGERPRINT_CACHE_KEY = 'tariff_knowledge:compressed_note_refresh:fingerprint'.freeze
 
-    Result = Data.define(:goods_nomenclature_count, :expired_note_count)
+    Result = Data.define(:goods_nomenclature_count, :expired_note_count, :skipped)
 
     def self.call
       new.call
@@ -13,7 +13,7 @@ module TariffKnowledge
       current_version = current_source_version
       current_sids    = current_goods_nomenclature_sids
 
-      return Result.new(goods_nomenclature_count: 0, expired_note_count: 0) \
+      return Result.new(goods_nomenclature_count: 0, expired_note_count: 0, skipped: true) \
         if fingerprint_unchanged?(current_version, current_sids)
 
       DeclarableNodeLoader.call
@@ -29,6 +29,7 @@ module TariffKnowledge
       Result.new(
         goods_nomenclature_count: current_sids.size,
         expired_note_count: expired_note_count,
+        skipped: false,
       )
     end
 

--- a/app/services/tariff_knowledge/compressed_note_refresh.rb
+++ b/app/services/tariff_knowledge/compressed_note_refresh.rb
@@ -1,6 +1,7 @@
 module TariffKnowledge
   class CompressedNoteRefresh
     BATCH_SIZE = 500
+    FINGERPRINT_CACHE_KEY = 'tariff_knowledge:compressed_note_refresh:fingerprint'.freeze
 
     Result = Data.define(:goods_nomenclature_count, :expired_note_count)
 
@@ -9,13 +10,20 @@ module TariffKnowledge
     end
 
     def call
+      current_version = current_source_version
+      current_sids    = current_goods_nomenclature_sids
+
+      return Result.new(goods_nomenclature_count: 0, expired_note_count: 0) \
+        if fingerprint_unchanged?(current_version, current_sids)
+
       DeclarableNodeLoader.call
       SourceGraphLoader.call
 
-      current_sids = current_goods_nomenclature_sids
       current_sids.each_slice(BATCH_SIZE) do |sids|
         CompressedNoteGenerator.call(goods_nomenclature_sids: sids)
       end
+
+      store_fingerprint(current_version, current_sids)
 
       Result.new(
         goods_nomenclature_count: current_sids.size,
@@ -24,6 +32,29 @@ module TariffKnowledge
     end
 
   private
+
+    def current_source_version
+      TimeMachine.now { CustomsTariffUpdate.latest.get(:version) }
+    end
+
+    def fingerprint_unchanged?(version, sids)
+      stored = Rails.cache.read(FINGERPRINT_CACHE_KEY)
+      return false unless stored
+
+      stored[:version] == version && stored[:sids_digest] == sids_digest(sids)
+    end
+
+    def store_fingerprint(version, sids)
+      Rails.cache.write(
+        FINGERPRINT_CACHE_KEY,
+        { version:, sids_digest: sids_digest(sids) },
+        expires_in: 8.days,
+      )
+    end
+
+    def sids_digest(sids)
+      Digest::SHA256.hexdigest(sids.join(','))
+    end
 
     def current_goods_nomenclature_sids
       if TimeMachine.date_is_set?

--- a/app/services/tariff_knowledge/compressed_note_refresh.rb
+++ b/app/services/tariff_knowledge/compressed_note_refresh.rb
@@ -23,11 +23,12 @@ module TariffKnowledge
         CompressedNoteGenerator.call(goods_nomenclature_sids: sids)
       end
 
+      expired_note_count = expire_non_current_notes(current_sids)
       store_fingerprint(current_version, current_sids)
 
       Result.new(
         goods_nomenclature_count: current_sids.size,
-        expired_note_count: expire_non_current_notes(current_sids),
+        expired_note_count: expired_note_count,
       )
     end
 

--- a/app/services/tariff_knowledge/source_graph_loader.rb
+++ b/app/services/tariff_knowledge/source_graph_loader.rb
@@ -296,7 +296,6 @@ module TariffKnowledge
     end
 
     def upsert_node(attributes)
-      key = attributes.fetch(:key)
       now = Time.zone.now
       values = attributes.merge(
         metadata: Sequel.pg_jsonb(attributes.fetch(:metadata, { 'loader' => self.class.name })),
@@ -304,11 +303,13 @@ module TariffKnowledge
         updated_at: now,
       )
 
-      Node.dataset
-          .insert_conflict(target: :key, update: node_update_values)
-          .insert(values)
+      row = Node.dataset
+                .returning
+                .insert_conflict(target: :key, update: node_update_values)
+                .insert(values)
+                .first
 
-      Node.by_key(key).first
+      Node.call(row)
     end
 
     def upsert_edge(source_node, target_node, relationship_type)

--- a/app/services/tariff_knowledge/source_graph_loader.rb
+++ b/app/services/tariff_knowledge/source_graph_loader.rb
@@ -309,7 +309,7 @@ module TariffKnowledge
                 .insert(values)
                 .first
 
-      Node.call(row)
+      Node.load(row)
     end
 
     def upsert_edge(source_node, target_node, relationship_type)

--- a/app/workers/refresh_tariff_knowledge_compressed_notes_worker.rb
+++ b/app/workers/refresh_tariff_knowledge_compressed_notes_worker.rb
@@ -4,6 +4,11 @@ class RefreshTariffKnowledgeCompressedNotesWorker
   sidekiq_options queue: :sync, retry: false
 
   def perform
-    TariffKnowledge::CompressedNoteRefresh.call
+    result = TariffKnowledge::CompressedNoteRefresh.call
+    if result.skipped
+      logger.info('CompressedNoteRefresh skipped: fingerprint unchanged since last run')
+    else
+      logger.info("CompressedNoteRefresh complete: #{result.goods_nomenclature_count} notes, #{result.expired_note_count} expired")
+    end
   end
 end

--- a/spec/lib/tasks/tariff_knowledge_rake_spec.rb
+++ b/spec/lib/tasks/tariff_knowledge_rake_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe 'tariff_knowledge rake tasks' do
     it 'runs compressed note refresh inline' do
       allow(TariffKnowledge::CompressedNoteRefresh)
         .to receive(:call)
-        .and_return(TariffKnowledge::CompressedNoteRefresh::Result.new(goods_nomenclature_count: 2, expired_note_count: 1))
+        .and_return(TariffKnowledge::CompressedNoteRefresh::Result.new(goods_nomenclature_count: 2, expired_note_count: 1, skipped: false))
 
       suppress_output { Rake::Task['tariff_knowledge:compressed_notes:refresh:run'].invoke }
 

--- a/spec/services/tariff_knowledge/compressed_note_generator_spec.rb
+++ b/spec/services/tariff_knowledge/compressed_note_generator_spec.rb
@@ -548,6 +548,20 @@ RSpec.describe TariffKnowledge::CompressedNoteGenerator do
         .to include('horses and asses')
     end
 
+    it 'fetches existing notes for the batch in one query rather than per-node lookups' do
+      create(
+        :tariff_knowledge_compressed_note,
+        goods_nomenclature_sid: 123,
+        goods_nomenclature_item_id: '0101210000',
+        content: 'Old content',
+        stale: false,
+      )
+
+      expect(TariffKnowledge::CompressedNote).not_to receive(:[])
+
+      described_class.call(goods_nomenclature_sids: [123])
+    end
+
     it 'does not overwrite manually edited notes' do
       create(
         :tariff_knowledge_compressed_note,

--- a/spec/services/tariff_knowledge/compressed_note_generator_spec.rb
+++ b/spec/services/tariff_knowledge/compressed_note_generator_spec.rb
@@ -556,10 +556,23 @@ RSpec.describe TariffKnowledge::CompressedNoteGenerator do
         content: 'Old content',
         stale: false,
       )
+      create(
+        :tariff_knowledge_node,
+        key: 'goods_nomenclature:456',
+        goods_nomenclature_sid: 456,
+        goods_nomenclature_item_id: '0101290000',
+      )
+      create(
+        :tariff_knowledge_compressed_note,
+        goods_nomenclature_sid: 456,
+        goods_nomenclature_item_id: '0101290000',
+        content: 'Old content 2',
+        stale: false,
+      )
 
-      expect(TariffKnowledge::CompressedNote).not_to receive(:[])
+      queries = sql_queries { described_class.call(goods_nomenclature_sids: [123, 456]) }
 
-      described_class.call(goods_nomenclature_sids: [123])
+      expect(queries.grep(/FROM "tariff_knowledge_compressed_notes"/).size).to eq(1)
     end
 
     it 'does not overwrite manually edited notes' do

--- a/spec/services/tariff_knowledge/compressed_note_generator_spec.rb
+++ b/spec/services/tariff_knowledge/compressed_note_generator_spec.rb
@@ -577,6 +577,33 @@ RSpec.describe TariffKnowledge::CompressedNoteGenerator do
         .to eq('Reviewed human content')
     end
 
+    it 'does not overwrite a note edited by an admin between prefetch and upsert' do
+      create(
+        :tariff_knowledge_compressed_note,
+        goods_nomenclature_sid: 123,
+        goods_nomenclature_item_id: '0101210000',
+        content: 'Original generated content',
+        manually_edited: false,
+      )
+
+      allow(TariffKnowledge::CompressedNote).to receive(:by_sids).and_wrap_original do |original, *args|
+        dataset = original.call(*args)
+        stale_records = dataset.all
+        TariffKnowledge::CompressedNote
+          .where(goods_nomenclature_sid: 123)
+          .update(content: 'Admin edited content', manually_edited: true)
+        allow(dataset).to receive(:all).and_return(stale_records)
+        dataset
+      end
+
+      described_class.call(goods_nomenclature_sids: [123])
+
+      expect(TariffKnowledge::CompressedNote[123]).to have_attributes(
+        content: 'Admin edited content',
+        manually_edited: true,
+      )
+    end
+
     it 'marks manually edited notes stale when graph context changes' do
       create(
         :tariff_knowledge_compressed_note,

--- a/spec/services/tariff_knowledge/compressed_note_generator_spec.rb
+++ b/spec/services/tariff_knowledge/compressed_note_generator_spec.rb
@@ -600,13 +600,11 @@ RSpec.describe TariffKnowledge::CompressedNoteGenerator do
       )
 
       allow(TariffKnowledge::CompressedNote).to receive(:by_sids).and_wrap_original do |original, *args|
-        dataset = original.call(*args)
-        stale_records = dataset.all
+        stale_records = original.call(*args).all
         TariffKnowledge::CompressedNote
           .where(goods_nomenclature_sid: 123)
           .update(content: 'Admin edited content', manually_edited: true)
-        allow(dataset).to receive(:all).and_return(stale_records)
-        dataset
+        instance_double(Sequel::Dataset, all: stale_records)
       end
 
       described_class.call(goods_nomenclature_sids: [123])

--- a/spec/services/tariff_knowledge/compressed_note_refresh_spec.rb
+++ b/spec/services/tariff_knowledge/compressed_note_refresh_spec.rb
@@ -103,6 +103,24 @@ RSpec.describe TariffKnowledge::CompressedNoteRefresh do
       end
     end
 
+    context 'when expiring stale notes fails' do
+      let(:cache) { ActiveSupport::Cache::MemoryStore.new }
+      let(:refresh_instance) { described_class.new }
+
+      before do
+        allow(Rails).to receive(:cache).and_return(cache)
+        create(:commodity, parent: heading, goods_nomenclature_sid: 123, goods_nomenclature_item_id: '0101210000')
+        GoodsNomenclatures::TreeNode.refresh!
+        allow(refresh_instance).to receive(:expire_non_current_notes).and_raise(Sequel::DatabaseError)
+        allow(described_class).to receive(:new).and_return(refresh_instance)
+      end
+
+      it 'does not cache the fingerprint so the next run performs a full refresh' do
+        expect { described_class.call }.to raise_error(Sequel::DatabaseError)
+        expect(cache.read(described_class::FINGERPRINT_CACHE_KEY)).to be_nil
+      end
+    end
+
     context 'when the declarable sids change between runs' do
       let(:cache) { ActiveSupport::Cache::MemoryStore.new }
 

--- a/spec/services/tariff_knowledge/compressed_note_refresh_spec.rb
+++ b/spec/services/tariff_knowledge/compressed_note_refresh_spec.rb
@@ -77,5 +77,51 @@ RSpec.describe TariffKnowledge::CompressedNoteRefresh do
 
       expect(TariffKnowledge::CompressedNote[999].expired).to be(true)
     end
+
+    context 'when the source version and declarable sids are unchanged since the last run' do
+      let(:cache) { ActiveSupport::Cache::MemoryStore.new }
+
+      before do
+        allow(Rails).to receive(:cache).and_return(cache)
+        create(:commodity, parent: heading, goods_nomenclature_sid: 123, goods_nomenclature_item_id: '0101210000')
+        GoodsNomenclatures::TreeNode.refresh!
+        described_class.call
+      end
+
+      it 'skips DeclarableNodeLoader, SourceGraphLoader, and CompressedNoteGenerator' do
+        described_class.call
+
+        expect(TariffKnowledge::DeclarableNodeLoader).to have_received(:call).once
+        expect(TariffKnowledge::SourceGraphLoader).to have_received(:call).once
+        expect(TariffKnowledge::CompressedNoteGenerator).to have_received(:call).once
+      end
+
+      it 'returns zero counts' do
+        result = described_class.call
+
+        expect(result).to have_attributes(goods_nomenclature_count: 0, expired_note_count: 0)
+      end
+    end
+
+    context 'when the declarable sids change between runs' do
+      let(:cache) { ActiveSupport::Cache::MemoryStore.new }
+
+      before do
+        allow(Rails).to receive(:cache).and_return(cache)
+        create(:commodity, parent: heading, goods_nomenclature_sid: 123, goods_nomenclature_item_id: '0101210000')
+        GoodsNomenclatures::TreeNode.refresh!
+        described_class.call
+        create(:commodity, parent: heading, goods_nomenclature_sid: 124, goods_nomenclature_item_id: '0101290000')
+        GoodsNomenclatures::TreeNode.refresh!
+      end
+
+      it 'runs all sub-services again' do
+        described_class.call
+
+        expect(TariffKnowledge::DeclarableNodeLoader).to have_received(:call).twice
+        expect(TariffKnowledge::SourceGraphLoader).to have_received(:call).twice
+        expect(TariffKnowledge::CompressedNoteGenerator).to have_received(:call).twice
+      end
+    end
   end
 end

--- a/spec/services/tariff_knowledge/compressed_note_refresh_spec.rb
+++ b/spec/services/tariff_knowledge/compressed_note_refresh_spec.rb
@@ -96,10 +96,32 @@ RSpec.describe TariffKnowledge::CompressedNoteRefresh do
         expect(TariffKnowledge::CompressedNoteGenerator).to have_received(:call).once
       end
 
-      it 'returns zero counts' do
+      it 'returns zero counts and marks the result as skipped' do
         result = described_class.call
 
-        expect(result).to have_attributes(goods_nomenclature_count: 0, expired_note_count: 0)
+        expect(result).to have_attributes(goods_nomenclature_count: 0, expired_note_count: 0, skipped: true)
+      end
+    end
+
+    context 'when the source version changes but the declarable sids are unchanged' do
+      let(:cache) { ActiveSupport::Cache::MemoryStore.new }
+      let(:refresh_instance) { described_class.new }
+
+      before do
+        allow(Rails).to receive(:cache).and_return(cache)
+        create(:commodity, parent: heading, goods_nomenclature_sid: 123, goods_nomenclature_item_id: '0101210000')
+        GoodsNomenclatures::TreeNode.refresh!
+        described_class.call
+        allow(refresh_instance).to receive(:current_source_version).and_return('new-version')
+        allow(described_class).to receive(:new).and_return(refresh_instance)
+      end
+
+      it 'runs all sub-services again' do
+        described_class.call
+
+        expect(TariffKnowledge::DeclarableNodeLoader).to have_received(:call).twice
+        expect(TariffKnowledge::SourceGraphLoader).to have_received(:call).twice
+        expect(TariffKnowledge::CompressedNoteGenerator).to have_received(:call).twice
       end
     end
 

--- a/spec/services/tariff_knowledge/source_graph_loader_spec.rb
+++ b/spec/services/tariff_knowledge/source_graph_loader_spec.rb
@@ -791,6 +791,20 @@ RSpec.describe TariffKnowledge::SourceGraphLoader do
       expect(edge_exists?(source_node, stale_fragment_node, TariffKnowledge::Edge::CONTAINS)).to be(false)
     end
 
+    it 'upserts nodes without a follow-up select query' do
+      create(
+        :customs_tariff_chapter_note,
+        :approved,
+        customs_tariff_update: update,
+        chapter_id: '01',
+        content: 'Chapter content.',
+      )
+
+      expect(TariffKnowledge::Node).not_to receive(:by_key)
+
+      described_class.call
+    end
+
     it 'removes stale range references when fragment content changes' do
       note = create(
         :customs_tariff_chapter_note,

--- a/spec/services/tariff_knowledge/source_graph_loader_spec.rb
+++ b/spec/services/tariff_knowledge/source_graph_loader_spec.rb
@@ -800,9 +800,13 @@ RSpec.describe TariffKnowledge::SourceGraphLoader do
         content: 'Chapter content.',
       )
 
-      expect(TariffKnowledge::Node).not_to receive(:by_key)
+      queries = sql_queries { described_class.call }
 
-      described_class.call
+      node_inserts = queries.count { |q| q.include?('INSERT INTO "tariff_knowledge_nodes"') }
+      node_key_lookups = queries.count { |q| q.include?('FROM "tariff_knowledge_nodes"') && q.include?('"key"') }
+
+      expect(node_inserts).to be_positive
+      expect(node_key_lookups).to eq(0)
     end
 
     it 'removes stale range references when fragment content changes' do
@@ -826,6 +830,21 @@ RSpec.describe TariffKnowledge::SourceGraphLoader do
       expect(edge_exists?(fragment_node, current_range_node, TariffKnowledge::Edge::REFERENCES)).to be(true)
       expect(edge_exists?(fragment_node, stale_range_node, TariffKnowledge::Edge::REFERENCES)).to be(false)
     end
+  end
+
+  def sql_queries
+    queries = []
+    logger = Logger.new(StringIO.new)
+    logger.formatter = proc do |_severity, _datetime, _progname, message|
+      queries << message
+      nil
+    end
+
+    Sequel::Model.db.loggers << logger
+    yield
+    queries
+  ensure
+    Sequel::Model.db.loggers.delete(logger)
   end
 
   def edge_exists?(source_node, target_node, relationship_type)

--- a/spec/workers/refresh_tariff_knowledge_compressed_notes_worker_spec.rb
+++ b/spec/workers/refresh_tariff_knowledge_compressed_notes_worker_spec.rb
@@ -1,11 +1,27 @@
 RSpec.describe RefreshTariffKnowledgeCompressedNotesWorker, type: :worker do
   describe '#perform' do
-    it 'delegates compressed note refresh' do
-      allow(TariffKnowledge::CompressedNoteRefresh).to receive(:call)
+    let(:worker) { described_class.new }
 
-      described_class.new.perform
+    it 'logs a skipped message when the fingerprint is unchanged' do
+      result = TariffKnowledge::CompressedNoteRefresh::Result.new(
+        goods_nomenclature_count: 0, expired_note_count: 0, skipped: true,
+      )
+      allow(TariffKnowledge::CompressedNoteRefresh).to receive(:call).and_return(result)
 
-      expect(TariffKnowledge::CompressedNoteRefresh).to have_received(:call)
+      expect(worker.logger).to receive(:info).with(/skipped/)
+
+      worker.perform
+    end
+
+    it 'logs a completion message with counts when the full run completes' do
+      result = TariffKnowledge::CompressedNoteRefresh::Result.new(
+        goods_nomenclature_count: 42, expired_note_count: 3, skipped: false,
+      )
+      allow(TariffKnowledge::CompressedNoteRefresh).to receive(:call).and_return(result)
+
+      expect(worker.logger).to receive(:info).with(/42.*3|3.*42|complete/)
+
+      worker.perform
     end
   end
 


### PR DESCRIPTION
## What:
Eliminate the 30-minute daily DB pressure spike caused by `RefreshTariffKnowledgeCompressedNotesWorker`. Three fixes to the compressed note refresh pipeline, each with a failing test written before implementation.

**Fix 1 — skip guard on unchanged state**
`CompressedNoteRefresh#call` now computes a fingerprint of the current tariff source version and sorted declarable SID set before running any loaders. If it matches the value stored in `Rails.cache` from the previous run, the worker returns immediately. On a normal day with no tariff changes this reduces the worker from ~30 minutes to milliseconds. The fingerprint expires after 8 days so a cache eviction triggers at most one redundant full run.

**Fix 2 — RETURNING in `SourceGraphLoader#upsert_node`**
Every node insert previously did an `INSERT ... ON CONFLICT DO UPDATE` followed by a separate `Node.by_key(key).first` SELECT to retrieve the row. Changed to `INSERT ... ON CONFLICT ... RETURNING *` with `Node.call(row)`, halving DB round-trips for every source, fragment, block, and range node upserted.

**Fix 3 — batch prefetch in `CompressedNoteGenerator`**
`upsert_note` and `mark_existing_note_stale` each called `CompressedNote[sid]` — a PK lookup per commodity — inside the per-batch loop. Now a single `by_sids` query prefetches all existing notes for the batch at the start of `call`; the pre-fetched note is threaded through `generate_for`, `upsert_note`, and `mark_existing_note_stale`.

## Why:
New Relic showed `RefreshTariffKnowledgeCompressedNotesWorker` running for 30–37 minutes daily at 03:00 UTC, keeping the backend DB under sustained write load and causing the frontend to hit its 15s Faraday timeout on random endpoints (`Timeout::ExitException`, first seen Feb 2026, still firing daily). A `SearchAnalyticsSnapshotWorker` retry cascade (19–20 runs/day on Jul 22–23 after a bug fix) caused the recent spike, but the underlying baseline timeouts trace back to this worker growing slower as the tariff knowledge dataset grows.

## Ticket:
BAU

## Risk:
**Risk level:** 🟢
