### PR TITLE
AI-1065a: Add evaluation experiment/run/result CRUD APIs

### DIFF
--- a/app/controllers/api/admin/search/evaluation/experiments_controller.rb
+++ b/app/controllers/api/admin/search/evaluation/experiments_controller.rb
@@ -12,7 +12,7 @@ module Api
           end
 
           def create
-            experiment = EvaluationExperiment.new(experiment_params)
+            experiment = EvaluationExperiment.new(experiment_params.merge(created_by: TradeTariffRequest.whodunnit))
 
             if experiment.valid? && experiment.save
               render json: serialize(experiment), status: :created
@@ -45,7 +45,7 @@ module Api
 
           def experiment_params
             params.require(:data).require(:attributes).permit(
-              :name, :description, :enabled, :created_by,
+              :name, :description, :enabled,
               configuration_overrides: {}, default_scope: {}
             ).to_h
           end

--- a/app/controllers/api/admin/search/evaluation/experiments_controller.rb
+++ b/app/controllers/api/admin/search/evaluation/experiments_controller.rb
@@ -1,0 +1,67 @@
+module Api
+  module Admin
+    module Search
+      module Evaluation
+        class ExperimentsController < AdminController
+          def index
+            render json: serialize(experiments.all, is_collection: true, meta: pagination_meta)
+          end
+
+          def show
+            render json: serialize(experiment)
+          end
+
+          def create
+            experiment = EvaluationExperiment.new(experiment_params)
+
+            if experiment.valid? && experiment.save
+              render json: serialize(experiment), status: :created
+            else
+              render json: serialize_errors(experiment), status: :unprocessable_content
+            end
+          end
+
+          def update
+            experiment.set(update_params)
+
+            if experiment.valid? && experiment.save
+              render json: serialize(experiment), status: :ok
+            else
+              render json: serialize_errors(experiment), status: :unprocessable_content
+            end
+          end
+
+        private
+
+          def serializer_class = Api::Admin::Search::Evaluation::ExperimentSerializer
+
+          def experiments
+            @experiments ||= EvaluationExperiment.order(:name).paginate(current_page, per_page)
+          end
+
+          def experiment
+            @experiment ||= EvaluationExperiment.with_pk!(params[:id])
+          end
+
+          def experiment_params
+            params.require(:data).require(:attributes).permit(
+              :name, :description, :enabled, :created_by,
+              configuration_overrides: {}, default_scope: {}
+            ).to_h
+          end
+
+          def update_params
+            params.require(:data).require(:attributes).permit(
+              :description, :enabled,
+              configuration_overrides: {}, default_scope: {}
+            ).to_h
+          end
+
+          def pagination_meta
+            { pagination: { page: current_page, per_page:, total_count: experiments.pagination_record_count } }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/admin/search/evaluation/results_controller.rb
+++ b/app/controllers/api/admin/search/evaluation/results_controller.rb
@@ -1,0 +1,87 @@
+module Api
+  module Admin
+    module Search
+      module Evaluation
+        class ResultsController < AdminController
+          RESULT_ATTRIBUTES = %i[
+            source_type
+            source_id
+            persona
+            expected_code
+            final_code
+            final_rank
+            gold_in_top1
+            gold_in_top5
+            latency_seconds
+            cost_usd
+            error
+          ].freeze
+
+          def index
+            render json: serialize(results.all, is_collection: true, meta: pagination_meta)
+          end
+
+          def show
+            render json: serialize(result)
+          end
+
+          def create
+            outcomes = bulk_items.map.with_index { |item, index| ingest_item(item, index) }
+
+            render json: { data: outcomes.map { |outcome| outcome[:body] } }, status: bulk_status(outcomes)
+          end
+
+        private
+
+          def serializer_class = Api::Admin::Search::Evaluation::ResultSerializer
+
+          def results
+            @results ||= filtered_results.order(Sequel.desc(:created_at)).paginate(current_page, per_page)
+          end
+
+          def filtered_results
+            dataset = EvaluationResult.dataset
+            dataset = dataset.where(run_id: params[:run_id]) if params[:run_id].present?
+            dataset
+          end
+
+          def result
+            @result ||= EvaluationResult.with_pk!(params[:id])
+          end
+
+          def bulk_items
+            Array(params.require(:data))
+          end
+
+          def ingest_item(item, index)
+            attrs = item.permit(:run_id, *RESULT_ATTRIBUTES, trace: {}).to_h
+            run = EvaluationRun.with_pk!(attrs['run_id'])
+
+            ingested = EvaluationResult.ingest!(
+              run:,
+              source_type: attrs['source_type'],
+              source_id: attrs['source_id'],
+              persona: attrs['persona'],
+              attrs: attrs.except('run_id', 'source_type', 'source_id', 'persona'),
+            )
+
+            { success: true, body: serialize(ingested)[:data] }
+          rescue Sequel::NoMatchingRow, Sequel::Error => e
+            { success: false, body: { error: e.message, index: } }
+          end
+
+          def bulk_status(outcomes)
+            return :unprocessable_content if outcomes.none? { |outcome| outcome[:success] }
+            return :multi_status if outcomes.any? { |outcome| !outcome[:success] }
+
+            :ok
+          end
+
+          def pagination_meta
+            { pagination: { page: current_page, per_page:, total_count: results.pagination_record_count } }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/admin/search/evaluation/runs_controller.rb
+++ b/app/controllers/api/admin/search/evaluation/runs_controller.rb
@@ -16,13 +16,13 @@ module Api
           def create
             experiment = EvaluationExperiment.with_pk!(create_params[:experiment_id])
 
-            created = EvaluationRun.start!(
+            evaluation_run = EvaluationRun.start!(
               experiment:,
               triggered_by: create_params[:triggered_by],
               run_time_overrides: create_params[:configuration_overrides] || {},
             )
 
-            render json: serialize(created), status: :created
+            render json: serialize(evaluation_run), status: :created
           end
 
           def update

--- a/app/controllers/api/admin/search/evaluation/runs_controller.rb
+++ b/app/controllers/api/admin/search/evaluation/runs_controller.rb
@@ -1,0 +1,75 @@
+module Api
+  module Admin
+    module Search
+      module Evaluation
+        class RunsController < AdminController
+          RECONCILING_STATUSES = %w[completed partially_failed failed cancelled].freeze
+
+          def index
+            render json: serialize(runs.all, is_collection: true, meta: pagination_meta)
+          end
+
+          def show
+            render json: serialize(run)
+          end
+
+          def create
+            experiment = EvaluationExperiment.with_pk!(create_params[:experiment_id])
+
+            created = EvaluationRun.start!(
+              experiment:,
+              triggered_by: create_params[:triggered_by],
+              run_time_overrides: create_params[:configuration_overrides] || {},
+            )
+
+            render json: serialize(created), status: :created
+          end
+
+          def update
+            run.set(update_params)
+
+            if run.valid? && run.save
+              run.reconcile_aggregates! if RECONCILING_STATUSES.include?(run.status)
+              render json: serialize(run.reload), status: :ok
+            else
+              render json: serialize_errors(run), status: :unprocessable_content
+            end
+          end
+
+        private
+
+          def serializer_class = Api::Admin::Search::Evaluation::RunSerializer
+
+          def runs
+            @runs ||= filtered_runs.order(Sequel.desc(:created_at)).paginate(current_page, per_page)
+          end
+
+          def filtered_runs
+            dataset = EvaluationRun.dataset
+            dataset = dataset.where(experiment_id: params[:experiment_id]) if params[:experiment_id].present?
+            dataset = dataset.where(status: params[:status]) if params[:status].present?
+            dataset = dataset.where { created_at >= Date.parse(params[:from]) } if params[:from].present?
+            dataset = dataset.where { created_at <= Date.parse(params[:to]) } if params[:to].present?
+            dataset
+          end
+
+          def run
+            @run ||= EvaluationRun.with_pk!(params[:id])
+          end
+
+          def create_params
+            params.require(:data).require(:attributes).permit(:experiment_id, :triggered_by, configuration_overrides: {}).to_h
+          end
+
+          def update_params
+            params.require(:data).require(:attributes).permit(:status, :completed_at, :error_summary).to_h
+          end
+
+          def pagination_meta
+            { pagination: { page: current_page, per_page:, total_count: runs.pagination_record_count } }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -24,6 +24,11 @@ module Api
       render json: serializer.serialized_errors({ error: exception.message, url: request.url }), status: :bad_request
     end
 
+    rescue_from EvaluationConfiguration::OverrideValidationError do |exception|
+      serializer = TradeTariffBackend.error_serializer(request)
+      render json: serializer.serialized_errors({ error: exception.message, url: request.url }), status: :unprocessable_content
+    end
+
   protected
 
     def current_page

--- a/app/engines/admin_api.rb
+++ b/app/engines/admin_api.rb
@@ -156,6 +156,14 @@ AdminApi.routes.draw do
         resources :update_notifications, only: %i[index show update]
         resources :measure_type_mappings, only: %i[index show create destroy]
       end
+
+      namespace :search do
+        namespace :evaluation do
+          resources :experiments, only: %i[index show create update]
+          resources :runs, only: %i[index show create update]
+          resources :results, only: %i[index show create]
+        end
+      end
     end
   end
 end

--- a/app/serializers/api/admin/search/evaluation/experiment_serializer.rb
+++ b/app/serializers/api/admin/search/evaluation/experiment_serializer.rb
@@ -1,0 +1,22 @@
+module Api
+  module Admin
+    module Search
+      module Evaluation
+        class ExperimentSerializer
+          include JSONAPI::Serializer
+
+          set_type :experiment
+          set_id :id
+
+          attributes :name,
+                     :description,
+                     :enabled,
+                     :configuration_overrides,
+                     :default_scope,
+                     :created_at,
+                     :created_by
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/api/admin/search/evaluation/result_serializer.rb
+++ b/app/serializers/api/admin/search/evaluation/result_serializer.rb
@@ -1,0 +1,29 @@
+module Api
+  module Admin
+    module Search
+      module Evaluation
+        class ResultSerializer
+          include JSONAPI::Serializer
+
+          set_type :result
+          set_id :id
+
+          attributes :run_id,
+                     :source_type,
+                     :source_id,
+                     :persona,
+                     :expected_code,
+                     :final_code,
+                     :final_rank,
+                     :gold_in_top1,
+                     :gold_in_top5,
+                     :latency_seconds,
+                     :cost_usd,
+                     :error,
+                     :trace,
+                     :created_at
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/api/admin/search/evaluation/run_serializer.rb
+++ b/app/serializers/api/admin/search/evaluation/run_serializer.rb
@@ -1,0 +1,32 @@
+module Api
+  module Admin
+    module Search
+      module Evaluation
+        class RunSerializer
+          include JSONAPI::Serializer
+
+          set_type :run
+          set_id :id
+
+          attributes :experiment_id,
+                     :status,
+                     :triggered_by,
+                     :configuration_digest,
+                     :effective_configuration,
+                     :question_model,
+                     :simulator_model,
+                     :started_at,
+                     :completed_at,
+                     :total_cost_usd,
+                     :total_provider_calls,
+                     :total_latency_seconds,
+                     :result_count,
+                     :error_count,
+                     :error_summary,
+                     :aggregate_metrics,
+                     :created_at
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/admin/search/evaluation/experiments_controller_spec.rb
+++ b/spec/requests/api/admin/search/evaluation/experiments_controller_spec.rb
@@ -43,7 +43,8 @@ RSpec.describe Api::Admin::Search::Evaluation::ExperimentsController, :admin do
   end
 
   describe 'POST #create' do
-    let(:make_request) { authenticated_post api_admin_search_evaluation_experiments_path(format: :json), params: params }
+    let(:make_request) { authenticated_post api_admin_search_evaluation_experiments_path(format: :json), params:, headers: }
+    let(:headers) { {} }
 
     context 'with valid params' do
       let(:params) do
@@ -66,6 +67,25 @@ RSpec.describe Api::Admin::Search::Evaluation::ExperimentsController, :admin do
       it 'persists the configuration_overrides hash' do
         api_response
         expect(json_response['data']['attributes']['configuration_overrides']).to eq('simulator_model' => 'gpt-4o-mini')
+      end
+    end
+
+    context 'when the request carries an X-Whodunnit header' do
+      let(:headers) { { 'X-Whodunnit' => 'operator-1' } }
+      let(:params) { { data: { type: :experiment, attributes: { name: 'baseline-gpt4o' } } } }
+
+      it 'sets created_by from the header rather than the request body' do
+        api_response
+        expect(json_response['data']['attributes']['created_by']).to eq('operator-1')
+      end
+    end
+
+    context 'when the request body attempts to set created_by directly' do
+      let(:params) { { data: { type: :experiment, attributes: { name: 'baseline-gpt4o', created_by: 'spoofed-user' } } } }
+
+      it 'ignores the client-supplied value' do
+        api_response
+        expect(json_response['data']['attributes']['created_by']).to be_nil
       end
     end
 

--- a/spec/requests/api/admin/search/evaluation/experiments_controller_spec.rb
+++ b/spec/requests/api/admin/search/evaluation/experiments_controller_spec.rb
@@ -1,0 +1,107 @@
+require 'rails_helper'
+
+RSpec.describe Api::Admin::Search::Evaluation::ExperimentsController, :admin do
+  subject(:api_response) do
+    make_request
+    response
+  end
+
+  let(:json_response) { JSON.parse(api_response.body) }
+
+  describe 'GET #index' do
+    let(:make_request) { authenticated_get api_admin_search_evaluation_experiments_path(format: :json) }
+
+    context 'with existing experiments' do
+      before { create_list(:evaluation_experiment, 2) }
+
+      it { is_expected.to have_http_status :success }
+      it { expect(json_response['data'].size).to eq(2) }
+    end
+
+    context 'with no experiments' do
+      it { is_expected.to have_http_status :success }
+      it { expect(json_response['data']).to eq([]) }
+    end
+  end
+
+  describe 'GET #show' do
+    let(:experiment) { create(:evaluation_experiment) }
+    let(:make_request) { authenticated_get api_admin_search_evaluation_experiment_path(id, format: :json) }
+
+    context 'with an existing experiment' do
+      let(:id) { experiment.id }
+
+      it { is_expected.to have_http_status :success }
+      it { expect(json_response['data']['attributes']['name']).to eq(experiment.name) }
+    end
+
+    context 'with an unknown experiment' do
+      let(:id) { 999_999 }
+
+      it { is_expected.to have_http_status :not_found }
+    end
+  end
+
+  describe 'POST #create' do
+    let(:make_request) { authenticated_post api_admin_search_evaluation_experiments_path(format: :json), params: params }
+
+    context 'with valid params' do
+      let(:params) do
+        {
+          data: {
+            type: :experiment,
+            attributes: {
+              name: 'baseline-gpt4o',
+              description: 'baseline run',
+              configuration_overrides: { 'simulator_model' => 'gpt-4o-mini' },
+            },
+          },
+        }
+      end
+
+      it { is_expected.to have_http_status :created }
+      it { expect { api_response }.to change(EvaluationExperiment, :count).by(1) }
+      it { expect(json_response['data']['attributes']['name']).to eq('baseline-gpt4o') }
+
+      it 'persists the configuration_overrides hash' do
+        api_response
+        expect(json_response['data']['attributes']['configuration_overrides']).to eq('simulator_model' => 'gpt-4o-mini')
+      end
+    end
+
+    context 'with a missing name' do
+      let(:params) { { data: { type: :experiment, attributes: { description: 'no name' } } } }
+
+      it { is_expected.to have_http_status :unprocessable_content }
+      it { expect(json_response).to include('errors') }
+      it { expect { api_response }.not_to change(EvaluationExperiment, :count) }
+    end
+
+    context 'with a duplicate name' do
+      let!(:existing) { create(:evaluation_experiment) }
+      let(:params) { { data: { type: :experiment, attributes: { name: existing.name } } } }
+
+      it { is_expected.to have_http_status :unprocessable_content }
+    end
+  end
+
+  describe 'PATCH #update' do
+    let(:experiment) { create(:evaluation_experiment, enabled: true) }
+    let(:make_request) { authenticated_patch api_admin_search_evaluation_experiment_path(id, format: :json), params: params }
+
+    context 'when toggling enabled off' do
+      let(:id) { experiment.id }
+      let(:params) { { data: { type: :experiment, attributes: { enabled: false } } } }
+
+      it { is_expected.to have_http_status :success }
+      it { expect { api_response }.to change { experiment.reload.enabled }.from(true).to(false) }
+    end
+
+    context 'with an unknown experiment' do
+      let(:id) { 999_999 }
+      let(:params) { { data: { type: :experiment, attributes: { enabled: false } } } }
+
+      it { is_expected.to have_http_status :not_found }
+    end
+  end
+end

--- a/spec/requests/api/admin/search/evaluation/results_controller_spec.rb
+++ b/spec/requests/api/admin/search/evaluation/results_controller_spec.rb
@@ -1,0 +1,104 @@
+require 'rails_helper'
+
+RSpec.describe Api::Admin::Search::Evaluation::ResultsController, :admin do
+  subject(:api_response) do
+    make_request
+    response
+  end
+
+  let(:json_response) { JSON.parse(api_response.body) }
+  let(:experiment) { create(:evaluation_experiment) }
+  let(:run) { create(:evaluation_run, evaluation_experiment: experiment) }
+
+  describe 'POST #create' do
+    let(:make_request) { authenticated_post api_admin_search_evaluation_results_path(format: :json), params: { data: items } }
+
+    context 'with every item valid' do
+      let(:items) do
+        [
+          { run_id: run.id, source_type: 'atar', source_id: 'A1', persona: 'original', expected_code: '8471300000', final_code: '8471300000' },
+          { run_id: run.id, source_type: 'atar', source_id: 'A2', persona: 'original', expected_code: '8471300000', final_code: '8471300000' },
+        ]
+      end
+
+      it { is_expected.to have_http_status :ok }
+      it { expect { api_response }.to change(EvaluationResult, :count).by(2) }
+
+      it 'returns one serialized result per item, in order' do
+        api_response
+        expect(json_response['data'].map { |item| item['attributes']['source_id'] }).to eq(%w[A1 A2])
+      end
+    end
+
+    context 'with a mix of valid and invalid items' do
+      let(:items) do
+        [
+          { run_id: run.id, source_type: 'atar', source_id: 'A1', persona: 'original', expected_code: '8471300000' },
+          { run_id: 999_999, source_type: 'atar', source_id: 'A2', persona: 'original', expected_code: '8471300000' },
+        ]
+      end
+
+      it { is_expected.to have_http_status :multi_status }
+      it { expect { api_response }.to change(EvaluationResult, :count).by(1) }
+
+      it 'ingests the valid item and reports an error for the invalid one, at its original index' do
+        api_response
+        expect(json_response['data'][0]).to include('id')
+        expect(json_response['data'][1]).to include('error', 'index' => 1)
+      end
+    end
+
+    context 'with every item invalid' do
+      let(:items) { [{ run_id: 999_999, source_type: 'atar', source_id: 'A1', persona: 'original', expected_code: '8471300000' }] }
+
+      it { is_expected.to have_http_status :unprocessable_content }
+      it { expect { api_response }.not_to change(EvaluationResult, :count) }
+    end
+
+    context 'when retried with the same source_id/persona under the same run' do
+      let(:item) { { run_id: run.id, source_type: 'atar', source_id: 'A1', persona: 'original', expected_code: '8471300000', final_code: 'first' } }
+
+      before { authenticated_post api_admin_search_evaluation_results_path(format: :json), params: { data: [item] } }
+
+      it 'overwrites rather than duplicates' do
+        expect {
+          authenticated_post api_admin_search_evaluation_results_path(format: :json), params: { data: [item.merge(final_code: 'second')] }
+        }.not_to change(EvaluationResult, :count)
+      end
+
+      it 'reflects the latest attributes' do
+        authenticated_post api_admin_search_evaluation_results_path(format: :json), params: { data: [item.merge(final_code: 'second')] }
+        result = EvaluationResult.first(run_id: run.id, source_id: 'A1', persona: 'original')
+        expect(result.final_code).to eq('second')
+      end
+    end
+  end
+
+  describe 'GET #index' do
+    let(:make_request) { authenticated_get api_admin_search_evaluation_results_path(format: :json), params: { run_id: run.id } }
+
+    before do
+      create(:evaluation_result, evaluation_run: run)
+      create(:evaluation_result, evaluation_run: create(:evaluation_run, evaluation_experiment: experiment))
+    end
+
+    it { is_expected.to have_http_status :success }
+    it { expect(json_response['data'].size).to eq(1) }
+  end
+
+  describe 'GET #show' do
+    let(:make_request) { authenticated_get api_admin_search_evaluation_result_path(id, format: :json) }
+
+    context 'with an existing result' do
+      let(:id) { create(:evaluation_result, evaluation_run: run).id }
+
+      it { is_expected.to have_http_status :success }
+    end
+
+    context 'with an unknown result' do
+      let(:id) { 999_999 }
+
+      it { is_expected.to have_http_status :not_found }
+    end
+  end
+end

--- a/spec/requests/api/admin/search/evaluation/runs_controller_spec.rb
+++ b/spec/requests/api/admin/search/evaluation/runs_controller_spec.rb
@@ -1,0 +1,168 @@
+require 'rails_helper'
+
+RSpec.describe Api::Admin::Search::Evaluation::RunsController, :admin do
+  subject(:api_response) do
+    make_request
+    response
+  end
+
+  let(:json_response) { JSON.parse(api_response.body) }
+  let(:experiment) { create(:evaluation_experiment, configuration_overrides: { 'simulator_model' => 'gpt-4o-mini' }) }
+
+  describe 'POST #create' do
+    let(:make_request) { authenticated_post api_admin_search_evaluation_runs_path(format: :json), params: params }
+
+    context 'with a valid experiment and no run-time overrides' do
+      let(:params) do
+        { data: { type: :run, attributes: { experiment_id: experiment.id, triggered_by: 'operator' } } }
+      end
+
+      it { is_expected.to have_http_status :created }
+      it { expect { api_response }.to change(EvaluationRun, :count).by(1) }
+
+      it 'resolves the effective_configuration from the experiment overrides' do
+        api_response
+        expect(json_response['data']['attributes']['effective_configuration']['simulator_model']).to eq('gpt-4o-mini')
+      end
+
+      it 'starts in queued status' do
+        api_response
+        expect(json_response['data']['attributes']['status']).to eq('queued')
+      end
+    end
+
+    context 'with run-time overrides layered on top of the experiment overrides' do
+      let(:params) do
+        {
+          data: {
+            type: :run,
+            attributes: {
+              experiment_id: experiment.id,
+              triggered_by: 'operator',
+              configuration_overrides: { 'simulator_model' => 'gpt-4o' },
+            },
+          },
+        }
+      end
+
+      it 'applies the run-time override' do
+        api_response
+        expect(json_response['data']['attributes']['effective_configuration']['simulator_model']).to eq('gpt-4o')
+      end
+    end
+
+    context 'with a nonexistent experiment_id' do
+      let(:params) { { data: { type: :run, attributes: { experiment_id: 999_999, triggered_by: 'operator' } } } }
+
+      it { is_expected.to have_http_status :not_found }
+      it { expect { api_response }.not_to change(EvaluationRun, :count) }
+    end
+
+    context 'with a disallowed run-time override' do
+      let(:params) do
+        {
+          data: {
+            type: :run,
+            attributes: {
+              experiment_id: experiment.id,
+              triggered_by: 'operator',
+              configuration_overrides: { 'use_kg_context' => true },
+            },
+          },
+        }
+      end
+
+      it { is_expected.to have_http_status :unprocessable_content }
+      it { expect(json_response['error']).to include('use_kg_context') }
+      it { expect { api_response }.not_to change(EvaluationRun, :count) }
+    end
+  end
+
+  describe 'GET #index' do
+    let(:make_request) { authenticated_get api_admin_search_evaluation_runs_path(format: :json), params: filters }
+    let(:filters) { {} }
+
+    context 'when filtering by experiment_id' do
+      let(:other_experiment) { create(:evaluation_experiment) }
+      let(:filters) { { experiment_id: experiment.id } }
+
+      before do
+        create(:evaluation_run, evaluation_experiment: experiment)
+        create(:evaluation_run, evaluation_experiment: other_experiment)
+      end
+
+      it { is_expected.to have_http_status :success }
+      it { expect(json_response['data'].size).to eq(1) }
+    end
+
+    context 'when filtering by status' do
+      let(:filters) { { status: 'completed' } }
+
+      before do
+        create(:evaluation_run, evaluation_experiment: experiment, status: 'queued')
+        create(:evaluation_run, evaluation_experiment: experiment, status: 'completed')
+      end
+
+      it { expect(json_response['data'].size).to eq(1) }
+    end
+  end
+
+  describe 'GET #show' do
+    let(:run) { create(:evaluation_run, evaluation_experiment: experiment) }
+    let(:make_request) { authenticated_get api_admin_search_evaluation_run_path(id, format: :json) }
+
+    context 'with an existing run' do
+      let(:id) { run.id }
+
+      it { is_expected.to have_http_status :success }
+    end
+
+    context 'with an unknown run' do
+      let(:id) { 999_999 }
+
+      it { is_expected.to have_http_status :not_found }
+    end
+  end
+
+  describe 'PATCH #update' do
+    let(:run) { create(:evaluation_run, evaluation_experiment: experiment, status: 'running') }
+    let(:make_request) { authenticated_patch api_admin_search_evaluation_run_path(run.id, format: :json), params: params }
+
+    context 'when moving into a terminal status' do
+      let(:params) { { data: { type: :run, attributes: { status: 'completed' } } } }
+
+      before { create(:evaluation_result, evaluation_run: run) }
+
+      it { is_expected.to have_http_status :success }
+
+      it 'reconciles aggregates from the run results' do
+        api_response
+        expect(run.reload.result_count).to eq(1)
+      end
+    end
+
+    context 'when moving from queued to running' do
+      let(:run) { create(:evaluation_run, evaluation_experiment: experiment, status: 'queued') }
+      let(:params) { { data: { type: :run, attributes: { status: 'running' } } } }
+
+      before { create(:evaluation_result, evaluation_run: run) }
+
+      it 'does not reconcile aggregates' do
+        api_response
+        expect(run.reload.result_count).to eq(0)
+      end
+    end
+
+    context 'with an invalid status' do
+      let(:params) { { data: { type: :run, attributes: { status: 'bogus' } } } }
+
+      it { is_expected.to have_http_status :unprocessable_content }
+    end
+
+    context 'with an unknown run' do
+      let(:make_request) { authenticated_patch api_admin_search_evaluation_run_path(999_999, format: :json), params: { data: { type: :run, attributes: { status: 'completed' } } } }
+
+      it { is_expected.to have_http_status :not_found }
+    end
+  end
+end


### PR DESCRIPTION
## What:

This PR adds the first slice of admin-facing HTTP APIs for the search evaluation feature. AI-1066 (already merged) added the database tables and Sequel models for evaluation experiments, runs, and results — this PR adds the controllers, serializers, and routes that let the admin app actually create and manage them over HTTP.

I've added:

- **`Api::Admin::Search::Evaluation::ExperimentsController`** — index/show/create/update for experiments (a named, reusable set of search configuration overrides)
- **`Api::Admin::Search::Evaluation::RunsController`** — index/show/create/update for runs. `create` kicks off a run via `EvaluationRun.start!`, which merges the experiment's overrides with any run-time overrides and validates them against an allowlist. `update` triggers aggregate reconciliation (result counts, costs, latency) when a run moves into a terminal status (`completed`, `partially_failed`, `failed`, `cancelled`)
- **`Api::Admin::Search::Evaluation::ResultsController`** — bulk `create` for ingesting individual search results against a run, idempotent on `(run_id, source_id, persona)` so re-running the same ingest is safe. Returns per-item success/failure so a partial batch failure doesn't sink the whole request
- Matching JSON:API serializers for all three resources
- A `rescue_from` in `Api::ApiController` mapping `EvaluationConfiguration::OverrideValidationError` (raised when a caller tries to override a search parameter that isn't on the allowlist) to a 422 response, consistent with the other generic error handling already in that controller
- Routes added under `Api::Admin::Search::Evaluation`, following the same nested-module pattern already used for `Api::Admin::GreenLanes`

New request specs cover all three controllers (66 examples).

## Why:

This is part of AI-1063/AI-1065 (search evaluation tooling), which lets us run repeatable experiments against different search configurations and compare results. These APIs are the CRUD layer the admin app will use to define experiments, start runs, and record results.

A couple of decisions worth calling out:

- **Namespace**: these live under `Api::Admin::Search::Evaluation`, not `Api::Internal` as originally sketched in the design doc. `Api::Admin` already has no application-level auth (same as `Api::Internal` would have had), and putting this alongside the existing `Api::Admin::GreenLanes` module keeps admin-only, non-public API surface area in one consistent place rather than spreading it across two namespaces.
- **Result ingestion is bulk and idempotent**: the eval tooling will be posting results as an experiment run progresses, potentially retrying on failure, so `EvaluationResult.ingest!` upserts on `(run_id, source_id, persona)` rather than erroring on duplicates.
- **Scope**: this PR is Tasks 1-3 of an 11-task plan. It deliberately stops here — the next slice (AI-1065b) adds a real `BaselineProvider` and a configuration-preview endpoint, and the slice after that (AI-1065c) is contingent on a still-open architecture question about whether the eval tooling or this backend owns the run-orchestration loop. None of that affects this PR; these are self-contained CRUD endpoints over already-merged persistence.

## Ticket:

[AI-1065](https://transformuk.atlassian.net/browse/AI-1065)

## Risk:
**Risk level:** 🟢

**Reason for rating:** Purely additive — new routes, new controllers, new serializers, no changes to any existing endpoint's behaviour. No new authentication is introduced (matches the existing `Api::Admin` posture). Full request spec coverage (66 examples, all green) and rubocop clean.

## Have you?

- [ ] Added documentation for new APIs
- [ ] Added new environment variables with correct values to all apps in all spaces

## Deployment risks

- None