### PR TITLE
Trigger ReportWorker from sync completion events rather than a fixed cron

### DIFF
--- a/app/lib/trade_tariff_backend/tariff_update_event_listener.rb
+++ b/app/lib/trade_tariff_backend/tariff_update_event_listener.rb
@@ -18,7 +18,7 @@ module TradeTariffBackend
       ClearInvalidSearchReferences.perform_async
       TreeIntegrityCheckWorker.perform_async
       PopulateChangesTableWorker.perform_async
-      ReportWorker.perform_async
+      ReportWorker.perform_in(15.minutes)
 
       if payload[:service] == 'xi'
         # NOTE: Delayed to allow materialized views to finish populating before

--- a/app/lib/trade_tariff_backend/tariff_update_event_listener.rb
+++ b/app/lib/trade_tariff_backend/tariff_update_event_listener.rb
@@ -18,6 +18,7 @@ module TradeTariffBackend
       ClearInvalidSearchReferences.perform_async
       TreeIntegrityCheckWorker.perform_async
       PopulateChangesTableWorker.perform_async
+      ReportWorker.perform_async
 
       if payload[:service] == 'xi'
         # NOTE: Delayed to allow materialized views to finish populating before

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -50,8 +50,9 @@
       queue: within_1_day
       description: "Refreshes cached aggregate search analytics snapshots"
     ReportWorker:
-      cron: "30 10 * * *" # Needs to run even if the UpdatesSynchronizerWorker failed
-      description: "Generates reports and persists them to S3"
+      cron: "30 10 * * *"
+      enabled: false
+      description: "Generates reports and persists them to S3 — triggered by CDS/TARIC sync completion via TariffUpdateEventListener"
     OneWeekTreeIntegrityCheck:
       cron: '05 8 * * 1'
       class: TreeIntegrityCheckWorker

--- a/spec/lib/trade_tariff_backend/tariff_update_event_listener_spec.rb
+++ b/spec/lib/trade_tariff_backend/tariff_update_event_listener_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe TradeTariffBackend::TariffUpdateEventListener do
     allow(ClearInvalidSearchReferences).to receive(:perform_async)
     allow(TreeIntegrityCheckWorker).to receive(:perform_async)
     allow(PopulateChangesTableWorker).to receive(:perform_async)
+    allow(ReportWorker).to receive(:perform_async)
     allow(GreenLanesUpdatesWorker).to receive(:perform_in)
     allow(PopulateTariffChangesWorker).to receive(:perform_async)
   end
@@ -16,6 +17,7 @@ RSpec.describe TradeTariffBackend::TariffUpdateEventListener do
       it { expect(ClearInvalidSearchReferences).to have_received(:perform_async) }
       it { expect(TreeIntegrityCheckWorker).to have_received(:perform_async) }
       it { expect(PopulateChangesTableWorker).to have_received(:perform_async) }
+      it { expect(ReportWorker).to have_received(:perform_async) }
       it { expect(GreenLanesUpdatesWorker).not_to have_received(:perform_in) }
     end
 
@@ -26,6 +28,7 @@ RSpec.describe TradeTariffBackend::TariffUpdateEventListener do
       it { expect(ClearInvalidSearchReferences).to have_received(:perform_async) }
       it { expect(TreeIntegrityCheckWorker).to have_received(:perform_async) }
       it { expect(PopulateChangesTableWorker).to have_received(:perform_async) }
+      it { expect(ReportWorker).to have_received(:perform_async) }
       it { expect(GreenLanesUpdatesWorker).to have_received(:perform_in).with(15.minutes, '2024-01-15') }
     end
   end

--- a/spec/lib/trade_tariff_backend/tariff_update_event_listener_spec.rb
+++ b/spec/lib/trade_tariff_backend/tariff_update_event_listener_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe TradeTariffBackend::TariffUpdateEventListener do
     allow(ClearInvalidSearchReferences).to receive(:perform_async)
     allow(TreeIntegrityCheckWorker).to receive(:perform_async)
     allow(PopulateChangesTableWorker).to receive(:perform_async)
-    allow(ReportWorker).to receive(:perform_async)
+    allow(ReportWorker).to receive(:perform_in)
     allow(GreenLanesUpdatesWorker).to receive(:perform_in)
     allow(PopulateTariffChangesWorker).to receive(:perform_async)
   end
@@ -17,7 +17,7 @@ RSpec.describe TradeTariffBackend::TariffUpdateEventListener do
       it { expect(ClearInvalidSearchReferences).to have_received(:perform_async) }
       it { expect(TreeIntegrityCheckWorker).to have_received(:perform_async) }
       it { expect(PopulateChangesTableWorker).to have_received(:perform_async) }
-      it { expect(ReportWorker).to have_received(:perform_async) }
+      it { expect(ReportWorker).to have_received(:perform_in).with(15.minutes) }
       it { expect(GreenLanesUpdatesWorker).not_to have_received(:perform_in) }
     end
 
@@ -28,7 +28,7 @@ RSpec.describe TradeTariffBackend::TariffUpdateEventListener do
       it { expect(ClearInvalidSearchReferences).to have_received(:perform_async) }
       it { expect(TreeIntegrityCheckWorker).to have_received(:perform_async) }
       it { expect(PopulateChangesTableWorker).to have_received(:perform_async) }
-      it { expect(ReportWorker).to have_received(:perform_async) }
+      it { expect(ReportWorker).to have_received(:perform_in).with(15.minutes) }
       it { expect(GreenLanesUpdatesWorker).to have_received(:perform_in).with(15.minutes, '2024-01-15') }
     end
   end


### PR DESCRIPTION
## What:
Wires `ReportWorker` to fire immediately when CDS/TARIC sync completes, via the existing `TARIFF_UPDATES_APPLIED` event in `TariffUpdateEventListener`. Disables the 10:30am sidekiq-scheduler cron entry.

## Why:
The 10:30am cron was a conservative buffer to ensure both the TARIC (XI, midnight) and CDS (UK, 5am) syncs had time to finish before generating reports. This caused reports to run during the working day with an unnecessary multi-hour lag after the data was ready.

With the event-driven approach:
- XI fires its `ReportWorker` immediately after TARIC sync completes (~1–2am)
- UK fires its `ReportWorker` immediately after CDS sync completes (~7–8am)
- The existing 30-minute `DifferencesReportWorker` delay inside `ReportWorker` is unaffected — by the time UK's reports complete and schedule it, XI's reports finished hours earlier

The cron entry is disabled (`enabled: false`) rather than deleted, so it can be re-enabled as a fallback if needed.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:** Change only affects when `ReportWorker` is enqueued — earlier in the day rather than later. No changes to report logic, data processing, or sync behaviour. The reports overwrite S3 objects and are idempotent by nature.