### PR TITLE
[ci skip] -  document uk/xi shared-schema pattern for cross-service models

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,15 @@ psql -h localhost tariff_development < tariff-merged-staging.sql
    - `bundle exec sidekiq`
 3. Run the rails server as normal - `bin/rails s`
 
+`SERVICE` controls the Postgres `search_path` (see `config/database.yml`), so
+migrations run under `SERVICE=xi` create tables in the `xi` schema. A few
+models (`AdminConfiguration`, `EvaluationExperiment`, `EvaluationRun`,
+`EvaluationResult`) are hardcoded to the `uk` schema instead, because they're
+shared across both services rather than duplicated per-service. Always run
+migrations for those with the default `SERVICE=uk` - migrating them under
+`SERVICE=xi` will not create the tables they actually query, and you'll see
+`relation "uk.<table>" does not exist` errors from the xi service instead.
+
 ### Performing daily updates
 
 These are run daily by a background job, `CdsUpdatesSynchronizerWorker` or

--- a/docs/architecture/platform-context.md
+++ b/docs/architecture/platform-context.md
@@ -28,6 +28,8 @@ The service catalogue groups OTT capabilities into areas that map back to this b
 
 Confluence platform docs describe the applications as ECS Fargate services deployed through GitHub Actions, with PostgreSQL, Redis/Valkey, OpenSearch, CloudFront, S3, and AWS-managed secrets around them.
 
+UK and XI run as separate web and Sidekiq services (`SERVICE=uk` / `SERVICE=xi`) against a single shared Postgres instance, split into `uk`, `xi`, and `public` schemas. `SERVICE` sets the connection's `search_path` (`config/database.yml`), so most Sequel models resolve to the schema matching whichever service is running. A small set of models opt out of this and are hardcoded to the `uk` schema instead (`Sequel::Model(Sequel[:table].qualify(:uk))`) - `AdminConfiguration` and the `Evaluation*` models - because that data is meant to be a single shared source of truth read and written by both services, not duplicated per schema. Migrations for those tables must run with the default `SERVICE=uk`; running them under `SERVICE=xi` creates the table in the wrong schema and leaves the xi service unable to find it.
+
 For this repository, verify platform details in:
 
 - `.github/workflows/`


### PR DESCRIPTION
## What
- Added a note to the README's "Running an XI service" section listing the models hardcoded to the uk schema(AdminConfiguration, EvaluationExperiment, EvaluationRun, EvaluationResult) and the exact error (relation  `uk.<table>` does not exist) you'll see if you migrate them under the wrong SERVICE. 
 - Added a paragraph to docs/architecture/platform-context.md describing the underlying architecture: UK and XI run as separate services against one shared Postgres instance, split into uk/xi/public schemas via search_path, with a small set of models opting out of per-service schema resolution. 


## Why:
 Migrations for AdminConfiguration and the Evaluation* models must run under SERVICE=uk, since they're pinned to the uk schema on purpose (shared across services). Migrating under SERVICE=xi instead lands the table in the wrong schema and throws relation `uk.<table>` does not exist on worker-xi undocumented until now, which cost a round trip through the model code and git history to confirm it wasn't a bug.
## Ticket:
N/A

## Risk:
**Risk level:** 🟢 


**Reason for rating:**
It is just documentation change so no risk at all.
