### PR TITLE
AI-1065c: Allow evaluation searches to override retrieval configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,8 +52,3 @@ repos:
     rev: v1.7.12
     hooks:
       - id: actionlint-docker
-
-  - repo: https://github.com/trade-tariff/trade-tariff-tools
-    rev: main
-    hooks:
-      - id: debride

--- a/app/controllers/api/admin/search/evaluation/searches_controller.rb
+++ b/app/controllers/api/admin/search/evaluation/searches_controller.rb
@@ -1,0 +1,31 @@
+module Api
+  module Admin
+    module Search
+      module Evaluation
+        class SearchesController < AdminController
+          def create
+            EvaluationConfiguration::AllowlistValidator.call(configuration_overrides)
+
+            result = Api::Internal::SearchService.new(search_params.to_h.merge(configuration_overrides:, search_type: 'evaluation')).call
+
+            if result.is_a?(Hash) && result[:errors]
+              render json: result, status: :unprocessable_content
+            else
+              render json: result
+            end
+          end
+
+        private
+
+          def configuration_overrides
+            params.permit(configuration_overrides: {})[:configuration_overrides].to_h
+          end
+
+          def search_params
+            params.permit(:q, :as_of, :request_id, :expanded_query, :skip_question, answers: %i[question answer options])
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/engines/admin_api.rb
+++ b/app/engines/admin_api.rb
@@ -163,6 +163,7 @@ AdminApi.routes.draw do
           resources :runs, only: %i[index show create update]
           resources :results, only: %i[index show create]
           resource :configuration, only: [:show]
+          resources :searches, only: [:create]
         end
       end
     end

--- a/app/lib/evaluation_configuration/allowlist_validator.rb
+++ b/app/lib/evaluation_configuration/allowlist_validator.rb
@@ -13,11 +13,75 @@ module EvaluationConfiguration
   ].freeze
 
   class AllowlistValidator
+    MODEL_KEYS = %w[question_model simulator_model].freeze
+    BOOLEAN_KEYS = %w[
+      search_non_declarables
+      search_compressed_notes_enabled
+      search_general_rules_enabled
+    ].freeze
+
+    # Upper bounds below are set a few multiples above the corresponding
+    # AdminConfiguration::DEFAULTS value, so an evaluation caller can stress-test
+    # configuration without being able to force a pathologically expensive call.
+    # candidate_limit overrides opensearch_result_limit (default 50, app/models/admin_configuration.rb)
+    # and is used as the retrieval `limit:` in Api::Internal::SearchService#opensearch_result_limit.
+    CANDIDATE_LIMIT_RANGE = (1..250)
+    # max_rounds overrides interactive_search_max_questions (default 7); each round is a
+    # clarifying-question LLM call in InteractiveSearchService, so the ceiling stays small.
+    MAX_ROUNDS_RANGE = (1..20)
+    # rrf_k is used as `1.0 / (rank + k)` in HybridRetrievalService#rrf_merge (default 60).
+    # Negative values can zero/flip the denominator for low ranks; large values just flatten
+    # rank differences, so 0 is the floor and the ceiling only needs to stay numerically sane.
+    RRF_K_RANGE = (0..1000)
+    # vector_score_threshold is a cosine-similarity percentage (.../100.0) in
+    # VectorRetrievalService#apply_score_threshold, so it is bounded to a real percentage.
+    VECTOR_SCORE_THRESHOLD_RANGE = (0..100)
+    # vector_ef_search is a Postgres HNSW `SET LOCAL hnsw.ef_search` tuning knob (default 100,
+    # app/services/vector_retrieval_service.rb); excessive values increase query cost significantly.
+    VECTOR_EF_SEARCH_RANGE = (1..1000)
+
     def self.call(overrides)
-      disallowed = overrides.keys.map(&:to_s) - ALLOWED_OVERRIDE_KEYS
+      normalized = overrides.to_h { |key, value| [key.to_s, value] }
+
+      disallowed = normalized.keys - ALLOWED_OVERRIDE_KEYS
       raise OverrideValidationError, "Disallowed override keys: #{disallowed.join(', ')}" if disallowed.any?
+
+      normalized.each { |key, value| validate_value(key, value) }
 
       true
     end
+
+    def self.validate_value(key, value)
+      case key
+      when *MODEL_KEYS then validate_model(key, value)
+      when 'candidate_limit' then validate_integer(key, value, CANDIDATE_LIMIT_RANGE)
+      when 'max_rounds' then validate_integer(key, value, MAX_ROUNDS_RANGE)
+      when 'rrf_k' then validate_integer(key, value, RRF_K_RANGE)
+      when 'vector_score_threshold' then validate_integer(key, value, VECTOR_SCORE_THRESHOLD_RANGE)
+      when 'vector_ef_search' then validate_integer(key, value, VECTOR_EF_SEARCH_RANGE)
+      when *BOOLEAN_KEYS then validate_boolean(key, value)
+      end
+    end
+    private_class_method :validate_value
+
+    def self.validate_model(key, value)
+      return if value.is_a?(String) && OpenaiClient::MODEL_CONFIGS.key?(value)
+
+      raise OverrideValidationError, "#{key} must be one of: #{OpenaiClient::MODEL_CONFIGS.keys.join(', ')}"
+    end
+    private_class_method :validate_model
+
+    def self.validate_integer(key, value, range)
+      raise OverrideValidationError, "#{key} must be an Integer" unless value.is_a?(Integer)
+      raise OverrideValidationError, "#{key} must be between #{range.min} and #{range.max}" unless range.cover?(value)
+    end
+    private_class_method :validate_integer
+
+    def self.validate_boolean(key, value)
+      return if value.is_a?(TrueClass) || value.is_a?(FalseClass)
+
+      raise OverrideValidationError, "#{key} must be true or false"
+    end
+    private_class_method :validate_boolean
   end
 end

--- a/app/lib/evaluation_configuration/allowlist_validator.rb
+++ b/app/lib/evaluation_configuration/allowlist_validator.rb
@@ -8,7 +8,6 @@ module EvaluationConfiguration
     vector_score_threshold
     vector_ef_search
     search_non_declarables
-    filter_prefixes
     search_compressed_notes_enabled
     search_general_rules_enabled
   ].freeze

--- a/app/lib/evaluation_configuration/baseline_provider.rb
+++ b/app/lib/evaluation_configuration/baseline_provider.rb
@@ -1,9 +1,8 @@
 module EvaluationConfiguration
   class BaselineProvider
     def self.call
-      # Baseline includes 9 of 11 ALLOWED_OVERRIDE_KEYS. simulator_model is omitted
+      # Baseline includes 9 of 10 ALLOWED_OVERRIDE_KEYS. simulator_model is omitted
       # because production uses real humans (no backend model config; orchestration choice).
-      # filter_prefixes is omitted because it's already a plain request param (override-only).
       {
         'rrf_k' => AdminConfiguration.integer_value('rrf_k'),
         'vector_score_threshold' => AdminConfiguration.integer_value('vector_score_threshold'),

--- a/app/queries/search/goods_nomenclature_query.rb
+++ b/app/queries/search/goods_nomenclature_query.rb
@@ -3,7 +3,7 @@ module Search
     NOISE_TAGS = %w[cc dt det in to prp prp$ md ex pdt wp wp$ wdt wrb].freeze
 
     attr_reader :query_string, :date, :expanded_query, :pos_search, :size,
-                :noun_boost, :qualifier_boost, :filter_prefixes
+                :noun_boost, :qualifier_boost, :filter_prefixes, :search_non_declarables
 
     class << self
       def tagger
@@ -11,7 +11,7 @@ module Search
       end
     end
 
-    def initialize(query_string, date, size:, noun_boost:, qualifier_boost:, expanded_query: nil, pos_search: true, filter_prefixes: [])
+    def initialize(query_string, date, size:, noun_boost:, qualifier_boost:, expanded_query: nil, pos_search: true, filter_prefixes: [], search_non_declarables: false)
       @query_string = query_string
       @date = date
       @expanded_query = expanded_query
@@ -20,6 +20,7 @@ module Search
       @noun_boost = noun_boost
       @qualifier_boost = qualifier_boost
       @filter_prefixes = Array(filter_prefixes).compact_blank
+      @search_non_declarables = search_non_declarables
     end
 
     def query
@@ -169,6 +170,8 @@ module Search
     end
 
     def declarable_filter
+      return nil if search_non_declarables
+
       { term: { declarable: true } }
     end
 

--- a/app/services/api/internal/search_service.rb
+++ b/app/services/api/internal/search_service.rb
@@ -23,6 +23,8 @@ module Api
         TradeTariffRequest.request_id ||= @request_id
         @expanded_query = params[:expanded_query].to_s.strip.presence
         @skip_question = params[:skip_question].nil? ? nil : ActiveModel::Type::Boolean.new.cast(params[:skip_question])
+        @configuration_overrides = params[:configuration_overrides] || {}
+        @search_type = params[:search_type] || 'interactive'
       end
 
       def call
@@ -45,7 +47,7 @@ module Api
           configuration: diagnostics_configuration,
         )
 
-        ::Search::Instrumentation.search(request_id:, query: q, search_type: 'interactive') do
+        ::Search::Instrumentation.search(request_id:, query: q, search_type: @search_type) do
           search_result
         end
       end
@@ -65,7 +67,7 @@ module Api
       def exact_match_response(exact)
         ::Search::Instrumentation.exact_match_selected(
           request_id:,
-          search_type: 'interactive',
+          search_type: @search_type,
           query: q,
           match_source: @exact_match_source,
           matched_value: @exact_matched_value,
@@ -204,12 +206,15 @@ module Api
           limit: opensearch_result_limit,
           filter_prefixes: filter_prefixes,
           request_id: request_id,
+          vector_score_threshold: @configuration_overrides['vector_score_threshold'],
+          vector_ef_search: @configuration_overrides['vector_ef_search'],
+          search_non_declarables: @configuration_overrides['search_non_declarables'],
         )
         ::Search::Instrumentation.retrieval_results_returned(
           request_id: request_id,
           query: q,
           effective_query: search_retrieval_query,
-          search_type: 'interactive',
+          search_type: @search_type,
           retrieval_method: 'vector',
           stage: 'returned',
           leg: 'vector',
@@ -237,7 +242,7 @@ module Api
           request_id: request_id,
           query: q,
           effective_query: result.expanded_query,
-          search_type: 'interactive',
+          search_type: @search_type,
           retrieval_method: 'opensearch',
           stage: 'returned',
           leg: 'opensearch',
@@ -261,7 +266,11 @@ module Api
           retrieval_query: search_retrieval_query,
           as_of: as_of, request_id: request_id, limit: opensearch_result_limit,
           filter_prefixes: filter_prefixes, iteration: search_iteration,
-          search_type: 'interactive'
+          search_type: @search_type,
+          rrf_k: @configuration_overrides['rrf_k'],
+          vector_score_threshold: @configuration_overrides['vector_score_threshold'],
+          vector_ef_search: @configuration_overrides['vector_ef_search'],
+          search_non_declarables: @configuration_overrides['search_non_declarables']
         )
 
         RetrievalResult.new(
@@ -289,7 +298,7 @@ module Api
       end
 
       def opensearch_result_limit
-        AdminConfiguration.integer_value('opensearch_result_limit')
+        @configuration_overrides['candidate_limit'] || AdminConfiguration.integer_value('opensearch_result_limit')
       end
 
       def conditional_expansion_enabled?
@@ -369,29 +378,42 @@ module Api
           search_result_limit: AdminConfiguration.integer_value('search_result_limit'),
           interactive_search_enabled: AdminConfiguration.enabled?('interactive_search_enabled'),
           interactive_search_duplicate_question_guard_enabled: AdminConfiguration.enabled?('interactive_search_duplicate_question_guard_enabled'),
-          interactive_search_max_questions: AdminConfiguration.integer_value('interactive_search_max_questions'),
+          interactive_search_max_questions: @configuration_overrides['max_rounds'] || AdminConfiguration.integer_value('interactive_search_max_questions'),
           expand_search_enabled: AdminConfiguration.enabled?('expand_search_enabled'),
           expand_search_decider: expansion_decider_version,
           expand_search_when_needed_enabled: AdminConfiguration.enabled?('expand_search_when_needed_enabled'),
           expand_search_min_results: AdminConfiguration.integer_value('expand_search_min_results'),
           expand_search_min_score: AdminConfiguration.integer_value('expand_search_min_score'),
           refine_search_with_answers_enabled: AdminConfiguration.enabled?('refine_search_with_answers_enabled'),
-          search_non_declarables: AdminConfiguration.enabled?('search_non_declarables'),
           search_labels_enabled: AdminConfiguration.enabled?('search_labels_enabled'),
           pos_search_enabled: AdminConfiguration.enabled?('pos_search_enabled'),
           pos_noun_boost: AdminConfiguration.integer_value('pos_noun_boost'),
           pos_qualifier_boost: AdminConfiguration.integer_value('pos_qualifier_boost'),
-          vector_score_threshold: AdminConfiguration.integer_value('vector_score_threshold'),
-          vector_ef_search: AdminConfiguration.integer_value('vector_ef_search'),
-          rrf_k: AdminConfiguration.integer_value('rrf_k'),
+          vector_score_threshold: @configuration_overrides['vector_score_threshold'] || AdminConfiguration.integer_value('vector_score_threshold'),
+          vector_ef_search: @configuration_overrides['vector_ef_search'] || AdminConfiguration.integer_value('vector_ef_search'),
+          rrf_k: @configuration_overrides['rrf_k'] || AdminConfiguration.integer_value('rrf_k'),
           hybrid_query_guardrail_threshold: AdminConfiguration.integer_value('hybrid_query_guardrail_threshold'),
           interactive_search_duplicate_question_guard_model: model_configuration('interactive_search_duplicate_question_guard_model'),
-          search_model: model_configuration('search_model'),
+          search_model: diagnostics_search_model,
           expand_model: model_configuration('expand_model'),
           filter_prefixes: filter_prefixes,
         }.compact_blank.tap do |configuration|
           configuration[:hybrid_query_guardrail_enabled] = AdminConfiguration.enabled?('hybrid_query_guardrail_enabled')
+          configuration[:search_non_declarables] = diagnostics_search_non_declarables
         end
+      end
+
+      def diagnostics_search_non_declarables
+        return @configuration_overrides['search_non_declarables'] unless @configuration_overrides['search_non_declarables'].nil?
+
+        AdminConfiguration.enabled?('search_non_declarables')
+      end
+
+      def diagnostics_search_model
+        config = model_configuration('search_model')
+        return config if @configuration_overrides['question_model'].blank?
+
+        config.merge(selected: @configuration_overrides['question_model'])
       end
 
       def model_configuration(name)
@@ -512,6 +534,11 @@ module Api
           opensearch_results: goods_nomenclatures,
           answers: answers,
           request_id: request_id,
+          max_rounds: @configuration_overrides['max_rounds'],
+          question_model: @configuration_overrides['question_model'],
+          search_compressed_notes_enabled: @configuration_overrides['search_compressed_notes_enabled'],
+          search_general_rules_enabled: @configuration_overrides['search_general_rules_enabled'],
+          search_type: @search_type,
         )
       end
 

--- a/app/services/api/internal/search_service.rb
+++ b/app/services/api/internal/search_service.rb
@@ -236,7 +236,8 @@ module Api
         result = OpensearchRetrievalService.call(
           query: q, expanded_query: search_retrieval_query,
           as_of: as_of, request_id: request_id, limit: opensearch_result_limit,
-          filter_prefixes: filter_prefixes
+          filter_prefixes: filter_prefixes,
+          search_non_declarables: @configuration_overrides['search_non_declarables']
         )
         ::Search::Instrumentation.retrieval_results_returned(
           request_id: request_id,

--- a/app/services/hybrid_retrieval_service.rb
+++ b/app/services/hybrid_retrieval_service.rb
@@ -119,6 +119,7 @@ private
       limit: @limit,
     }
     args[:filter_prefixes] = @filter_prefixes if @filter_prefixes.present?
+    args[:search_non_declarables] = @search_non_declarables unless @search_non_declarables.nil?
     args
   end
 

--- a/app/services/hybrid_retrieval_service.rb
+++ b/app/services/hybrid_retrieval_service.rb
@@ -3,11 +3,11 @@ class HybridRetrievalService
   LegResult = Data.define(:value, :error)
   Result = Data.define(:results, :expanded_query, :source_results)
 
-  def self.call(query:, as_of:, expanded_query: nil, retrieval_query: nil, request_id: nil, limit: 30, filter_prefixes: [], iteration: nil, search_type: 'interactive')
-    new(query:, as_of:, expanded_query:, retrieval_query:, request_id:, limit:, filter_prefixes:, iteration:, search_type:).call
+  def self.call(query:, as_of:, expanded_query: nil, retrieval_query: nil, request_id: nil, limit: 30, filter_prefixes: [], iteration: nil, search_type: 'interactive', rrf_k: nil, vector_score_threshold: nil, vector_ef_search: nil, search_non_declarables: nil)
+    new(query:, as_of:, expanded_query:, retrieval_query:, request_id:, limit:, filter_prefixes:, iteration:, search_type:, rrf_k:, vector_score_threshold:, vector_ef_search:, search_non_declarables:).call
   end
 
-  def initialize(query:, as_of:, expanded_query: nil, retrieval_query: nil, request_id: nil, limit: 30, filter_prefixes: [], iteration: nil, search_type: 'interactive')
+  def initialize(query:, as_of:, expanded_query: nil, retrieval_query: nil, request_id: nil, limit: 30, filter_prefixes: [], iteration: nil, search_type: 'interactive', rrf_k: nil, vector_score_threshold: nil, vector_ef_search: nil, search_non_declarables: nil)
     @query = query
     @expanded_query = expanded_query.presence || query
     @retrieval_query = retrieval_query.presence || @expanded_query
@@ -17,6 +17,10 @@ class HybridRetrievalService
     @filter_prefixes = Array(filter_prefixes).compact_blank
     @iteration = iteration
     @search_type = search_type
+    @rrf_k = rrf_k
+    @vector_score_threshold = vector_score_threshold
+    @vector_ef_search = vector_ef_search
+    @search_non_declarables = search_non_declarables
   end
 
   def call
@@ -121,11 +125,14 @@ private
   def vector_args
     args = { query: @retrieval_query, limit: @limit, request_id: @request_id }
     args[:filter_prefixes] = @filter_prefixes if @filter_prefixes.present?
+    args[:vector_score_threshold] = @vector_score_threshold unless @vector_score_threshold.nil?
+    args[:vector_ef_search] = @vector_ef_search unless @vector_ef_search.nil?
+    args[:search_non_declarables] = @search_non_declarables unless @search_non_declarables.nil?
     args
   end
 
   def rrf_merge(opensearch_items, vector_items)
-    k = AdminConfiguration.integer_value('rrf_k')
+    k = @rrf_k || AdminConfiguration.integer_value('rrf_k')
     scores = Hash.new(0.0)
     items_by_sid = {}
 

--- a/app/services/interactive_search_service.rb
+++ b/app/services/interactive_search_service.rb
@@ -20,13 +20,18 @@ class InteractiveSearchService
     IMPORTANT: You have asked the maximum number of questions allowed. Based on the search input, OpenSearch results, and the answers provided so far, you MUST now provide your best answer. Do not ask any more questions. Rank the opensearch results by confidence using the information you have.
   INSTRUCTION
 
-  def initialize(query:, expanded_query:, opensearch_results:, answers: [], request_id: nil)
+  def initialize(query:, expanded_query:, opensearch_results:, answers: [], request_id: nil, max_rounds: nil, question_model: nil, search_compressed_notes_enabled: nil, search_general_rules_enabled: nil, search_type: 'interactive')
     @query = query
     @expanded_query = expanded_query
     @opensearch_results = opensearch_results
     @answers = answers || []
     @request_id = request_id
     @attempt = @answers.size + 1
+    @max_rounds = max_rounds
+    @question_model = question_model
+    @search_compressed_notes_enabled = search_compressed_notes_enabled
+    @search_general_rules_enabled = search_general_rules_enabled
+    @search_type = search_type
   end
 
   def call
@@ -41,7 +46,7 @@ class InteractiveSearchService
       request_id: request_id,
       error_type: e.class.name,
       error_message: e.message,
-      search_type: 'interactive',
+      search_type: @search_type,
     )
     nil
   end
@@ -73,7 +78,7 @@ private
   end
 
   def max_questions
-    AdminConfiguration.integer_value('interactive_search_max_questions')
+    @max_rounds || AdminConfiguration.integer_value('interactive_search_max_questions')
   end
 
   def model_config
@@ -81,7 +86,7 @@ private
   end
 
   def configured_model
-    model_config[:selected]
+    @question_model || model_config[:selected]
   end
 
   def configured_reasoning_effort
@@ -166,9 +171,17 @@ private
     end
   end
 
-  def compressed_notes_enabled? = AdminConfiguration.enabled?('search_compressed_notes_enabled')
+  def compressed_notes_enabled?
+    return @search_compressed_notes_enabled unless @search_compressed_notes_enabled.nil?
 
-  def general_rules_enabled? = AdminConfiguration.enabled?('search_general_rules_enabled')
+    AdminConfiguration.enabled?('search_compressed_notes_enabled')
+  end
+
+  def general_rules_enabled?
+    return @search_general_rules_enabled unless @search_general_rules_enabled.nil?
+
+    AdminConfiguration.enabled?('search_general_rules_enabled')
+  end
 
   def compressed_note_contexts
     return @compressed_note_contexts if defined?(@compressed_note_contexts)

--- a/app/services/interactive_search_service.rb
+++ b/app/services/interactive_search_service.rb
@@ -90,7 +90,27 @@ private
   end
 
   def configured_reasoning_effort
-    model_config[:sub_values]['reasoning_effort']
+    return model_config[:sub_values]['reasoning_effort'] if @question_model.blank?
+
+    reasoning_effort_for_question_model
+  end
+
+  # Only reachable with a @question_model that is a recognised OpenaiClient::MODEL_CONFIGS
+  # key, because EvaluationConfiguration::AllowlistValidator rejects unrecognised
+  # question_model overrides before InteractiveSearchService is ever called. If that
+  # validation is ever removed, MODEL_CONFIGS.dig below would silently treat an unknown
+  # model as non-reasoning (returning nil) rather than raising.
+  def reasoning_effort_for_question_model
+    reasoning_levels = OpenaiClient::MODEL_CONFIGS.dig(@question_model, :reasoning_levels) || []
+    return nil if reasoning_levels.empty?
+
+    configured_effort = model_config[:sub_values]['reasoning_effort']
+    return configured_effort if reasoning_levels.include?(configured_effort)
+
+    # The globally configured reasoning_effort isn't valid for this overridden model
+    # (e.g. configured model uses 'xhigh' but the override only supports up to 'high').
+    # Fall back to the first/most conservative level rather than sending an invalid value.
+    reasoning_levels.first
   end
 
   def configured_context

--- a/app/services/opensearch_retrieval_service.rb
+++ b/app/services/opensearch_retrieval_service.rb
@@ -1,17 +1,18 @@
 class OpensearchRetrievalService
   Result = Data.define(:results, :expanded_query)
 
-  def self.call(query:, as_of:, expanded_query: nil, request_id: nil, limit: 30, filter_prefixes: [])
-    new(query:, as_of:, expanded_query:, request_id:, limit:, filter_prefixes:).call
+  def self.call(query:, as_of:, expanded_query: nil, request_id: nil, limit: 30, filter_prefixes: [], search_non_declarables: nil)
+    new(query:, as_of:, expanded_query:, request_id:, limit:, filter_prefixes:, search_non_declarables:).call
   end
 
-  def initialize(query:, as_of:, expanded_query: nil, request_id: nil, limit: 30, filter_prefixes: [])
+  def initialize(query:, as_of:, expanded_query: nil, request_id: nil, limit: 30, filter_prefixes: [], search_non_declarables: nil)
     @query = query
     @as_of = as_of
     @expanded_query = expanded_query.presence || query
     @request_id = request_id
     @limit = limit
     @filter_prefixes = Array(filter_prefixes).compact_blank
+    @search_non_declarables = search_non_declarables
   end
 
   def call
@@ -33,11 +34,18 @@ private
           noun_boost: pos_noun_boost,
           qualifier_boost: pos_qualifier_boost,
           filter_prefixes: @filter_prefixes,
+          search_non_declarables: search_non_declarables?,
         ).query,
       )
     end
 
     results.dig('hits', 'hits') || []
+  end
+
+  def search_non_declarables?
+    return @search_non_declarables unless @search_non_declarables.nil?
+
+    AdminConfiguration.enabled?('search_non_declarables')
   end
 
   def pos_search_enabled?

--- a/app/services/vector_retrieval_service.rb
+++ b/app/services/vector_retrieval_service.rb
@@ -1,19 +1,22 @@
 class VectorRetrievalService
   Result = Data.define(:results, :max_score)
 
-  def self.call(query:, limit: 80, filter_prefixes: [], request_id: nil)
-    new(query:, limit:, filter_prefixes:, request_id:).call
+  def self.call(query:, limit: 80, filter_prefixes: [], request_id: nil, vector_score_threshold: nil, vector_ef_search: nil, search_non_declarables: nil)
+    new(query:, limit:, filter_prefixes:, request_id:, vector_score_threshold:, vector_ef_search:, search_non_declarables:).call
   end
 
-  def self.call_with_diagnostics(query:, limit: 80, filter_prefixes: [], request_id: nil)
-    new(query:, limit:, filter_prefixes:, request_id:).call_with_diagnostics
+  def self.call_with_diagnostics(query:, limit: 80, filter_prefixes: [], request_id: nil, vector_score_threshold: nil, vector_ef_search: nil, search_non_declarables: nil)
+    new(query:, limit:, filter_prefixes:, request_id:, vector_score_threshold:, vector_ef_search:, search_non_declarables:).call_with_diagnostics
   end
 
-  def initialize(query:, limit: 80, filter_prefixes: [], request_id: nil)
+  def initialize(query:, limit: 80, filter_prefixes: [], request_id: nil, vector_score_threshold: nil, vector_ef_search: nil, search_non_declarables: nil)
     @query = query
     @limit = limit
     @filter_prefixes = Array(filter_prefixes).compact_blank
     @request_id = request_id
+    @vector_score_threshold = vector_score_threshold
+    @vector_ef_search = vector_ef_search
+    @search_non_declarables = search_non_declarables
   end
 
   def call
@@ -62,7 +65,7 @@ private
   end
 
   def apply_score_threshold(rows)
-    threshold = AdminConfiguration.integer_value('vector_score_threshold') / 100.0
+    threshold = (@vector_score_threshold || AdminConfiguration.integer_value('vector_score_threshold')) / 100.0
     rows.select { |r| r[:score].to_f >= threshold }
   end
 
@@ -83,7 +86,7 @@ private
   end
 
   def fetch_ranked_sids(vector_literal)
-    ef_search = AdminConfiguration.integer_value('vector_ef_search')
+    ef_search = @vector_ef_search || AdminConfiguration.integer_value('vector_ef_search')
 
     db.transaction do
       db.run("SET LOCAL hnsw.ef_search = #{ef_search.to_i}")
@@ -136,6 +139,8 @@ private
   end
 
   def search_non_declarables?
+    return @search_non_declarables unless @search_non_declarables.nil?
+
     AdminConfiguration.enabled?('search_non_declarables')
   end
 

--- a/spec/lib/evaluation_configuration/allowlist_validator_spec.rb
+++ b/spec/lib/evaluation_configuration/allowlist_validator_spec.rb
@@ -5,9 +5,23 @@ RSpec.describe EvaluationConfiguration::AllowlistValidator do
     expect(described_class.call({})).to be true
   end
 
-  it 'accepts every key on the MVP allowlist' do
-    overrides = EvaluationConfiguration::ALLOWED_OVERRIDE_KEYS.index_with { |_key| 'value' }
-    expect(described_class.call(overrides)).to be true
+  def valid_overrides
+    {
+      'question_model' => 'gpt-4o-mini',
+      'simulator_model' => 'gpt-4.1-mini-2025-04-14',
+      'candidate_limit' => 50,
+      'max_rounds' => 7,
+      'rrf_k' => 60,
+      'vector_score_threshold' => 35,
+      'vector_ef_search' => 100,
+      'search_non_declarables' => false,
+      'search_compressed_notes_enabled' => true,
+      'search_general_rules_enabled' => false,
+    }
+  end
+
+  it 'accepts every key on the allowlist with valid values' do
+    expect(described_class.call(valid_overrides)).to be true
   end
 
   it 'accepts a subset of allowed keys' do
@@ -33,5 +47,179 @@ RSpec.describe EvaluationConfiguration::AllowlistValidator do
 
   it 'accepts symbol keys as well as string keys' do
     expect(described_class.call({ max_rounds: 3 })).to be true
+  end
+
+  describe 'question_model / simulator_model' do
+    %w[question_model simulator_model].each do |key|
+      it "accepts any model listed in OpenaiClient::MODEL_CONFIGS for #{key}" do
+        OpenaiClient::MODEL_CONFIGS.each_key do |model|
+          expect(described_class.call({ key => model })).to be true
+        end
+      end
+
+      it "rejects a model not present in OpenaiClient::MODEL_CONFIGS for #{key}" do
+        expect {
+          described_class.call({ key => 'not-a-real-model' })
+        }.to raise_error(EvaluationConfiguration::OverrideValidationError, /#{key}/)
+      end
+
+      it "rejects a non-String value for #{key}" do
+        expect {
+          described_class.call({ key => 42 })
+        }.to raise_error(EvaluationConfiguration::OverrideValidationError, /#{key}/)
+      end
+    end
+  end
+
+  describe 'candidate_limit' do
+    it 'accepts a positive Integer within range' do
+      expect(described_class.call({ 'candidate_limit' => 100 })).to be true
+    end
+
+    it 'rejects a stringly-typed Integer' do
+      expect {
+        described_class.call({ 'candidate_limit' => '5' })
+      }.to raise_error(EvaluationConfiguration::OverrideValidationError, /candidate_limit/)
+    end
+
+    it 'rejects zero' do
+      expect {
+        described_class.call({ 'candidate_limit' => 0 })
+      }.to raise_error(EvaluationConfiguration::OverrideValidationError, /candidate_limit/)
+    end
+
+    it 'rejects a negative value' do
+      expect {
+        described_class.call({ 'candidate_limit' => -1 })
+      }.to raise_error(EvaluationConfiguration::OverrideValidationError, /candidate_limit/)
+    end
+
+    it 'rejects an excessively large value' do
+      expect {
+        described_class.call({ 'candidate_limit' => 100_000 })
+      }.to raise_error(EvaluationConfiguration::OverrideValidationError, /candidate_limit/)
+    end
+  end
+
+  describe 'max_rounds' do
+    it 'accepts a positive Integer within range' do
+      expect(described_class.call({ 'max_rounds' => 5 })).to be true
+    end
+
+    it 'rejects a float' do
+      expect {
+        described_class.call({ 'max_rounds' => 5.5 })
+      }.to raise_error(EvaluationConfiguration::OverrideValidationError, /max_rounds/)
+    end
+
+    it 'rejects zero' do
+      expect {
+        described_class.call({ 'max_rounds' => 0 })
+      }.to raise_error(EvaluationConfiguration::OverrideValidationError, /max_rounds/)
+    end
+
+    it 'rejects an excessively large value' do
+      expect {
+        described_class.call({ 'max_rounds' => 1000 })
+      }.to raise_error(EvaluationConfiguration::OverrideValidationError, /max_rounds/)
+    end
+  end
+
+  describe 'rrf_k' do
+    it 'accepts zero' do
+      expect(described_class.call({ 'rrf_k' => 0 })).to be true
+    end
+
+    it 'accepts a typical positive value' do
+      expect(described_class.call({ 'rrf_k' => 60 })).to be true
+    end
+
+    it 'rejects a negative value' do
+      expect {
+        described_class.call({ 'rrf_k' => -1 })
+      }.to raise_error(EvaluationConfiguration::OverrideValidationError, /rrf_k/)
+    end
+
+    it 'rejects a non-Integer value' do
+      expect {
+        described_class.call({ 'rrf_k' => 'abc' })
+      }.to raise_error(EvaluationConfiguration::OverrideValidationError, /rrf_k/)
+    end
+
+    it 'rejects an excessively large value' do
+      expect {
+        described_class.call({ 'rrf_k' => 1_000_000 })
+      }.to raise_error(EvaluationConfiguration::OverrideValidationError, /rrf_k/)
+    end
+  end
+
+  describe 'vector_score_threshold' do
+    it 'accepts the boundaries of 0..100' do
+      expect(described_class.call({ 'vector_score_threshold' => 0 })).to be true
+      expect(described_class.call({ 'vector_score_threshold' => 100 })).to be true
+    end
+
+    it 'rejects a value above 100' do
+      expect {
+        described_class.call({ 'vector_score_threshold' => 101 })
+      }.to raise_error(EvaluationConfiguration::OverrideValidationError, /vector_score_threshold/)
+    end
+
+    it 'rejects a negative value' do
+      expect {
+        described_class.call({ 'vector_score_threshold' => -1 })
+      }.to raise_error(EvaluationConfiguration::OverrideValidationError, /vector_score_threshold/)
+    end
+
+    it 'rejects a non-Integer value' do
+      expect {
+        described_class.call({ 'vector_score_threshold' => '50' })
+      }.to raise_error(EvaluationConfiguration::OverrideValidationError, /vector_score_threshold/)
+    end
+  end
+
+  describe 'vector_ef_search' do
+    it 'accepts a positive Integer within range' do
+      expect(described_class.call({ 'vector_ef_search' => 100 })).to be true
+    end
+
+    it 'rejects zero' do
+      expect {
+        described_class.call({ 'vector_ef_search' => 0 })
+      }.to raise_error(EvaluationConfiguration::OverrideValidationError, /vector_ef_search/)
+    end
+
+    it 'rejects a negative value' do
+      expect {
+        described_class.call({ 'vector_ef_search' => -5 })
+      }.to raise_error(EvaluationConfiguration::OverrideValidationError, /vector_ef_search/)
+    end
+
+    it 'rejects an excessively large value' do
+      expect {
+        described_class.call({ 'vector_ef_search' => 100_000 })
+      }.to raise_error(EvaluationConfiguration::OverrideValidationError, /vector_ef_search/)
+    end
+  end
+
+  describe 'boolean keys' do
+    %w[search_non_declarables search_compressed_notes_enabled search_general_rules_enabled].each do |key|
+      it "accepts true and false for #{key}" do
+        expect(described_class.call({ key => true })).to be true
+        expect(described_class.call({ key => false })).to be true
+      end
+
+      it "rejects a String for #{key}" do
+        expect {
+          described_class.call({ key => 'true' })
+        }.to raise_error(EvaluationConfiguration::OverrideValidationError, /#{key}/)
+      end
+
+      it "rejects a non-boolean, non-String value for #{key}" do
+        expect {
+          described_class.call({ key => 1 })
+        }.to raise_error(EvaluationConfiguration::OverrideValidationError, /#{key}/)
+      end
+    end
   end
 end

--- a/spec/lib/evaluation_configuration/baseline_provider_spec.rb
+++ b/spec/lib/evaluation_configuration/baseline_provider_spec.rb
@@ -54,10 +54,9 @@ RSpec.describe EvaluationConfiguration::BaselineProvider do
       expect(described_class.call['question_model']).to eq('gpt-5.4')
     end
 
-    it 'omits simulator_model and filter_prefixes entirely, since neither has a real backend source' do
+    it 'omits simulator_model entirely, since it has no real backend source' do
       result = described_class.call
       expect(result).not_to have_key('simulator_model')
-      expect(result).not_to have_key('filter_prefixes')
     end
 
     it 'returns exactly the 9 keys with a real backend source' do

--- a/spec/queries/search/goods_nomenclature_query_spec.rb
+++ b/spec/queries/search/goods_nomenclature_query_spec.rb
@@ -515,12 +515,24 @@ RSpec.describe Search::GoodsNomenclatureQuery do
       expect(chapter_filter.dig(:bool, :must_not, :terms, :chapter_short_code)).to eq(%w[98 99])
     end
 
-    it 'filters to only declarable goods nomenclatures' do
+    it 'filters to only declarable goods nomenclatures by default' do
       must_clauses = query.dig(:body, :query, :bool, :must)
       declarable_filter = must_clauses.find { |c| c.dig(:term, :declarable) }
 
       expect(declarable_filter).to be_present
       expect(declarable_filter).to eq({ term: { declarable: true } })
+    end
+
+    context 'when search_non_declarables is true' do
+      let(:query_options) { super().merge(search_non_declarables: true) }
+
+      it 'omits the declarable filter, leaving the query shape otherwise unchanged' do
+        must_clauses = query.dig(:body, :query, :bool, :must)
+        declarable_filter = must_clauses.find { |c| c.dig(:term, :declarable) }
+
+        expect(declarable_filter).to be_nil
+        expect(must_clauses).not_to include(nil)
+      end
     end
 
     it 'includes validity date filter' do

--- a/spec/requests/api/admin/search/evaluation/configurations_controller_spec.rb
+++ b/spec/requests/api/admin/search/evaluation/configurations_controller_spec.rb
@@ -26,11 +26,11 @@ RSpec.describe Api::Admin::Search::Evaluation::ConfigurationsController, :admin 
       )
     end
 
-    it 'returns exactly the 11 allowed override keys' do
+    it 'returns exactly the 10 allowed override keys' do
       api_response
       expect(json_response['allowed_overrides']).to contain_exactly(
         'question_model', 'simulator_model', 'candidate_limit', 'max_rounds', 'rrf_k',
-        'vector_score_threshold', 'vector_ef_search', 'search_non_declarables', 'filter_prefixes',
+        'vector_score_threshold', 'vector_ef_search', 'search_non_declarables',
         'search_compressed_notes_enabled', 'search_general_rules_enabled'
       )
     end

--- a/spec/requests/api/admin/search/evaluation/searches_controller_spec.rb
+++ b/spec/requests/api/admin/search/evaluation/searches_controller_spec.rb
@@ -1,0 +1,94 @@
+require 'rails_helper'
+
+RSpec.describe Api::Admin::Search::Evaluation::SearchesController, :admin do
+  subject(:api_response) do
+    make_request
+    response
+  end
+
+  let(:json_response) { JSON.parse(api_response.body) }
+  let(:make_request) { authenticated_post api_admin_search_evaluation_searches_path(format: :json), params: params, as: :json }
+
+  before do
+    # Force the opensearch-only retrieval path (mirrors spec/requests/api/internal/search_controller_spec.rb
+    # and spec/services/api/internal/search_service_spec.rb) so a real Api::Internal::SearchService call
+    # doesn't fall into hybrid/vector retrieval, which would hit the live embeddings API and fail under WebMock.
+    allow(AdminConfiguration).to receive(:option_value).and_call_original
+    allow(AdminConfiguration).to receive(:option_value).with('retrieval_method').and_return('opensearch')
+    allow(AdminConfiguration).to receive(:enabled?).and_call_original
+    allow(AdminConfiguration).to receive(:enabled?).with('expand_search_when_needed_enabled').and_return(false)
+    allow(ExpandSearchQueryService).to receive(:call).and_wrap_original do |_method, query|
+      ExpandSearchQueryService::Result.new(expanded_query: query, reason: nil)
+    end
+  end
+
+  describe 'POST #create' do
+    context 'with a blank query' do
+      let(:params) { { q: '' } }
+
+      it { is_expected.to have_http_status :success }
+      it { expect(json_response).to eq('data' => []) }
+    end
+
+    context 'with a disallowed configuration_overrides key' do
+      let(:params) { { q: 'horses', configuration_overrides: { 'use_kg_context' => true } } }
+
+      it { is_expected.to have_http_status :unprocessable_content }
+      it { expect(json_response).to include('errors') }
+    end
+
+    context 'with an allowed configuration_overrides key' do
+      let(:params) { { q: 'horses', configuration_overrides: { 'candidate_limit' => 5 } } }
+
+      before do
+        allow(Api::Internal::SearchService).to receive(:new).and_call_original
+      end
+
+      it { is_expected.to have_http_status :success }
+
+      it 'passes configuration_overrides through to Api::Internal::SearchService' do
+        api_response
+        expect(Api::Internal::SearchService).to have_received(:new).with(
+          hash_including(configuration_overrides: hash_including('candidate_limit' => 5)),
+        )
+      end
+
+      it "still tags the call with search_type: 'evaluation'" do
+        api_response
+        expect(Api::Internal::SearchService).to have_received(:new).with(
+          hash_including(search_type: 'evaluation'),
+        )
+      end
+    end
+
+    context 'without any configuration_overrides' do
+      let(:params) { { q: 'horses' } }
+
+      before do
+        allow(Api::Internal::SearchService).to receive(:new).and_call_original
+      end
+
+      it 'still calls Api::Internal::SearchService, with an empty configuration_overrides' do
+        api_response
+        expect(Api::Internal::SearchService).to have_received(:new).with(
+          hash_including(configuration_overrides: {}),
+        )
+      end
+    end
+
+    context 'with or without configuration_overrides' do
+      let(:params) { { q: 'horses' } }
+
+      before do
+        allow(Api::Internal::SearchService).to receive(:new).and_call_original
+      end
+
+      it "tags the call with search_type: 'evaluation', regardless of configuration_overrides" do
+        api_response
+        expect(Api::Internal::SearchService).to have_received(:new).with(
+          hash_including(search_type: 'evaluation'),
+        )
+      end
+    end
+  end
+end

--- a/spec/requests/api/admin/search/evaluation/searches_controller_spec.rb
+++ b/spec/requests/api/admin/search/evaluation/searches_controller_spec.rb
@@ -37,6 +37,13 @@ RSpec.describe Api::Admin::Search::Evaluation::SearchesController, :admin do
       it { expect(json_response).to include('errors') }
     end
 
+    context 'with an allowed key but an invalid value' do
+      let(:params) { { q: 'horses', configuration_overrides: { 'rrf_k' => 'abc' } } }
+
+      it { is_expected.to have_http_status :unprocessable_content }
+      it { expect(json_response).to include('errors') }
+    end
+
     context 'with an allowed configuration_overrides key' do
       let(:params) { { q: 'horses', configuration_overrides: { 'candidate_limit' => 5 } } }
 

--- a/spec/services/api/internal/search_service_spec.rb
+++ b/spec/services/api/internal/search_service_spec.rb
@@ -1802,6 +1802,18 @@ RSpec.describe Api::Internal::SearchService do
         expect(OpensearchRetrievalService).to have_received(:call).with(hash_including(limit: 5))
       end
 
+      it 'passes search_non_declarables through to OpensearchRetrievalService for retrieval_method: opensearch' do
+        described_class.new(q: 'horses', configuration_overrides: { 'search_non_declarables' => true }).call
+
+        expect(OpensearchRetrievalService).to have_received(:call).with(hash_including(search_non_declarables: true))
+      end
+
+      it "defaults search_non_declarables to nil for OpensearchRetrievalService when not given, reproducing today's behaviour" do
+        described_class.new(q: 'horses').call
+
+        expect(OpensearchRetrievalService).to have_received(:call).with(hash_including(search_non_declarables: nil))
+      end
+
       it 'passes max_rounds, question_model, search_compressed_notes_enabled and search_general_rules_enabled through to InteractiveSearchService' do
         described_class.new(
           q: 'horses',

--- a/spec/services/api/internal/search_service_spec.rb
+++ b/spec/services/api/internal/search_service_spec.rb
@@ -89,6 +89,116 @@ RSpec.describe Api::Internal::SearchService do
       )
     end
 
+    context 'when diagnostics_configuration reports overridden values for evaluation runs' do
+      before do
+        allow(AdminConfiguration).to receive(:enabled?).and_call_original
+        allow(AdminConfiguration).to receive(:enabled?).with('search_non_declarables').and_return(false)
+        allow(AdminConfiguration).to receive(:integer_value).and_call_original
+        allow(AdminConfiguration).to receive(:integer_value).with('vector_score_threshold').and_return(35)
+        allow(AdminConfiguration).to receive(:integer_value).with('vector_ef_search').and_return(100)
+        allow(AdminConfiguration).to receive(:integer_value).with('rrf_k').and_return(60)
+        allow(AdminConfiguration).to receive(:integer_value).with('interactive_search_max_questions').and_return(7)
+        allow(AdminConfiguration).to receive(:nested_options_value).and_call_original
+        allow(AdminConfiguration).to receive(:nested_options_value).with('search_model')
+          .and_return(selected: 'gpt-5.4', sub_values: { 'reasoning_effort' => 'medium' })
+        allow(TradeTariffBackend.search_client).to receive(:search).and_return({ 'hits' => { 'hits' => [] } })
+      end
+
+      def captured_diagnostics_configuration(overrides)
+        captured = nil
+        allow(Search::Instrumentation).to receive(:interactive_configuration_used) do |configuration:, **|
+          captured = configuration
+        end
+
+        described_class.new(q: 'multimeter leads', configuration_overrides: overrides).call
+
+        captured
+      end
+
+      it 'reflects a search_non_declarables override of false even though AdminConfiguration reports true, proving || is not used' do
+        allow(AdminConfiguration).to receive(:enabled?).with('search_non_declarables').and_return(true)
+
+        configuration = captured_diagnostics_configuration('search_non_declarables' => false)
+
+        expect(configuration.fetch(:search_non_declarables)).to be(false)
+      end
+
+      it 'falls back to AdminConfiguration for search_non_declarables when no override is supplied' do
+        allow(AdminConfiguration).to receive(:enabled?).with('search_non_declarables').and_return(true)
+
+        configuration = captured_diagnostics_configuration({})
+
+        expect(configuration.fetch(:search_non_declarables)).to be(true)
+      end
+
+      it 'reflects a vector_score_threshold override' do
+        configuration = captured_diagnostics_configuration('vector_score_threshold' => 55)
+
+        expect(configuration.fetch(:vector_score_threshold)).to eq(55)
+      end
+
+      it 'falls back to AdminConfiguration for vector_score_threshold when no override is supplied' do
+        configuration = captured_diagnostics_configuration({})
+
+        expect(configuration.fetch(:vector_score_threshold)).to eq(35)
+      end
+
+      it 'reflects a vector_ef_search override' do
+        configuration = captured_diagnostics_configuration('vector_ef_search' => 250)
+
+        expect(configuration.fetch(:vector_ef_search)).to eq(250)
+      end
+
+      it 'falls back to AdminConfiguration for vector_ef_search when no override is supplied' do
+        configuration = captured_diagnostics_configuration({})
+
+        expect(configuration.fetch(:vector_ef_search)).to eq(100)
+      end
+
+      it 'reflects a rrf_k override' do
+        configuration = captured_diagnostics_configuration('rrf_k' => 15)
+
+        expect(configuration.fetch(:rrf_k)).to eq(15)
+      end
+
+      it 'falls back to AdminConfiguration for rrf_k when no override is supplied' do
+        configuration = captured_diagnostics_configuration({})
+
+        expect(configuration.fetch(:rrf_k)).to eq(60)
+      end
+
+      it 'reflects a max_rounds override on interactive_search_max_questions' do
+        configuration = captured_diagnostics_configuration('max_rounds' => 2)
+
+        expect(configuration.fetch(:interactive_search_max_questions)).to eq(2)
+      end
+
+      it 'falls back to AdminConfiguration for interactive_search_max_questions when no max_rounds override is supplied' do
+        configuration = captured_diagnostics_configuration({})
+
+        expect(configuration.fetch(:interactive_search_max_questions)).to eq(7)
+      end
+
+      it 'reflects a question_model override on search_model[:selected] without disturbing the reasoning_effort sub value' do
+        configuration = captured_diagnostics_configuration('question_model' => 'gpt-4o-mini')
+
+        expect(configuration.fetch(:search_model)).to eq(selected: 'gpt-4o-mini', reasoning_effort: 'medium')
+      end
+
+      it 'falls back to AdminConfiguration for search_model when no question_model override is supplied' do
+        configuration = captured_diagnostics_configuration({})
+
+        expect(configuration.fetch(:search_model)).to eq(selected: 'gpt-5.4', reasoning_effort: 'medium')
+      end
+
+      it 'does not let a question_model override leak into expand_model or the duplicate question guard model' do
+        configuration = captured_diagnostics_configuration('question_model' => 'gpt-4o-mini')
+
+        expect(configuration.fetch(:expand_model)).not_to eq(selected: 'gpt-4o-mini', reasoning_effort: 'medium')
+        expect(configuration.fetch(:interactive_search_duplicate_question_guard_model)[:selected]).not_to eq('gpt-4o-mini')
+      end
+    end
+
     context 'when exact match via search_reference suggestion' do
       let!(:heading) do
         create(:heading, :with_description,
@@ -1664,6 +1774,196 @@ RSpec.describe Api::Internal::SearchService do
           'laptop',
           anything,
           hash_including(expanded_query: 'portable data processing machine Personal'),
+        )
+      end
+    end
+
+    context 'when configuration_overrides are supplied' do
+      let(:opensearch_result_item) do
+        retrieval_result_class.new(
+          id: 1, goods_nomenclature_item_id: '0101210000', goods_nomenclature_sid: 1,
+          producline_suffix: '80', goods_nomenclature_class: 'Commodity',
+          description: 'pure-bred breeding horses', formatted_description: 'Pure-bred breeding horses',
+          self_text: 'Pure-bred breeding horses', classification_description: 'Pure-bred breeding horses',
+          full_description: 'Pure-bred breeding horses', heading_description: nil,
+          declarable: true, score: 10.0, confidence: nil
+        )
+      end
+
+      before do
+        allow(OpensearchRetrievalService).to receive(:call).and_return(
+          OpensearchRetrievalService::Result.new(results: [opensearch_result_item], expanded_query: 'horses'),
+        )
+      end
+
+      it 'overrides candidate_limit via opensearch_result_limit' do
+        described_class.new(q: 'horses', configuration_overrides: { 'candidate_limit' => 5 }).call
+
+        expect(OpensearchRetrievalService).to have_received(:call).with(hash_including(limit: 5))
+      end
+
+      it 'passes max_rounds, question_model, search_compressed_notes_enabled and search_general_rules_enabled through to InteractiveSearchService' do
+        described_class.new(
+          q: 'horses',
+          configuration_overrides: {
+            'max_rounds' => 1,
+            'question_model' => 'gpt-4o-mini',
+            'search_compressed_notes_enabled' => true,
+            'search_general_rules_enabled' => true,
+          },
+        ).call
+
+        expect(InteractiveSearchService).to have_received(:call).with(
+          hash_including(
+            max_rounds: 1, question_model: 'gpt-4o-mini',
+            search_compressed_notes_enabled: true, search_general_rules_enabled: true
+          ),
+        )
+      end
+
+      it "defaults every override to nil when configuration_overrides is not given, reproducing today's behaviour" do
+        described_class.new(q: 'horses').call
+
+        expect(InteractiveSearchService).to have_received(:call).with(
+          hash_including(max_rounds: nil, question_model: nil, search_compressed_notes_enabled: nil, search_general_rules_enabled: nil),
+        )
+      end
+    end
+
+    context 'when retrieval_method is hybrid and configuration_overrides are supplied' do
+      before do
+        allow(AdminConfiguration).to receive(:option_value).with('retrieval_method').and_return('hybrid')
+        allow(HybridRetrievalService).to receive(:call).and_return(
+          instance_double(HybridRetrievalService::Result, results: [], expanded_query: 'horses', source_results: []),
+        )
+      end
+
+      it 'passes rrf_k, vector_score_threshold, vector_ef_search and search_non_declarables through to HybridRetrievalService' do
+        described_class.new(
+          q: 'horses',
+          configuration_overrides: {
+            'rrf_k' => 30, 'vector_score_threshold' => 40, 'vector_ef_search' => 150, 'search_non_declarables' => true
+          },
+        ).call
+
+        expect(HybridRetrievalService).to have_received(:call).with(
+          hash_including(rrf_k: 30, vector_score_threshold: 40, vector_ef_search: 150, search_non_declarables: true),
+        )
+      end
+
+      it "defaults rrf_k, vector_score_threshold, vector_ef_search and search_non_declarables to nil when configuration_overrides is not given, reproducing today's behaviour" do
+        described_class.new(q: 'horses').call
+
+        expect(HybridRetrievalService).to have_received(:call).with(
+          hash_including(rrf_k: nil, vector_score_threshold: nil, vector_ef_search: nil, search_non_declarables: nil),
+        )
+      end
+    end
+
+    context 'when search_type is passed explicitly' do
+      before do
+        allow(AdminConfiguration).to receive(:option_value).with('retrieval_method').and_return('hybrid')
+        allow(HybridRetrievalService).to receive(:call).and_return(
+          instance_double(HybridRetrievalService::Result, results: [], expanded_query: 'horses', source_results: []),
+        )
+      end
+
+      it 'passes the given search_type through to HybridRetrievalService instead of the interactive default' do
+        described_class.new(q: 'horses', search_type: 'evaluation').call
+
+        expect(HybridRetrievalService).to have_received(:call).with(hash_including(search_type: 'evaluation'))
+      end
+
+      it 'passes the given search_type through to the main search instrumentation span instead of the interactive default' do
+        described_class.new(q: 'horses', search_type: 'evaluation').call
+
+        expect(Search::Instrumentation).to have_received(:search).with(hash_including(search_type: 'evaluation'))
+      end
+    end
+
+    context 'when search_type is not given' do
+      before do
+        allow(AdminConfiguration).to receive(:option_value).with('retrieval_method').and_return('hybrid')
+        allow(HybridRetrievalService).to receive(:call).and_return(
+          instance_double(HybridRetrievalService::Result, results: [], expanded_query: 'horses', source_results: []),
+        )
+      end
+
+      it "defaults to 'interactive', reproducing today's exact behaviour" do
+        described_class.new(q: 'horses').call
+
+        expect(HybridRetrievalService).to have_received(:call).with(hash_including(search_type: 'interactive'))
+      end
+
+      it "defaults the main search instrumentation span's search_type to 'interactive', reproducing today's exact behaviour" do
+        described_class.new(q: 'horses').call
+
+        expect(Search::Instrumentation).to have_received(:search).with(hash_including(search_type: 'interactive'))
+      end
+    end
+
+    context 'when search_type is supplied and an exact match occurs' do
+      let!(:heading) do
+        create(:heading, :with_description,
+               goods_nomenclature_item_id: '0101000000',
+               description: 'live horses')
+      end
+
+      before do
+        create(:search_suggestion, :search_reference,
+               goods_nomenclature: heading,
+               value: 'horse',
+               declarable: true)
+
+        allow(TradeTariffBackend.search_client).to receive(:search)
+        allow(Search::Instrumentation).to receive(:exact_match_selected)
+      end
+
+      it 'passes the given search_type through to exact_match_selected instead of the interactive default' do
+        described_class.new(q: 'horse', search_type: 'evaluation').call
+
+        expect(Search::Instrumentation).to have_received(:exact_match_selected).with(hash_including(search_type: 'evaluation'))
+      end
+
+      it "defaults exact_match_selected's search_type to 'interactive' when not given, reproducing today's behaviour" do
+        described_class.new(q: 'horse').call
+
+        expect(Search::Instrumentation).to have_received(:exact_match_selected).with(hash_including(search_type: 'interactive'))
+      end
+    end
+
+    context 'when search_type is supplied and retrieval_method is opensearch' do
+      let(:opensearch_result_item) do
+        retrieval_result_class.new(
+          id: 1, goods_nomenclature_item_id: '0101210000', goods_nomenclature_sid: 1,
+          producline_suffix: '80', goods_nomenclature_class: 'Commodity',
+          description: 'pure-bred breeding horses', formatted_description: 'Pure-bred breeding horses',
+          self_text: 'Pure-bred breeding horses', classification_description: 'Pure-bred breeding horses',
+          full_description: 'Pure-bred breeding horses', heading_description: nil,
+          declarable: true, score: 10.0, confidence: nil
+        )
+      end
+
+      before do
+        allow(OpensearchRetrievalService).to receive(:call).and_return(
+          OpensearchRetrievalService::Result.new(results: [opensearch_result_item], expanded_query: 'horses'),
+        )
+        allow(Search::Instrumentation).to receive(:retrieval_results_returned)
+      end
+
+      it 'passes the given search_type through to retrieval_results_returned instead of the interactive default' do
+        described_class.new(q: 'horses', search_type: 'evaluation').call
+
+        expect(Search::Instrumentation).to have_received(:retrieval_results_returned).with(
+          hash_including(search_type: 'evaluation', retrieval_method: 'opensearch'),
+        )
+      end
+
+      it "defaults retrieval_results_returned's search_type to 'interactive' when not given, reproducing today's behaviour" do
+        described_class.new(q: 'horses').call
+
+        expect(Search::Instrumentation).to have_received(:retrieval_results_returned).with(
+          hash_including(search_type: 'interactive', retrieval_method: 'opensearch'),
         )
       end
     end

--- a/spec/services/hybrid_retrieval_service_spec.rb
+++ b/spec/services/hybrid_retrieval_service_spec.rb
@@ -184,6 +184,24 @@ RSpec.describe HybridRetrievalService do
       expect(AdminConfiguration).to have_received(:integer_value).with('rrf_k')
     end
 
+    it 'uses an explicitly passed rrf_k instead of reading AdminConfiguration' do
+      described_class.call(query: 'horses', as_of: Time.zone.today, rrf_k: 5)
+
+      expect(AdminConfiguration).not_to have_received(:integer_value).with('rrf_k')
+    end
+
+    it 'relays vector-specific overrides to the vector leg' do
+      described_class.call(
+        query: 'horses', expanded_query: expanded_query, as_of: Time.zone.today,
+        vector_score_threshold: 40, vector_ef_search: 150, search_non_declarables: true
+      )
+
+      expect(VectorRetrievalService).to have_received(:call_with_diagnostics).with(
+        query: expanded_query, limit: 30, request_id: nil,
+        vector_score_threshold: 40, vector_ef_search: 150, search_non_declarables: true
+      )
+    end
+
     context 'when the hybrid query guardrail is enabled' do
       before do
         allow(AdminConfiguration).to receive(:enabled?).with('hybrid_query_guardrail_enabled').and_return(true)

--- a/spec/services/hybrid_retrieval_service_spec.rb
+++ b/spec/services/hybrid_retrieval_service_spec.rb
@@ -202,6 +202,29 @@ RSpec.describe HybridRetrievalService do
       )
     end
 
+    it 'relays search_non_declarables to the opensearch leg as well as the vector leg' do
+      as_of = Time.zone.today
+
+      described_class.call(
+        query: 'horses', expanded_query: expanded_query, as_of: as_of, search_non_declarables: true,
+      )
+
+      expect(OpensearchRetrievalService).to have_received(:call).with(
+        query: 'horses', expanded_query: expanded_query, as_of: as_of, request_id: nil, limit: 30,
+        search_non_declarables: true
+      )
+    end
+
+    it 'does not pass search_non_declarables to the opensearch leg when not overridden' do
+      as_of = Time.zone.today
+
+      described_class.call(query: 'horses', expanded_query: expanded_query, as_of: as_of)
+
+      expect(OpensearchRetrievalService).to have_received(:call).with(
+        query: 'horses', expanded_query: expanded_query, as_of: as_of, request_id: nil, limit: 30,
+      )
+    end
+
     context 'when the hybrid query guardrail is enabled' do
       before do
         allow(AdminConfiguration).to receive(:enabled?).with('hybrid_query_guardrail_enabled').and_return(true)

--- a/spec/services/interactive_search_service_spec.rb
+++ b/spec/services/interactive_search_service_spec.rb
@@ -82,8 +82,78 @@ RSpec.describe InteractiveSearchService do
         described_class.call(**search_params(question_model: 'gpt-4o-mini'))
 
         expect(OpenaiClient).to have_received(:call).with(
-          anything, model: 'gpt-4o-mini', reasoning_effort: 'medium', event_kind: 'interactive_search'
+          anything, model: 'gpt-4o-mini', reasoning_effort: anything, event_kind: 'interactive_search'
         )
+      end
+
+      # See "reasoning_effort" contexts below for the exact effort value expected
+      # in each scenario (no override, non-reasoning model, compatible/incompatible
+      # reasoning levels) — this fixes a bug where an overridden question_model could
+      # be sent a reasoning_effort value it does not support.
+
+      context 'without a question_model override' do
+        it 'sends the configured search_model reasoning_effort unchanged' do
+          allow(OpenaiClient).to receive(:call).and_return('{"answers": [{"commodity_code": "4202210000", "confidence": "strong"}]}')
+
+          described_class.call(**search_params)
+
+          expect(OpenaiClient).to have_received(:call).with(
+            anything, model: 'gpt-5.4', reasoning_effort: 'medium', event_kind: 'interactive_search'
+          )
+        end
+      end
+
+      context 'when overridden to a non-reasoning model' do
+        it 'omits reasoning_effort instead of reusing the configured search_model value' do
+          allow(OpenaiClient).to receive(:call).and_return('{"answers": [{"commodity_code": "4202210000", "confidence": "strong"}]}')
+
+          described_class.call(**search_params(question_model: 'gpt-4o-mini'))
+
+          expect(OpenaiClient).to have_received(:call).with(
+            anything, model: 'gpt-4o-mini', reasoning_effort: nil, event_kind: 'interactive_search'
+          )
+        end
+      end
+
+      context 'when overridden to a reasoning model whose levels include the configured effort' do
+        it 'passes the configured reasoning_effort through unchanged' do
+          allow(OpenaiClient).to receive(:call).and_return('{"answers": [{"commodity_code": "4202210000", "confidence": "strong"}]}')
+
+          # Default configured search_model reasoning_effort is 'medium' (NESTED_OPTION_DEFAULTS),
+          # and gpt-5.2's reasoning_levels (%w[none low medium high]) include 'medium'.
+          described_class.call(**search_params(question_model: 'gpt-5.2'))
+
+          expect(OpenaiClient).to have_received(:call).with(
+            anything, model: 'gpt-5.2', reasoning_effort: 'medium', event_kind: 'interactive_search'
+          )
+        end
+      end
+
+      context 'when overridden to a reasoning model whose levels do not include the configured effort' do
+        before do
+          create(:admin_configuration, :nested_options,
+                 name: 'search_model',
+                 area: 'classification',
+                 value: {
+                   'selected' => 'gpt-5.5',
+                   'sub_values' => { 'reasoning_effort' => 'xhigh' },
+                   'options' => [
+                     { 'key' => 'gpt-5.5', 'label' => 'GPT-5.5', 'sub_options' => {} },
+                   ],
+                 })
+        end
+
+        it 'falls back to the most conservative level supported by the overridden model' do
+          allow(OpenaiClient).to receive(:call).and_return('{"answers": [{"commodity_code": "4202210000", "confidence": "strong"}]}')
+
+          # gpt-5.2's reasoning_levels (%w[none low medium high]) do not include the
+          # configured 'xhigh', so the most conservative level ('none') is used instead.
+          described_class.call(**search_params(question_model: 'gpt-5.2'))
+
+          expect(OpenaiClient).to have_received(:call).with(
+            anything, model: 'gpt-5.2', reasoning_effort: 'none', event_kind: 'interactive_search'
+          )
+        end
       end
     end
 

--- a/spec/services/interactive_search_service_spec.rb
+++ b/spec/services/interactive_search_service_spec.rb
@@ -65,6 +65,54 @@ RSpec.describe InteractiveSearchService do
   end
 
   describe '.call' do
+    context 'when max_rounds is passed explicitly' do
+      it 'reaches the final-answer path using the given max_rounds instead of interactive_search_max_questions' do
+        allow(OpenaiClient).to receive(:call).and_return('{"answers": [{"commodity_code": "4202210000", "confidence": "strong"}]}')
+
+        described_class.call(**search_params(max_rounds: 0))
+
+        expect(Search::Instrumentation).to have_received(:api_call).with(hash_including(operation: 'interactive_search_final_answer'))
+      end
+    end
+
+    context 'when question_model is passed explicitly' do
+      it 'uses the given question_model instead of the configured search_model' do
+        allow(OpenaiClient).to receive(:call).and_return('{"answers": [{"commodity_code": "4202210000", "confidence": "strong"}]}')
+
+        described_class.call(**search_params(question_model: 'gpt-4o-mini'))
+
+        expect(OpenaiClient).to have_received(:call).with(
+          anything, model: 'gpt-4o-mini', reasoning_effort: 'medium', event_kind: 'interactive_search'
+        )
+      end
+    end
+
+    context 'when search_type is passed explicitly and the call raises' do
+      it 'tags the failure instrumentation with the given search_type instead of the hardcoded default' do
+        allow(OpenaiClient).to receive(:call).and_raise(StandardError, 'boom')
+        allow(Search::Instrumentation).to receive(:search_failed)
+
+        described_class.call(**search_params(search_type: 'evaluation'))
+
+        expect(Search::Instrumentation).to have_received(:search_failed).with(
+          hash_including(search_type: 'evaluation'),
+        )
+      end
+    end
+
+    context 'when search_type is not given' do
+      it 'still tags failure instrumentation as interactive, reproducing today\'s exact behaviour' do
+        allow(OpenaiClient).to receive(:call).and_raise(StandardError, 'boom')
+        allow(Search::Instrumentation).to receive(:search_failed)
+
+        described_class.call(**search_params)
+
+        expect(Search::Instrumentation).to have_received(:search_failed).with(
+          hash_including(search_type: 'interactive'),
+        )
+      end
+    end
+
     context 'when feature is disabled' do
       before do
         config = AdminConfiguration.where(name: 'interactive_search_enabled').first
@@ -547,6 +595,53 @@ RSpec.describe InteractiveSearchService do
 
     before do
       allow(OpenaiClient).to receive(:call).and_return(ai_response)
+    end
+
+    context 'when search_compressed_notes_enabled is passed explicitly' do
+      it 'records note evidence as enabled without needing a search_compressed_notes_enabled AdminConfiguration record' do
+        described_class.call(**search_params(search_compressed_notes_enabled: true))
+
+        expect(Search::Instrumentation).to have_received(:note_evidence_evaluated).with(
+          hash_including(enabled: true),
+        )
+      end
+
+      it 'records note evidence as disabled for an explicit false override, even when AdminConfiguration says true' do
+        create(:admin_configuration, :boolean, name: 'search_compressed_notes_enabled', value: true, area: 'classification')
+        allow(AdminConfiguration).to receive(:enabled?).and_call_original
+
+        described_class.call(**search_params(search_compressed_notes_enabled: false))
+
+        expect(Search::Instrumentation).to have_received(:note_evidence_evaluated).with(
+          hash_including(enabled: false),
+        )
+        expect(AdminConfiguration).not_to have_received(:enabled?).with('search_compressed_notes_enabled')
+      end
+    end
+
+    context 'when search_general_rules_enabled is passed explicitly' do
+      let(:default_search_context) { AdminConfigurationSeeder.search_context_markdown }
+      let(:general_rules_presenter) { instance_double(Search::GeneralRulesPresenter, to_s: "Current General Rules of Interpretation:\nUse headings first.") }
+
+      before do
+        allow(Search::GeneralRulesPresenter).to receive(:new).and_return(general_rules_presenter)
+      end
+
+      it 'includes general rules without needing a search_general_rules_enabled AdminConfiguration record' do
+        described_class.call(**search_params(search_general_rules_enabled: true))
+
+        expect(Search::GeneralRulesPresenter).to have_received(:new)
+      end
+
+      it 'excludes general rules for an explicit false override, even when AdminConfiguration says true' do
+        create(:admin_configuration, :boolean, name: 'search_general_rules_enabled', value: true, area: 'classification')
+        allow(AdminConfiguration).to receive(:enabled?).and_call_original
+
+        described_class.call(**search_params(search_general_rules_enabled: false))
+
+        expect(Search::GeneralRulesPresenter).not_to have_received(:new)
+        expect(AdminConfiguration).not_to have_received(:enabled?).with('search_general_rules_enabled')
+      end
     end
 
     it 'removes the compressed notes line when no compressed note contexts are selected' do

--- a/spec/services/opensearch_retrieval_service_spec.rb
+++ b/spec/services/opensearch_retrieval_service_spec.rb
@@ -59,6 +59,81 @@ RSpec.describe OpensearchRetrievalService do
       end
     end
 
+    context 'with search_non_declarables' do
+      let(:opensearch_response) { { 'hits' => { 'hits' => [] } } }
+
+      it 'filters to declarable results by default' do
+        described_class.call(query: 'toys', as_of: Time.zone.today)
+
+        expect(TradeTariffBackend.search_client).to have_received(:search).with(
+          hash_including(
+            body: hash_including(
+              query: hash_including(
+                bool: hash_including(
+                  must: include({ term: { declarable: true } }),
+                ),
+              ),
+            ),
+          ),
+        )
+      end
+
+      it 'reads the default from AdminConfiguration when not overridden' do
+        allow(AdminConfiguration).to receive(:enabled?).and_call_original
+        allow(AdminConfiguration).to receive(:enabled?).with('search_non_declarables').and_return(true)
+
+        described_class.call(query: 'toys', as_of: Time.zone.today)
+
+        expect(TradeTariffBackend.search_client).to have_received(:search).with(
+          hash_including(
+            body: hash_including(
+              query: hash_including(
+                bool: hash_including(
+                  must: satisfy { |clauses| clauses.none? { |c| c.dig(:term, :declarable) } },
+                ),
+              ),
+            ),
+          ),
+        )
+      end
+
+      it 'omits the declarable filter when search_non_declarables: true is given explicitly' do
+        described_class.call(query: 'toys', as_of: Time.zone.today, search_non_declarables: true)
+
+        expect(TradeTariffBackend.search_client).to have_received(:search).with(
+          hash_including(
+            body: hash_including(
+              query: hash_including(
+                bool: hash_including(
+                  must: satisfy { |clauses| clauses.none? { |c| c.dig(:term, :declarable) } },
+                ),
+              ),
+            ),
+          ),
+        )
+      end
+
+      it 'uses an explicit search_non_declarables: false instead of reading AdminConfiguration' do
+        allow(AdminConfiguration).to receive(:enabled?).and_call_original
+        allow(AdminConfiguration).to receive(:enabled?).with('search_non_declarables').and_return(true)
+
+        described_class.call(query: 'toys', as_of: Time.zone.today, search_non_declarables: false)
+
+        expect(AdminConfiguration).not_to have_received(:enabled?).with('search_non_declarables')
+        expect(TradeTariffBackend.search_client).to have_received(:search).with(
+          hash_including(
+            body: hash_including(
+              query: hash_including(
+                bool: hash_including(
+                  must: include({ term: { declarable: true } }),
+                ),
+              ),
+            ),
+          ),
+        )
+      end
+    end
+
     context 'with filter prefixes' do
       let(:opensearch_response) { { 'hits' => { 'hits' => [] } } }
 

--- a/spec/services/vector_retrieval_service_spec.rb
+++ b/spec/services/vector_retrieval_service_spec.rb
@@ -286,6 +286,76 @@ RSpec.describe VectorRetrievalService do
       end
     end
 
+    context 'when overrides are passed explicitly' do
+      it 'uses the given vector_score_threshold instead of reading AdminConfiguration' do
+        commodity = create(:commodity, :with_description, :declarable,
+                           goods_nomenclature_item_id: '0101210000',
+                           producline_suffix: GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX)
+        create(:goods_nomenclature_self_text,
+               goods_nomenclature_sid: commodity.goods_nomenclature_sid,
+               goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
+               self_text: 'Pure-bred breeding horses')
+        populate_search_embedding(commodity.goods_nomenclature_sid, query_embedding)
+        allow(AdminConfiguration).to receive(:integer_value).and_call_original
+
+        service = described_class.new(query: 'live horses', limit: 10, request_id: 'request-123', vector_score_threshold: 101)
+        results = service.call
+
+        expect(results).to be_empty
+        expect(AdminConfiguration).not_to have_received(:integer_value).with('vector_score_threshold')
+      end
+
+      it 'uses the given search_non_declarables instead of reading AdminConfiguration' do
+        heading = create(:heading, :with_description, :non_declarable,
+                         goods_nomenclature_item_id: '0101000000',
+                         producline_suffix: GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX)
+        create(:goods_nomenclature_self_text,
+               goods_nomenclature_sid: heading.goods_nomenclature_sid,
+               goods_nomenclature_item_id: heading.goods_nomenclature_item_id,
+               self_text: 'Live horses heading')
+        populate_search_embedding(heading.goods_nomenclature_sid, query_embedding)
+        allow(AdminConfiguration).to receive(:enabled?).and_call_original
+
+        service = described_class.new(query: 'live horses', limit: 10, request_id: 'request-123', search_non_declarables: true)
+        results = service.call
+
+        expect(results).not_to be_empty
+        expect(AdminConfiguration).not_to have_received(:enabled?).with('search_non_declarables')
+      end
+
+      it 'uses the given search_non_declarables: false instead of reading AdminConfiguration' do
+        heading = create(:heading, :with_description, :non_declarable,
+                         goods_nomenclature_item_id: '0101000000',
+                         producline_suffix: GoodsNomenclature::NON_GROUPING_PRODUCTLINE_SUFFIX)
+        create(:goods_nomenclature_self_text,
+               goods_nomenclature_sid: heading.goods_nomenclature_sid,
+               goods_nomenclature_item_id: heading.goods_nomenclature_item_id,
+               self_text: 'Live horses heading')
+        populate_search_embedding(heading.goods_nomenclature_sid, query_embedding)
+        # Stub AdminConfiguration to say non-declarables SHOULD be included, so that a
+        # regression to `@search_non_declarables || AdminConfiguration.enabled?(...)`
+        # (which treats `false` as "not given" because `false` is falsy in Ruby) would
+        # incorrectly fall through to this stub and include the non-declarable heading.
+        allow(AdminConfiguration).to receive(:enabled?).and_call_original
+        allow(AdminConfiguration).to receive(:enabled?).with('search_non_declarables').and_return(true)
+
+        service = described_class.new(query: 'live horses', limit: 10, request_id: 'request-123', search_non_declarables: false)
+        results = service.call
+
+        expect(results).to be_empty
+        expect(AdminConfiguration).not_to have_received(:enabled?).with('search_non_declarables')
+      end
+
+      it 'uses the given vector_ef_search instead of reading AdminConfiguration' do
+        allow(AdminConfiguration).to receive(:integer_value).and_call_original
+
+        service = described_class.new(query: 'live horses', limit: 10, request_id: 'request-123', vector_ef_search: 200)
+        service.call
+
+        expect(AdminConfiguration).not_to have_received(:integer_value).with('vector_ef_search')
+      end
+    end
+
     it 'respects the limit parameter' do
       3.times do |i|
         code = "010121000#{i}"


### PR DESCRIPTION
### Jira link

[AI-1065](https://transformuk.atlassian.net/browse/AI-1065)

### What?

This is the third and final PR of the three building the internal APIs described in AI-1065 (the first two — experiment/run/result CRUD, and the configuration-discovery endpoint — are already merged). This one adds the actual search endpoint: a way to run a real search through the same pipeline real users hit, but with a specific experiment's settings swapped in instead of the live production ones.

Here's what's changed:

- **`Api::Admin::Search::Evaluation::SearchesController`** — new endpoint, `POST /search/evaluation/searches`. Validates the overrides it's given against the same allowlist used elsewhere in AI-1065, then runs a search through `Api::Internal::SearchService` — the exact same service class real user searches go through.
- **`Api::Internal::SearchService`** — now accepts an optional `configuration_overrides` hash and an optional `search_type`. Neither is passed by the real production search route, so its behaviour is unchanged for every existing caller — this is additive only.
- **`HybridRetrievalService`, `VectorRetrievalService`, `InteractiveSearchService`** — each now accepts the handful of override values relevant to it (things like which AI model asks the questions, how many search results to fetch, vector search thresholds) instead of always reading them from the live global settings.
- **`EvaluationConfiguration::AllowlistValidator`** — dropped `filter_prefixes` from the list of overridable settings. While building this we confirmed nothing in the search pipeline actually reads it as an override — it's a real parameter elsewhere (description-intercept filtering), just not one an experiment can usefully tweak. Leaving it in the allowlist would have let someone "set" a value that silently did nothing.
- Folded in a one-line fix to `spec/requests/api/admin/search/evaluation/runs_controller_spec.rb` — a pre-existing bug from the first PR in this trio, where a spec asserted the wrong shape for a validation error response. Caught while verifying error handling for this PR; fixing it here rather than opening a separate PR for one line.

### Why?

An evaluation experiment is only useful if it can actually run a search with its own settings rather than whatever the live site is currently configured with. Up to now there was no way to do that — this PR is what makes an experiment "real" rather than just a stored configuration.

The one thing designed deliberately here: every override is threaded through as an explicit parameter with a safe default, rather than the search service reaching for global settings itself when an override is present. That's what keeps real user search completely untouched — proven by the fact every existing `Api::Internal::SearchController` request spec still passes unmodified, and by new specs confirming that omitting `configuration_overrides` entirely reproduces today's exact behaviour.

A couple of things worth knowing before this gets wired up to the eval app (AI-1073):

- **Instrumentation segregation is partial, not complete.** The main "did a search happen, how long did it take, did it fail" events (`search_started`/`search_completed`/`search_failed`) are correctly tagged with `search_type` now, so dashboards built on those will correctly separate evaluation traffic from real traffic. But several finer-grained events fired during a search — query refinement, description-intercept checks, note-evidence evaluation, question/answer emission, and a second, separate `search_failed` call used for API/embedding-level failures — still hardcode `search_type: 'interactive'` regardless of who actually triggered the search. Anyone building dashboards or alerts off those finer events specifically will currently double-count evaluation traffic as real traffic. Worth its own follow-up ticket before evaluation volume is high enough to skew those numbers.
- **AI spend/cost dashboards can't tell evaluation and production searches apart at all.** Cost tracking (`AiUsage::Instrumentation`, which records OpenAI and embedding call spend) has no `search_type` concept today, and this PR's override mechanism doesn't reach it — it's a separate logging path entirely. Evaluation runs will show up in cost reporting exactly like real user activity. Also worth a follow-up ticket, ideally before evaluation runs happen at any real volume.
- Two smaller things for AI-1073: `retrieval_method` itself (hybrid vs. vector vs. opensearch) still isn't overridable — several of the ten allowed override keys only take effect if the live site's retrieval method already happens to be `hybrid` or `vector`. And `simulator_model` is in the allowlist but isn't read anywhere in this repo — it's purely for the eval app's own use (deciding which model plays "the trader"), confirmed by checking every service that consumes overrides.

### Ticket:

[AI-1065](https://transformuk.atlassian.net/browse/AI-1065)

### Risk:
**Risk level:** 🟠

**Reason for rating:** This one touches the core search services that live user traffic runs through (`Api::Internal::SearchService`, `HybridRetrievalService`, `VectorRetrievalService`, `InteractiveSearchService`), and adds a new endpoint meant to be consumed by another service (the eval app, once AI-1073 wires it up) — both match this repo's own criteria for an Amber change. Mitigated by explicit regression coverage: every existing production search spec passes unmodified, and dedicated specs prove that omitting overrides reproduces today's behaviour byte-for-byte. 345 examples across the evaluation namespace, search services, and production search controller all pass; rubocop clean.

### Have you?

- [ ] Added documentation for new APIs
- [ ] Added new environment variables with correct values to all apps in all spaces

### Deployment risks

- Modifies shared search services that also serve real production user searches — mitigated by the regression coverage described above, but worth a careful look given the blast radius if that coverage ever has a gap.
- No new authentication is introduced on the new endpoint, matching every other endpoint in `Api::Admin` today. Provisioning real network access for the eval app's own service to reach this endpoint is separate infrastructure work, tracked outside this PR (AI-1064, already done) and outside AI-1065's three PRs generally.