### PR TITLE
HMRC-2587: Bump ECS service module to v3.2.1

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -21,9 +21,9 @@ Terraform to deploy the service into AWS.
 | Name | Source | Version |
 | ---- | ------ | ------- |
 | <a name="module_ai_costs_dashboard"></a> [ai\_costs\_dashboard](#module\_ai\_costs\_dashboard) | ./modules/ai_costs_dashboard | n/a |
-| <a name="module_backend-job"></a> [backend-job](#module\_backend-job) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.2.0 |
-| <a name="module_backend_uk"></a> [backend\_uk](#module\_backend\_uk) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.2.0 |
-| <a name="module_backend_xi"></a> [backend\_xi](#module\_backend\_xi) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.2.0 |
+| <a name="module_backend-job"></a> [backend-job](#module\_backend-job) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.2.1 |
+| <a name="module_backend_uk"></a> [backend\_uk](#module\_backend\_uk) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.2.1 |
+| <a name="module_backend_xi"></a> [backend\_xi](#module\_backend\_xi) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.2.1 |
 | <a name="module_label_generator_dashboard"></a> [label\_generator\_dashboard](#module\_label\_generator\_dashboard) | ./modules/label_generator_dashboard | n/a |
 | <a name="module_search_dashboard"></a> [search\_dashboard](#module\_search\_dashboard) | ./modules/search_dashboard | n/a |
 | <a name="module_search_experiment_dashboard"></a> [search\_experiment\_dashboard](#module\_search\_experiment\_dashboard) | ./modules/search_experiment_dashboard | n/a |
@@ -32,8 +32,8 @@ Terraform to deploy the service into AWS.
 | <a name="module_self_text_generator_dashboard"></a> [self\_text\_generator\_dashboard](#module\_self\_text\_generator\_dashboard) | ./modules/self_text_generator_dashboard | n/a |
 | <a name="module_tariff_note_pipeline_dashboard"></a> [tariff\_note\_pipeline\_dashboard](#module\_tariff\_note\_pipeline\_dashboard) | ./modules/tariff_note_pipeline_dashboard | n/a |
 | <a name="module_tariff_sync_dashboard"></a> [tariff\_sync\_dashboard](#module\_tariff\_sync\_dashboard) | ./modules/tariff_sync_dashboard | n/a |
-| <a name="module_worker_uk"></a> [worker\_uk](#module\_worker\_uk) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.2.0 |
-| <a name="module_worker_xi"></a> [worker\_xi](#module\_worker\_xi) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.2.0 |
+| <a name="module_worker_uk"></a> [worker\_uk](#module\_worker\_uk) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.2.1 |
+| <a name="module_worker_xi"></a> [worker\_xi](#module\_worker\_xi) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.2.1 |
 
 ## Resources
 

--- a/terraform/backend_job.tf
+++ b/terraform/backend_job.tf
@@ -1,5 +1,5 @@
 module "backend-job" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v3.2.0"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v3.2.1"
 
   region = var.region
 

--- a/terraform/backend_uk.tf
+++ b/terraform/backend_uk.tf
@@ -1,5 +1,5 @@
 module "backend_uk" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v3.2.0"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v3.2.1"
 
   region = var.region
 

--- a/terraform/backend_xi.tf
+++ b/terraform/backend_xi.tf
@@ -1,5 +1,5 @@
 module "backend_xi" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v3.2.0"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v3.2.1"
 
   region = var.region
 

--- a/terraform/worker_uk.tf
+++ b/terraform/worker_uk.tf
@@ -1,5 +1,5 @@
 module "worker_uk" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v3.2.0"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v3.2.1"
 
   service_name = "worker-uk"
   region       = var.region

--- a/terraform/worker_xi.tf
+++ b/terraform/worker_xi.tf
@@ -1,5 +1,5 @@
 module "worker_xi" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v3.2.0"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v3.2.1"
 
   service_name = "worker-xi"
   region       = var.region


### PR DESCRIPTION
## What:
Updated application Terraform configurations to use `aws/ecs-service-v3.2.1`

## Why:
Version v3.2.1 removes CloudWatch ok_actions from the `ecs_high_cpu` alarm, reducing non-actionable recovery notifications while preserving alarm-state notifications.

## Ticket:
[HMRC-2587](https://transformuk.atlassian.net/browse/HMRC-2587)

## Risk:
**Risk level:** 🟢

**Reason for rating:**

- Module version update only.
- No infrastructure changes expected.
- No impact to alarm detection or alerting.
- Only recovery notifications for ECS high CPU alarms are affected.