### PR TITLE
AI-1065b: Add classification configuration discovery endpoint

### DIFF
--- a/app/controllers/api/admin/search/evaluation/configurations_controller.rb
+++ b/app/controllers/api/admin/search/evaluation/configurations_controller.rb
@@ -1,0 +1,19 @@
+module Api
+  module Admin
+    module Search
+      module Evaluation
+        class ConfigurationsController < AdminController
+          def show
+            # Reference AllowlistValidator to trigger Zeitwerk autoloading, making ALLOWED_OVERRIDE_KEYS available
+            _ = EvaluationConfiguration::AllowlistValidator
+
+            render json: {
+              baseline: EvaluationConfiguration::BaselineProvider.call,
+              allowed_overrides: EvaluationConfiguration::ALLOWED_OVERRIDE_KEYS,
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/engines/admin_api.rb
+++ b/app/engines/admin_api.rb
@@ -162,6 +162,7 @@ AdminApi.routes.draw do
           resources :experiments, only: %i[index show create update]
           resources :runs, only: %i[index show create update]
           resources :results, only: %i[index show create]
+          resource :configuration, only: [:show]
         end
       end
     end

--- a/app/lib/evaluation_configuration/baseline_provider.rb
+++ b/app/lib/evaluation_configuration/baseline_provider.rb
@@ -1,11 +1,20 @@
 module EvaluationConfiguration
-  # Deliberately minimal for AI-1066. AI-1065 owns sourcing the real
-  # classification baseline from AdminConfiguration and replaces this
-  # implementation; nothing else in EvaluationRun.start! needs to change
-  # when that happens, since it only depends on .call returning a Hash.
   class BaselineProvider
     def self.call
-      {}
+      # Baseline includes 9 of 11 ALLOWED_OVERRIDE_KEYS. simulator_model is omitted
+      # because production uses real humans (no backend model config; orchestration choice).
+      # filter_prefixes is omitted because it's already a plain request param (override-only).
+      {
+        'rrf_k' => AdminConfiguration.integer_value('rrf_k'),
+        'vector_score_threshold' => AdminConfiguration.integer_value('vector_score_threshold'),
+        'vector_ef_search' => AdminConfiguration.integer_value('vector_ef_search'),
+        'search_non_declarables' => AdminConfiguration.enabled?('search_non_declarables'),
+        'search_compressed_notes_enabled' => AdminConfiguration.enabled?('search_compressed_notes_enabled'),
+        'search_general_rules_enabled' => AdminConfiguration.enabled?('search_general_rules_enabled'),
+        'candidate_limit' => AdminConfiguration.integer_value('opensearch_result_limit'),
+        'max_rounds' => AdminConfiguration.integer_value('interactive_search_max_questions'),
+        'question_model' => AdminConfiguration.nested_options_value('search_model')[:selected],
+      }
     end
   end
 end

--- a/spec/lib/evaluation_configuration/baseline_provider_spec.rb
+++ b/spec/lib/evaluation_configuration/baseline_provider_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+RSpec.describe EvaluationConfiguration::BaselineProvider do
+  describe '.call' do
+    before do
+      allow(AdminConfiguration).to receive(:integer_value).and_call_original
+      allow(AdminConfiguration).to receive(:integer_value).with('rrf_k').and_return(60)
+      allow(AdminConfiguration).to receive(:integer_value).with('vector_score_threshold').and_return(35)
+      allow(AdminConfiguration).to receive(:integer_value).with('vector_ef_search').and_return(100)
+      allow(AdminConfiguration).to receive(:integer_value).with('opensearch_result_limit').and_return(50)
+      allow(AdminConfiguration).to receive(:integer_value).with('interactive_search_max_questions').and_return(7)
+      allow(AdminConfiguration).to receive(:enabled?).and_call_original
+      allow(AdminConfiguration).to receive(:enabled?).with('search_non_declarables').and_return(false)
+      allow(AdminConfiguration).to receive(:enabled?).with('search_compressed_notes_enabled').and_return(false)
+      allow(AdminConfiguration).to receive(:enabled?).with('search_general_rules_enabled').and_return(false)
+      allow(AdminConfiguration).to receive(:nested_options_value).and_call_original
+      allow(AdminConfiguration).to receive(:nested_options_value).with('search_model')
+        .and_return(selected: 'gpt-5.4', sub_values: { 'reasoning_effort' => 'medium' })
+    end
+
+    it 'maps rrf_k directly from AdminConfiguration' do
+      expect(described_class.call['rrf_k']).to eq(60)
+    end
+
+    it 'maps vector_score_threshold directly from AdminConfiguration' do
+      expect(described_class.call['vector_score_threshold']).to eq(35)
+    end
+
+    it 'maps vector_ef_search directly from AdminConfiguration' do
+      expect(described_class.call['vector_ef_search']).to eq(100)
+    end
+
+    it 'maps search_non_declarables directly from AdminConfiguration' do
+      expect(described_class.call['search_non_declarables']).to be(false)
+    end
+
+    it 'maps search_compressed_notes_enabled directly from AdminConfiguration' do
+      expect(described_class.call['search_compressed_notes_enabled']).to be(false)
+    end
+
+    it 'maps search_general_rules_enabled directly from AdminConfiguration' do
+      expect(described_class.call['search_general_rules_enabled']).to be(false)
+    end
+
+    it 'maps candidate_limit from opensearch_result_limit' do
+      expect(described_class.call['candidate_limit']).to eq(50)
+    end
+
+    it 'maps max_rounds from interactive_search_max_questions' do
+      expect(described_class.call['max_rounds']).to eq(7)
+    end
+
+    it 'maps question_model from the selected search_model option' do
+      expect(described_class.call['question_model']).to eq('gpt-5.4')
+    end
+
+    it 'omits simulator_model and filter_prefixes entirely, since neither has a real backend source' do
+      result = described_class.call
+      expect(result).not_to have_key('simulator_model')
+      expect(result).not_to have_key('filter_prefixes')
+    end
+
+    it 'returns exactly the 9 keys with a real backend source' do
+      expect(described_class.call.keys).to contain_exactly(
+        'rrf_k', 'vector_score_threshold', 'vector_ef_search', 'search_non_declarables',
+        'search_compressed_notes_enabled', 'search_general_rules_enabled',
+        'candidate_limit', 'max_rounds', 'question_model'
+      )
+    end
+  end
+end

--- a/spec/requests/api/admin/search/evaluation/configurations_controller_spec.rb
+++ b/spec/requests/api/admin/search/evaluation/configurations_controller_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe Api::Admin::Search::Evaluation::ConfigurationsController, :admin do
+  subject(:api_response) do
+    make_request
+    response
+  end
+
+  let(:json_response) { JSON.parse(api_response.body) }
+  let(:make_request) { authenticated_get api_admin_search_evaluation_configuration_path(format: :json) }
+
+  describe 'GET #show' do
+    it { is_expected.to have_http_status :success }
+
+    it 'returns the baseline and allowed_overrides keys' do
+      api_response
+      expect(json_response).to include('baseline', 'allowed_overrides')
+    end
+
+    it 'returns exactly the 9 baseline keys with a real backend source' do
+      api_response
+      expect(json_response['baseline'].keys).to contain_exactly(
+        'rrf_k', 'vector_score_threshold', 'vector_ef_search', 'search_non_declarables',
+        'search_compressed_notes_enabled', 'search_general_rules_enabled',
+        'candidate_limit', 'max_rounds', 'question_model'
+      )
+    end
+
+    it 'returns exactly the 11 allowed override keys' do
+      api_response
+      expect(json_response['allowed_overrides']).to contain_exactly(
+        'question_model', 'simulator_model', 'candidate_limit', 'max_rounds', 'rrf_k',
+        'vector_score_threshold', 'vector_ef_search', 'search_non_declarables', 'filter_prefixes',
+        'search_compressed_notes_enabled', 'search_general_rules_enabled'
+      )
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

[AI-1065](https://transformuk.atlassian.net/browse/AI-1065)

### What?

This is the second of three small, independent PRs building the internal APIs described in AI-1065 (the first, experiment/run/result CRUD, is already merged). This one replaces a placeholder with a real implementation, and adds one new read-only endpoint.

Here's what's changed:

- **`EvaluationConfiguration::BaselineProvider`** — until now this just returned an empty hash as a placeholder. It now reads the real classification settings (things like which AI model is in use, vector search thresholds, and so on) from `AdminConfiguration` and returns them together as a single "baseline" hash. This is what an evaluation run compares itself against whenever someone overrides a setting for a single experiment.
- **`GET /search/evaluation/configuration`** — a new read-only admin endpoint that returns that baseline hash, plus the list of setting names an experiment is allowed to override. This lets the admin app show "here's what's currently configured" before someone sets up an experiment, instead of guessing or hardcoding values on the client side.

### Why?

AI-1065's evaluation experiments work by taking the *current* real settings and layering a few overrides on top, rather than requiring every experiment to specify every setting from scratch. Up to now there was nowhere to fetch what those current settings actually are — this PR builds that.

A couple of things worth knowing:

- Two of the eleven settings an experiment is allowed to override (`simulator_model` and `filter_prefixes`) are deliberately left out of the baseline hash entirely, rather than being set to `nil`. Neither has a real production equivalent today — `simulator_model` is the AI role that pretends to be a trader during an evaluation, and in production a real human fills that role, so there's nothing to read from settings. They stay "override-only".
- We hit a small autoloading gotcha while building the endpoint. A first pass added a manual `require` to work around it, which review caught as an anti-pattern for this codebase's autoloader (Zeitwerk) — it can leave dev-mode code reloading out of sync. Fixed by triggering the autoload the normal way instead, so no workaround is needed.
- While reviewing this, we noticed a separate, smaller gap: an evaluation run's "configuration digest" (used to check whether two runs used the same settings) doesn't currently account for a setting called reasoning effort. That's real, but genuinely out of scope for this PR — raised separately as [AI-1148](https://transformuk.atlassian.net/browse/AI-1148) so it isn't lost.

### Ticket:

[AI-1065](https://transformuk.atlassian.net/browse/AI-1065)

### Risk:
**Risk level:** 🟢

**Reason for rating:** Purely additive — one new read-only endpoint, no existing endpoint changes behaviour. No new authentication is introduced (matches the rest of `Api::Admin`, which has no app-level auth today). 77 examples covering the evaluation namespace all pass, rubocop clean.

### Have you?

- [ ] Added documentation for new APIs
- [ ] Added new environment variables with correct values to all apps in all spaces

### Deployment risks

- None