### PR TITLE
HMRC-2500: Replace global importer notification collectors with a per-import OperationTracker

### DIFF
--- a/app/lib/cds_importer.rb
+++ b/app/lib/cds_importer.rb
@@ -23,35 +23,26 @@ class CdsImporter
     CdsImporter::ExcelWriter,
   ].freeze
 
+  OPERATION_KEYS = %i[create update destroy destroy_missing skipped].freeze
+
   def initialize(cds_update, handler_classes: DEFAULT_HANDLER_CLASSES, staging_manager: nil)
     @cds_update = cds_update
     @handler_classes = handler_classes
     @staging_manager = staging_manager
-    @oplog_inserts = {
-      operations: {
-        create: { count: 0, duration: 0 },
-        update: { count: 0, duration: 0 },
-        destroy: { count: 0, duration: 0 },
-        destroy_missing: { count: 0, duration: 0 },
-        skipped: { count: 0, duration: 0 },
-      },
-      total_count: 0,
-      total_duration: 0,
-    }
+    @tracker = TariffSynchronizer::Import::OperationTracker.new(operation_keys: OPERATION_KEYS)
   end
 
   def import
     zip_file = TariffSynchronizer::FileService.file_as_stringio(@cds_update)
     handlers = @handler_classes.map do |klass|
       if klass == CdsImporter::RecordInserter
-        klass.new(@cds_update.filename, staging_manager: @staging_manager)
+        klass.new(@cds_update.filename, staging_manager: @staging_manager, tracker: @tracker)
       else
         klass.new(@cds_update.filename)
       end
     end
     handler = XmlProcessor.new(@cds_update.filename, handlers)
 
-    subscribe_to_oplog_inserts
     Rails.logger.info "CDS Importer batch size: #{TradeTariffBackend.cds_importer_batch_size}"
 
     Zip::File.open_buffer(zip_file) do |archive|
@@ -66,7 +57,7 @@ class CdsImporter
       end
     end
 
-    @oplog_inserts
+    @tracker.result
   end
 
   class XmlProcessor
@@ -104,46 +95,5 @@ class CdsImporter
     end
 
     attr_reader :key, :instance, :mapper, :element_id
-  end
-
-private
-
-  attr_reader :oplog_inserts
-
-  def subscribe_to_oplog_inserts
-    ActiveSupport::Notifications.subscribe('cds_importer.import.operations') do |*args|
-      oplog_event = ActiveSupport::Notifications::Event.new(*args)
-
-      count = oplog_event.payload[:count]
-
-      if count.positive?
-        duration = oplog_event.duration
-        mapper = oplog_event.payload[:mapper]
-        operation = oplog_event.payload[:operation]
-        entity_class = mapper.entity_class
-        mapping_path = mapper.mapping_path
-
-        oplog_inserts[:operations][operation][entity_class] ||= {}
-        oplog_inserts[:operations][operation][entity_class][:count] ||= 0
-        oplog_inserts[:operations][operation][entity_class][:duration] ||= 0
-        oplog_inserts[:operations][operation][entity_class][:count] += count
-        oplog_inserts[:operations][operation][entity_class][:duration] += duration
-        oplog_inserts[:operations][operation][entity_class][:mapping_path] = mapping_path
-
-        # We only accumulate skipped operations because we can work out from the file which record was inserted for non-missing operation types
-        if [CdsImporter::RecordInserter::SKIPPED_OPERATION].include?(operation)
-          record = oplog_event.payload[:record]
-
-          oplog_inserts[:operations][operation][entity_class][:records] ||= []
-          oplog_inserts[:operations][operation][entity_class][:records] << record.identification
-        end
-
-        oplog_inserts[:operations][operation][:count] += count
-        oplog_inserts[:operations][operation][:duration] += duration
-
-        oplog_inserts[:total_count] += count
-        oplog_inserts[:total_duration] += duration
-      end
-    end
   end
 end

--- a/app/lib/cds_importer/record_inserter.rb
+++ b/app/lib/cds_importer/record_inserter.rb
@@ -2,13 +2,12 @@ class CdsImporter
   class RecordInserter
     SKIPPED_OPERATION = :skipped
 
-    delegate :instrument, to: ActiveSupport::Notifications
-
-    def initialize(filename, staging_manager: nil)
+    def initialize(filename, staging_manager: nil, tracker: nil)
       @count = 0
       @record_batch = []
       @filename = filename
       @staging_manager = staging_manager
+      @tracker = tracker || TariffSynchronizer::Import::OperationTracker.new(operation_keys: CdsImporter::OPERATION_KEYS)
     end
 
     def process_record(cds_entity)
@@ -48,11 +47,9 @@ class CdsImporter
 
       grouped_batch.each do |operation_klass, group|
         first_entity = group.first
-        instrument('cds_importer.import.operations', mapper: first_entity.mapper, operation: first_entity.instance.operation, count: group.size) do
+        tracker.track('cds_importer.import.operations', mapper: first_entity.mapper, operation: first_entity.instance.operation, count: group.size) do
           save_group(operation_klass, group)
         end
-      rescue StandardError
-        raise
       end
     end
 
@@ -77,10 +74,10 @@ class CdsImporter
     end
 
     def instrument_skip_record(record, mapper)
-      instrument('cds_importer.import.operations', mapper:, operation: SKIPPED_OPERATION, count: 1, record:)
+      tracker.record('cds_importer.import.operations', mapper:, operation: SKIPPED_OPERATION, count: 1, record:)
     end
 
-    attr_reader :record_batch, :filename
+    attr_reader :record_batch, :filename, :tracker
 
     def logger_enabled?
       CdsSynchronizer.cds_logger_enabled

--- a/app/lib/taric_importer.rb
+++ b/app/lib/taric_importer.rb
@@ -21,30 +21,21 @@ class TaricImporter
     TaricImporter::RecordInserter,
   ].freeze
 
+  OPERATION_KEYS = %i[create update destroy skipped].freeze
+
   def initialize(taric_update, handler_classes: DEFAULT_HANDLER_CLASSES, staging_manager: nil)
     @taric_update = taric_update
     @handler_classes = handler_classes
     @staging_manager = staging_manager
-    @oplog_inserts = {
-      operations: {
-        create: { count: 0, duration: 0 },
-        update: { count: 0, duration: 0 },
-        destroy: { count: 0, duration: 0 },
-        skipped: { count: 0, duration: 0 },
-      },
-      total_count: 0,
-      total_duration: 0,
-    }
+    @tracker = TariffSynchronizer::Import::OperationTracker.new(operation_keys: OPERATION_KEYS)
   end
 
   def import
-    subscription = nil
     filename = determine_filename(@taric_update.file_path)
     return unless proceed_with_import?(filename)
 
-    subscription = subscribe_to_oplog_inserts
     handlers = @handler_classes.map do |handler_class|
-      handler_class.new(filename, staging_manager: @staging_manager)
+      handler_class.new(filename, staging_manager: @staging_manager, tracker: @tracker)
     end
     handler = XmlProcessor.new(@taric_update.issue_date, handlers:, national_sid_counter: NationalSidCounter.new)
     file = TariffSynchronizer::FileService.file_as_stringio(@taric_update)
@@ -52,9 +43,7 @@ class TaricImporter
     handler.after_parse
     post_import(file_path: @taric_update.file_path, filename:)
 
-    @oplog_inserts
-  ensure
-    ActiveSupport::Notifications.unsubscribe(subscription) if subscription
+    @tracker.result
   end
 
   class XmlProcessor
@@ -92,34 +81,6 @@ class TaricImporter
   )
 
 private
-
-  attr_reader :oplog_inserts
-
-  def subscribe_to_oplog_inserts
-    ActiveSupport::Notifications.subscribe('taric_importer.import.operations') do |*args|
-      oplog_event = ActiveSupport::Notifications::Event.new(*args)
-
-      count = oplog_event.payload[:count]
-      if count.positive?
-        duration = oplog_event.duration
-        mapper = oplog_event.payload[:mapper]
-        operation = oplog_event.payload[:operation]
-        entity_class = mapper.entity_class
-
-        oplog_inserts[:operations][operation][entity_class] ||= {}
-        oplog_inserts[:operations][operation][entity_class][:count] ||= 0
-        oplog_inserts[:operations][operation][entity_class][:duration] ||= 0
-        oplog_inserts[:operations][operation][entity_class][:count] += count
-        oplog_inserts[:operations][operation][entity_class][:duration] += duration
-
-        oplog_inserts[:operations][operation][:count] += count
-        oplog_inserts[:operations][operation][:duration] += duration
-
-        oplog_inserts[:total_count] += count
-        oplog_inserts[:total_duration] += duration
-      end
-    end
-  end
 
   def proceed_with_import?(filename)
     return true unless TradeTariffBackend.uk?

--- a/app/lib/taric_importer/record_inserter.rb
+++ b/app/lib/taric_importer/record_inserter.rb
@@ -28,5 +28,9 @@ class TaricImporter
         count: group.size,
       }
     end
+
+    def default_operation_keys
+      TaricImporter::OPERATION_KEYS
+    end
   end
 end

--- a/app/lib/tariff_synchronizer/import/batch_record_inserter.rb
+++ b/app/lib/tariff_synchronizer/import/batch_record_inserter.rb
@@ -1,12 +1,11 @@
 module TariffSynchronizer
   module Import
     class BatchRecordInserter
-      delegate :instrument, to: ActiveSupport::Notifications
-
-      def initialize(filename, staging_manager: nil)
+      def initialize(filename, staging_manager: nil, tracker: nil)
         @record_batch = []
         @filename = filename
         @staging_manager = staging_manager
+        @tracker = tracker || OperationTracker.new(operation_keys: default_operation_keys)
       end
 
       def process_record(entity)
@@ -27,7 +26,7 @@ module TariffSynchronizer
 
     private
 
-      attr_reader :filename, :record_batch, :staging_manager
+      attr_reader :filename, :record_batch, :staging_manager, :tracker
 
       def process_batch
         save_batch
@@ -41,7 +40,7 @@ module TariffSynchronizer
           first_entity = group.first
           operation_klass = first_entity.instance.class.operation_klass
 
-          instrument(event_name, event_payload(first_entity, group)) do
+          tracker.track(event_name, **event_payload(first_entity, group)) do
             save_group(operation_klass, group)
           end
         end
@@ -80,7 +79,7 @@ module TariffSynchronizer
 
       def instrument_skipped_records
         record_batch.each do |entity|
-          instrument(event_name, skipped_event_payload(entity)) if skip_record?(entity)
+          tracker.record(event_name, **skipped_event_payload(entity)) if skip_record?(entity)
         end
       end
 
@@ -113,6 +112,10 @@ module TariffSynchronizer
       end
 
       def grouped_records(_records)
+        raise NotImplementedError
+      end
+
+      def default_operation_keys
         raise NotImplementedError
       end
     end

--- a/app/lib/tariff_synchronizer/import/operation_metrics.rb
+++ b/app/lib/tariff_synchronizer/import/operation_metrics.rb
@@ -1,0 +1,36 @@
+module TariffSynchronizer
+  module Import
+    class OperationMetrics
+      def initialize(operation_keys)
+        @operations = operation_keys.index_with { { count: 0, duration: 0 } }
+        @total_count = 0
+        @total_duration = 0
+      end
+
+      def record(operation:, entity_class:, count:, duration:, metadata: {})
+        return unless count.positive?
+
+        operation_bucket = @operations.fetch(operation)
+        operation_bucket[:count] += count
+        operation_bucket[:duration] += duration
+
+        entity_bucket = (operation_bucket[entity_class] ||= { count: 0, duration: 0 })
+        entity_bucket[:count] += count
+        entity_bucket[:duration] += duration
+        entity_bucket[:mapping_path] = metadata[:mapping_path] if metadata[:mapping_path]
+
+        if metadata[:record_identifier]
+          entity_bucket[:records] ||= []
+          entity_bucket[:records] << metadata[:record_identifier]
+        end
+
+        @total_count += count
+        @total_duration += duration
+      end
+
+      def result
+        Result.new(operations: @operations, total_count: @total_count, total_duration: @total_duration)
+      end
+    end
+  end
+end

--- a/app/lib/tariff_synchronizer/import/operation_tracker.rb
+++ b/app/lib/tariff_synchronizer/import/operation_tracker.rb
@@ -1,0 +1,53 @@
+module TariffSynchronizer
+  module Import
+    class OperationTracker
+      def initialize(operation_keys:, publish_notifications: true)
+        @metrics = OperationMetrics.new(operation_keys)
+        @publish_notifications = publish_notifications
+      end
+
+      def track(event_name, mapper:, operation:, count:, record: nil)
+        started_at = monotonic_now
+        begin
+          result = yield
+        ensure
+          duration = monotonic_now - started_at
+          record_operation(event_name, mapper:, operation:, count:, duration:, record:)
+        end
+
+        result
+      end
+
+      def record(event_name, mapper:, operation:, count:, record: nil)
+        record_operation(event_name, mapper:, operation:, count:, duration: 0, record:)
+      end
+
+      delegate :result, to: :@metrics
+
+    private
+
+      def record_operation(event_name, mapper:, operation:, count:, duration:, record:)
+        metadata = {
+          mapping_path: (mapper.mapping_path if mapper.respond_to?(:mapping_path)),
+          record_identifier: record&.identification,
+        }
+
+        @metrics.record(operation:, entity_class: mapper.entity_class, count:, duration:, metadata:)
+        publish(event_name, mapper:, operation:, count:, record:)
+      end
+
+      def publish(event_name, mapper:, operation:, count:, record: nil)
+        return unless @publish_notifications
+
+        payload = { mapper:, operation:, count: }
+        payload[:record] = record if record
+
+        ActiveSupport::Notifications.instrument(event_name, payload)
+      end
+
+      def monotonic_now
+        Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      end
+    end
+  end
+end

--- a/app/lib/tariff_synchronizer/import/result.rb
+++ b/app/lib/tariff_synchronizer/import/result.rb
@@ -1,0 +1,10 @@
+module TariffSynchronizer
+  module Import
+    class Result < Hash
+      def initialize(operations:, total_count:, total_duration:)
+        super()
+        merge!(operations:, total_count:, total_duration:)
+      end
+    end
+  end
+end

--- a/spec/integration/cds_importer/cds_importer_spec.rb
+++ b/spec/integration/cds_importer/cds_importer_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe CdsImporter do
     it 'creates new instance of XmlProcessor' do
       allow(CdsImporter::XmlProcessor).to receive(:new).and_call_original
       allow(CdsImporter::ExcelWriter).to receive(:new).with(cds_update.filename).and_call_original
-      allow(CdsImporter::RecordInserter).to receive(:new).with(cds_update.filename, staging_manager: nil).and_call_original
+      allow(CdsImporter::RecordInserter).to receive(:new).with(cds_update.filename, staging_manager: nil, tracker: kind_of(TariffSynchronizer::Import::OperationTracker)).and_call_original
 
       importer.import
       expect(CdsImporter::XmlProcessor).to have_received(:new).with(cds_update.filename, kind_of(Array))
@@ -34,12 +34,21 @@ RSpec.describe CdsImporter do
       expect(importer.import).to eql(expected_default_oplog_inserts)
     end
 
-    it 'subscribes to oplog events' do
+    it 'does not use a global notification subscription to calculate the result' do
       allow(ActiveSupport::Notifications).to receive(:subscribe).and_call_original
 
       importer.import
 
-      expect(ActiveSupport::Notifications).to have_received(:subscribe).with('cds_importer.import.operations')
+      expect(ActiveSupport::Notifications).not_to have_received(:subscribe).with('cds_importer.import.operations')
+    end
+
+    it 'still publishes notifications for external observability' do
+      allow(ActiveSupport::Notifications).to receive(:instrument).and_call_original
+      footnote_update = TariffSynchronizer::CdsUpdate.new(filename: 'footnote.gzip')
+
+      described_class.new(footnote_update).import
+
+      expect(ActiveSupport::Notifications).to have_received(:instrument).with('cds_importer.import.operations', anything).at_least(:once)
     end
 
     context 'when importing a footnote with a long description' do

--- a/spec/lib/cds_importer/record_inserter_spec.rb
+++ b/spec/lib/cds_importer/record_inserter_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CdsImporter::RecordInserter do
       values: { goods_nomenclature_item_id: '0101210000' },
     )
 
-    CdsImporter::CdsEntity.new('1', 'GoodsNomenclature', instance, instance_double(CdsImporter::EntityMapper::GoodsNomenclatureMapper))
+    CdsImporter::CdsEntity.new('1', 'GoodsNomenclature', instance, instance_double(CdsImporter::EntityMapper::GoodsNomenclatureMapper, entity_class: 'GoodsNomenclature', mapping_path: nil))
   end
 
   describe '#after_parse' do

--- a/spec/unit/tariff_synchronizer/import/operation_metrics_spec.rb
+++ b/spec/unit/tariff_synchronizer/import/operation_metrics_spec.rb
@@ -1,0 +1,70 @@
+RSpec.describe TariffSynchronizer::Import::OperationMetrics do
+  subject(:metrics) { described_class.new(%i[create update destroy skipped]) }
+
+  describe '#result' do
+    it 'starts with every operation key zeroed' do
+      expect(metrics.result[:operations]).to eq(
+        create: { count: 0, duration: 0 },
+        update: { count: 0, duration: 0 },
+        destroy: { count: 0, duration: 0 },
+        skipped: { count: 0, duration: 0 },
+      )
+      expect(metrics.result[:total_count]).to eq(0)
+      expect(metrics.result[:total_duration]).to eq(0)
+    end
+  end
+
+  describe '#record' do
+    it 'accumulates count and duration under the operation and entity class' do
+      metrics.record(operation: :create, entity_class: 'Measure', count: 3, duration: 1.5)
+
+      expect(metrics.result[:operations][:create]).to include(count: 3, duration: 1.5)
+      expect(metrics.result[:operations][:create]['Measure']).to eq(count: 3, duration: 1.5)
+      expect(metrics.result[:total_count]).to eq(3)
+      expect(metrics.result[:total_duration]).to eq(1.5)
+    end
+
+    it 'accumulates across multiple calls for the same operation and entity class' do
+      metrics.record(operation: :create, entity_class: 'Measure', count: 3, duration: 1.0)
+      metrics.record(operation: :create, entity_class: 'Measure', count: 2, duration: 0.5)
+
+      expect(metrics.result[:operations][:create]).to include(count: 5, duration: 1.5)
+      expect(metrics.result[:operations][:create]['Measure']).to eq(count: 5, duration: 1.5)
+    end
+
+    it 'keeps separate entity class breakdowns under the same operation' do
+      metrics.record(operation: :create, entity_class: 'Measure', count: 1, duration: 0.1)
+      metrics.record(operation: :create, entity_class: 'Certificate', count: 2, duration: 0.2)
+
+      expect(metrics.result[:operations][:create]['Measure']).to eq(count: 1, duration: 0.1)
+      expect(metrics.result[:operations][:create]['Certificate']).to eq(count: 2, duration: 0.2)
+      expect(metrics.result[:operations][:create]).to include(count: 3, duration: 0.30000000000000004)
+    end
+
+    it 'ignores non-positive counts' do
+      metrics.record(operation: :create, entity_class: 'Measure', count: 0, duration: 1.0)
+
+      expect(metrics.result[:operations][:create]).to include(count: 0, duration: 0)
+      expect(metrics.result[:total_count]).to eq(0)
+    end
+
+    it 'records a mapping_path from metadata against the entity class bucket' do
+      metrics.record(operation: :create, entity_class: 'Measure', count: 1, duration: 0.1, metadata: { mapping_path: 'measure.path' })
+
+      expect(metrics.result[:operations][:create]['Measure'][:mapping_path]).to eq('measure.path')
+    end
+
+    it 'appends record identifiers from metadata under a records array' do
+      metrics.record(operation: :skipped, entity_class: 'Measure', count: 1, duration: 0, metadata: { record_identifier: 'sid-1' })
+      metrics.record(operation: :skipped, entity_class: 'Measure', count: 1, duration: 0, metadata: { record_identifier: 'sid-2' })
+
+      expect(metrics.result[:operations][:skipped]['Measure'][:records]).to eq(%w[sid-1 sid-2])
+    end
+
+    it 'raises for an operation key that was not declared upfront' do
+      expect {
+        metrics.record(operation: :unknown, entity_class: 'Measure', count: 1, duration: 0)
+      }.to raise_error(KeyError)
+    end
+  end
+end

--- a/spec/unit/tariff_synchronizer/import/operation_tracker_spec.rb
+++ b/spec/unit/tariff_synchronizer/import/operation_tracker_spec.rb
@@ -1,0 +1,90 @@
+RSpec.describe TariffSynchronizer::Import::OperationTracker do
+  subject(:tracker) { described_class.new(operation_keys: %i[create update destroy skipped]) }
+
+  let(:mapper) { instance_double(TaricImporter::EntityMapper, entity_class: 'Measure') }
+
+  describe '#track' do
+    it 'runs the given block and returns its value' do
+      value = tracker.track('taric_importer.import.operations', mapper:, operation: :create, count: 1) { 'inserted' }
+
+      expect(value).to eq('inserted')
+    end
+
+    it 'records the operation, entity class and count against the result', :aggregate_failures do
+      tracker.track('taric_importer.import.operations', mapper:, operation: :create, count: 3) { true }
+
+      expect(tracker.result[:operations][:create]).to include(count: 3)
+      expect(tracker.result[:operations][:create]['Measure']).to include(count: 3)
+      expect(tracker.result[:total_count]).to eq(3)
+    end
+
+    it 'measures a positive duration around the block using the monotonic clock' do
+      tracker.track('taric_importer.import.operations', mapper:, operation: :create, count: 1) { sleep 0.01 }
+
+      expect(tracker.result[:total_duration]).to be > 0
+    end
+
+    it 'still records the operation when the block raises, then re-raises' do
+      expect {
+        tracker.track('taric_importer.import.operations', mapper:, operation: :create, count: 1) { raise 'boom' }
+      }.to raise_error('boom')
+    end
+
+    it 'republishes a notification with the same payload shape used before the tracker existed' do
+      allow(ActiveSupport::Notifications).to receive(:instrument).and_call_original
+
+      tracker.track('taric_importer.import.operations', mapper:, operation: :create, count: 1) { true }
+
+      expect(ActiveSupport::Notifications).to have_received(:instrument).with(
+        'taric_importer.import.operations',
+        { mapper:, operation: :create, count: 1 },
+      )
+    end
+
+    it 'does not publish a notification when publish_notifications is false' do
+      silent_tracker = described_class.new(operation_keys: %i[create], publish_notifications: false)
+      allow(ActiveSupport::Notifications).to receive(:instrument)
+
+      silent_tracker.track('taric_importer.import.operations', mapper:, operation: :create, count: 1) { true }
+
+      expect(ActiveSupport::Notifications).not_to have_received(:instrument)
+    end
+  end
+
+  describe '#record' do
+    it 'records without executing any block, with zero duration' do
+      tracker.record('cds_importer.import.operations', mapper:, operation: :skipped, count: 1, record: double(identification: 'sid-1'))
+
+      expect(tracker.result[:operations][:skipped]).to include(count: 1, duration: 0)
+      expect(tracker.result[:operations][:skipped]['Measure'][:records]).to eq(%w[sid-1])
+    end
+
+    it 'republishes a notification including the record for skipped-style calls' do
+      allow(ActiveSupport::Notifications).to receive(:instrument).and_call_original
+      record = double(identification: 'sid-1')
+
+      tracker.record('cds_importer.import.operations', mapper:, operation: :skipped, count: 1, record:)
+
+      expect(ActiveSupport::Notifications).to have_received(:instrument).with(
+        'cds_importer.import.operations',
+        { mapper:, operation: :skipped, count: 1, record: },
+      )
+    end
+  end
+
+  describe '#result' do
+    it 'returns an Import::Result' do
+      expect(tracker.result).to be_a(TariffSynchronizer::Import::Result)
+    end
+  end
+
+  context 'when the mapper carries a mapping_path' do
+    let(:mapper) { instance_double(CdsImporter::EntityMapper::MeasureMapper, entity_class: 'Measure', mapping_path: 'measure.path') }
+
+    it 'records the mapping_path against the entity class bucket' do
+      tracker.track('cds_importer.import.operations', mapper:, operation: :create, count: 1) { true }
+
+      expect(tracker.result[:operations][:create]['Measure'][:mapping_path]).to eq('measure.path')
+    end
+  end
+end

--- a/spec/unit/tariff_synchronizer/import/result_spec.rb
+++ b/spec/unit/tariff_synchronizer/import/result_spec.rb
@@ -1,0 +1,34 @@
+RSpec.describe TariffSynchronizer::Import::Result do
+  subject(:result) do
+    described_class.new(
+      operations: { create: { count: 1, duration: 0.5 } },
+      total_count: 1,
+      total_duration: 0.5,
+    )
+  end
+
+  it 'is a Hash' do
+    expect(result).to be_a(Hash)
+  end
+
+  it 'exposes operations, total_count and total_duration via bracket access' do
+    expect(result[:operations]).to eq(create: { count: 1, duration: 0.5 })
+    expect(result[:total_count]).to eq(1)
+    expect(result[:total_duration]).to eq(0.5)
+  end
+
+  it 'supports #fetch with a default like a plain hash' do
+    expect(result.fetch(:total_count, 0)).to eq(1)
+    expect(result.fetch(:missing_key, 0)).to eq(0)
+  end
+
+  it 'serializes to JSON as a plain hash' do
+    parsed = JSON.parse(result.to_json)
+
+    expect(parsed).to eq(
+      'operations' => { 'create' => { 'count' => 1, 'duration' => 0.5 } },
+      'total_count' => 1,
+      'total_duration' => 0.5,
+    )
+  end
+end


### PR DESCRIPTION
## What:
Replaces the global `ActiveSupport::Notifications` subscriptions that `TaricImporter` and `CdsImporter` used to calculate import result counts/durations with a `TariffSynchronizer::Import::OperationTracker` created per import and injected at the points where persistence happens (the shared `BatchRecordInserter` for TARIC, `CdsImporter::RecordInserter` for CDS).

- New `TariffSynchronizer::Import::OperationMetrics` — the per-import accumulator (same aggregation shape as the old subscriber: per-operation/entity-class counts and durations, `mapping_path`, skipped-record `records` array).
- New `TariffSynchronizer::Import::OperationTracker` — times each persistence block with a monotonic clock, records via `OperationMetrics`, and republishes the *same* notification payloads as before for external observability (nothing subscribes to them to build the result anymore).
- New `TariffSynchronizer::Import::Result` — a `Hash` subclass, so `TaricUpdate`/`CdsUpdate` (which do `[:total_count]`, `#fetch`, `#to_json`) needed no changes.
- `TaricImporter`/`CdsImporter` each build one tracker per import and return `tracker.result`; the `subscribe`/`unsubscribe` machinery is gone entirely.

## Why:
TARIC and CDS importers subscribed globally to `ActiveSupport::Notifications` to calculate operation counts and durations. These subscriptions were never removed for CDS, and only unsubscribed after building the whole result for TARIC. Every import left another live subscriber holding a reference to its importer state — risking retained memory over time and, for concurrent imports, one import's events being processed by another's leftover subscriber. Each import now owns an isolated tracker instead.

## Ticket:
https://transformuk.atlassian.net/browse/HMRC-2500

## Risk:
**Risk level:** 🟠

**Reason for rating:** Behaviour-preserving refactor with full test coverage (result hash structure, oplog writes, CDS batching, staging promotion and TARIC transaction behaviour are all unchanged, verified by the existing integration suite), but it touches the core TARIC/CDS import pipeline directly, so flagging as amber rather than green.