### PR TITLE
Generate daily reports when a sync applies no updates

### DIFF
--- a/app/workers/cds_updates_synchronizer_worker.rb
+++ b/app/workers/cds_updates_synchronizer_worker.rb
@@ -23,6 +23,13 @@ class CdsUpdatesSynchronizerWorker
 
     TariffSynchronizer::Instrumentation.apply_started(pending_count: TariffSynchronizer::BaseUpdate.pending.count)
     unless CdsSynchronizer.apply # return if nothing changed
+      # A quiet day (nothing pending, nothing failed) must still generate the
+      # daily reports - see TaricUpdatesSynchronizerWorker; without this the
+      # event-driven ReportWorker never runs on zero-apply days. Skipped when
+      # updates are pending or failed so reports are never built from broken
+      # data.
+      ReportWorker.perform_in(15.minutes) if TariffSynchronizer::BaseUpdate.pending_or_failed.none?
+
       emit_sync_run_completed(start_time)
       return
     end

--- a/app/workers/taric_updates_synchronizer_worker.rb
+++ b/app/workers/taric_updates_synchronizer_worker.rb
@@ -18,6 +18,12 @@ class TaricUpdatesSynchronizerWorker
 
     TariffSynchronizer::Instrumentation.apply_started(pending_count: TariffSynchronizer::BaseUpdate.pending.count)
     unless TaricSynchronizer.apply # return if nothing changed
+      # A quiet day (nothing pending, nothing failed - e.g. no TARIC files at
+      # weekends) must still generate the daily reports, or Monday's
+      # differences report finds no XI CSVs. Skipped when updates are pending
+      # or failed so reports are never built from broken data.
+      ReportWorker.perform_in(15.minutes) if TariffSynchronizer::BaseUpdate.pending_or_failed.none?
+
       emit_sync_run_completed(start_time)
       return
     end

--- a/spec/workers/cds_updates_synchronizer_worker_spec.rb
+++ b/spec/workers/cds_updates_synchronizer_worker_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe CdsUpdatesSynchronizerWorker, type: :worker do
       allow(TaricSynchronizer).to receive(:apply).and_return(changes_applied)
       allow(CdsSynchronizer).to receive(:download)
       allow(CdsSynchronizer).to receive(:apply).and_return(changes_applied)
+      allow(ReportWorker).to receive(:perform_in)
+      allow(TariffSynchronizer::BaseUpdate).to receive(:pending_or_failed).and_return(pending_or_failed)
 
       allow(ActiveSupport::Notifications).to receive(:instrument).and_call_original
       allow(ActiveSupport::Notifications).to receive(:instrument).with(
@@ -38,6 +40,7 @@ RSpec.describe CdsUpdatesSynchronizerWorker, type: :worker do
     end
 
     let(:changes_applied) { true }
+    let(:pending_or_failed) { instance_double(Sequel::Dataset, none?: true) }
     let(:service) { 'uk' }
     let(:cut_off_time) { Time.zone.now.end_of_day }
 
@@ -166,11 +169,23 @@ RSpec.describe CdsUpdatesSynchronizerWorker, type: :worker do
         it { expect(CdsSynchronizer).to have_received(:download) }
         it { expect(CdsSynchronizer).to have_received(:apply) }
 
+        it 'schedules report generation for the quiet day' do
+          expect(ReportWorker).to have_received(:perform_in).with(15.minutes)
+        end
+
         context 'with reapply_data_migrations option' do
           subject(:perform) { described_class.new.perform(true, true) }
 
           it { expect(CdsSynchronizer).to have_received(:download) }
           it { expect(DataMigrator).not_to have_received(:migrate_up!) }
+        end
+
+        context 'with pending or failed updates present' do
+          let(:pending_or_failed) { instance_double(Sequel::Dataset, none?: false) }
+
+          it 'does not schedule report generation' do
+            expect(ReportWorker).not_to have_received(:perform_in)
+          end
         end
       end
     end

--- a/spec/workers/taric_updates_synchronizer_worker_spec.rb
+++ b/spec/workers/taric_updates_synchronizer_worker_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe TaricUpdatesSynchronizerWorker, type: :worker do
       allow(TaricSynchronizer).to receive(:apply).and_return(changes_applied)
       allow(CdsSynchronizer).to receive(:download)
       allow(CdsSynchronizer).to receive(:apply).and_return(changes_applied)
+      allow(ReportWorker).to receive(:perform_in)
+      allow(TariffSynchronizer::BaseUpdate).to receive(:pending_or_failed).and_return(pending_or_failed)
 
       allow(TradeTariffBackend).to receive(:service).and_return(service)
 
@@ -34,6 +36,7 @@ RSpec.describe TaricUpdatesSynchronizerWorker, type: :worker do
     end
 
     let(:changes_applied) { true }
+    let(:pending_or_failed) { instance_double(Sequel::Dataset, none?: true) }
 
     context 'when on the xi service' do
       before { perform }
@@ -74,11 +77,23 @@ RSpec.describe TaricUpdatesSynchronizerWorker, type: :worker do
         it { expect(TaricSynchronizer).to have_received(:download) }
         it { expect(TaricSynchronizer).to have_received(:apply) }
 
+        it 'schedules report generation for the quiet day' do
+          expect(ReportWorker).to have_received(:perform_in).with(15.minutes)
+        end
+
         context 'with reapply_data_migrations option' do
           subject(:perform) { described_class.new.perform(true) }
 
           it { expect(TaricSynchronizer).to have_received(:download) }
           it { expect(DataMigrator).not_to have_received(:migrate_up!) }
+        end
+
+        context 'with pending or failed updates present' do
+          let(:pending_or_failed) { instance_double(Sequel::Dataset, none?: false) }
+
+          it 'does not schedule report generation' do
+            expect(ReportWorker).not_to have_received(:perform_in)
+          end
         end
       end
     end


### PR DESCRIPTION
## What:
- Schedule ReportWorker 15 minutes after a sync that completes with nothing to apply (and nothing pending or failed), so daily reporting CSVs are generated on quiet days - e.g. weekends, when TARIC publishes no files

## Why:
Since #3604, ReportWorker only runs off the updates-applied event, which zero-apply syncs never emit. TARIC ships nothing Sat/Sun, so Monday 3 Aug had no XI reporting CSVs and the differences report died fetching them (CSV::MalformedCSVError "Illegal quoting in line 1", JID 256a0dd4ab9e44d80394a0c0). Recurs every Monday until fixed.

Reports are skipped when updates are pending or failed, so quiet-day generation never runs against broken data. Known accepted caveat: a manual same-day sync replay can schedule a second ReportWorker run (and on a Monday a second differences email) - the same behaviour applied-day replays already have on main.

## Ticket:
https://transformuk.atlassian.net/browse/HMRC-2596

## Risk:
**Risk level:** 🟠

**Reason for rating:** Changes when report generation is scheduled, not how updates are downloaded or applied. Covered by the synchronizer worker suites (64 examples green locally).
