### PR TITLE
Cap Sidekiq retries and harden a few hot-path jobs

### DIFF
--- a/app/workers/action_log_report_worker.rb
+++ b/app/workers/action_log_report_worker.rb
@@ -3,6 +3,9 @@ require 'csv'
 class ActionLogReportWorker
   include Sidekiq::Worker
 
+  # Report jobs: one delayed retry, avoid Sidekiq default (25).
+  sidekiq_options retry: 1, retry_in: 1.hour
+
   def perform
     return unless TradeTariffBackend.uk?
 
@@ -10,10 +13,10 @@ class ActionLogReportWorker
     start_date = 1.month.ago.beginning_of_day
     end_date = yesterday.end_of_day
 
+    # Stream the dataset (no .all) so large months do not load entirely into memory.
     action_logs = PublicUsers::ActionLog
-                    .where(Sequel.lit('created_at >= ? AND created_at <= ?', start_date, end_date))
+                    .where(created_at: start_date..end_date)
                     .order(:id)
-                    .all
 
     return if action_logs.empty?
 

--- a/app/workers/appendix5a_email_worker.rb
+++ b/app/workers/appendix5a_email_worker.rb
@@ -1,6 +1,9 @@
 class Appendix5aEmailWorker
   include Sidekiq::Worker
 
+  # Cap retries: Notify outages must not use Sidekiq's default (25) and crowd the default queue.
+  sidekiq_options retry: 3
+
   TEMPLATE_ID = NOTIFY_CONFIGURATION.dig(:templates, :notifications, :appendix5a)
 
   def perform(recipient_index, new_count, changed_count, removed_count)

--- a/app/workers/appendix5a_notification_status_check_worker.rb
+++ b/app/workers/appendix5a_notification_status_check_worker.rb
@@ -1,7 +1,8 @@
 class Appendix5aNotificationStatusCheckWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: :default
+  # Cap retries: Notify status checks must not use Sidekiq's default (25).
+  sidekiq_options queue: :default, retry: 3
 
   FAILURE_STATUSES = [
     GovukNotifier::PERMANENT_FAILURE,

--- a/app/workers/enquiry_form/send_submission_email_worker.rb
+++ b/app/workers/enquiry_form/send_submission_email_worker.rb
@@ -10,6 +10,9 @@ class EnquiryForm::SendSubmissionEmailWorker
 
   include Sidekiq::Worker
 
+  # Cap retries: Notify outages must not use Sidekiq's default (25) and crowd the default queue.
+  sidekiq_options retry: 3
+
   def perform(reference)
     form_data = enquiry_form_data(reference)
 

--- a/app/workers/external_user_deletion_worker.rb
+++ b/app/workers/external_user_deletion_worker.rb
@@ -3,6 +3,9 @@
 class ExternalUserDeletionWorker
   include Sidekiq::Worker
 
+  # External Identity API calls; cap retries vs Sidekiq default (25).
+  sidekiq_options retry: 3
+
   def perform(user_id)
     user = PublicUsers::User[user_id]
     return unless user&.deleted

--- a/app/workers/govuk_notifier_status_check_worker.rb
+++ b/app/workers/govuk_notifier_status_check_worker.rb
@@ -3,7 +3,8 @@ class GovukNotifierStatusCheckWorker
 
   CHECK_DELAY = 10.minutes
 
-  sidekiq_options queue: :default
+  # Cap retries: Notify status checks must not use Sidekiq's default (25).
+  sidekiq_options queue: :default, retry: 3
 
   def perform(user_id, notification_id)
     return if notification_id.blank?

--- a/app/workers/green_lanes_updates_worker.rb
+++ b/app/workers/green_lanes_updates_worker.rb
@@ -33,15 +33,33 @@ private
     created_updates = updates.select do |update|
       update.status == ::GreenLanes::UpdateNotification::NotificationStatus::CREATED
     end
+    return if created_updates.empty?
+
+    # Preload lookups once per batch — avoids N+1 per update.
+    measure_type_ids = created_updates.map(&:measure_type_id).uniq
+    identified_by_measure_type = GreenLanes::IdentifiedMeasureTypeCategoryAssessment
+      .where(measure_type_id: measure_type_ids)
+      .all
+      .index_by(&:measure_type_id)
+
+    existing_assessment_keys = GreenLanes::CategoryAssessment
+      .where(measure_type_id: measure_type_ids)
+      .select_map(%i[regulation_id regulation_role measure_type_id])
+      .to_set
+
+    theme_ids = identified_by_measure_type.values.map(&:theme_id).uniq
+    themes_by_id = if theme_ids.empty?
+                     {}
+                   else
+                     GreenLanes::Theme.where(id: theme_ids).all.index_by(&:id)
+                   end
 
     created_updates.each do |update|
-      identified_ca = GreenLanes::IdentifiedMeasureTypeCategoryAssessment.where(measure_type_id: update.measure_type_id).first
-
+      identified_ca = identified_by_measure_type[update.measure_type_id]
       next unless identified_ca
 
-      next if GreenLanes::CategoryAssessment[regulation_id: update.regulation_id,
-                                             regulation_role: update.regulation_role,
-                                             measure_type_id: update.measure_type_id]
+      assessment_key = [update.regulation_id, update.regulation_role, update.measure_type_id]
+      next if existing_assessment_keys.include?(assessment_key)
 
       logger.info "Creating category assessment for #{update.measure_type_id}"
 
@@ -50,9 +68,11 @@ private
                                                       measure_type_id: update.measure_type_id,
                                                       theme_id: identified_ca.theme_id)
       assessment.save(validate: true)
+      existing_assessment_keys << assessment_key
+
       update.status = ::GreenLanes::UpdateNotification::NotificationStatus::CA_CREATED
       update.theme_id = identified_ca.theme_id
-      update.theme = ::GreenLanes::Theme.find(id: identified_ca.theme_id)&.to_s
+      update.theme = themes_by_id[identified_ca.theme_id]&.to_s
     end
   end
 

--- a/app/workers/invalidate_cache_worker.rb
+++ b/app/workers/invalidate_cache_worker.rb
@@ -1,6 +1,9 @@
 class InvalidateCacheWorker
   include Sidekiq::Worker
 
+  # CloudFront invalidation; cap retries vs Sidekiq default (25).
+  sidekiq_options retry: 3
+
   SERVICES = ['/uk', '/xi', ''].freeze
   PATHS = %w[/api/*].freeze
 

--- a/app/workers/my_commodities_email_worker.rb
+++ b/app/workers/my_commodities_email_worker.rb
@@ -1,6 +1,9 @@
 class MyCommoditiesEmailWorker
   include Sidekiq::Worker
 
+  # Cap retries: Notify outages must not use Sidekiq's default (25) and crowd the default queue.
+  sidekiq_options retry: 3
+
   TEMPLATE_ID = NOTIFY_CONFIGURATION.dig(:templates, :myott, :tariff_change)
   REPLY_TO_ID = NOTIFY_CONFIGURATION.dig(:reply_to, :tariff_management)
 

--- a/app/workers/my_commodities_subscription_worker.rb
+++ b/app/workers/my_commodities_subscription_worker.rb
@@ -1,6 +1,9 @@
 class MyCommoditiesSubscriptionWorker
   include Sidekiq::Worker
 
+  # Orchestrator only enqueues children; keep retries low to limit duplicate fan-out.
+  sidekiq_options retry: 3
+
   def perform(date = Time.zone.yesterday.iso8601)
     @date = Date.parse(date)
     queue

--- a/app/workers/notifications_worker.rb
+++ b/app/workers/notifications_worker.rb
@@ -1,7 +1,8 @@
 class NotificationsWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: :default
+  # Cap retries: Notify outages must not use Sidekiq's default (25).
+  sidekiq_options queue: :default, retry: 3
 
   def perform(notification_id)
     notification_data = notification_data(notification_id)

--- a/app/workers/precache_headings_worker.rb
+++ b/app/workers/precache_headings_worker.rb
@@ -1,7 +1,8 @@
 class PrecacheHeadingsWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: :sync
+  # Precache is re-enqueued after cache clear; avoid Sidekiq default (25) retries.
+  sidekiq_options queue: :sync, retry: 3
 
   def perform(date = nil)
     date = date ? Time.zone.parse(date).to_date : Time.zone.tomorrow

--- a/app/workers/prewarm_commodities_worker.rb
+++ b/app/workers/prewarm_commodities_worker.rb
@@ -1,7 +1,9 @@
 class PrewarmCommoditiesWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: :sync, retry: true
+  # Best-effort cache warm (CloudWatch poll can sleep up to ~60s). Prefer
+  # within_1_hour so long polls do not contend with the hot sync queue.
+  sidekiq_options queue: :within_1_hour, retry: true
 
   DEFAULT_LOOKBACK_HOURS = 24
   DEFAULT_LIMIT = 1000

--- a/app/workers/prewarm_commodities_worker.rb
+++ b/app/workers/prewarm_commodities_worker.rb
@@ -3,7 +3,8 @@ class PrewarmCommoditiesWorker
 
   # Best-effort cache warm (CloudWatch poll can sleep up to ~60s). Prefer
   # within_1_hour so long polls do not contend with the hot sync queue.
-  sidekiq_options queue: :within_1_hour, retry: true
+  # Cap retries: retry: true uses Sidekiq's default (~25).
+  sidekiq_options queue: :within_1_hour, retry: 3
 
   DEFAULT_LOOKBACK_HOURS = 24
   DEFAULT_LIMIT = 1000

--- a/app/workers/prewarm_quota_order_numbers_worker.rb
+++ b/app/workers/prewarm_quota_order_numbers_worker.rb
@@ -1,7 +1,8 @@
 class PrewarmQuotaOrderNumbersWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: :sync, retry: true
+  # Cap retries: retry: true uses Sidekiq's default (~25).
+  sidekiq_options queue: :sync, retry: 3
 
   def perform
     TimeMachine.now do

--- a/app/workers/remove_failed_subscribers_worker.rb
+++ b/app/workers/remove_failed_subscribers_worker.rb
@@ -1,6 +1,9 @@
 class RemoveFailedSubscribersWorker
   include Sidekiq::Worker
 
+  # Soft-deletes are mostly idempotent; keep retries low vs Sidekiq default (25).
+  sidekiq_options retry: 3
+
   def perform
     return unless TradeTariffBackend.uk?
 

--- a/app/workers/stop_press_email_worker.rb
+++ b/app/workers/stop_press_email_worker.rb
@@ -1,6 +1,9 @@
 class StopPressEmailWorker
   include Sidekiq::Worker
 
+  # Cap retries: Notify outages must not use Sidekiq's default (25) and crowd the default queue.
+  sidekiq_options retry: 3
+
   TEMPLATE_ID = NOTIFY_CONFIGURATION.dig(:templates, :myott, :stop_press)
   REPLY_TO_ID = NOTIFY_CONFIGURATION.dig(:reply_to, :tariff_management)
 

--- a/app/workers/stop_press_subscription_worker.rb
+++ b/app/workers/stop_press_subscription_worker.rb
@@ -1,6 +1,9 @@
 class StopPressSubscriptionWorker
   include Sidekiq::Worker
 
+  # Orchestrator only enqueues children; keep retries low to limit duplicate fan-out.
+  sidekiq_options retry: 3
+
   def perform(stop_press_id)
     @stop_press = News::Item.find(id: stop_press_id)
     queue

--- a/app/workers/synchronizer_check_worker.rb
+++ b/app/workers/synchronizer_check_worker.rb
@@ -1,6 +1,9 @@
 class SynchronizerCheckWorker
   include Sidekiq::Worker
 
+  # Metric-only job; reruns every 30 minutes via scheduler — do not retry-storm.
+  sidekiq_options retry: false
+
   # Sentinel value recorded when no applied updates exist at all, ensuring
   # the NR alert condition fires immediately rather than silently passing.
   NO_SYNC_SENTINEL_MINUTES = 99_999

--- a/app/workers/tree_integrity_check_worker.rb
+++ b/app/workers/tree_integrity_check_worker.rb
@@ -1,7 +1,8 @@
 class TreeIntegrityCheckWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: :sync
+  # Integrity check is scheduled weekly; avoid Sidekiq default (25) retries.
+  sidekiq_options queue: :sync, retry: 1
 
   def perform
     check(7)

--- a/app/workers/watch_list_invitation_email_worker.rb
+++ b/app/workers/watch_list_invitation_email_worker.rb
@@ -1,6 +1,9 @@
 class WatchListInvitationEmailWorker
   include Sidekiq::Worker
 
+  # Cap retries: Notify outages must not use Sidekiq's default (25) and crowd the default queue.
+  sidekiq_options retry: 3
+
   TEMPLATE_ID = '50b0bce2-3116-46dd-a2b2-2ba253534f01'.freeze
   REPLY_TO_ID = 'a208a7ea-41d3-48dd-8bf7-24d4be1f4832'.freeze # Indu
 

--- a/db/migrate/20260730140000_add_created_at_index_to_user_action_logs.rb
+++ b/db/migrate/20260730140000_add_created_at_index_to_user_action_logs.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# ActionLogReportWorker filters user_action_logs by created_at range (≈1 month).
+# Without an index, that query degrades to a sequential scan as the table grows.
+Sequel.migration do
+  up do
+    run <<~SQL
+      CREATE INDEX IF NOT EXISTS user_action_logs_created_at_index
+        ON public.user_action_logs (created_at);
+    SQL
+  end
+
+  down do
+    run <<~SQL
+      DROP INDEX IF EXISTS public.user_action_logs_created_at_index;
+    SQL
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -10533,6 +10533,13 @@ CREATE UNIQUE INDEX user_subscriptions_target_unique_idx ON public.user_subscrip
 
 
 --
+-- Name: user_action_logs_created_at_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX user_action_logs_created_at_index ON public.user_action_logs USING btree (created_at);
+
+
+--
 -- Name: abrogation_regulation_id; Type: INDEX; Schema: uk; Owner: -
 --
 
@@ -14757,3 +14764,4 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20260626120000_create_tari
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260708130000_add_derived_facts_to_public_atar_rulings.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260716120000_drop_status_from_customs_tariff_note_tables.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260716120100_drop_status_from_customs_tariff_updates.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20260730140000_add_created_at_index_to_user_action_logs.rb');

--- a/spec/workers/action_log_report_worker_spec.rb
+++ b/spec/workers/action_log_report_worker_spec.rb
@@ -1,4 +1,10 @@
 RSpec.describe ActionLogReportWorker do
+  describe 'sidekiq options' do
+    it 'uses a single delayed retry' do
+      expect(described_class.sidekiq_options['retry']).to eq(1)
+    end
+  end
+
   describe '#perform' do
     subject(:worker) { described_class.new }
 

--- a/spec/workers/appendix5a_email_worker_spec.rb
+++ b/spec/workers/appendix5a_email_worker_spec.rb
@@ -13,6 +13,12 @@ RSpec.describe Appendix5aEmailWorker, type: :worker do
     allow(Appendix5aNotificationStatusCheckWorker).to receive(:perform_in)
   end
 
+  describe 'sidekiq options' do
+    it 'caps retries below Sidekiq default' do
+      expect(described_class.sidekiq_options['retry']).to eq(3)
+    end
+  end
+
   describe '#perform' do
     it 'resolves the recipient email from configured index and sends via GovukNotifier' do
       worker.perform(0, 2, 3, 1)

--- a/spec/workers/appendix5a_notification_status_check_worker_spec.rb
+++ b/spec/workers/appendix5a_notification_status_check_worker_spec.rb
@@ -13,6 +13,12 @@ RSpec.describe Appendix5aNotificationStatusCheckWorker, type: :worker do
     allow(Rails.logger).to receive(:error)
   end
 
+  describe 'sidekiq options' do
+    it 'caps retries below Sidekiq default' do
+      expect(described_class.sidekiq_options['retry']).to eq(3)
+    end
+  end
+
   context 'when notification_uuid is blank' do
     it 'does nothing' do
       worker.perform(recipient_index, nil)

--- a/spec/workers/enquiry_form/send_submission_email_worker_spec.rb
+++ b/spec/workers/enquiry_form/send_submission_email_worker_spec.rb
@@ -1,8 +1,7 @@
 RSpec.describe EnquiryForm::SendSubmissionEmailWorker, type: :worker do
   subject(:worker) { described_class.new }
 
-  let(:reference) { 'ABC12345' }
-
+  let(:notifier_client) { instance_double(GovukNotifier, send_email: true) }
   let(:form_data) do
     {
       name: 'John Doe',
@@ -15,8 +14,11 @@ RSpec.describe EnquiryForm::SendSubmissionEmailWorker, type: :worker do
       created_at: '2025-08-15 10:00',
     }
   end
+  let(:reference) { 'ABC12345' }
 
-  let(:notifier_client) { instance_double(GovukNotifier, send_email: true) }
+  after do
+    Sidekiq.redis { |conn| conn.del(described_class.cache_key(reference)) }
+  end
 
   before do
     Sidekiq.redis { |conn| conn.set(described_class.cache_key(reference), form_data.to_json, ex: 3600) }
@@ -24,8 +26,10 @@ RSpec.describe EnquiryForm::SendSubmissionEmailWorker, type: :worker do
     allow(GovukNotifier).to receive(:new).and_return(notifier_client)
   end
 
-  after do
-    Sidekiq.redis { |conn| conn.del(described_class.cache_key(reference)) }
+  describe 'sidekiq options' do
+    it 'caps retries below Sidekiq default' do
+      expect(described_class.sidekiq_options['retry']).to eq(3)
+    end
   end
 
   describe '#perform' do

--- a/spec/workers/external_user_deletion_worker_spec.rb
+++ b/spec/workers/external_user_deletion_worker_spec.rb
@@ -6,6 +6,12 @@ RSpec.describe ExternalUserDeletionWorker, type: :worker do
     allow(PublicUsers::User).to receive(:[]).with(user.id).and_return(user)
   end
 
+  describe 'sidekiq options' do
+    it 'caps retries below Sidekiq default' do
+      expect(described_class.sidekiq_options['retry']).to eq(3)
+    end
+  end
+
   context 'when user is not deleted' do
     it 'returns without doing anything' do
       allow(user).to receive(:deleted).and_return(false)

--- a/spec/workers/govuk_notifier_status_check_worker_spec.rb
+++ b/spec/workers/govuk_notifier_status_check_worker_spec.rb
@@ -11,6 +11,12 @@ RSpec.describe GovukNotifierStatusCheckWorker, type: :worker do
     allow(notifier).to receive(:get_email_status).and_return(status)
   end
 
+  describe 'sidekiq options' do
+    it 'caps retries below Sidekiq default' do
+      expect(described_class.sidekiq_options['retry']).to eq(3)
+    end
+  end
+
   context 'when notification id is blank' do
     it 'does nothing' do
       worker.perform(user.id, nil)

--- a/spec/workers/green_lanes_updates_worker_spec.rb
+++ b/spec/workers/green_lanes_updates_worker_spec.rb
@@ -6,10 +6,11 @@ RSpec.describe GreenLanesUpdatesWorker, type: :worker do
 
   before do
     allow(TradeTariffBackend).to receive(:service).and_return 'xi'
-    worker.perform
   end
 
   describe 'run green lanes updates worker' do
+    before { worker.perform }
+
     it 'creates CA with identified measure type' do
       category_assessments = GreenLanes::CategoryAssessment.all.pluck(:measure_type_id, :regulation_id, :regulation_role)
 
@@ -44,6 +45,48 @@ RSpec.describe GreenLanesUpdatesWorker, type: :worker do
                                        measure.measure_generating_regulation_role,
                                        ::GreenLanes::UpdateNotification::NotificationStatus::CREATED,
                                        nil])
+    end
+  end
+
+  describe '#create_automated_ca' do
+    def build_created_update(measure)
+      GreenLanesUpdatesPublisher::GreenLanesUpdate.new(
+        measure.measure_generating_regulation_id,
+        measure.measure_generating_regulation_role,
+        measure.measure_type_id,
+        ::GreenLanes::UpdateNotification::NotificationStatus::CREATED,
+      )
+    end
+
+    it 'creates a category assessment for each created update with an identified CA' do
+      first_measure = create(:measure, trade_movement_code: '1', generating_regulation: create(:base_regulation))
+      second_measure = create(:measure, trade_movement_code: '1', generating_regulation: create(:base_regulation))
+      first_identified = create(:identified_measure_type_category_assessment, measure: first_measure)
+      second_identified = create(:identified_measure_type_category_assessment, measure: second_measure)
+      updates = [build_created_update(first_measure), build_created_update(second_measure)]
+
+      expect { worker.send(:create_automated_ca, updates) }
+        .to change(GreenLanes::CategoryAssessment, :count).by(2)
+
+      expect(updates.map(&:status)).to all(eq(::GreenLanes::UpdateNotification::NotificationStatus::CA_CREATED))
+      expect(updates.map(&:theme_id)).to contain_exactly(first_identified.theme_id, second_identified.theme_id)
+    end
+
+    it 'skips updates that already have a category assessment' do
+      first_measure = create(:measure, trade_movement_code: '1', generating_regulation: create(:base_regulation))
+      second_measure = create(:measure, trade_movement_code: '1', generating_regulation: create(:base_regulation))
+      create(:identified_measure_type_category_assessment, measure: first_measure)
+      create(:identified_measure_type_category_assessment, measure: second_measure)
+      create(:category_assessment, measure: first_measure)
+      updates = [build_created_update(first_measure), build_created_update(second_measure)]
+
+      expect { worker.send(:create_automated_ca, updates) }
+        .to change(GreenLanes::CategoryAssessment, :count).by(1)
+
+      expect(updates.map(&:status)).to contain_exactly(
+        ::GreenLanes::UpdateNotification::NotificationStatus::CREATED,
+        ::GreenLanes::UpdateNotification::NotificationStatus::CA_CREATED,
+      )
     end
   end
 end

--- a/spec/workers/invalidate_cache_worker_spec.rb
+++ b/spec/workers/invalidate_cache_worker_spec.rb
@@ -1,8 +1,6 @@
 RSpec.describe InvalidateCacheWorker, type: :worker do
   subject(:worker) { described_class.new }
 
-  let(:client) { Aws::CloudFront::Client.new(stub_responses: true) }
-
   let(:base_distribution) do
     {
       id: 'DEFAULT123',
@@ -25,6 +23,13 @@ RSpec.describe InvalidateCacheWorker, type: :worker do
       is_ipv6_enabled: true,
       staging: false,
     }
+  end
+  let(:client) { Aws::CloudFront::Client.new(stub_responses: true) }
+
+  describe 'sidekiq options' do
+    it 'caps retries below Sidekiq default' do
+      expect(described_class.sidekiq_options['retry']).to eq(3)
+    end
   end
 
   describe '#perform' do

--- a/spec/workers/my_commodities_email_worker_spec.rb
+++ b/spec/workers/my_commodities_email_worker_spec.rb
@@ -15,6 +15,12 @@ RSpec.describe MyCommoditiesEmailWorker, type: :worker do
     allow(mock_notifier).to receive(:schedule_status_check)
   end
 
+  describe 'sidekiq options' do
+    it 'caps retries below Sidekiq default' do
+      expect(described_class.sidekiq_options['retry']).to eq(3)
+    end
+  end
+
   describe '#perform' do
     context 'when all parameters are valid' do
       it 'sends an email to the user' do

--- a/spec/workers/my_commodities_subscription_worker_spec.rb
+++ b/spec/workers/my_commodities_subscription_worker_spec.rb
@@ -4,6 +4,12 @@ RSpec.describe MyCommoditiesSubscriptionWorker, type: :worker do
   let(:date) { '2025-12-08' }
   let(:status) { instance_double(TariffChangesJobStatus, mark_emails_sent!: true) }
 
+  describe 'sidekiq options' do
+    it 'caps retries below Sidekiq default' do
+      expect(described_class.sidekiq_options['retry']).to eq(3)
+    end
+  end
+
   describe '#perform' do
     context 'when users have tariff changes on the date' do
       let(:first_user) { create(:public_user, :with_my_commodities_subscription) }

--- a/spec/workers/notifications_worker_spec.rb
+++ b/spec/workers/notifications_worker_spec.rb
@@ -1,6 +1,12 @@
 RSpec.describe NotificationsWorker, type: :worker do
   subject(:worker) { described_class.new }
 
+  describe 'sidekiq options' do
+    it 'caps retries below Sidekiq default' do
+      expect(described_class.sidekiq_options['retry']).to eq(3)
+    end
+  end
+
   describe '#perform' do
     let(:notification_id) { SecureRandom.uuid }
 

--- a/spec/workers/precache_headings_worker_spec.rb
+++ b/spec/workers/precache_headings_worker_spec.rb
@@ -1,6 +1,12 @@
 RSpec.describe PrecacheHeadingsWorker, type: :worker do
   let(:date) { Time.zone.today }
 
+  describe 'sidekiq options' do
+    it 'caps retries below Sidekiq default' do
+      expect(described_class.sidekiq_options['retry']).to eq(3)
+    end
+  end
+
   describe '#perform' do
     before do
       allow(Rails.cache).to receive(:write).and_call_original

--- a/spec/workers/prewarm_commodities_worker_spec.rb
+++ b/spec/workers/prewarm_commodities_worker_spec.rb
@@ -36,6 +36,12 @@ RSpec.describe PrewarmCommoditiesWorker do
     allow(ENV).to receive(:fetch).with('PREWARM_COMMODITY_IDS', '').and_return('')
   end
 
+  describe 'sidekiq options' do
+    it 'runs on within_1_hour so CloudWatch polling does not block the sync queue' do
+      expect(described_class.sidekiq_options['queue']).to eq(:within_1_hour)
+    end
+  end
+
   describe '#perform' do
     it 'queries CloudWatch and prewarms cached commodities' do
       worker.perform

--- a/spec/workers/prewarm_commodities_worker_spec.rb
+++ b/spec/workers/prewarm_commodities_worker_spec.rb
@@ -40,6 +40,10 @@ RSpec.describe PrewarmCommoditiesWorker do
     it 'runs on within_1_hour so CloudWatch polling does not block the sync queue' do
       expect(described_class.sidekiq_options['queue']).to eq(:within_1_hour)
     end
+
+    it 'caps retries below Sidekiq default' do
+      expect(described_class.sidekiq_options['retry']).to eq(3)
+    end
   end
 
   describe '#perform' do

--- a/spec/workers/prewarm_quota_order_numbers_worker_spec.rb
+++ b/spec/workers/prewarm_quota_order_numbers_worker_spec.rb
@@ -1,6 +1,12 @@
 RSpec.describe PrewarmQuotaOrderNumbersWorker do
   subject(:worker) { described_class.new }
 
+  describe 'sidekiq options' do
+    it 'caps retries below Sidekiq default' do
+      expect(described_class.sidekiq_options['retry']).to eq(3)
+    end
+  end
+
   describe '#perform' do
     it 'calls the CachedQuotaOrderNumberService' do
       allow(CachedQuotaOrderNumberService).to receive(:new).and_call_original

--- a/spec/workers/remove_failed_subscribers_worker_spec.rb
+++ b/spec/workers/remove_failed_subscribers_worker_spec.rb
@@ -6,6 +6,12 @@ RSpec.describe RemoveFailedSubscribersWorker, type: :worker do
     allow(PublicUsers::User).to receive(:failed_subscribers).and_return([user])
   end
 
+  describe 'sidekiq options' do
+    it 'caps retries below Sidekiq default' do
+      expect(described_class.sidekiq_options['retry']).to eq(3)
+    end
+  end
+
   it 'calls soft_delete! on all failed subscribers' do
     described_class.new.perform
     expect(user).to have_received(:soft_delete!)

--- a/spec/workers/stop_press_email_worker_spec.rb
+++ b/spec/workers/stop_press_email_worker_spec.rb
@@ -4,6 +4,12 @@ RSpec.describe StopPressEmailWorker, type: :worker do
   let(:stop_press) { create(:news_item) }
   let(:user) { create(:public_user, :with_active_stop_press_subscription) }
 
+  describe 'sidekiq options' do
+    it 'caps retries below Sidekiq default' do
+      expect(described_class.sidekiq_options['retry']).to eq(3)
+    end
+  end
+
   describe '#perform' do
     let(:client) { instance_double(GovukNotifier) }
     let(:email_address) { 'test@example.com' }

--- a/spec/workers/stop_press_subscription_worker_spec.rb
+++ b/spec/workers/stop_press_subscription_worker_spec.rb
@@ -4,6 +4,12 @@ RSpec.describe StopPressSubscriptionWorker, type: :worker do
   let(:stop_press) { create(:news_item) }
   let(:user) { create(:public_user, :with_active_stop_press_subscription) }
 
+  describe 'sidekiq options' do
+    it 'caps retries below Sidekiq default' do
+      expect(described_class.sidekiq_options['retry']).to eq(3)
+    end
+  end
+
   describe '#perform' do
     it 'returns users with active stop press subscriptions matching chapters', :aggregate_failures do
       allow(stop_press).to receive_messages(emailable?: true, chapters: '01, 02')

--- a/spec/workers/synchronizer_check_worker_spec.rb
+++ b/spec/workers/synchronizer_check_worker_spec.rb
@@ -1,4 +1,10 @@
 RSpec.describe SynchronizerCheckWorker, type: :worker do
+  describe 'sidekiq options' do
+    it 'does not retry metric-only jobs' do
+      expect(described_class.sidekiq_options['retry']).to be(false)
+    end
+  end
+
   describe '#perform' do
     subject(:perform) { described_class.new.perform }
 

--- a/spec/workers/tree_integrity_check_worker_spec.rb
+++ b/spec/workers/tree_integrity_check_worker_spec.rb
@@ -1,6 +1,12 @@
 RSpec.describe TreeIntegrityCheckWorker, type: :worker do
   let(:date) { Time.zone.today }
 
+  describe 'sidekiq options' do
+    it 'uses a single retry' do
+      expect(described_class.sidekiq_options['retry']).to eq(1)
+    end
+  end
+
   describe '#perform' do
     before do
       allow(::NewRelic::Agent).to receive(:notice_error)

--- a/spec/workers/watch_list_invitation_email_worker_spec.rb
+++ b/spec/workers/watch_list_invitation_email_worker_spec.rb
@@ -1,0 +1,7 @@
+RSpec.describe WatchListInvitationEmailWorker, type: :worker do
+  describe 'sidekiq options' do
+    it 'caps retries below Sidekiq default' do
+      expect(described_class.sidekiq_options['retry']).to eq(3)
+    end
+  end
+end


### PR DESCRIPTION
## What:
- [x] Cap Sidekiq retries on email, Notify status, subscription, cache, and related workers (replace Sidekiq default ~25)
- [x] Preload Green Lanes identified CAs, existing assessments, and themes in `create_automated_ca` (remove N+1 lookups)
- [x] Add `user_action_logs(created_at)` index for the action log report window query
- [x] Stream `ActionLogReportWorker` results instead of loading the full month with `.all`
- [x] Move `PrewarmCommoditiesWorker` from `sync` to `within_1_hour` so CloudWatch polling does not block the hot sync queue
- [x] Specs covering sidekiq options and Green Lanes batch creation

## Why:
An AppSignal/Ruby Weekly Sidekiq-slowness review highlighted capacity risks that apply here: default retries can storm the default queue during Notify outages, long prewarm sleeps contend with sync work, and a couple of job paths still do per-row DB lookups or unindexed range scans. This PR applies the low-risk hardening steps only (retry policy, index, preload, queue move) with targeted worker coverage.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:** Additive index and job config/retry policy changes; Green Lanes preload preserves existing create/skip behaviour; no public API or tariff-data processing change. Covered by worker specs (102 examples green locally).