### PR TITLE
Point generic intercept help link at help_url placeholder

### DIFF
--- a/app/models/admin_configuration.rb
+++ b/app/models/admin_configuration.rb
@@ -58,7 +58,7 @@ class AdminConfiguration < Sequel::Model(Sequel[:admin_configurations].qualify(:
 
     ## What if I need more help?
 
-    Guidance on classifying products can be found in [help on using the tariff (opens in new tab)](https://www.gov.uk/guidance/classification-of-goods/) where you can find information about:
+    Guidance on classifying products can be found in [help on using the tariff (opens in new tab)]({{help_url}}) where you can find information about:
 
     - structure of commodity codes
     - the information you need to classify a product

--- a/spec/lib/tasks/admin_configurations_rake_spec.rb
+++ b/spec/lib/tasks/admin_configurations_rake_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe 'admin_configurations:seed' do
       'guidance_location' => 'interstitial',
       'sources' => %w[guided_search fpo_search],
     )
-    expect(config.value['generic']['attributes']['message']).to include('Guidance on classifying products can be found in [help on using the tariff (opens in new tab)]')
+    expect(config.value['generic']['attributes']['message']).to include('Guidance on classifying products can be found in [help on using the tariff (opens in new tab)]({{help_url}})')
     expect(config.value['escalation']['label']).to eq('Escalation guidance')
     expect(config.value['escalation']['attributes']).to include(
       'excluded' => true,

--- a/spec/models/admin_configuration_spec.rb
+++ b/spec/models/admin_configuration_spec.rb
@@ -503,7 +503,7 @@ RSpec.describe AdminConfiguration do
 
       expect(templates['generic']['attributes']['message']).to include(
         '## What if I need more help?',
-        'Guidance on classifying products can be found in [help on using the tariff (opens in new tab)]',
+        'Guidance on classifying products can be found in [help on using the tariff (opens in new tab)]({{help_url}})',
         '- structure of commodity codes',
         '- the information you need to classify a product',
         '- detailed guidance on hard to classify products',


### PR DESCRIPTION
## What:
- [x] Update the default generic description intercept template to use `{{help_url}}` for the "help on using the tariff" link
- [x] Update seed/default specs for the new template copy

## Why:
The generic intercept template should point traders at the Online Trade Tariff general help page, not GOV.UK classification guidance. The frontend resolves `{{help_url}}` to `/help`.

## Ticket:
N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:** Default template copy only. Existing stored intercepts are unchanged until re-imported or edited; frontend also rewrites known legacy destinations.