### PR TITLE
AI-1082: Notify operators of Customs Tariff document updates

### DIFF
--- a/app/lib/notifications/instrumentation.rb
+++ b/app/lib/notifications/instrumentation.rb
@@ -1,0 +1,27 @@
+require 'active_support/notifications'
+
+module Notifications
+  module Instrumentation
+  module_function
+
+    def instrument(event_name, payload = {})
+      ActiveSupport::Notifications.instrument("#{event_name}.notifications", payload)
+    end
+
+    def send_skipped(pipeline:, identifier:, reason:)
+      instrument('send_skipped', pipeline:, identifier:, reason:)
+    end
+
+    def enqueue_retrying(pipeline:, item:, attempt:, error_class:, error_message:)
+      instrument('enqueue_retrying', pipeline:, item:, attempt:, error_class:, error_message:)
+    end
+
+    def enqueue_failed(pipeline:, items:, attempts:)
+      instrument('enqueue_failed', pipeline:, items:, attempts:)
+    end
+
+    def delivery_failed(pipeline:, identifier:, notification_uuid:, status:)
+      instrument('delivery_failed', pipeline:, identifier:, notification_uuid:, status:)
+    end
+  end
+end

--- a/app/lib/notifications/logger.rb
+++ b/app/lib/notifications/logger.rb
@@ -1,0 +1,42 @@
+require 'active_support/log_subscriber'
+
+module Notifications
+  class Logger < ActiveSupport::LogSubscriber
+    def send_skipped(event)
+      error log_entry(event: 'send_skipped', pipeline: event.payload[:pipeline], identifier: event.payload[:identifier], reason: event.payload[:reason])
+    end
+
+    def enqueue_retrying(event)
+      error log_entry(
+        event: 'enqueue_retrying',
+        pipeline: event.payload[:pipeline],
+        item: event.payload[:item],
+        attempt: event.payload[:attempt],
+        error_class: event.payload[:error_class],
+        error_message: event.payload[:error_message],
+      )
+    end
+
+    def enqueue_failed(event)
+      error log_entry(event: 'enqueue_failed', pipeline: event.payload[:pipeline], items: event.payload[:items], attempts: event.payload[:attempts])
+    end
+
+    def delivery_failed(event)
+      error log_entry(
+        event: 'delivery_failed',
+        pipeline: event.payload[:pipeline],
+        identifier: event.payload[:identifier],
+        notification_uuid: event.payload[:notification_uuid],
+        status: event.payload[:status],
+      )
+    end
+
+  private
+
+    def log_entry(data)
+      data.merge(service: 'notifications', timestamp: Time.current.iso8601).to_json
+    end
+  end
+end
+
+Notifications::Logger.attach_to :notifications unless Rails.env.test?

--- a/app/services/customs_tariff_update_change_summary.rb
+++ b/app/services/customs_tariff_update_change_summary.rb
@@ -1,0 +1,56 @@
+class CustomsTariffUpdateChangeSummary
+  def initialize(update)
+    @update = update
+  end
+
+  def call
+    {
+      chapter_ids: changed_ids(CustomsTariffChapterNote, :chapter_id, previous_chapter_notes),
+      section_ids: changed_ids(CustomsTariffSectionNote, :section_id, previous_section_notes),
+    }
+  end
+
+private
+
+  def changed_ids(note_class, id_attribute, baseline_by_id)
+    note_class
+      .where(customs_tariff_update_version: @update.version)
+      .all
+      .select { |note| changed?(note, id_attribute, baseline_by_id) }
+      .map(&id_attribute)
+      .sort
+  end
+
+  def changed?(note, id_attribute, baseline_by_id)
+    baseline = baseline_by_id[note.public_send(id_attribute)]
+    return true if baseline.nil?
+
+    VersionDiffService.new(
+      note.class.name,
+      { 'content' => baseline.content },
+      { 'content' => note.content },
+    ).call.present?
+  end
+
+  def previous_update
+    start_date = @update.validity_start_date
+
+    @previous_update ||= CustomsTariffUpdate
+      .imported
+      .where { validity_start_date < start_date }
+      .order(Sequel.desc(:validity_start_date))
+      .first
+  end
+
+  def previous_chapter_notes
+    return {} unless previous_update
+
+    CustomsTariffChapterNote.where(customs_tariff_update_version: previous_update.version).all.index_by(&:chapter_id)
+  end
+
+  def previous_section_notes
+    return {} unless previous_update
+
+    CustomsTariffSectionNote.where(customs_tariff_update_version: previous_update.version).all.index_by(&:section_id)
+  end
+end

--- a/app/services/customs_tariff_update_notifier_service.rb
+++ b/app/services/customs_tariff_update_notifier_service.rb
@@ -1,0 +1,54 @@
+require_relative '../lib/notifications/instrumentation'
+require_relative '../lib/notifications/logger'
+
+class CustomsTariffUpdateNotifierService
+  PIPELINE = 'customs_tariff_update'.freeze
+  TEMPLATE_ID = NOTIFY_CONFIGURATION.dig(:templates, :notifications, :customs_tariff_update)
+
+  def initialize(version)
+    @version = version
+  end
+
+  def call
+    email = TradeTariffBackend.support_email
+
+    if email.blank?
+      Notifications::Instrumentation.send_skipped(pipeline: PIPELINE, identifier: @version, reason: 'recipient_not_configured')
+      return
+    end
+
+    update = CustomsTariffUpdate[@version]
+
+    if update.nil?
+      Notifications::Instrumentation.send_skipped(pipeline: PIPELINE, identifier: @version, reason: 'update_not_found')
+      return
+    end
+
+    changes = CustomsTariffUpdateChangeSummary.new(update).call
+    personalisation = build_personalisation(update, changes)
+
+    Notifications::EnqueueService.new([@version], pipeline: PIPELINE) { |version|
+      status_check_args = [version]
+      Notifications::EmailWorker.perform_async(email, TEMPLATE_ID, personalisation, 'CustomsTariffUpdateNotificationStatusCheckWorker', status_check_args)
+    }.call
+  end
+
+private
+
+  def build_personalisation(update, changes)
+    {
+      'version' => update.version,
+      'document_type' => document_type_label,
+      'document_created_on' => update.document_created_on&.iso8601 || 'Not available',
+      'document_url' => update.source_url.presence || 'Not available',
+      'imported_on' => update.created_at&.iso8601,
+      'entry_into_force_on' => update.validity_start_date&.iso8601,
+      'chapter_ids' => changes[:chapter_ids].join(', '),
+      'section_ids' => changes[:section_ids].join(', '),
+    }
+  end
+
+  def document_type_label
+    TradeTariffBackend.uk? ? 'UK Customs Tariff' : 'XI Combined Nomenclature'
+  end
+end

--- a/app/services/notifications/delivery_status_checker.rb
+++ b/app/services/notifications/delivery_status_checker.rb
@@ -1,0 +1,37 @@
+require_relative '../../lib/notifications/instrumentation'
+require_relative '../../lib/notifications/logger'
+
+module Notifications
+  class DeliveryStatusChecker
+    FAILURE_STATUSES = [
+      GovukNotifier::PERMANENT_FAILURE,
+      GovukNotifier::TEMPORARY_FAILURE,
+      GovukNotifier::TECHNICAL_FAILURE,
+    ].freeze
+
+    def initialize(notification_uuid, pipeline:, identifier:)
+      @notification_uuid = notification_uuid
+      @pipeline = pipeline
+      @identifier = identifier
+    end
+
+    def call
+      return if @notification_uuid.blank?
+
+      status = GovukNotifier.new.get_email_status(@notification_uuid)
+      return unless FAILURE_STATUSES.include?(status)
+
+      Instrumentation.delivery_failed(pipeline: @pipeline, identifier: @identifier, notification_uuid: @notification_uuid, status:)
+      notify_slack("#{@pipeline}: notification delivery failed for #{@identifier} (status: #{status}) — check logs")
+      status
+    end
+
+  private
+
+    def notify_slack(message)
+      SlackNotifierService.call(message)
+    rescue StandardError => e
+      Rails.logger.error("#{@pipeline}_notification_slack_failed: #{e.class.name}: #{e.message}")
+    end
+  end
+end

--- a/app/services/notifications/enqueue_service.rb
+++ b/app/services/notifications/enqueue_service.rb
@@ -1,0 +1,54 @@
+require_relative '../../lib/notifications/instrumentation'
+require_relative '../../lib/notifications/logger'
+
+module Notifications
+  class EnqueueService
+    MAX_ATTEMPTS = 3
+    RETRY_DELAY = 30.seconds
+
+    Result = Data.define(:failed_items, :attempts)
+
+    def initialize(items, pipeline:, max_attempts: MAX_ATTEMPTS, retry_delay: RETRY_DELAY, &enqueue)
+      @items = items
+      @pipeline = pipeline
+      @max_attempts = max_attempts
+      @retry_delay = retry_delay
+      @enqueue = enqueue
+    end
+
+    def call
+      pending = @items
+      attempt = 0
+
+      until pending.empty? || attempt >= @max_attempts
+        attempt += 1
+        pending = attempt_enqueue(pending, attempt)
+        sleep(@retry_delay) if pending.any? && attempt < @max_attempts
+      end
+
+      if pending.any?
+        Instrumentation.enqueue_failed(pipeline: @pipeline, items: pending, attempts: attempt)
+        notify_slack("#{@pipeline}: failed to enqueue notification for #{pending.join(', ')} after #{attempt} attempts — check logs")
+      end
+
+      Result.new(failed_items: pending, attempts: attempt)
+    end
+
+  private
+
+    def attempt_enqueue(pending, attempt)
+      pending.each_with_object([]) do |item, failed|
+        @enqueue.call(item)
+      rescue StandardError => e
+        failed << item
+        Instrumentation.enqueue_retrying(pipeline: @pipeline, item:, attempt:, error_class: e.class.name, error_message: e.message)
+      end
+    end
+
+    def notify_slack(message)
+      SlackNotifierService.call(message)
+    rescue StandardError => e
+      Rails.logger.error("#{@pipeline}_notification_slack_failed: #{e.class.name}: #{e.message}")
+    end
+  end
+end

--- a/app/workers/customs_tariff_update_notification_status_check_worker.rb
+++ b/app/workers/customs_tariff_update_notification_status_check_worker.rb
@@ -1,0 +1,11 @@
+class CustomsTariffUpdateNotificationStatusCheckWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :default
+
+  PIPELINE = 'customs_tariff_update'.freeze
+
+  def perform(version, notification_uuid)
+    Notifications::DeliveryStatusChecker.new(notification_uuid, pipeline: PIPELINE, identifier: version).call
+  end
+end

--- a/app/workers/customs_tariff_update_notification_status_check_worker.rb
+++ b/app/workers/customs_tariff_update_notification_status_check_worker.rb
@@ -1,7 +1,7 @@
 class CustomsTariffUpdateNotificationStatusCheckWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: :default
+  sidekiq_options queue: :default, retry: 3
 
   PIPELINE = 'customs_tariff_update'.freeze
 

--- a/app/workers/import_customs_tariff_document_worker.rb
+++ b/app/workers/import_customs_tariff_document_worker.rb
@@ -25,6 +25,7 @@ class ImportCustomsTariffDocumentWorker
     )
 
     notify_completed(results)
+    notify_update_recipients(results)
   rescue StandardError => e
     CustomsTariffImporter::Instrumentation.import_run_failed(
       error_class: e.class.name,
@@ -35,6 +36,20 @@ class ImportCustomsTariffDocumentWorker
   end
 
 private
+
+  def notify_update_recipients(results)
+    results.select { |r| r.status == :imported }.each do |result|
+      CustomsTariffUpdateNotifierService.new(result.version).call
+    rescue StandardError => e
+      Rails.logger.error(
+        "customs_tariff_update_notifier_failed: version=#{result.version} error_class=#{e.class.name} error_message=#{e.message}",
+      )
+      notify_slack(
+        'Customs tariff document import succeeded, but sending the update notification failed for ' \
+        "version #{result.version}. #{e.class}: #{e.message}",
+      )
+    end
+  end
 
   def notify_completed(results)
     imported = results.select { |r| r.status == :imported }

--- a/app/workers/import_xi_cn_document_worker.rb
+++ b/app/workers/import_xi_cn_document_worker.rb
@@ -1,3 +1,6 @@
+require_relative '../lib/xi_cn_importer/instrumentation'
+require_relative '../lib/xi_cn_importer/logger'
+
 class ImportXiCnDocumentWorker
   include Sidekiq::Worker
 
@@ -22,6 +25,7 @@ class ImportXiCnDocumentWorker
     )
 
     notify_completed(results)
+    notify_update_recipients(results)
   rescue StandardError => e
     XiCnImporter::Instrumentation.import_run_failed(
       error_class: e.class.name,
@@ -32,6 +36,20 @@ class ImportXiCnDocumentWorker
   end
 
 private
+
+  def notify_update_recipients(results)
+    results.select { |r| r.status == :imported }.each do |result|
+      CustomsTariffUpdateNotifierService.new(result.celex).call
+    rescue StandardError => e
+      Rails.logger.error(
+        "customs_tariff_update_notifier_failed: celex=#{result.celex} error_class=#{e.class.name} error_message=#{e.message}",
+      )
+      notify_slack(
+        'XI Combined Nomenclature document import succeeded, but sending the update notification failed for ' \
+        "CELEX ID #{result.celex}. #{e.class}: #{e.message}",
+      )
+    end
+  end
 
   def notify_completed(results)
     imported = results.select { |r| r.status == :imported }

--- a/app/workers/notifications/email_worker.rb
+++ b/app/workers/notifications/email_worker.rb
@@ -2,7 +2,7 @@ module Notifications
   class EmailWorker
     include Sidekiq::Worker
 
-    sidekiq_options queue: :default
+    sidekiq_options queue: :default, retry: 3
 
     def perform(email, template_id, personalisation, status_check_worker_class, status_check_args)
       notification = client.send_email(email, template_id, personalisation, nil, nil)

--- a/app/workers/notifications/email_worker.rb
+++ b/app/workers/notifications/email_worker.rb
@@ -1,0 +1,28 @@
+module Notifications
+  class EmailWorker
+    include Sidekiq::Worker
+
+    sidekiq_options queue: :default
+
+    def perform(email, template_id, personalisation, status_check_worker_class, status_check_args)
+      notification = client.send_email(email, template_id, personalisation, nil, nil)
+      notification_uuid = notification.notification_uuid
+
+      begin
+        status_check_worker_class.constantize.perform_in(
+          GovukNotifierStatusCheckWorker::CHECK_DELAY, *status_check_args, notification_uuid
+        )
+      rescue StandardError => e
+        Rails.logger.error(
+          "notifications_email_worker_status_check_schedule_failed: #{e.class.name}: #{e.message} " \
+          "status_check_worker_class=#{status_check_worker_class} status_check_args=#{status_check_args.inspect} " \
+          "notification_uuid=#{notification_uuid}",
+        )
+      end
+    end
+
+    def client
+      @client ||= GovukNotifier.new
+    end
+  end
+end

--- a/config/initializers/notify.rb
+++ b/config/initializers/notify.rb
@@ -11,6 +11,7 @@ NOTIFY_CONFIGURATION =
         },
         notifications: {
           appendix5a: 'c35e387b-a2b8-4308-997c-06e1f3b36900',
+          customs_tariff_update: '02da9ea8-4919-45af-a9d4-68c908f49c9c',
         },
       },
       reply_to: {
@@ -29,6 +30,7 @@ NOTIFY_CONFIGURATION =
         },
         notifications: {
           appendix5a: '943fd08f-d9f0-47e0-b9dd-40284f308414',
+          customs_tariff_update: 'eae01fd6-3e73-4a21-83ed-175eec3701c5',
         },
       },
       reply_to: {
@@ -47,6 +49,7 @@ NOTIFY_CONFIGURATION =
         },
         notifications: {
           appendix5a: '7b53d787-2659-4cd2-9e45-afe93ad61eec',
+          customs_tariff_update: 'b99d0cef-0dce-414f-b3e2-28cf25075a43',
         },
       },
       reply_to: {

--- a/spec/config/initializers/notify_spec.rb
+++ b/spec/config/initializers/notify_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe 'Notify configuration' do
         NOTIFY_CONFIGURATION.dig(:templates, :myott, :tariff_change),
         NOTIFY_CONFIGURATION.dig(:reply_to, :tariff_management),
         NOTIFY_CONFIGURATION.dig(:templates, :notifications, :appendix5a),
+        NOTIFY_CONFIGURATION.dig(:templates, :notifications, :customs_tariff_update),
       ]
     RUBY
     output, error, status = Open3.capture3({ 'ENVIRONMENT' => environment }, RbConfig.ruby, '-e', script)
@@ -32,6 +33,7 @@ RSpec.describe 'Notify configuration' do
         5db33f13-7235-4ed8-b704-e3fddc01ee09
         61e19d5e-4fae-4b7e-aa2e-cd05a87f4cf8
         c35e387b-a2b8-4308-997c-06e1f3b36900
+        02da9ea8-4919-45af-a9d4-68c908f49c9c
       ])
     end
   end
@@ -45,6 +47,7 @@ RSpec.describe 'Notify configuration' do
         53c88c0c-69be-4375-829f-c6fbb1b9e2ef
         ed4f4168-e8c5-4b80-94b9-050c86a40f0f
         943fd08f-d9f0-47e0-b9dd-40284f308414
+        eae01fd6-3e73-4a21-83ed-175eec3701c5
       ])
     end
   end
@@ -56,6 +59,7 @@ RSpec.describe 'Notify configuration' do
         d25ab0ca-0114-47dc-954a-488516301580
         e780283a-471f-42ae-a573-4364ef604fea
         7b53d787-2659-4cd2-9e45-afe93ad61eec
+        b99d0cef-0dce-414f-b3e2-28cf25075a43
       ])
     end
   end

--- a/spec/lib/notifications/instrumentation_spec.rb
+++ b/spec/lib/notifications/instrumentation_spec.rb
@@ -1,0 +1,45 @@
+RSpec.describe Notifications::Instrumentation do
+  describe '.send_skipped' do
+    it 'emits send_skipped with the pipeline, identifier and reason' do
+      allow(ActiveSupport::Notifications).to receive(:instrument)
+      described_class.send_skipped(pipeline: 'customs_tariff_update', identifier: '1.30', reason: 'recipient_not_configured')
+      expect(ActiveSupport::Notifications).to have_received(:instrument).with(
+        'send_skipped.notifications',
+        hash_including(pipeline: 'customs_tariff_update', identifier: '1.30', reason: 'recipient_not_configured'),
+      )
+    end
+  end
+
+  describe '.enqueue_retrying' do
+    it 'emits enqueue_retrying with the pipeline, item, attempt and error details' do
+      allow(ActiveSupport::Notifications).to receive(:instrument)
+      described_class.enqueue_retrying(pipeline: 'customs_tariff_update', item: '1.30', attempt: 1, error_class: 'RuntimeError', error_message: 'boom')
+      expect(ActiveSupport::Notifications).to have_received(:instrument).with(
+        'enqueue_retrying.notifications',
+        hash_including(pipeline: 'customs_tariff_update', item: '1.30', attempt: 1, error_class: 'RuntimeError', error_message: 'boom'),
+      )
+    end
+  end
+
+  describe '.enqueue_failed' do
+    it 'emits enqueue_failed with the pipeline, items and attempts' do
+      allow(ActiveSupport::Notifications).to receive(:instrument)
+      described_class.enqueue_failed(pipeline: 'customs_tariff_update', items: ['1.30'], attempts: 3)
+      expect(ActiveSupport::Notifications).to have_received(:instrument).with(
+        'enqueue_failed.notifications',
+        hash_including(pipeline: 'customs_tariff_update', items: ['1.30'], attempts: 3),
+      )
+    end
+  end
+
+  describe '.delivery_failed' do
+    it 'emits delivery_failed with the pipeline, identifier, notification uuid and status' do
+      allow(ActiveSupport::Notifications).to receive(:instrument)
+      described_class.delivery_failed(pipeline: 'customs_tariff_update', identifier: '1.30', notification_uuid: 'abc-123', status: 'permanent-failure')
+      expect(ActiveSupport::Notifications).to have_received(:instrument).with(
+        'delivery_failed.notifications',
+        hash_including(pipeline: 'customs_tariff_update', identifier: '1.30', notification_uuid: 'abc-123', status: 'permanent-failure'),
+      )
+    end
+  end
+end

--- a/spec/lib/notifications/logger_spec.rb
+++ b/spec/lib/notifications/logger_spec.rb
@@ -1,0 +1,65 @@
+RSpec.describe Notifications::Logger do
+  let(:log_subscriber) { described_class.new }
+
+  def build_event(event_name, payload: {}, duration: 0.0)
+    ActiveSupport::Notifications::Event.new(
+      "#{event_name}.notifications",
+      Time.current - (duration / 1000.0),
+      Time.current,
+      SecureRandom.hex(5),
+      payload,
+    )
+  end
+
+  describe '#send_skipped' do
+    it 'logs the pipeline, identifier and reason at error level' do
+      allow(log_subscriber).to receive(:error)
+
+      log_subscriber.send_skipped(build_event('send_skipped', payload: { pipeline: 'customs_tariff_update', identifier: '1.30', reason: 'recipient_not_configured' }))
+
+      expect(log_subscriber).to have_received(:error) do |json|
+        entry = JSON.parse(json)
+        expect(entry).to include('event' => 'send_skipped', 'pipeline' => 'customs_tariff_update', 'identifier' => '1.30', 'reason' => 'recipient_not_configured')
+      end
+    end
+  end
+
+  describe '#enqueue_retrying' do
+    it 'logs the pipeline, item, attempt and error details at error level' do
+      allow(log_subscriber).to receive(:error)
+
+      log_subscriber.enqueue_retrying(build_event('enqueue_retrying', payload: { pipeline: 'customs_tariff_update', item: '1.30', attempt: 1, error_class: 'RuntimeError', error_message: 'boom' }))
+
+      expect(log_subscriber).to have_received(:error) do |json|
+        entry = JSON.parse(json)
+        expect(entry).to include('event' => 'enqueue_retrying', 'pipeline' => 'customs_tariff_update', 'item' => '1.30', 'attempt' => 1, 'error_class' => 'RuntimeError', 'error_message' => 'boom')
+      end
+    end
+  end
+
+  describe '#enqueue_failed' do
+    it 'logs the pipeline, items and attempts at error level' do
+      allow(log_subscriber).to receive(:error)
+
+      log_subscriber.enqueue_failed(build_event('enqueue_failed', payload: { pipeline: 'customs_tariff_update', items: ['1.30'], attempts: 3 }))
+
+      expect(log_subscriber).to have_received(:error) do |json|
+        entry = JSON.parse(json)
+        expect(entry).to include('event' => 'enqueue_failed', 'pipeline' => 'customs_tariff_update', 'items' => ['1.30'], 'attempts' => 3)
+      end
+    end
+  end
+
+  describe '#delivery_failed' do
+    it 'logs the pipeline, identifier, notification uuid and status at error level' do
+      allow(log_subscriber).to receive(:error)
+
+      log_subscriber.delivery_failed(build_event('delivery_failed', payload: { pipeline: 'customs_tariff_update', identifier: '1.30', notification_uuid: 'abc-123', status: 'permanent-failure' }))
+
+      expect(log_subscriber).to have_received(:error) do |json|
+        entry = JSON.parse(json)
+        expect(entry).to include('event' => 'delivery_failed', 'pipeline' => 'customs_tariff_update', 'identifier' => '1.30', 'notification_uuid' => 'abc-123', 'status' => 'permanent-failure')
+      end
+    end
+  end
+end

--- a/spec/services/customs_tariff_update_change_summary_spec.rb
+++ b/spec/services/customs_tariff_update_change_summary_spec.rb
@@ -1,0 +1,64 @@
+RSpec.describe CustomsTariffUpdateChangeSummary do
+  describe '#call' do
+    it 'treats a chapter/section with no previous version as changed' do
+      update = create(:customs_tariff_update, validity_start_date: Date.new(2026, 2, 1))
+      create(:customs_tariff_chapter_note, customs_tariff_update: update, chapter_id: '01', content: 'New chapter note')
+      create(:customs_tariff_section_note, customs_tariff_update: update, section_id: 1, content: 'New section note')
+
+      result = described_class.new(update).call
+
+      expect(result[:chapter_ids]).to eq(%w[01])
+      expect(result[:section_ids]).to eq([1])
+    end
+
+    it 'excludes a chapter whose content is unchanged from the previous version' do
+      previous_update = create(:customs_tariff_update, validity_start_date: Date.new(2026, 1, 1))
+      create(:customs_tariff_chapter_note, customs_tariff_update: previous_update, chapter_id: '01', content: 'Unchanged content')
+
+      update = create(:customs_tariff_update, validity_start_date: Date.new(2026, 2, 1))
+      create(:customs_tariff_chapter_note, customs_tariff_update: update, chapter_id: '01', content: 'Unchanged content')
+
+      result = described_class.new(update).call
+
+      expect(result[:chapter_ids]).to eq([])
+    end
+
+    it 'includes a chapter whose content differs from the previous version' do
+      previous_update = create(:customs_tariff_update, validity_start_date: Date.new(2026, 1, 1))
+      create(:customs_tariff_chapter_note, customs_tariff_update: previous_update, chapter_id: '01', content: 'Old content')
+
+      update = create(:customs_tariff_update, validity_start_date: Date.new(2026, 2, 1))
+      create(:customs_tariff_chapter_note, customs_tariff_update: update, chapter_id: '01', content: 'New content')
+
+      result = described_class.new(update).call
+
+      expect(result[:chapter_ids]).to eq(%w[01])
+    end
+
+    it 'ignores a failed update when looking for the previous baseline' do
+      create(:customs_tariff_update, :failed, validity_start_date: Date.new(2026, 1, 15))
+      previous_update = create(:customs_tariff_update, validity_start_date: Date.new(2026, 1, 1))
+      create(:customs_tariff_chapter_note, customs_tariff_update: previous_update, chapter_id: '01', content: 'Old content')
+
+      update = create(:customs_tariff_update, validity_start_date: Date.new(2026, 2, 1))
+      create(:customs_tariff_chapter_note, customs_tariff_update: update, chapter_id: '01', content: 'Old content')
+
+      result = described_class.new(update).call
+
+      expect(result[:chapter_ids]).to eq([])
+    end
+
+    it 'returns sorted chapter and section ids' do
+      update = create(:customs_tariff_update, validity_start_date: Date.new(2026, 2, 1))
+      create(:customs_tariff_chapter_note, customs_tariff_update: update, chapter_id: '99', content: 'note')
+      create(:customs_tariff_chapter_note, customs_tariff_update: update, chapter_id: '01', content: 'note')
+      create(:customs_tariff_section_note, customs_tariff_update: update, section_id: 21, content: 'note')
+      create(:customs_tariff_section_note, customs_tariff_update: update, section_id: 1, content: 'note')
+
+      result = described_class.new(update).call
+
+      expect(result[:chapter_ids]).to eq(%w[01 99])
+      expect(result[:section_ids]).to eq([1, 21])
+    end
+  end
+end

--- a/spec/services/customs_tariff_update_notifier_service_spec.rb
+++ b/spec/services/customs_tariff_update_notifier_service_spec.rb
@@ -1,0 +1,144 @@
+RSpec.describe CustomsTariffUpdateNotifierService do
+  subject(:service) { described_class.new(update.version) }
+
+  let(:update) { create(:customs_tariff_update, validity_start_date: Date.new(2026, 2, 1)) }
+
+  before do
+    create(:customs_tariff_chapter_note, customs_tariff_update: update, chapter_id: '01', content: 'note')
+  end
+
+  describe '#call' do
+    context 'when no recipient is configured' do
+      before { allow(TradeTariffBackend).to receive(:support_email).and_return('') }
+
+      it 'fires send_skipped and does not attempt to enqueue anything' do
+        allow(Notifications::Instrumentation).to receive(:send_skipped)
+        allow(Notifications::EnqueueService).to receive(:new)
+
+        service.call
+
+        expect(Notifications::Instrumentation).to have_received(:send_skipped).with(
+          pipeline: 'customs_tariff_update', identifier: update.version, reason: 'recipient_not_configured',
+        )
+        expect(Notifications::EnqueueService).not_to have_received(:new)
+      end
+    end
+
+    context 'when the version does not correspond to any known update' do
+      subject(:service) { described_class.new('unknown-version') }
+
+      before { allow(TradeTariffBackend).to receive(:support_email).and_return('recipient@example.com') }
+
+      it 'fires send_skipped with update_not_found and does not build a change summary or enqueue anything' do
+        allow(Notifications::Instrumentation).to receive(:send_skipped)
+        allow(CustomsTariffUpdateChangeSummary).to receive(:new)
+        allow(Notifications::EnqueueService).to receive(:new)
+
+        service.call
+
+        expect(Notifications::Instrumentation).to have_received(:send_skipped).with(
+          pipeline: 'customs_tariff_update', identifier: 'unknown-version', reason: 'update_not_found',
+        )
+        expect(CustomsTariffUpdateChangeSummary).not_to have_received(:new)
+        expect(Notifications::EnqueueService).not_to have_received(:new)
+      end
+    end
+
+    context 'when a recipient is configured' do
+      before { allow(TradeTariffBackend).to receive(:support_email).and_return('recipient@example.com') }
+
+      it 'enqueues Notifications::EmailWorker via Notifications::EnqueueService with the built personalisation' do
+        allow(Notifications::EmailWorker).to receive(:perform_async)
+
+        service.call
+
+        expect(Notifications::EmailWorker).to have_received(:perform_async).with(
+          'recipient@example.com',
+          described_class::TEMPLATE_ID,
+          hash_including(
+            'version' => update.version,
+            'document_created_on' => update.document_created_on.iso8601,
+            'document_url' => update.source_url,
+            'imported_on' => update.created_at.iso8601,
+            'entry_into_force_on' => update.validity_start_date.iso8601,
+            'chapter_ids' => '01',
+            'section_ids' => '',
+          ),
+          'CustomsTariffUpdateNotificationStatusCheckWorker',
+          [update.version],
+        )
+      end
+
+      it 'builds a String-keyed personalisation hash and enqueues via the real Sidekiq perform_async boundary without raising' do
+        Sidekiq::Testing.fake! do
+          Notifications::EmailWorker.jobs.clear
+
+          expect { service.call }.not_to raise_error
+
+          expect(Notifications::EmailWorker.jobs.size).to eq(1)
+          args = Notifications::EmailWorker.jobs.first['args']
+          personalisation = args[2]
+
+          expect(personalisation.keys).to all(be_a(String))
+          expect(personalisation).to include(
+            'version' => update.version,
+            'chapter_ids' => '01',
+          )
+        end
+      end
+
+      it 'falls back to a placeholder string when document_created_on is nil, rather than sending a null personalisation value' do
+        update.update(document_created_on: nil)
+        allow(Notifications::EmailWorker).to receive(:perform_async)
+
+        service.call
+
+        expect(Notifications::EmailWorker).to have_received(:perform_async).with(
+          anything, anything, hash_including('document_created_on' => 'Not available'), anything, anything
+        )
+      end
+
+      it 'falls back to a placeholder string when source_url is blank, rather than sending an empty personalisation value' do
+        update.update(source_url: nil)
+        allow(Notifications::EmailWorker).to receive(:perform_async)
+
+        service.call
+
+        expect(Notifications::EmailWorker).to have_received(:perform_async).with(
+          anything, anything, hash_including('document_url' => 'Not available'), anything, anything
+        )
+      end
+
+      it 'labels the document as UK Customs Tariff when running in the UK service' do
+        allow(TradeTariffBackend).to receive(:uk?).and_return(true)
+        allow(Notifications::EmailWorker).to receive(:perform_async)
+
+        service.call
+
+        expect(Notifications::EmailWorker).to have_received(:perform_async).with(
+          anything, anything, hash_including('document_type' => 'UK Customs Tariff'), anything, anything
+        )
+      end
+
+      it 'labels the document as XI Combined Nomenclature when running in the XI service' do
+        allow(TradeTariffBackend).to receive(:uk?).and_return(false)
+        allow(Notifications::EmailWorker).to receive(:perform_async)
+
+        service.call
+
+        expect(Notifications::EmailWorker).to have_received(:perform_async).with(
+          anything, anything, hash_including('document_type' => 'XI Combined Nomenclature'), anything, anything
+        )
+      end
+    end
+  end
+
+  describe 'the status-check worker class string used to schedule delivery checks' do
+    it 'constantizes to the real CustomsTariffUpdateNotificationStatusCheckWorker class, which supports perform_in' do
+      constantized = 'CustomsTariffUpdateNotificationStatusCheckWorker'.constantize
+
+      expect(constantized).to eq(CustomsTariffUpdateNotificationStatusCheckWorker)
+      expect(constantized).to respond_to(:perform_in)
+    end
+  end
+end

--- a/spec/services/notifications/delivery_status_checker_spec.rb
+++ b/spec/services/notifications/delivery_status_checker_spec.rb
@@ -1,0 +1,53 @@
+RSpec.describe Notifications::DeliveryStatusChecker do
+  subject(:checker) { described_class.new(notification_uuid, pipeline: 'test_pipeline', identifier: '1.30') }
+
+  let(:client) { instance_double(GovukNotifier) }
+  let(:notification_uuid) { SecureRandom.uuid }
+
+  before do
+    allow(GovukNotifier).to receive(:new).and_return(client)
+  end
+
+  describe '#call' do
+    it 'returns nil and does not call Notify when the notification uuid is blank' do
+      blank_checker = described_class.new(nil, pipeline: 'test_pipeline', identifier: '1.30')
+
+      expect(blank_checker.call).to be_nil
+      expect(GovukNotifier).not_to have_received(:new)
+    end
+
+    it 'returns nil and does not alert when delivery succeeded' do
+      allow(client).to receive(:get_email_status).and_return('delivered')
+
+      expect(checker.call).to be_nil
+    end
+
+    %w[permanent-failure temporary-failure technical-failure].each do |status|
+      it "fires delivery_failed and alerts Slack for #{status}" do
+        allow(client).to receive(:get_email_status).and_return(status)
+        allow(Notifications::Instrumentation).to receive(:delivery_failed)
+        allow(SlackNotifierService).to receive(:call)
+
+        result = checker.call
+
+        expect(result).to eq(status)
+        expect(Notifications::Instrumentation).to have_received(:delivery_failed).with(
+          pipeline: 'test_pipeline', identifier: '1.30', notification_uuid:, status:,
+        )
+        expect(SlackNotifierService).to have_received(:call).with(
+          "test_pipeline: notification delivery failed for 1.30 (status: #{status}) — check logs",
+        )
+      end
+    end
+
+    it 'rescues a Slack failure and logs it instead of raising' do
+      allow(client).to receive(:get_email_status).and_return('permanent-failure')
+      allow(SlackNotifierService).to receive(:call).and_raise('slack down')
+      allow(Rails.logger).to receive(:error)
+
+      expect { checker.call }.not_to raise_error
+
+      expect(Rails.logger).to have_received(:error).with(a_string_including('test_pipeline_notification_slack_failed'))
+    end
+  end
+end

--- a/spec/services/notifications/enqueue_service_spec.rb
+++ b/spec/services/notifications/enqueue_service_spec.rb
@@ -1,0 +1,80 @@
+RSpec.describe Notifications::EnqueueService do
+  describe '#call' do
+    it 'succeeds without retrying when the block does not raise' do
+      enqueued = []
+
+      result = described_class.new(%w[a b], pipeline: 'test_pipeline') { |item| enqueued << item }.call
+
+      expect(enqueued).to eq(%w[a b])
+      expect(result.failed_items).to eq([])
+      expect(result.attempts).to eq(1)
+    end
+
+    it 'retries a failing item, fires enqueue_retrying, then succeeds on a later attempt' do
+      allow(Notifications::Instrumentation).to receive(:enqueue_retrying)
+      attempts_seen = Hash.new(0)
+
+      result = described_class.new(%w[a], pipeline: 'test_pipeline', retry_delay: 0) { |item|
+        attempts_seen[item] += 1
+        raise 'boom' if attempts_seen[item] == 1
+      }.call
+
+      expect(result.failed_items).to eq([])
+      expect(Notifications::Instrumentation).to have_received(:enqueue_retrying).with(
+        pipeline: 'test_pipeline', item: 'a', attempt: 1, error_class: 'RuntimeError', error_message: 'boom',
+      )
+    end
+
+    it 'fires enqueue_failed, alerts Slack, and returns the still-failing items after max_attempts' do
+      allow(Notifications::Instrumentation).to receive(:enqueue_failed)
+      allow(SlackNotifierService).to receive(:call)
+
+      result = described_class.new(%w[a], pipeline: 'test_pipeline', max_attempts: 2, retry_delay: 0) { |_item| raise 'boom' }.call
+
+      expect(result.failed_items).to eq(%w[a])
+      expect(result.attempts).to eq(2)
+      expect(Notifications::Instrumentation).to have_received(:enqueue_failed).with(pipeline: 'test_pipeline', items: %w[a], attempts: 2)
+      expect(SlackNotifierService).to have_received(:call).with('test_pipeline: failed to enqueue notification for a after 2 attempts — check logs')
+    end
+
+    it 'does not sleep after the final attempt' do
+      instance = described_class.new(%w[a], pipeline: 'test_pipeline', max_attempts: 2, retry_delay: 0) { |_item| raise 'boom' }
+      allow(instance).to receive(:sleep)
+
+      instance.call
+
+      expect(instance).to have_received(:sleep).once
+    end
+
+    it 'does not re-invoke a successful item\'s block while another item is still retrying' do
+      allow(Notifications::Instrumentation).to receive(:enqueue_retrying)
+      succeeded_calls = 0
+      failed_attempts = Hash.new(0)
+
+      result = described_class.new(%w[good bad], pipeline: 'test_pipeline', max_attempts: 3, retry_delay: 0) { |item|
+        if item == 'good'
+          succeeded_calls += 1
+        else
+          failed_attempts[item] += 1
+          raise 'boom'
+        end
+      }.call
+
+      expect(succeeded_calls).to eq(1)
+      expect(failed_attempts['bad']).to eq(3)
+      expect(result.failed_items).to eq(%w[bad])
+      expect(result.attempts).to eq(3)
+    end
+
+    it 'rescues a Slack failure and logs it instead of raising' do
+      allow(SlackNotifierService).to receive(:call).and_raise('slack down')
+      allow(Rails.logger).to receive(:error)
+
+      expect {
+        described_class.new(%w[a], pipeline: 'test_pipeline', max_attempts: 1, retry_delay: 0) { |_item| raise 'boom' }.call
+      }.not_to raise_error
+
+      expect(Rails.logger).to have_received(:error).with(a_string_including('test_pipeline_notification_slack_failed'))
+    end
+  end
+end

--- a/spec/workers/customs_tariff_update_notification_status_check_worker_spec.rb
+++ b/spec/workers/customs_tariff_update_notification_status_check_worker_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe CustomsTariffUpdateNotificationStatusCheckWorker, type: :worker do
+  subject(:worker) { described_class.new }
+
+  describe '#perform' do
+    it 'delegates to Notifications::DeliveryStatusChecker with the customs_tariff_update pipeline and the version as identifier' do
+      checker = instance_double(Notifications::DeliveryStatusChecker, call: nil)
+      allow(Notifications::DeliveryStatusChecker).to receive(:new).and_return(checker)
+
+      worker.perform('1.30', 'abc-123')
+
+      expect(Notifications::DeliveryStatusChecker).to have_received(:new).with(
+        'abc-123', pipeline: 'customs_tariff_update', identifier: '1.30'
+      )
+      expect(checker).to have_received(:call)
+    end
+  end
+end

--- a/spec/workers/import_customs_tariff_document_worker_spec.rb
+++ b/spec/workers/import_customs_tariff_document_worker_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe ImportCustomsTariffDocumentWorker, type: :worker do
     allow(CustomsTariffImporter::Instrumentation).to receive(:import_run_started)
     allow(CustomsTariffImporter::Instrumentation).to receive(:import_run_completed)
     allow(CustomsTariffImporter::Instrumentation).to receive(:import_run_failed)
+    allow(CustomsTariffUpdateNotifierService).to receive(:new).and_return(instance_double(CustomsTariffUpdateNotifierService, call: nil))
   end
 
   context 'when SERVICE is not uk' do
@@ -66,6 +67,92 @@ RSpec.describe ImportCustomsTariffDocumentWorker, type: :worker do
         expect(CustomsTariffImporter::Instrumentation).to have_received(:import_run_completed)
       end
     end
+
+    it 'calls CustomsTariffUpdateNotifierService for the imported version' do
+      allow(CustomsTariffUpdateNotifierService).to receive(:new).and_return(instance_double(CustomsTariffUpdateNotifierService, call: nil))
+
+      perform
+
+      expect(CustomsTariffUpdateNotifierService).to have_received(:new).with('1.30')
+    end
+  end
+
+  context 'when the notifier raises for one of several imported results' do
+    before do
+      allow(CustomsTariffImporter::Importer).to receive(:new).and_return(
+        instance_double(CustomsTariffImporter::Importer,
+                        call: [
+                          result(status: :imported, version: '1.30'),
+                          result(status: :imported, version: '1.31'),
+                        ]),
+      )
+
+      notifier_1_30 = instance_double(CustomsTariffUpdateNotifierService)
+      allow(notifier_1_30).to receive(:call).and_raise(RuntimeError, 'notify boom')
+      notifier_1_31 = instance_double(CustomsTariffUpdateNotifierService, call: nil)
+
+      allow(CustomsTariffUpdateNotifierService).to receive(:new).with('1.30').and_return(notifier_1_30)
+      allow(CustomsTariffUpdateNotifierService).to receive(:new).with('1.31').and_return(notifier_1_31)
+      allow(Rails.logger).to receive(:error)
+    end
+
+    it 'still reports the import as completed successfully' do
+      perform
+
+      expect(CustomsTariffImporter::Instrumentation).to have_received(:import_run_completed).with(
+        imported: 2,
+        failed: 0,
+        duration_ms: a_kind_of(Float),
+      )
+      expect(SlackNotifierService).to have_received(:call).with(
+        include('Customs tariff document import completed', 'imported: 2'),
+      )
+      expect(CustomsTariffImporter::Instrumentation).not_to have_received(:import_run_failed)
+    end
+
+    it 'does not re-raise the notifier error' do
+      expect { perform }.not_to raise_error
+    end
+
+    it 'still calls the notifier for the later document even though the earlier one raised' do
+      perform
+
+      expect(CustomsTariffUpdateNotifierService).to have_received(:new).with('1.30')
+      expect(CustomsTariffUpdateNotifierService).to have_received(:new).with('1.31')
+    end
+
+    it 'logs the failure with identifying detail via Rails.logger.error' do
+      perform
+
+      expect(Rails.logger).to have_received(:error).with(
+        a_string_including('1.30', 'RuntimeError', 'notify boom'),
+      )
+    end
+
+    it 'posts a distinct Slack message making clear the import succeeded but the notification failed' do
+      perform
+
+      expect(SlackNotifierService).to have_received(:call).with(
+        a_string_including('notification failed', '1.30'),
+      )
+    end
+  end
+
+  context 'when a document is skipped for duplicate content' do
+    before do
+      allow(CustomsTariffImporter::Importer).to receive(:new).and_return(
+        instance_double(CustomsTariffImporter::Importer,
+                        call: [result(status: :duplicate_content, version: '1.30')]),
+      )
+    end
+
+    it 'does not call CustomsTariffUpdateNotifierService' do
+      allow(CustomsTariffUpdateNotifierService).to receive(:new)
+
+      perform
+
+      expect(CustomsTariffUpdateNotifierService).not_to have_received(:new)
+    end
   end
 
   context 'when all documents are skipped' do
@@ -90,6 +177,14 @@ RSpec.describe ImportCustomsTariffDocumentWorker, type: :worker do
         include('Nothing new to import'),
       )
     end
+
+    it 'does not call CustomsTariffUpdateNotifierService' do
+      allow(CustomsTariffUpdateNotifierService).to receive(:new)
+
+      perform
+
+      expect(CustomsTariffUpdateNotifierService).not_to have_received(:new)
+    end
   end
 
   context 'when a document import fails' do
@@ -113,6 +208,14 @@ RSpec.describe ImportCustomsTariffDocumentWorker, type: :worker do
       expect(SlackNotifierService).to have_received(:call).with(
         include('Customs tariff document import completed with failures', 'failed: 1'),
       )
+    end
+
+    it 'does not call CustomsTariffUpdateNotifierService' do
+      allow(CustomsTariffUpdateNotifierService).to receive(:new)
+
+      perform
+
+      expect(CustomsTariffUpdateNotifierService).not_to have_received(:new)
     end
   end
 

--- a/spec/workers/import_xi_cn_document_worker_spec.rb
+++ b/spec/workers/import_xi_cn_document_worker_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe ImportXiCnDocumentWorker do
     allow(TradeTariffBackend).to receive(:xi?).and_return(true)
     allow(XiCnImporter::Importer).to receive(:new).and_return(importer_double)
     allow(SlackNotifierService).to receive(:call)
+    allow(CustomsTariffUpdateNotifierService).to receive(:new).and_return(instance_double(CustomsTariffUpdateNotifierService, call: nil))
   end
 
   describe '#perform' do
@@ -33,6 +34,82 @@ RSpec.describe ImportXiCnDocumentWorker do
         expect(SlackNotifierService).to have_received(:call)
           .with(a_string_including('imported: 1'))
       end
+
+      it 'calls CustomsTariffUpdateNotifierService for the imported celex id' do
+        allow(CustomsTariffUpdateNotifierService).to receive(:new).and_return(instance_double(CustomsTariffUpdateNotifierService, call: nil))
+
+        worker.perform
+
+        expect(CustomsTariffUpdateNotifierService).to have_received(:new).with('32025R1926')
+      end
+    end
+
+    context 'when the notifier raises for one of several imported results' do
+      before do
+        allow(importer_double).to receive(:call).and_return([
+          XiCnImporter::Importer::Result.new(status: :imported, celex: '32025R1926'),
+          XiCnImporter::Importer::Result.new(status: :imported, celex: '32025R1927'),
+        ])
+
+        notifier_1926 = instance_double(CustomsTariffUpdateNotifierService)
+        allow(notifier_1926).to receive(:call).and_raise(RuntimeError, 'notify boom')
+        notifier_1927 = instance_double(CustomsTariffUpdateNotifierService, call: nil)
+
+        allow(CustomsTariffUpdateNotifierService).to receive(:new).with('32025R1926').and_return(notifier_1926)
+        allow(CustomsTariffUpdateNotifierService).to receive(:new).with('32025R1927').and_return(notifier_1927)
+        allow(Rails.logger).to receive(:error)
+      end
+
+      it 'still reports the import as completed successfully' do
+        worker.perform
+
+        expect(SlackNotifierService).to have_received(:call).with(
+          a_string_including('imported: 2'),
+        )
+      end
+
+      it 'does not re-raise the notifier error' do
+        expect { worker.perform }.not_to raise_error
+      end
+
+      it 'still calls the notifier for the later document even though the earlier one raised' do
+        worker.perform
+
+        expect(CustomsTariffUpdateNotifierService).to have_received(:new).with('32025R1926')
+        expect(CustomsTariffUpdateNotifierService).to have_received(:new).with('32025R1927')
+      end
+
+      it 'logs the failure with identifying detail via Rails.logger.error' do
+        worker.perform
+
+        expect(Rails.logger).to have_received(:error).with(
+          a_string_including('32025R1926', 'RuntimeError', 'notify boom'),
+        )
+      end
+
+      it 'posts a distinct Slack message making clear the import succeeded but the notification failed' do
+        worker.perform
+
+        expect(SlackNotifierService).to have_received(:call).with(
+          a_string_including('notification failed', '32025R1926'),
+        )
+      end
+    end
+
+    context 'when a document import fails' do
+      before do
+        allow(importer_double).to receive(:call).and_return([
+          XiCnImporter::Importer::Result.new(status: :failed, error: 'HTTP 503'),
+        ])
+      end
+
+      it 'does not call CustomsTariffUpdateNotifierService' do
+        allow(CustomsTariffUpdateNotifierService).to receive(:new)
+
+        worker.perform
+
+        expect(CustomsTariffUpdateNotifierService).not_to have_received(:new)
+      end
     end
 
     context 'when no new documents are found' do
@@ -44,6 +121,14 @@ RSpec.describe ImportXiCnDocumentWorker do
         worker.perform
         expect(SlackNotifierService).to have_received(:call)
           .with(a_string_including('Nothing new to import'))
+      end
+
+      it 'does not call CustomsTariffUpdateNotifierService' do
+        allow(CustomsTariffUpdateNotifierService).to receive(:new)
+
+        worker.perform
+
+        expect(CustomsTariffUpdateNotifierService).not_to have_received(:new)
       end
     end
 

--- a/spec/workers/notifications/email_worker_spec.rb
+++ b/spec/workers/notifications/email_worker_spec.rb
@@ -1,0 +1,61 @@
+RSpec.describe Notifications::EmailWorker, type: :worker do
+  subject(:worker) { described_class.new }
+
+  let(:client) { instance_double(GovukNotifier) }
+  let(:notify_response) { instance_double(GovukNotifierAudit, notification_uuid: SecureRandom.uuid) }
+  let(:email) { 'recipient@example.com' }
+  let(:template_id) { SecureRandom.uuid }
+  let(:personalisation) { { version: '1.30' } }
+
+  before do
+    allow(GovukNotifier).to receive(:new).and_return(client)
+    allow(client).to receive(:send_email).and_return(notify_response)
+    stub_const('TestNotificationStatusCheckWorker', Class.new { include Sidekiq::Worker })
+    allow(TestNotificationStatusCheckWorker).to receive(:perform_in)
+  end
+
+  describe '#perform' do
+    it 'sends the email with the given template id and personalisation' do
+      worker.perform(email, template_id, personalisation, 'TestNotificationStatusCheckWorker', ['1.30'])
+
+      expect(client).to have_received(:send_email).with(email, template_id, personalisation, nil, nil)
+    end
+
+    it 'schedules the given status-check worker class with the given args and the resolved notification uuid' do
+      worker.perform(email, template_id, personalisation, 'TestNotificationStatusCheckWorker', ['1.30'])
+
+      expect(TestNotificationStatusCheckWorker).to have_received(:perform_in).with(
+        GovukNotifierStatusCheckWorker::CHECK_DELAY,
+        '1.30',
+        notify_response.notification_uuid,
+      )
+    end
+
+    it 'lets a send_email failure propagate without scheduling a status check' do
+      allow(client).to receive(:send_email).and_raise(StandardError, 'notify unavailable')
+
+      expect { worker.perform(email, template_id, personalisation, 'TestNotificationStatusCheckWorker', ['1.30']) }
+        .to raise_error(StandardError, 'notify unavailable')
+
+      expect(TestNotificationStatusCheckWorker).not_to have_received(:perform_in)
+    end
+
+    it 'does not raise or resend the email when scheduling the status check fails' do
+      allow(TestNotificationStatusCheckWorker).to receive(:perform_in).and_raise(StandardError, 'redis unavailable')
+      allow(Rails.logger).to receive(:error)
+
+      expect { worker.perform(email, template_id, personalisation, 'TestNotificationStatusCheckWorker', ['1.30']) }.not_to raise_error
+
+      expect(client).to have_received(:send_email).once
+      expect(Rails.logger).to have_received(:error).with(
+        a_string_including(
+          'notifications_email_worker_status_check_schedule_failed',
+          'redis unavailable',
+          'TestNotificationStatusCheckWorker',
+          '1.30',
+          notify_response.notification_uuid,
+        ),
+      )
+    end
+  end
+end


### PR DESCRIPTION
## What:

This PR adds email notifications for operators whenever a new UK Customs
Tariff document or XI Combined Nomenclature document is imported, so the
team finds out about the update without having to watch Slack or the
database. It generalises the `Notifications::` pattern already used for
the Appendix 5a guidance-change emails so future notification pipelines
can reuse the same building blocks.

Here's what's been added:

- **`CustomsTariffUpdateNotifierService`** — looks up the imported
  `CustomsTariffUpdate`, works out which chapters/sections changed via
  `CustomsTariffUpdateChangeSummary`, builds the email personalisation,
  and hands off to the shared enqueue service
- **`Notifications::EnqueueService`**, **`Notifications::EmailWorker`**
  (Sidekiq `default` queue), **`Notifications::Instrumentation`** and
  **`Notifications::Logger`** — a shared, pipeline-agnostic set of
  building blocks for sending a Notify email with bounded retry
  (3 attempts, 30s apart) and a Slack alert if all retries are exhausted
- **`Notifications::DeliveryStatusChecker`** and
  **`CustomsTariffUpdateNotificationStatusCheckWorker`** (`default`
  queue) — follow up with GOV.UK Notify after sending to confirm the
  email actually delivered, alerting to Slack on permanent, temporary,
  or technical failure
- **`CustomsTariffUpdateChangeSummary`** — compares a newly imported
  update against the previous one to report which chapters and
  sections actually changed
- `ImportCustomsTariffDocumentWorker` and `ImportXiCnDocumentWorker`
  now call the notifier for each successfully imported version, with
  notifier failures rescued and alerted separately from import
  failures so the two don't get confused with each other in Slack
- The notification's `document_created_on` and `document_url`
  personalisation fields fall back to a readable placeholder instead
  of sending `null`, since GOV.UK Notify rejects missing personalisation
  outright and the source document's publication date is genuinely
  optional for XI Combined Nomenclature documents (it comes from an
  `OPTIONAL` SPARQL binding on the EU's own publication metadata)
- Added the real GOV.UK Notify template UUID for all three environments
  (production, staging, development), replacing the placeholders

## Why:

Right now, operators only find out about a new Customs Tariff or XI CN
import via Slack or by checking the database directly. This closes that
gap with a proper email notification, reusing the Appendix 5a email
infrastructure rather than building a one-off.

A couple of decisions worth calling out:

- Notifier failures are deliberately isolated per-item inside the
  import loop, so a broken notification never fails the underlying
  document import — the two are alerted to Slack separately so an
  on-call engineer isn't left guessing which one actually broke
- We chose readable fallback text over `null`/blank for optional
  personalisation fields because GOV.UK Notify's API hard-rejects a
  `null` value for any placeholder the template declares — this was
  caught via a real `Missing personalisation: document_created_on`
  error while manually testing the XI CN path locally

## Ticket:

[AI-1082](https://transformuk.atlassian.net/browse/AI-1082)

## Risk:
**Risk level:** 🟢

**Reason for rating:** No changes to measure, duty, quota, or sync
logic — this only adds an extra step at the end of an already-working
import, wrapped in its own rescue so a notification failure can't break
the import itself. Fully covered by tests (75 examples) and clean on
rubocop. Worth knowing regardless: this is the first time this pipeline
will send a real outbound email in production, so flagging it here even
though it doesn't hit any of the Amber/Red trigger categories.

## Have you? (optional)

- [ ] Added documentation for new APIs
- [x] Added new environment variables with correct values to all apps in all spaces

## Deployment risks (optional)

- None beyond the new outbound email noted in the Risk section above —
  no destructive migrations, no changes to an API used in production.