### PR TITLE
feat(HMRC-2608): add Sidekiq queue-depth telemetry

### DIFF
--- a/app/workers/sidekiq_queue_metrics_worker.rb
+++ b/app/workers/sidekiq_queue_metrics_worker.rb
@@ -1,0 +1,35 @@
+class SidekiqQueueMetricsWorker
+  include Sidekiq::Worker
+
+  # Metric-only job; reruns every 5 minutes via scheduler — do not retry-storm.
+  sidekiq_options retry: false
+
+  NAMESPACE = 'TradeTariff/Sidekiq'.freeze
+
+  def self.client
+    @client ||= Aws::CloudWatch::Client.new
+  end
+
+  def perform
+    metric_data = Sidekiq::Queue.all.flat_map { |queue| metrics_for(queue) }
+
+    self.class.client.put_metric_data(
+      namespace: NAMESPACE,
+      metric_data: metric_data,
+    )
+  end
+
+private
+
+  def metrics_for(queue)
+    dimensions = [
+      { name: 'Queue', value: queue.name },
+      { name: 'Environment', value: TradeTariffBackend.environment.to_s },
+    ]
+
+    [
+      { metric_name: 'QueueDepth', value: queue.size, unit: 'Count', dimensions: },
+      { metric_name: 'QueueLatency', value: queue.latency, unit: 'Seconds', dimensions: },
+    ]
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -105,3 +105,6 @@
       queue: within_1_day
       description: "Imports public Advance Tariff Rulings for tariff knowledge retrieval"
       enabled: <%= ENV.fetch('SERVICE', 'uk') == 'uk' %>
+    SidekiqQueueMetricsWorker:
+      cron: "*/5 * * * *"
+      description: "Emits Sidekiq queue depth and latency as CloudWatch custom metrics every 5 minutes"

--- a/spec/workers/sidekiq_queue_metrics_worker_spec.rb
+++ b/spec/workers/sidekiq_queue_metrics_worker_spec.rb
@@ -1,0 +1,77 @@
+RSpec.describe SidekiqQueueMetricsWorker, type: :worker do
+  describe 'sidekiq options' do
+    it 'does not retry metric-only jobs' do
+      expect(described_class.sidekiq_options['retry']).to be(false)
+    end
+  end
+
+  describe '#perform' do
+    subject(:perform) { described_class.new.perform }
+
+    let(:cloudwatch_client) { instance_double(Aws::CloudWatch::Client, put_metric_data: nil) }
+    let(:queue_sync) { instance_double(Sidekiq::Queue, name: 'sync', size: 3, latency: 60.0) }
+    let(:queue_default) { instance_double(Sidekiq::Queue, name: 'default', size: 15, latency: 2.5) }
+
+    before do
+      allow(described_class).to receive(:client).and_return(cloudwatch_client)
+      allow(TradeTariffBackend).to receive(:environment).and_return(ActiveSupport::StringInquirer.new('production'))
+    end
+
+    context 'when queues have jobs' do
+      before do
+        allow(Sidekiq::Queue).to receive(:all).and_return([queue_sync, queue_default])
+        perform
+      end
+
+      it 'emits a single batched put_metric_data call' do
+        expect(cloudwatch_client).to have_received(:put_metric_data).once
+      end
+
+      it 'emits QueueDepth and QueueLatency for each queue in the TradeTariff/Sidekiq namespace' do
+        expect(cloudwatch_client).to have_received(:put_metric_data).with(
+          namespace: 'TradeTariff/Sidekiq',
+          metric_data: [
+            {
+              metric_name: 'QueueDepth',
+              value: 3,
+              unit: 'Count',
+              dimensions: [{ name: 'Queue', value: 'sync' }, { name: 'Environment', value: 'production' }],
+            },
+            {
+              metric_name: 'QueueLatency',
+              value: 60.0,
+              unit: 'Seconds',
+              dimensions: [{ name: 'Queue', value: 'sync' }, { name: 'Environment', value: 'production' }],
+            },
+            {
+              metric_name: 'QueueDepth',
+              value: 15,
+              unit: 'Count',
+              dimensions: [{ name: 'Queue', value: 'default' }, { name: 'Environment', value: 'production' }],
+            },
+            {
+              metric_name: 'QueueLatency',
+              value: 2.5,
+              unit: 'Seconds',
+              dimensions: [{ name: 'Queue', value: 'default' }, { name: 'Environment', value: 'production' }],
+            },
+          ],
+        )
+      end
+    end
+
+    context 'when there are no queues' do
+      before do
+        allow(Sidekiq::Queue).to receive(:all).and_return([])
+        perform
+      end
+
+      it 'still calls put_metric_data with an empty metric_data array' do
+        expect(cloudwatch_client).to have_received(:put_metric_data).with(
+          namespace: 'TradeTariff/Sidekiq',
+          metric_data: [],
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What:
Adds `SidekiqQueueMetricsWorker`, a metric-only Sidekiq worker that runs every 5 minutes and emits `QueueDepth` (Count) and `QueueLatency` (Seconds) as CloudWatch custom metrics under the `TradeTariff/Sidekiq` namespace, with `Queue` and `Environment` dimensions.

## Why:
Sidekiq had no queue-depth or job-latency monitoring. The only signal was the death handler, which fires after all retries are exhausted — by that point a job has been failing for hours. Runaway queue growth would not be detected until it caused resource pressure.

This adds the metric stream; the CloudWatch alarms that trigger `#production-alerts` are in [the companion Terraform PR](https://github.com/trade-tariff/trade-tariff-platform-aws-terraform/pull/new/feat/HMRC-2608-sidekiq-queue-depth-telemetry).

## Ticket:
https://transformuk.atlassian.net/browse/HMRC-2608

## Risk:
**Risk level:** 🟢

**Reason for rating:** Additive-only: a new Sidekiq worker and schedule entry. The worker only calls `put_metric_data`; it has no side effects on application state, data, or user-facing behaviour. `retry: false` prevents any retry storm if CloudWatch is temporarily unavailable.