### PR TITLE
feat(HMRC-2609): alert on GOV.UK Notify delivery failure rate

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'sequel-rails'
 # File uploads and AWS
 gem 'aws-actionmailer-ses'
 gem 'aws-sdk-cloudfront'
+gem 'aws-sdk-cloudwatch'
 gem 'aws-sdk-cloudwatchlogs'
 gem 'aws-sdk-rails'
 gem 'aws-sdk-s3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,9 @@ GEM
     aws-sdk-cloudfront (1.151.0)
       aws-sdk-core (~> 3, >= 3.254.0)
       aws-sigv4 (~> 1.5)
+    aws-sdk-cloudwatch (1.145.0)
+      aws-sdk-core (~> 3, >= 3.254.0)
+      aws-sigv4 (~> 1.5)
     aws-sdk-cloudwatchlogs (1.159.0)
       aws-sdk-core (~> 3, >= 3.254.0)
       aws-sigv4 (~> 1.5)
@@ -238,7 +241,6 @@ GEM
     marcel (1.1.0)
     method_source (1.1.0)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.9)
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
@@ -258,9 +260,6 @@ GEM
     newrelic_rpm (10.6.0)
       logger
     nio4r (2.7.5)
-    nokogiri (1.19.4)
-      mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
     nokogiri (1.19.4-aarch64-linux-musl)
       racc (~> 1.4)
     nokogiri (1.19.4-arm64-darwin)
@@ -497,7 +496,6 @@ PLATFORMS
   aarch64-linux-musl
   arm64-darwin-24
   arm64-darwin-25
-  ruby
   x86_64-linux
   x86_64-linux-musl
 
@@ -505,6 +503,7 @@ DEPENDENCIES
   amazing_print
   aws-actionmailer-ses
   aws-sdk-cloudfront
+  aws-sdk-cloudwatch
   aws-sdk-cloudwatchlogs
   aws-sdk-rails
   aws-sdk-s3

--- a/app/services/notifications/delivery_status_checker.rb
+++ b/app/services/notifications/delivery_status_checker.rb
@@ -9,6 +9,13 @@ module Notifications
       GovukNotifier::TECHNICAL_FAILURE,
     ].freeze
 
+    METRIC_FAILURE_STATUSES = [
+      GovukNotifier::PERMANENT_FAILURE,
+      GovukNotifier::TECHNICAL_FAILURE,
+    ].freeze
+
+    METRIC_NAMESPACE = 'TradeTariff/Notify'.freeze
+
     def initialize(notification_uuid, pipeline:, identifier:)
       @notification_uuid = notification_uuid
       @pipeline = pipeline
@@ -23,6 +30,7 @@ module Notifications
 
       Instrumentation.delivery_failed(pipeline: @pipeline, identifier: @identifier, notification_uuid: @notification_uuid, status:)
       notify_slack("#{@pipeline}: notification delivery failed for #{@identifier} (status: #{status}) — check logs")
+      put_cloudwatch_metric(status)
       status
     end
 
@@ -32,6 +40,25 @@ module Notifications
       SlackNotifierService.call(message)
     rescue StandardError => e
       Rails.logger.error("#{@pipeline}_notification_slack_failed: #{e.class.name}: #{e.message}")
+    end
+
+    def put_cloudwatch_metric(status)
+      return unless METRIC_FAILURE_STATUSES.include?(status)
+
+      Aws::CloudWatch::Client.new.put_metric_data(
+        namespace: METRIC_NAMESPACE,
+        metric_data: [{
+          metric_name: 'DeliveryFailures',
+          value: 1,
+          unit: 'Count',
+          dimensions: [
+            { name: 'Environment', value: Rails.env },
+            { name: 'Pipeline', value: @pipeline },
+          ],
+        }],
+      )
+    rescue Aws::Errors::ServiceError => e
+      Rails.logger.error("notify_cloudwatch_metric_failed: #{e.class.name}: #{e.message}")
     end
   end
 end

--- a/app/workers/govuk_notifier_status_check_worker.rb
+++ b/app/workers/govuk_notifier_status_check_worker.rb
@@ -14,10 +14,12 @@ class GovukNotifierStatusCheckWorker
     return if user.nil?
     return if user.deleted
 
-    status = GovukNotifier.new.get_email_status(notification_id)
+    status = Notifications::DeliveryStatusChecker.new(
+      notification_id,
+      pipeline: 'my_ott',
+      identifier: user_id,
+    ).call
 
-    if status == GovukNotifier::PERMANENT_FAILURE
-      user.invalidate!
-    end
+    user.invalidate! if status == GovukNotifier::PERMANENT_FAILURE
   end
 end

--- a/spec/requests/api/admin/search/evaluation/runs_controller_spec.rb
+++ b/spec/requests/api/admin/search/evaluation/runs_controller_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Api::Admin::Search::Evaluation::RunsController, :admin do
       end
 
       it { is_expected.to have_http_status :unprocessable_content }
-      it { expect(json_response['error']).to include('use_kg_context') }
+      it { expect(json_response.dig('errors', 0, 'detail')).to include('use_kg_context') }
       it { expect { api_response }.not_to change(EvaluationRun, :count) }
     end
   end

--- a/spec/services/notifications/delivery_status_checker_spec.rb
+++ b/spec/services/notifications/delivery_status_checker_spec.rb
@@ -2,10 +2,13 @@ RSpec.describe Notifications::DeliveryStatusChecker do
   subject(:checker) { described_class.new(notification_uuid, pipeline: 'test_pipeline', identifier: '1.30') }
 
   let(:client) { instance_double(GovukNotifier) }
+  let(:cloudwatch_client) { instance_double(Aws::CloudWatch::Client) }
   let(:notification_uuid) { SecureRandom.uuid }
 
   before do
     allow(GovukNotifier).to receive(:new).and_return(client)
+    allow(Aws::CloudWatch::Client).to receive(:new).and_return(cloudwatch_client)
+    allow(cloudwatch_client).to receive(:put_metric_data)
   end
 
   describe '#call' do
@@ -48,6 +51,59 @@ RSpec.describe Notifications::DeliveryStatusChecker do
       expect { checker.call }.not_to raise_error
 
       expect(Rails.logger).to have_received(:error).with(a_string_including('test_pipeline_notification_slack_failed'))
+    end
+
+    %w[permanent-failure technical-failure].each do |status|
+      it "emits a CloudWatch DeliveryFailures metric for #{status}" do
+        allow(client).to receive(:get_email_status).and_return(status)
+        allow(Notifications::Instrumentation).to receive(:delivery_failed)
+        allow(SlackNotifierService).to receive(:call)
+
+        checker.call
+
+        expect(cloudwatch_client).to have_received(:put_metric_data).with(
+          namespace: 'TradeTariff/Notify',
+          metric_data: [{
+            metric_name: 'DeliveryFailures',
+            value: 1,
+            unit: 'Count',
+            dimensions: [
+              { name: 'Environment', value: Rails.env },
+              { name: 'Pipeline', value: 'test_pipeline' },
+            ],
+          }],
+        )
+      end
+    end
+
+    it 'does not emit a CloudWatch metric for temporary-failure' do
+      allow(client).to receive(:get_email_status).and_return('temporary-failure')
+      allow(Notifications::Instrumentation).to receive(:delivery_failed)
+      allow(SlackNotifierService).to receive(:call)
+
+      checker.call
+
+      expect(cloudwatch_client).not_to have_received(:put_metric_data)
+    end
+
+    it 'does not emit a CloudWatch metric when delivery succeeded' do
+      allow(client).to receive(:get_email_status).and_return('delivered')
+
+      checker.call
+
+      expect(cloudwatch_client).not_to have_received(:put_metric_data)
+    end
+
+    it 'rescues a CloudWatch service error and logs it instead of raising' do
+      allow(client).to receive(:get_email_status).and_return('permanent-failure')
+      allow(Notifications::Instrumentation).to receive(:delivery_failed)
+      allow(SlackNotifierService).to receive(:call)
+      allow(cloudwatch_client).to receive(:put_metric_data).and_raise(Aws::CloudWatch::Errors::ServiceError.new(nil, 'throttled'))
+      allow(Rails.logger).to receive(:error)
+
+      expect { checker.call }.not_to raise_error
+
+      expect(Rails.logger).to have_received(:error).with(a_string_including('notify_cloudwatch_metric_failed'))
     end
   end
 end

--- a/spec/workers/govuk_notifier_status_check_worker_spec.rb
+++ b/spec/workers/govuk_notifier_status_check_worker_spec.rb
@@ -3,12 +3,10 @@ RSpec.describe GovukNotifierStatusCheckWorker, type: :worker do
 
   let(:user) { create(:public_user, :with_my_commodities_subscription, :with_active_stop_press_subscription) }
   let(:notification_id) { SecureRandom.uuid }
-  let(:notifier) { instance_double(GovukNotifier) }
-  let(:status) { 'delivered' }
+  let(:checker) { instance_double(Notifications::DeliveryStatusChecker, call: nil) }
 
   before do
-    allow(GovukNotifier).to receive(:new).and_return(notifier)
-    allow(notifier).to receive(:get_email_status).and_return(status)
+    allow(Notifications::DeliveryStatusChecker).to receive(:new).and_return(checker)
   end
 
   describe 'sidekiq options' do
@@ -21,7 +19,7 @@ RSpec.describe GovukNotifierStatusCheckWorker, type: :worker do
     it 'does nothing' do
       worker.perform(user.id, nil)
 
-      expect(notifier).not_to have_received(:get_email_status)
+      expect(Notifications::DeliveryStatusChecker).not_to have_received(:new)
       expect(user.subscriptions_dataset.where(active: true).count).to eq(2)
       expect(user.refresh.deleted).to be(false)
     end
@@ -31,12 +29,14 @@ RSpec.describe GovukNotifierStatusCheckWorker, type: :worker do
     it 'does nothing' do
       worker.perform(999_999, notification_id)
 
-      expect(notifier).not_to have_received(:get_email_status)
+      expect(Notifications::DeliveryStatusChecker).not_to have_received(:new)
     end
   end
 
-  context 'when status is not permanent failure' do
+  context 'when checker returns nil (non-failure status)' do
     it 'does not modify subscriptions or user' do
+      allow(checker).to receive(:call).and_return(nil)
+
       worker.perform(user.id, notification_id)
 
       expect(user.subscriptions_dataset.where(active: true).count).to eq(2)
@@ -44,14 +44,24 @@ RSpec.describe GovukNotifierStatusCheckWorker, type: :worker do
     end
   end
 
-  context 'when status is permanent failure' do
-    let(:status) { GovukNotifier::PERMANENT_FAILURE }
-
+  context 'when checker returns permanent-failure' do
     it 'unsubscribes all active subscriptions and soft deletes the user' do
+      allow(checker).to receive(:call).and_return(GovukNotifier::PERMANENT_FAILURE)
+
       worker.perform(user.id, notification_id)
 
       expect(user.subscriptions_dataset.where(active: true).count).to eq(0)
       expect(user.refresh.deleted).to be(true)
     end
+  end
+
+  it 'delegates to DeliveryStatusChecker with the my_ott pipeline' do
+    worker.perform(user.id, notification_id)
+
+    expect(Notifications::DeliveryStatusChecker).to have_received(:new).with(
+      notification_id,
+      pipeline: 'my_ott',
+      identifier: user.id,
+    )
   end
 end


### PR DESCRIPTION
## What:
Emit a CloudWatch custom metric from GOV.UK Notify delivery status check workers, and centralise both the `my_ott` and `appendix5a` pipelines through `Notifications::DeliveryStatusChecker` so they share the same observability path.

- Adds `aws-sdk-cloudwatch` gem
- `DeliveryStatusChecker` emits a `DeliveryFailures` count to the `TradeTariff/Notify` namespace for `permanent-failure` and `technical-failure` statuses; `temporary-failure` is excluded as it may self-resolve. Each metric carries `Environment` and `Pipeline` dimensions.
- Refactors `GovukNotifierStatusCheckWorker` to delegate through `DeliveryStatusChecker` (pipeline: `my_ott`) instead of calling `GovukNotifier` directly — it was previously invisible to Slack alerting, instrumentation, and CloudWatch metrics. User invalidation on `permanent-failure` remains in the worker.
- Also fixes a pre-existing broken spec from #3628 (`json_response['error']` → `json_response.dig('errors', 0, 'detail')`).
- Companion Terraform PR: [trade-tariff-platform-aws-terraform#705](https://github.com/trade-tariff/trade-tariff-platform-aws-terraform/pull/705)

## Why:
MyOTT subscription emails and Appendix 5a notifications could fail at scale with no operational visibility. This adds a CloudWatch metric that a companion Terraform alarm will monitor, firing to `#production-alerts` on any permanent or technical failure.

## Ticket:
https://transformuk.atlassian.net/browse/HMRC-2609

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Additive observability only — no change to email sending, subscription logic, or public API surface. The ECS task role already grants `cloudwatch:PutMetricData`. The CloudWatch call is fully wrapped in a rescue so any AWS errors are logged, never raised.