### PR TITLE
feat(HMRC-2611): scheduled job heartbeat monitoring

### DIFF
--- a/app/workers/concerns/scheduled_job_heartbeat.rb
+++ b/app/workers/concerns/scheduled_job_heartbeat.rb
@@ -1,0 +1,21 @@
+module ScheduledJobHeartbeat
+  METRIC_NAMESPACE = 'TradeTariff/ScheduledJobs'.freeze
+
+  def record_heartbeat
+    Aws::CloudWatch::Client.new.put_metric_data(
+      namespace: METRIC_NAMESPACE,
+      metric_data: [{
+        metric_name: 'JobSuccess',
+        value: 1,
+        unit: 'Count',
+        dimensions: [
+          { name: 'Job', value: self.class.name },
+          { name: 'Service', value: TradeTariffBackend.service },
+          { name: 'Environment', value: Rails.env },
+        ],
+      }],
+    )
+  rescue Aws::Errors::ServiceError => e
+    Rails.logger.error("scheduled_job_heartbeat_failed: job=#{self.class.name} #{e.class.name}: #{e.message}")
+  end
+end

--- a/app/workers/concerns/scheduled_job_heartbeat.rb
+++ b/app/workers/concerns/scheduled_job_heartbeat.rb
@@ -11,7 +11,7 @@ module ScheduledJobHeartbeat
         dimensions: [
           { name: 'Job', value: self.class.name },
           { name: 'Service', value: TradeTariffBackend.service },
-          { name: 'Environment', value: Rails.env },
+          { name: 'Environment', value: ENV.fetch('ENVIRONMENT', 'local') },
         ],
       }],
     )

--- a/app/workers/goods_nomenclature_reconciliation_worker.rb
+++ b/app/workers/goods_nomenclature_reconciliation_worker.rb
@@ -13,23 +13,27 @@
 # relabel page worker so they include fresh label data.
 class GoodsNomenclatureReconciliationWorker
   include Sidekiq::Worker
+  include ScheduledJobHeartbeat
 
   sidekiq_options queue: :default, retry: 2
 
   def perform
     affected = detect_changes
-    return if affected.empty?
 
-    chapters = affected.group_by { |_sid, _type, item_id| item_id[0, 2] }
+    unless affected.empty?
+      chapters = affected.group_by { |_sid, _type, item_id| item_id[0, 2] }
 
-    chapters.each do |chapter_code, entries|
-      sids = entries.map(&:first).uniq
-      mark_self_texts_stale(sids)
-      regenerate_self_texts(chapter_code)
+      chapters.each do |chapter_code, entries|
+        sids = entries.map(&:first).uniq
+        mark_self_texts_stale(sids)
+        regenerate_self_texts(chapter_code)
+      end
+
+      all_sids = affected.map(&:first).uniq
+      mark_labels_stale(all_sids)
     end
 
-    all_sids = affected.map(&:first).uniq
-    mark_labels_stale(all_sids)
+    record_heartbeat
   end
 
 private

--- a/app/workers/import_customs_tariff_document_worker.rb
+++ b/app/workers/import_customs_tariff_document_worker.rb
@@ -3,6 +3,7 @@ require_relative '../lib/customs_tariff_importer/logger'
 
 class ImportCustomsTariffDocumentWorker
   include Sidekiq::Worker
+  include ScheduledJobHeartbeat
 
   sidekiq_options queue: :default, retry: false, slack_alerts: false
 
@@ -26,6 +27,7 @@ class ImportCustomsTariffDocumentWorker
 
     notify_completed(results)
     notify_update_recipients(results)
+    record_heartbeat
   rescue StandardError => e
     CustomsTariffImporter::Instrumentation.import_run_failed(
       error_class: e.class.name,

--- a/app/workers/import_xi_cn_document_worker.rb
+++ b/app/workers/import_xi_cn_document_worker.rb
@@ -3,6 +3,7 @@ require_relative '../lib/xi_cn_importer/logger'
 
 class ImportXiCnDocumentWorker
   include Sidekiq::Worker
+  include ScheduledJobHeartbeat
 
   sidekiq_options queue: :default, retry: false, slack_alerts: false
 
@@ -26,6 +27,7 @@ class ImportXiCnDocumentWorker
 
     notify_completed(results)
     notify_update_recipients(results)
+    record_heartbeat
   rescue StandardError => e
     XiCnImporter::Instrumentation.import_run_failed(
       error_class: e.class.name,

--- a/app/workers/report_worker.rb
+++ b/app/workers/report_worker.rb
@@ -1,5 +1,6 @@
 class ReportWorker
   include Sidekiq::Worker
+  include ScheduledJobHeartbeat
 
   sidekiq_options retry: false
 
@@ -31,6 +32,8 @@ class ReportWorker
     schedule_differences_generation if trigger_differences_report
 
     raise failures.first[:error] if failures.any?
+
+    record_heartbeat
   end
 
 private

--- a/spec/workers/concerns/scheduled_job_heartbeat_spec.rb
+++ b/spec/workers/concerns/scheduled_job_heartbeat_spec.rb
@@ -1,0 +1,68 @@
+RSpec.describe ScheduledJobHeartbeat do
+  let(:cloudwatch_client) { instance_double(Aws::CloudWatch::Client) }
+  let(:worker_class) do
+    Class.new do
+      include ScheduledJobHeartbeat
+      def self.name = 'TestWorker'
+    end
+  end
+  let(:worker) { worker_class.new }
+
+  before do
+    allow(Aws::CloudWatch::Client).to receive(:new).and_return(cloudwatch_client)
+    allow(cloudwatch_client).to receive(:put_metric_data)
+    allow(TradeTariffBackend).to receive(:service).and_return('uk')
+  end
+
+  describe '#record_heartbeat' do
+    it 'emits a JobSuccess metric to TradeTariff/ScheduledJobs' do
+      worker.record_heartbeat
+
+      expect(cloudwatch_client).to have_received(:put_metric_data).with(
+        namespace: 'TradeTariff/ScheduledJobs',
+        metric_data: [{
+          metric_name: 'JobSuccess',
+          value: 1,
+          unit: 'Count',
+          dimensions: [
+            { name: 'Job', value: 'TestWorker' },
+            { name: 'Service', value: 'uk' },
+            { name: 'Environment', value: Rails.env },
+          ],
+        }],
+      )
+    end
+
+    it 'uses the current service in the Service dimension' do
+      allow(TradeTariffBackend).to receive(:service).and_return('xi')
+
+      worker.record_heartbeat
+
+      expect(cloudwatch_client).to have_received(:put_metric_data).with(
+        hash_including(
+          metric_data: [hash_including(dimensions: include({ name: 'Service', value: 'xi' }))],
+        ),
+      )
+    end
+
+    it 'does not raise when CloudWatch returns a service error' do
+      allow(cloudwatch_client).to receive(:put_metric_data)
+        .and_raise(Aws::CloudWatch::Errors::ServiceError.new(nil, 'throttled'))
+      allow(Rails.logger).to receive(:error)
+
+      expect { worker.record_heartbeat }.not_to raise_error
+    end
+
+    it 'logs the job name and error detail when CloudWatch raises a service error' do
+      allow(cloudwatch_client).to receive(:put_metric_data)
+        .and_raise(Aws::CloudWatch::Errors::ServiceError.new(nil, 'throttled'))
+      allow(Rails.logger).to receive(:error)
+
+      worker.record_heartbeat
+
+      expect(Rails.logger).to have_received(:error).with(
+        a_string_including('scheduled_job_heartbeat_failed', 'TestWorker'),
+      )
+    end
+  end
+end

--- a/spec/workers/concerns/scheduled_job_heartbeat_spec.rb
+++ b/spec/workers/concerns/scheduled_job_heartbeat_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe ScheduledJobHeartbeat do
           dimensions: [
             { name: 'Job', value: 'TestWorker' },
             { name: 'Service', value: 'uk' },
-            { name: 'Environment', value: Rails.env },
+            { name: 'Environment', value: ENV.fetch('ENVIRONMENT', 'local') },
           ],
         }],
       )

--- a/spec/workers/goods_nomenclature_reconciliation_worker_spec.rb
+++ b/spec/workers/goods_nomenclature_reconciliation_worker_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe GoodsNomenclatureReconciliationWorker, type: :worker do
   describe '#perform' do
     let(:embedding_service) { instance_double(EmbeddingService) }
+    let(:cloudwatch_client) { instance_double(Aws::CloudWatch::Client) }
 
     before do
       allow(GenerateSelfText::OtherSelfTextBuilder).to receive(:call)
@@ -8,6 +9,8 @@ RSpec.describe GoodsNomenclatureReconciliationWorker, type: :worker do
       allow(RelabelGoodsNomenclatureWorker).to receive(:perform_async)
       allow(EmbeddingService).to receive(:new).and_return(embedding_service)
       allow(embedding_service).to receive(:embed_batch) { |texts| texts.map { Array.new(1536, 0.0) } }
+      allow(Aws::CloudWatch::Client).to receive(:new).and_return(cloudwatch_client)
+      allow(cloudwatch_client).to receive(:put_metric_data)
     end
 
     context 'when there are no changes' do
@@ -15,6 +18,14 @@ RSpec.describe GoodsNomenclatureReconciliationWorker, type: :worker do
         described_class.new.perform
 
         expect(GenerateSelfText::OtherSelfTextBuilder).not_to have_received(:call)
+      end
+
+      it 'still emits a heartbeat' do
+        described_class.new.perform
+
+        expect(cloudwatch_client).to have_received(:put_metric_data).with(
+          hash_including(namespace: 'TradeTariff/ScheduledJobs'),
+        )
       end
     end
 
@@ -383,6 +394,20 @@ RSpec.describe GoodsNomenclatureReconciliationWorker, type: :worker do
           .first
 
         expect(self_text.stale).to be true
+      end
+    end
+
+    describe 'heartbeat' do
+      it 'emits a JobSuccess heartbeat when changes are detected' do
+        create(:goods_nomenclature,
+               goods_nomenclature_item_id: '1500000000',
+               validity_start_date: Date.current)
+
+        described_class.new.perform
+
+        expect(cloudwatch_client).to have_received(:put_metric_data).with(
+          hash_including(namespace: 'TradeTariff/ScheduledJobs'),
+        )
       end
     end
   end

--- a/spec/workers/import_customs_tariff_document_worker_spec.rb
+++ b/spec/workers/import_customs_tariff_document_worker_spec.rb
@@ -275,7 +275,7 @@ RSpec.describe ImportCustomsTariffDocumentWorker, type: :worker do
           dimensions: [
             { name: 'Job', value: 'ImportCustomsTariffDocumentWorker' },
             { name: 'Service', value: TradeTariffBackend.service },
-            { name: 'Environment', value: Rails.env },
+            { name: 'Environment', value: ENV.fetch('ENVIRONMENT', 'local') },
           ],
         }],
       )

--- a/spec/workers/import_customs_tariff_document_worker_spec.rb
+++ b/spec/workers/import_customs_tariff_document_worker_spec.rb
@@ -2,6 +2,7 @@ RSpec.describe ImportCustomsTariffDocumentWorker, type: :worker do
   subject(:perform) { described_class.new.perform }
 
   let(:importer_double) { instance_double(CustomsTariffImporter::Importer) }
+  let(:cloudwatch_client) { instance_double(Aws::CloudWatch::Client) }
 
   before do
     allow(TradeTariffBackend).to receive(:uk?).and_return(true)
@@ -11,6 +12,8 @@ RSpec.describe ImportCustomsTariffDocumentWorker, type: :worker do
     allow(CustomsTariffImporter::Instrumentation).to receive(:import_run_completed)
     allow(CustomsTariffImporter::Instrumentation).to receive(:import_run_failed)
     allow(CustomsTariffUpdateNotifierService).to receive(:new).and_return(instance_double(CustomsTariffUpdateNotifierService, call: nil))
+    allow(Aws::CloudWatch::Client).to receive(:new).and_return(cloudwatch_client)
+    allow(cloudwatch_client).to receive(:put_metric_data)
   end
 
   context 'when SERVICE is not uk' do
@@ -19,6 +22,11 @@ RSpec.describe ImportCustomsTariffDocumentWorker, type: :worker do
     it 'is a no-op' do
       perform
       expect(CustomsTariffImporter::Importer).not_to have_received(:new)
+    end
+
+    it 'does not emit a heartbeat' do
+      perform
+      expect(cloudwatch_client).not_to have_received(:put_metric_data)
     end
   end
 
@@ -242,6 +250,35 @@ RSpec.describe ImportCustomsTariffDocumentWorker, type: :worker do
       it 're-raises the original import error' do
         expect { perform }.to raise_error(RuntimeError, 'catastrophic failure')
       end
+    end
+
+    it 'does not emit a heartbeat' do
+      expect { perform }.to raise_error(RuntimeError)
+      expect(cloudwatch_client).not_to have_received(:put_metric_data)
+    end
+  end
+
+  describe 'heartbeat on success' do
+    before do
+      allow(importer_double).to receive(:call).and_return([result(status: :skipped, version: '1.30')])
+    end
+
+    it 'emits a JobSuccess heartbeat to TradeTariff/ScheduledJobs' do
+      perform
+
+      expect(cloudwatch_client).to have_received(:put_metric_data).with(
+        namespace: 'TradeTariff/ScheduledJobs',
+        metric_data: [{
+          metric_name: 'JobSuccess',
+          value: 1,
+          unit: 'Count',
+          dimensions: [
+            { name: 'Job', value: 'ImportCustomsTariffDocumentWorker' },
+            { name: 'Service', value: TradeTariffBackend.service },
+            { name: 'Environment', value: Rails.env },
+          ],
+        }],
+      )
     end
   end
 end

--- a/spec/workers/import_xi_cn_document_worker_spec.rb
+++ b/spec/workers/import_xi_cn_document_worker_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe ImportXiCnDocumentWorker do
             dimensions: [
               { name: 'Job', value: 'ImportXiCnDocumentWorker' },
               { name: 'Service', value: TradeTariffBackend.service },
-              { name: 'Environment', value: Rails.env },
+              { name: 'Environment', value: ENV.fetch('ENVIRONMENT', 'local') },
             ],
           }],
         )

--- a/spec/workers/import_xi_cn_document_worker_spec.rb
+++ b/spec/workers/import_xi_cn_document_worker_spec.rb
@@ -4,12 +4,15 @@ RSpec.describe ImportXiCnDocumentWorker do
   subject(:worker) { described_class.new }
 
   let(:importer_double) { instance_double(XiCnImporter::Importer) }
+  let(:cloudwatch_client) { instance_double(Aws::CloudWatch::Client) }
 
   before do
     allow(TradeTariffBackend).to receive(:xi?).and_return(true)
     allow(XiCnImporter::Importer).to receive(:new).and_return(importer_double)
     allow(SlackNotifierService).to receive(:call)
     allow(CustomsTariffUpdateNotifierService).to receive(:new).and_return(instance_double(CustomsTariffUpdateNotifierService, call: nil))
+    allow(Aws::CloudWatch::Client).to receive(:new).and_return(cloudwatch_client)
+    allow(cloudwatch_client).to receive(:put_metric_data)
   end
 
   describe '#perform' do
@@ -19,6 +22,11 @@ RSpec.describe ImportXiCnDocumentWorker do
       it 'does nothing' do
         worker.perform
         expect(XiCnImporter::Importer).not_to have_received(:new)
+      end
+
+      it 'does not emit a heartbeat' do
+        worker.perform
+        expect(cloudwatch_client).not_to have_received(:put_metric_data)
       end
     end
 
@@ -129,6 +137,35 @@ RSpec.describe ImportXiCnDocumentWorker do
         expect { worker.perform }.to raise_error(RuntimeError)
         expect(SlackNotifierService).to have_received(:call)
           .with(a_string_including('failed'))
+      end
+
+      it 'does not emit a heartbeat' do
+        expect { worker.perform }.to raise_error(RuntimeError)
+        expect(cloudwatch_client).not_to have_received(:put_metric_data)
+      end
+    end
+
+    describe 'heartbeat on success' do
+      before do
+        allow(importer_double).to receive(:call).and_return([])
+      end
+
+      it 'emits a JobSuccess heartbeat to TradeTariff/ScheduledJobs' do
+        worker.perform
+
+        expect(cloudwatch_client).to have_received(:put_metric_data).with(
+          namespace: 'TradeTariff/ScheduledJobs',
+          metric_data: [{
+            metric_name: 'JobSuccess',
+            value: 1,
+            unit: 'Count',
+            dimensions: [
+              { name: 'Job', value: 'ImportXiCnDocumentWorker' },
+              { name: 'Service', value: TradeTariffBackend.service },
+              { name: 'Environment', value: Rails.env },
+            ],
+          }],
+        )
       end
     end
   end

--- a/spec/workers/report_worker_spec.rb
+++ b/spec/workers/report_worker_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe ReportWorker, type: :worker do
             dimensions: [
               { name: 'Job', value: 'ReportWorker' },
               { name: 'Service', value: 'uk' },
-              { name: 'Environment', value: Rails.env },
+              { name: 'Environment', value: ENV.fetch('ENVIRONMENT', 'local') },
             ],
           }],
         )

--- a/spec/workers/report_worker_spec.rb
+++ b/spec/workers/report_worker_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe ReportWorker, type: :worker do
 
   describe '#perform' do
     let(:date) { '2023-10-30' } # a monday
+    let(:cloudwatch_client) { instance_double(Aws::CloudWatch::Client) }
 
     before do
       allow(Reporting::Commodities).to receive(:generate)
@@ -15,6 +16,8 @@ RSpec.describe ReportWorker, type: :worker do
       allow(Reporting::TariffUpdates).to receive(:generate)
       allow(DifferencesReportWorker).to receive(:perform_in).and_call_original
       allow(TradeTariffBackend).to receive(:service).and_return(service)
+      allow(Aws::CloudWatch::Client).to receive(:new).and_return(cloudwatch_client)
+      allow(cloudwatch_client).to receive(:put_metric_data)
       travel_to Date.parse(date).beginning_of_day
     end
 
@@ -114,6 +117,33 @@ RSpec.describe ReportWorker, type: :worker do
         expect { worker.perform }.to raise_error(Sequel::DatabaseConnectionError)
 
         expect(Rails.logger).to have_received(:error).with(/DeclarableDuties.*failed/)
+      end
+
+      it 'does not emit a heartbeat' do
+        expect { worker.perform }.to raise_error(Sequel::DatabaseConnectionError)
+        expect(cloudwatch_client).not_to have_received(:put_metric_data)
+      end
+    end
+
+    describe 'heartbeat on success' do
+      let(:service) { 'uk' }
+
+      before { worker.perform }
+
+      it 'emits a JobSuccess heartbeat to TradeTariff/ScheduledJobs' do
+        expect(cloudwatch_client).to have_received(:put_metric_data).with(
+          namespace: 'TradeTariff/ScheduledJobs',
+          metric_data: [{
+            metric_name: 'JobSuccess',
+            value: 1,
+            unit: 'Count',
+            dimensions: [
+              { name: 'Job', value: 'ReportWorker' },
+              { name: 'Service', value: 'uk' },
+              { name: 'Environment', value: Rails.env },
+            ],
+          }],
+        )
       end
     end
   end


### PR DESCRIPTION
## What:
Adds a `ScheduledJobHeartbeat` concern that emits a `JobSuccess` CloudWatch metric on each successful job completion, and wires it into 4 prioritised scheduled workers: `ImportCustomsTariffDocumentWorker`, `ImportXiCnDocumentWorker`, `GoodsNomenclatureReconciliationWorker`, and `ReportWorker`.

## Why:
Scheduled job failures are only surfaced after all Sidekiq retries are exhausted (death alert). Jobs like the customs tariff importers and goods nomenclature reconciliation can fail silently for an entire day. The heartbeat provides a per-job success signal; the companion Terraform PR ([trade-tariff-platform-aws-terraform#710](https://github.com/trade-tariff/trade-tariff-platform-aws-terraform/pull/710)) adds CloudWatch dead man's switch alarms that fire to `#production-alerts` if the metric stops appearing within the expected window.

Design matches the HMRC-2609 pattern: CloudWatch errors are caught and logged, never raised, so a metric failure never kills a job.

`GoodsNomenclatureReconciliationWorker` had its early return (`return if affected.empty?`) converted to an `unless` block so the heartbeat fires even on no-change days — the alarm needs a daily signal regardless of whether data changed.

## Ticket:
https://transformuk.atlassian.net/browse/HMRC-2611

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Additive observability only. No existing logic is altered except the `GoodsNomenclatureReconciliationWorker` early-return refactor (equivalent behaviour). CloudWatch errors are swallowed, so a metric emission failure cannot affect job correctness.

───────────────────────────────────────────────────

Rate the overall risk of deploying this change:

🟢 Green  – Low risk. Good to go, standard review applies.

🟠 Amber  – Medium risk. Socialise with the team before merging.

🔴 Red    – High risk. Requires explicit approval from Thor or Neil before merging.

───────────────────────────────────────────────────

🟢 GREEN – things that are typically low risk:
───────────────────────────────────────────────────
- Dependency bumps with no API changes (e.g. minor/patch gems, npm packages)
- Copy or content changes in GOV.UK-style UI components
- Adding or updating CloudWatch alarms or dashboards (read-only observability)
- New tests or improved test coverage with no production code changes
- Config/env var additions that are purely additive and have safe defaults
- Refactors with full test coverage and no behaviour change
- Terraform formatting or variable renaming with no resource recreation
- S3 lifecycle rule additions (non-destructive, time-delayed effect)

🟠 AMBER – things that need a team conversation first:
───────────────────────────────────────────────────
- Changes to commodity code lookups, measure type logic, or duty calculation
- Modifications to the search indexing pipeline (OpenSearch mappings, synonyms, stop words)
- Changes to declarable goods or quota logic
- New or modified API endpoints that other services (backend, frontend, admin) consume
- Adding or changing feature flags that affect live user journeys
- Infrastructure changes that alter networking, security groups, or IAM permissions in non-production first
- Terraform changes that will cause a resource replacement (check plan output carefully)
- Changes to CI/CD pipeline steps or deployment order dependencies
- S3 bucket policy or access control changes
- Removing or deprecating an endpoint or field that may still be consumed

🔴 RED – requires explicit approval from Thor or Neil:
───────────────────────────────────────────────────
- Dangerous database migrations, especially destructive ones (dropping columns/tables, removing indexes)
- Modifications to how measures, conditions, or footnotes are processed or surfaced
- Changes to the synchronisation mechanism from CDS or HMRC upstream data feeds
- Any change to production AWS infrastructure that cannot be easily rolled back (e.g. RDS parameter groups, KMS key policy, removal of resources)
- Secrets rotation or changes to how credentials are stored, scoped, or accessed
- Changes that affect trader-facing regulatory content or legally significant data (e.g. trade remedies, licensing, prohibitions)
- Significant architectural shifts (e.g. new service boundaries, queue/event topology changes)