### PR TITLE
Raise on failed report fetches and fix the differences report retry delay

### DIFF
--- a/app/lib/reporting.rb
+++ b/app/lib/reporting.rb
@@ -1,6 +1,10 @@
 module Reporting
   extend Reportable
 
+  # Raised when a published report cannot be fetched from the reporting CDN,
+  # so callers fail loudly instead of parsing an error page as report content.
+  class FetchError < StandardError; end
+
   class << self
     def get(object_key)
       if Rails.env.production?
@@ -29,7 +33,12 @@ module Reporting
     def get_published(object_key)
       return get(object_key) unless reporting_cdn_host?
 
-      Faraday.get(published_link(object_key)).body
+      url = published_link(object_key)
+      response = Faraday.get(url)
+
+      raise FetchError, "GET #{url} returned HTTP #{response.status}" unless response.success?
+
+      response.body
     end
 
     def published_link(object_key)

--- a/app/workers/differences_report_worker.rb
+++ b/app/workers/differences_report_worker.rb
@@ -1,7 +1,11 @@
 class DifferencesReportWorker
   include Sidekiq::Worker
 
-  sidekiq_options retry: 1, retry_in: 1.hour
+  # retry_in is not a Sidekiq option; sidekiq_retry_in is the supported way to
+  # delay retries, giving a late report publication time to appear.
+  sidekiq_options retry: 2
+
+  sidekiq_retry_in { 1.hour.to_i }
 
   def perform(deliver_email = true)
     differences = generate_differences

--- a/spec/lib/reporting_spec.rb
+++ b/spec/lib/reporting_spec.rb
@@ -8,12 +8,39 @@ RSpec.describe Reporting do
   end
 
   describe '.get_published' do
-    before do
-      stub_request(:get, cdn_url).to_return(status: 200, body: 'csv-data')
+    context 'when the report exists on the CDN' do
+      before do
+        stub_request(:get, cdn_url).to_return(status: 200, body: 'csv-data')
+      end
+
+      it 'fetches report content from the reporting CDN' do
+        expect(described_class.get_published(object_key)).to eq('csv-data')
+      end
     end
 
-    it 'fetches report content from the reporting CDN' do
-      expect(described_class.get_published(object_key)).to eq('csv-data')
+    context 'when the report is missing from the CDN' do
+      before do
+        stub_request(:get, cdn_url).to_return(
+          status: 404,
+          body: '<?xml version="1.0" encoding="UTF-8"?><Error><Code>NoSuchKey</Code></Error>',
+        )
+      end
+
+      it 'raises a fetch error naming the url and status' do
+        expect { described_class.get_published(object_key) }
+          .to raise_error(Reporting::FetchError, "GET #{cdn_url} returned HTTP 404")
+      end
+    end
+
+    context 'when the CDN returns a server error' do
+      before do
+        stub_request(:get, cdn_url).to_return(status: 503, body: 'Service Unavailable')
+      end
+
+      it 'raises a fetch error naming the url and status' do
+        expect { described_class.get_published(object_key) }
+          .to raise_error(Reporting::FetchError, "GET #{cdn_url} returned HTTP 503")
+      end
     end
   end
 

--- a/spec/workers/differences_report_worker_spec.rb
+++ b/spec/workers/differences_report_worker_spec.rb
@@ -1,6 +1,16 @@
 RSpec.describe DifferencesReportWorker, type: :worker do
   subject(:worker) { described_class.new }
 
+  describe 'sidekiq configuration' do
+    it 'retries twice' do
+      expect(described_class.get_sidekiq_options['retry']).to eq(2)
+    end
+
+    it 'waits an hour between retries so late report publications can appear' do
+      expect(described_class.sidekiq_retry_in_block.call(0, nil)).to eq(1.hour.to_i)
+    end
+  end
+
   describe '#perform' do
     before do
       allow(Reporting::Differences).to receive(:generate).and_return(differences)


### PR DESCRIPTION
## What:
- Raise Reporting::FetchError naming the URL and status when the reporting CDN returns non-2xx, instead of returning the error page body for CSV parsing
- Replace DifferencesReportWorker's inert retry_in: option with a real sidekiq_retry_in { 1.hour } (and retry: 2)

## Why:
Follow-up hardening from the 2026-08-03 differences report incident. The missing XI report surfaced as CSV::MalformedCSVError "Illegal quoting in line 1" because get_published handed S3's NoSuchKey 404 XML straight to CSV.parse - with this change the same failure reads "GET <url> returned HTTP 404". The worker's intended 1-hour retry actually ran after 19 seconds because retry_in: is not a Sidekiq option; sidekiq_retry_in is.

Note: get_published consumers now raise on missing objects instead of receiving an error page body.

## Ticket:
https://transformuk.atlassian.net/browse/HMRC-2596

## Risk:
**Risk level:** 🟠

**Reason for rating:** Changes failure behaviour of report fetching for its consumers (a clear error instead of garbage content). Covered by reporting and worker specs (12 examples green locally).