### PR TITLE
Add a shared import error class to avoid duplicate code

### DIFF
--- a/app/lib/cds_importer.rb
+++ b/app/lib/cds_importer.rb
@@ -4,12 +4,9 @@ require_relative 'cds_importer/xml_parser'
 require 'zip'
 
 class CdsImporter
-  class ImportException < StandardError
-    attr_reader :original
-
-    def initialize(msg = 'CdsImporter::ImportException', original = $ERROR_INFO)
-      super(msg)
-      @original = original
+  class ImportException < TariffSynchronizer::Import::Error
+    def initialize(message:, original: nil, context: {})
+      super(message:, source: :cds, original:, context:)
     end
   end
 
@@ -82,20 +79,15 @@ class CdsImporter
         end
       end
     rescue StandardError => e
-      cds_failed_log(e, key, hash_from_node)
-      raise ImportException
+      raise ImportException.new(
+        message: 'CDS record import failed',
+        original: e,
+        context: { key:, transaction: hash_from_node },
+      ), cause: e
     end
 
     def after_parse
       @handlers.each(&:after_parse)
-    end
-
-    def cds_failed_log(exception, key, hash)
-      "Cds import failed: #{exception}".tap do |message|
-        message << "\n Failed object: #{key}\n #{hash}"
-        message << "\n Backtrace:\n #{exception.backtrace.join("\n")}"
-        Rails.logger.error message
-      end
     end
   end
 

--- a/app/lib/taric_importer.rb
+++ b/app/lib/taric_importer.rb
@@ -6,12 +6,9 @@ require 'taric_importer/record_inserter'
 require 'taric_importer/national_sid_counter'
 
 class TaricImporter
-  class ImportException < StandardError
-    attr_reader :original
-
-    def initialize(msg = 'TaricImporter::ImportException', original = $ERROR_INFO)
-      super(msg)
-      @original = original
+  class ImportException < TariffSynchronizer::Import::Error
+    def initialize(message:, original: nil, context: {})
+      super(message:, source: :taric, original:, context:)
     end
   end
 
@@ -74,22 +71,15 @@ class TaricImporter
         end
       end
     rescue StandardError => e
-      taric_failed_log(e, hash_from_node)
-      raise ImportException
+      raise ImportException.new(
+        message: 'TARIC record import failed',
+        original: e,
+        context: { transaction: hash_from_node },
+      ), cause: e
     end
 
     def after_parse
       @handlers.each(&:after_parse)
-    end
-
-  private
-
-    def taric_failed_log(exception, hash)
-      "Taric import failed: #{exception}".tap do |message|
-        message << "\n Failed transaction:\n #{hash}"
-        message << "\n Backtrace:\n #{exception.backtrace.join("\n")}"
-        Rails.logger.error message
-      end
     end
   end
 

--- a/app/lib/taric_importer/entity_mapper.rb
+++ b/app/lib/taric_importer/entity_mapper.rb
@@ -55,10 +55,10 @@ class TaricImporter
 
     def operation
       OPERATION_MAP.fetch(record_hash['update_type']) do
-        Rails.logger.error "Unexpected Taric operation type: #{record_hash}"
-
-        raise TaricImporter::UnknownOperationError,
-              "Unknown TARIC operation: #{record_hash['update_type']}"
+        raise TaricImporter::UnknownOperationError.new(
+          message: "Unknown TARIC operation: #{record_hash['update_type']}",
+          context: { transaction: record_hash },
+        )
       end
     end
 

--- a/app/lib/tariff_synchronizer/import/error.rb
+++ b/app/lib/tariff_synchronizer/import/error.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module TariffSynchronizer
+  module Import
+    class Error < StandardError
+      attr_reader :original, :source, :context
+
+      def initialize(message:, source:, original: nil, context: {})
+        super(message)
+        @source = source
+        @original = original
+        @context = context
+        log!
+      end
+
+    private
+
+      def log!
+        Rails.logger.error(log_message)
+      end
+
+      def log_message
+        lines = ["#{source.to_s.capitalize} import failed: #{original || message}"]
+        context.each { |key, value| lines << "#{key.to_s.tr('_', ' ').capitalize}: #{value}" }
+
+        backtrace = (original || self).backtrace
+        lines << "Backtrace:\n#{backtrace.join("\n")}" if backtrace
+
+        lines.join("\n")
+      end
+    end
+  end
+end

--- a/spec/integration/cds_importer/cds_importer_spec.rb
+++ b/spec/integration/cds_importer/cds_importer_spec.rb
@@ -83,11 +83,25 @@ RSpec.describe CdsImporter do
 
       before do
         allow(CdsImporter::EntityMapper).to receive(:new).and_return(entity_mapper)
-        allow(entity_mapper).to receive(:build).and_raise(StandardError)
+        allow(entity_mapper).to receive(:build).and_raise(StandardError, 'entity mapper exploded')
       end
 
       it 'raises ImportException' do
         expect { processor.process_xml_node('AdditionalCode', {}) }.to raise_error(CdsImporter::ImportException)
+      end
+
+      it 'wraps the original error with source, context and cause', :aggregate_failures do
+        hash_from_node = { 'foo' => 'bar' }
+
+        expect { processor.process_xml_node('AdditionalCode', hash_from_node) }
+          .to raise_error(CdsImporter::ImportException) do |caught|
+            expect(caught.message).to eq('CDS record import failed')
+            expect(caught.source).to eq(:cds)
+            expect(caught.original).to be_a(StandardError)
+            expect(caught.original.message).to eq('entity mapper exploded')
+            expect(caught.context).to eq(key: 'AdditionalCode', transaction: hash_from_node)
+            expect(caught.cause).to eq(caught.original)
+          end
       end
     end
   end

--- a/spec/unit/taric_importer/entity_mapper_spec.rb
+++ b/spec/unit/taric_importer/entity_mapper_spec.rb
@@ -91,6 +91,15 @@ RSpec.describe TaricImporter::EntityMapper do
       expect { mapper.build }
         .to raise_error(TaricImporter::UnknownOperationError)
     end
+
+    it 'carries the taric source, a descriptive message and the failing record as context', :aggregate_failures do
+      expect { mapper.build }.to raise_error(TaricImporter::UnknownOperationError) do |caught|
+        expect(caught.source).to eq(:taric)
+        expect(caught.message).to eq('Unknown TARIC operation: 9')
+        expect(caught.context).to eq(transaction: record_hash)
+        expect(caught.original).to be_nil
+      end
+    end
   end
 
   context 'when the transaction id is missing' do

--- a/spec/unit/taric_importer_spec.rb
+++ b/spec/unit/taric_importer_spec.rb
@@ -176,13 +176,26 @@ RSpec.describe TaricImporter do
       end
     end
 
-    context 'on an unexpected update operation type'
+    context 'with an unexpected update operation type' do
+      it 'logs both the inner UnknownOperationError and the outer wrapper', :aggregate_failures do
+        allow(Rails.logger).to receive(:error)
+        importer = described_class.new(taric_update)
 
-    it 'logs an error event', :aggregate_failures do
-      allow(Rails.logger).to receive(:error)
-      importer = described_class.new(taric_update)
-      expect { importer.import }.to raise_error TaricImporter::ImportException
-      expect(Rails.logger).to have_received(:error).with(include('Unexpected Taric operation type:'))
+        expect { importer.import }.to raise_error TaricImporter::ImportException
+
+        expect(Rails.logger).to have_received(:error).with(include('Unknown TARIC operation:')).twice
+      end
+
+      it 'wraps the specific UnknownOperationError as the original, not a generic error', :aggregate_failures do
+        importer = described_class.new(taric_update)
+
+        expect { importer.import }.to raise_error(TaricImporter::ImportException) do |caught|
+          expect(caught.message).to eq('TARIC record import failed')
+          expect(caught.original).to be_a(TaricImporter::UnknownOperationError)
+          expect(caught.original.message).to include('Unknown TARIC operation:')
+          expect(caught.cause).to eq(caught.original)
+        end
+      end
     end
   end
 end

--- a/spec/unit/tariff_synchronizer/base_update_importer_spec.rb
+++ b/spec/unit/tariff_synchronizer/base_update_importer_spec.rb
@@ -80,4 +80,26 @@ RSpec.describe TariffSynchronizer::BaseUpdateImporter do
 
     it_behaves_like 'a base update importer'
   end
+
+  context 'with a TARIC update that fails with a nested import error', :truncation do
+    let(:update) { create :taric_update, :pending }
+
+    before do
+      allow(TradeTariffBackend).to receive(:service).and_return('xi')
+      ExplicitAbrogationRegulation.unrestrict_primary_key
+      allow(update).to receive(:file_path)
+        .and_return('spec/fixtures/taric_samples/unknown_record.xml')
+    end
+
+    after { ExplicitAbrogationRegulation.restrict_primary_key }
+
+    it 'persists the specific inner error, not the generic outer wrapper', :aggregate_failures do
+      base_update_importer.apply
+
+      expect(update.reload).to be_failed
+      expect(update.exception_class).to include('TaricImporter::UnknownOperationError')
+      expect(update.exception_class).to include('Unknown TARIC operation:')
+      expect(update.exception_class).not_to include('TARIC record import failed')
+    end
+  end
 end

--- a/spec/unit/tariff_synchronizer/import/error_spec.rb
+++ b/spec/unit/tariff_synchronizer/import/error_spec.rb
@@ -1,0 +1,90 @@
+RSpec.describe TariffSynchronizer::Import::Error do
+  before do
+    allow(Rails.logger).to receive(:error)
+  end
+
+  describe '#initialize' do
+    it 'requires a message and a source' do
+      expect { described_class.new }.to raise_error(ArgumentError)
+    end
+
+    it 'defaults original to nil and context to an empty hash' do
+      error = described_class.new(message: 'boom', source: :taric)
+
+      expect(error.original).to be_nil
+      expect(error.context).to eq({})
+    end
+
+    it 'exposes message, source, original and context', :aggregate_failures do
+      original = StandardError.new('root cause')
+
+      error = described_class.new(
+        message: 'boom',
+        source: :cds,
+        original:,
+        context: { key: 'AdditionalCode' },
+      )
+
+      expect(error.message).to eq('boom')
+      expect(error.source).to eq(:cds)
+      expect(error.original).to eq(original)
+      expect(error.context).to eq(key: 'AdditionalCode')
+    end
+  end
+
+  describe 'logging on construction' do
+    it 'logs itself exactly once' do
+      described_class.new(message: 'boom', source: :taric)
+
+      expect(Rails.logger).to have_received(:error).once
+    end
+
+    it 'capitalizes the source and includes the message when there is no original' do
+      described_class.new(message: 'boom', source: :taric)
+
+      expect(Rails.logger).to have_received(:error).with(include('Taric import failed: boom'))
+    end
+
+    it "logs the original exception's message instead of its own when an original is present" do
+      original = begin
+        raise 'root cause'
+      rescue StandardError => e
+        e
+      end
+
+      described_class.new(message: 'wrapper message', source: :cds, original:)
+
+      expect(Rails.logger).to have_received(:error).with(include('Cds import failed: root cause'))
+    end
+
+    it 'includes each context entry on its own line', :aggregate_failures do
+      transaction = { 'id' => 1 }
+      described_class.new(
+        message: 'boom',
+        source: :taric,
+        context: { transaction:, key: 'Foo' },
+      )
+
+      expect(Rails.logger).to have_received(:error).with(include("Transaction: #{transaction}"))
+      expect(Rails.logger).to have_received(:error).with(include('Key: Foo'))
+    end
+
+    it "includes the original exception's backtrace when available" do
+      original = begin
+        raise 'root cause'
+      rescue StandardError => e
+        e
+      end
+
+      described_class.new(message: 'wrapper', source: :taric, original:)
+
+      expect(Rails.logger).to have_received(:error).with(include('Backtrace:'))
+    end
+
+    it 'omits the backtrace section when neither the wrapper nor an original exception has one' do
+      described_class.new(message: 'boom', source: :taric)
+
+      expect(Rails.logger).to have_received(:error).with(satisfy { |message| !message.include?('Backtrace:') })
+    end
+  end
+end


### PR DESCRIPTION
## What:

- [x] Add a shared importer error class between CDS and Taric importer.
- [x] Refactor the logging and move it in the error class itself to avoid duplication.

## Why:

Remove duplicate code to make it easy for any future changes. 

## Ticket:

https://transformuk.atlassian.net/jira/software/c/projects/HMRC/boards/155?selectedIssue=HMRC-2498

## Risk:
**Risk level:** 🟢
**Reason for rating:**
It is a refactoring change and does not directly affect the functionality,

───────────────────────────────────────────────────

Rate the overall risk of deploying this change:

🟢 Green  – Low risk. Good to go, standard review applies.

🟠 Amber  – Medium risk. Socialise with the team before merging.

🔴 Red    – High risk. Requires explicit approval from Thor or Neil before merging.

───────────────────────────────────────────────────

🟢 GREEN – things that are typically low risk:
───────────────────────────────────────────────────
- Dependency bumps with no API changes (e.g. minor/patch gems, npm packages)
- Copy or content changes in GOV.UK-style UI components
- Adding or updating CloudWatch alarms or dashboards (read-only observability)
- New tests or improved test coverage with no production code changes
- Config/env var additions that are purely additive and have safe defaults
- Refactors with full test coverage and no behaviour change
- Terraform formatting or variable renaming with no resource recreation
- S3 lifecycle rule additions (non-destructive, time-delayed effect)

🟠 AMBER – things that need a team conversation first:
───────────────────────────────────────────────────
- Changes to commodity code lookups, measure type logic, or duty calculation
- Modifications to the search indexing pipeline (OpenSearch mappings, synonyms, stop words)
- Changes to declarable goods or quota logic
- New or modified API endpoints that other services (backend, frontend, admin) consume
- Adding or changing feature flags that affect live user journeys
- Infrastructure changes that alter networking, security groups, or IAM permissions in non-production first
- Terraform changes that will cause a resource replacement (check plan output carefully)
- Changes to CI/CD pipeline steps or deployment order dependencies
- S3 bucket policy or access control changes
- Removing or deprecating an endpoint or field that may still be consumed

🔴 RED – requires explicit approval from Thor or Neil:
───────────────────────────────────────────────────
- Dangerous database migrations, especially destructive ones (dropping columns/tables, removing indexes)
- Modifications to how measures, conditions, or footnotes are processed or surfaced
- Changes to the synchronisation mechanism from CDS or HMRC upstream data feeds
- Any change to production AWS infrastructure that cannot be easily rolled back (e.g. RDS parameter groups, KMS key policy, removal of resources)
- Secrets rotation or changes to how credentials are stored, scoped, or accessed
- Changes that affect trader-facing regulatory content or legally significant data (e.g. trade remedies, licensing, prohibitions)
- Significant architectural shifts (e.g. new service boundaries, queue/event topology changes)
