### PR TITLE
[HMRC-2476] - Add Categorisation API routes that will be routed through API gateway

### DIFF
--- a/app/controllers/api/v2/categorisation/faq_feedback_controller.rb
+++ b/app/controllers/api/v2/categorisation/faq_feedback_controller.rb
@@ -1,8 +1,9 @@
 module Api
   module V2
     module Categorisation
-      # See GoodsNomenclaturesController — reachable via API Gateway (tariff/categorisation
-      # scope) instead of the legacy static API key/token.
+      # Same behaviour as GreenLanes::FaqFeedbackController, but reachable through
+      # API Gateway under the tariff/categorisation OAuth scope instead of the legacy
+      # static API key/token. The two routes run in parallel during the migration.
       class FaqFeedbackController < GreenLanes::FaqFeedbackController
         skip_before_action :authenticate
       end

--- a/app/controllers/api/v2/categorisation/faq_feedback_controller.rb
+++ b/app/controllers/api/v2/categorisation/faq_feedback_controller.rb
@@ -1,0 +1,11 @@
+module Api
+  module V2
+    module Categorisation
+      # See GoodsNomenclaturesController — reachable via API Gateway (tariff/categorisation
+      # scope) instead of the legacy static API key/token.
+      class FaqFeedbackController < GreenLanes::FaqFeedbackController
+        skip_before_action :authenticate
+      end
+    end
+  end
+end

--- a/app/controllers/api/v2/categorisation/goods_nomenclatures_controller.rb
+++ b/app/controllers/api/v2/categorisation/goods_nomenclatures_controller.rb
@@ -1,0 +1,12 @@
+module Api
+  module V2
+    module Categorisation
+      # Same behaviour as GreenLanes::GoodsNomenclaturesController, but reachable through
+      # API Gateway under the tariff/categorisation OAuth scope instead of the legacy
+      # static API key/token. The two routes run in parallel during the migration.
+      class GoodsNomenclaturesController < GreenLanes::GoodsNomenclaturesController
+        skip_before_action :authenticate
+      end
+    end
+  end
+end

--- a/app/controllers/api/v2/categorisation/themes_controller.rb
+++ b/app/controllers/api/v2/categorisation/themes_controller.rb
@@ -1,8 +1,9 @@
 module Api
   module V2
     module Categorisation
-      # See GoodsNomenclaturesController — reachable via API Gateway (tariff/categorisation
-      # scope) instead of the legacy static API key/token.
+      # Same behaviour as GreenLanes::ThemesController, but reachable through
+      # API Gateway under the tariff/categorisation OAuth scope instead of the legacy
+      # static API key/token. The two routes run in parallel during the migration.
       class ThemesController < GreenLanes::ThemesController
         skip_before_action :authenticate
       end

--- a/app/controllers/api/v2/categorisation/themes_controller.rb
+++ b/app/controllers/api/v2/categorisation/themes_controller.rb
@@ -1,0 +1,11 @@
+module Api
+  module V2
+    module Categorisation
+      # See GoodsNomenclaturesController — reachable via API Gateway (tariff/categorisation
+      # scope) instead of the legacy static API key/token.
+      class ThemesController < GreenLanes::ThemesController
+        skip_before_action :authenticate
+      end
+    end
+  end
+end

--- a/app/engines/v2_api.rb
+++ b/app/engines/v2_api.rb
@@ -166,6 +166,17 @@ V2Api.routes.draw do
         resources :faq_feedback, only: %i[create index show]
       end
 
+      # Parallel route for the same Categorisation API, authenticated via API Gateway's
+      # tariff/categorisation OAuth scope instead of green_lanes' static API key/token.
+      # Remove the green_lanes routes above once consumers have migrated.
+      namespace :categorisation do
+        resources :goods_nomenclatures, only: %i[show], constraints: { id: /\d{4,10}/ }
+
+        resources :themes, only: %i[index]
+
+        resources :faq_feedback, only: %i[create index show]
+      end
+
       match '/400', to: 'errors#bad_request', via: :all
       match '/404', to: 'errors#not_found', via: :all
       match '/405', to: 'errors#method_not_allowed', via: :all

--- a/spec/requests/api/v2/categorisation/faq_feedback_controller_spec.rb
+++ b/spec/requests/api/v2/categorisation/faq_feedback_controller_spec.rb
@@ -1,0 +1,44 @@
+RSpec.describe Api::V2::Categorisation::FaqFeedbackController, :v2 do
+  subject(:api_response) do
+    make_request
+    response
+  end
+
+  before do
+    allow(TradeTariffBackend).to receive(:uk?).and_return(false)
+  end
+
+  describe 'POST to #create' do
+    let(:make_request) do
+      post api_categorisation_faq_feedback_index_path, params: params, headers: headers, as: :json
+    end
+
+    let(:params) do
+      {
+        data: {
+          type: :green_lanes_faq_feedback,
+          attributes: attributes,
+        },
+      }
+    end
+
+    let(:headers) do
+      {
+        'Accept' => 'application/vnd.hmrc.2.0+json',
+        'Content-Type' => 'application/json',
+      }
+    end
+
+    context 'with valid params and no legacy API key/token' do
+      let(:attributes) { attributes_for(:green_lanes_faq_feedback) }
+
+      it { is_expected.to have_http_status :created }
+    end
+
+    context 'with invalid params' do
+      let(:attributes) { attributes_for(:green_lanes_faq_feedback, session_id: nil) }
+
+      it { is_expected.to have_http_status :unprocessable_content }
+    end
+  end
+end

--- a/spec/requests/api/v2/categorisation/goods_nomenclatures_controller_spec.rb
+++ b/spec/requests/api/v2/categorisation/goods_nomenclatures_controller_spec.rb
@@ -1,0 +1,45 @@
+RSpec.describe Api::V2::Categorisation::GoodsNomenclaturesController, :v2 do
+  before do
+    TradeTariffRequest.time_machine_now = Time.current
+    create :category_assessment, measure: gn.measures.first
+    allow(TradeTariffBackend).to receive(:service).and_return('xi')
+  end
+
+  let :gn do
+    create :goods_nomenclature, :with_measures,
+           goods_nomenclature_item_id: '1234560000'
+  end
+
+  let(:request_item_id) { gn.goods_nomenclature_item_id.first(6) }
+
+  let :make_request do
+    api_get api_categorisation_goods_nomenclature_path(request_item_id, format: :json), params:
+  end
+
+  let(:params) { {} }
+
+  describe 'GET #show' do
+    subject(:api_response) do
+      make_request
+      response
+    end
+
+    context 'when no legacy API key/token is provided' do
+      context 'when the good nomenclature has applicable measures with categorisation' do
+        it_behaves_like 'a successful jsonapi response'
+      end
+    end
+
+    context 'when the good nomenclature id is not a subheading' do
+      let(:request_item_id) { '1234000000' }
+
+      it { is_expected.to have_http_status(:not_found) }
+    end
+
+    context 'when request on uk service' do
+      before { allow(TradeTariffBackend).to receive(:service).and_return 'uk' }
+
+      it { is_expected.to have_http_status(:not_found) }
+    end
+  end
+end

--- a/spec/requests/api/v2/categorisation/themes_controller_spec.rb
+++ b/spec/requests/api/v2/categorisation/themes_controller_spec.rb
@@ -1,0 +1,34 @@
+RSpec.describe Api::V2::Categorisation::ThemesController, :v2 do
+  subject(:api_response) do
+    make_request
+    response
+  end
+
+  before { allow(TradeTariffBackend).to receive(:service).and_return 'xi' }
+
+  let(:theme) { create :green_lanes_theme }
+
+  describe 'GET to #index' do
+    let(:make_request) do
+      api_get api_categorisation_themes_path(format: :json)
+    end
+
+    context 'when theme data is found' do
+      it_behaves_like 'a successful jsonapi response'
+    end
+
+    context 'when no legacy API key/token is provided' do
+      it 'does not require the green_lanes static API key/token' do
+        expect(api_response).to have_http_status(:success)
+      end
+    end
+
+    context 'when request on uk service' do
+      before do
+        allow(TradeTariffBackend).to receive(:service).and_return 'uk'
+      end
+
+      it { is_expected.to have_http_status(:not_found) }
+    end
+  end
+end

--- a/spec/swagger/api/v2/categorisation/faq_feedback_spec.rb
+++ b/spec/swagger/api/v2/categorisation/faq_feedback_spec.rb
@@ -1,0 +1,138 @@
+require 'swagger_helper'
+
+RSpec.describe 'Categorisation FAQ Feedback', swagger_doc: 'v2/swagger.json', type: :request do
+  let(:accept) { 'application/vnd.hmrc.2.0+json' }
+
+  before { allow(TradeTariffBackend).to receive(:uk?).and_return(false) }
+
+  faq_feedback_schema = {
+    type: :object,
+    required: %w[id type attributes],
+    properties: {
+      id: { type: :string },
+      type: { type: :string, enum: %w[green_lanes_faq_feedback] },
+      attributes: {
+        type: :object,
+        properties: {
+          session_id: { type: :string },
+          category_id: { type: :integer },
+          question_id: { type: :integer },
+          useful: { type: :boolean },
+        },
+      },
+    },
+  }.freeze
+
+  faq_feedback_request_schema = {
+    type: :object,
+    required: %w[data],
+    properties: {
+      data: {
+        type: :object,
+        required: %w[type attributes],
+        properties: {
+          type: { type: :string, enum: %w[green_lanes_faq_feedback] },
+          attributes: {
+            type: :object,
+            required: %w[session_id category_id question_id useful],
+            properties: {
+              session_id: { type: :string, description: 'Opaque session identifier supplied by the client.' },
+              category_id: { type: :integer, description: 'FAQ category being rated.' },
+              question_id: { type: :integer, description: 'FAQ question being rated.' },
+              useful: { type: :boolean, description: 'Whether the FAQ answer was useful.' },
+            },
+          },
+        },
+      },
+    },
+  }.freeze
+
+  path '/api/categorisation/faq_feedback' do
+    parameter '$ref' => '#/components/parameters/accept_header'
+
+    get 'List Categorisation FAQ feedback' do
+      tags 'Categorisation'
+      security [{ oauth2_client_credentials: ['tariff/categorisation'] }]
+      produces 'application/json'
+      description 'Returns all submitted Categorisation (Green Lanes) FAQ feedback records. ' \
+                   'Available on the Northern Ireland (XI) service only.'
+      operationId 'getCategorisationFaqFeedback'
+
+      response '200', 'FAQ feedback listed' do
+        schema type: :object,
+               required: %w[data],
+               properties: {
+                 data: {
+                   type: :array,
+                   items: faq_feedback_schema,
+                 },
+               }
+
+        before { create(:green_lanes_faq_feedback) }
+
+        run_test!
+      end
+    end
+
+    post 'Submit Categorisation FAQ feedback' do
+      tags 'Categorisation'
+      security [{ oauth2_client_credentials: ['tariff/categorisation'] }]
+      consumes 'application/json'
+      produces 'application/json'
+      description 'Records whether a Categorisation (Green Lanes) FAQ answer was useful. ' \
+                   'Available on the Northern Ireland (XI) service only.'
+      operationId 'postCategorisationFaqFeedback'
+
+      parameter name: :faq_feedback, in: :body, required: true,
+                schema: faq_feedback_request_schema,
+                description: 'JSON:API request body containing the feedback to record.'
+
+      response '201', 'FAQ feedback recorded' do
+        schema type: :object,
+               required: %w[data],
+               properties: {
+                 data: faq_feedback_schema,
+               }
+
+        let(:faq_feedback) do
+          {
+            data: {
+              type: 'green_lanes_faq_feedback',
+              attributes: attributes_for(:green_lanes_faq_feedback),
+            },
+          }
+        end
+
+        run_test!
+      end
+
+      response '422', 'FAQ feedback invalid' do
+        schema type: :object,
+               required: %w[errors],
+               properties: {
+                 errors: {
+                   type: :array,
+                   items: {
+                     type: :object,
+                     properties: {
+                       title: { type: :string, description: 'Invalid attribute name.' },
+                       detail: { type: :array, items: { type: :string }, description: 'Validation messages for the attribute.' },
+                     },
+                   },
+                 },
+               }
+
+        let(:faq_feedback) do
+          {
+            data: {
+              type: 'green_lanes_faq_feedback',
+              attributes: attributes_for(:green_lanes_faq_feedback, session_id: nil),
+            },
+          }
+        end
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/swagger/api/v2/categorisation/goods_nomenclatures_spec.rb
+++ b/spec/swagger/api/v2/categorisation/goods_nomenclatures_spec.rb
@@ -1,0 +1,109 @@
+require 'swagger_helper'
+
+RSpec.describe 'Categorisation Goods Nomenclatures', swagger_doc: 'v2/swagger.json', type: :request do
+  let(:accept) { 'application/vnd.hmrc.2.0+json' }
+
+  before { allow(TradeTariffBackend).to receive(:uk?).and_return(false) }
+
+  relationship_schema = {
+    type: :object,
+    properties: {
+      data: {
+        type: :array,
+        items: {
+          type: :object,
+          properties: {
+            id: { type: :string },
+            type: { type: :string },
+          },
+        },
+      },
+    },
+  }.freeze
+
+  goods_nomenclature_schema = {
+    type: :object,
+    required: %w[id type attributes],
+    properties: {
+      id: { type: :string, description: 'Goods nomenclature SID.' },
+      type: { type: :string, enum: %w[goods_nomenclature] },
+      attributes: {
+        type: :object,
+        properties: {
+          goods_nomenclature_sid: { type: :integer },
+          goods_nomenclature_item_id: { type: :string },
+          description: { type: :string, nullable: true },
+          formatted_description: { type: :string, nullable: true },
+          validity_start_date: { type: :string, nullable: true, format: 'date-time' },
+          validity_end_date: { type: :string, nullable: true, format: 'date-time' },
+          description_plain: { type: :string, nullable: true },
+          producline_suffix: { type: :string, nullable: true },
+          parent_sid: { type: :integer, nullable: true },
+          supplementary_measure_unit: { type: :string, nullable: true },
+        },
+      },
+      relationships: {
+        type: :object,
+        properties: {
+          applicable_category_assessments: relationship_schema,
+          descendant_category_assessments: relationship_schema,
+          ancestors: relationship_schema,
+          descendants: relationship_schema,
+          licences: relationship_schema,
+        },
+      },
+    },
+  }.freeze
+
+  path '/api/categorisation/goods_nomenclatures/{id}' do
+    parameter '$ref' => '#/components/parameters/accept_header'
+    parameter name: :id, in: :path, required: true,
+              schema: { type: :string, pattern: '^\d{4,10}$' },
+              description: 'Goods nomenclature SID (4-10 digits). Available on the Northern Ireland (XI) service only.'
+    parameter name: :filter, in: :query, required: false,
+              style: :deepObject, explode: true,
+              schema: {
+                type: :object,
+                properties: {
+                  geographical_area_id: { type: :string },
+                },
+              },
+              description: 'Optional `filter[geographical_area_id]` to scope applicable category assessments to a geographical area.'
+
+    get 'Retrieve a Categorisation goods nomenclature by id' do
+      tags 'Categorisation'
+      security [{ oauth2_client_credentials: ['tariff/categorisation'] }]
+      produces 'application/json'
+      description 'Returns a single goods nomenclature together with its applicable and descendant category ' \
+                   'assessments, licences, ancestors, and descendants. Available on the Northern Ireland (XI) service only.'
+      operationId 'getCategorisationGoodsNomenclature'
+
+      response '200', 'goods nomenclature found' do
+        schema type: :object,
+               required: %w[data],
+               properties: {
+                 data: goods_nomenclature_schema,
+                 included: { type: :array, items: { type: :object } },
+               }
+
+        before do
+          TradeTariffRequest.time_machine_now = Time.current
+          create(:category_assessment, measure: gn.measures.first)
+        end
+
+        let(:gn) { create(:goods_nomenclature, :with_measures, goods_nomenclature_item_id: '1234560000') }
+        let(:id) { gn.goods_nomenclature_item_id.first(6) }
+        let(:filter) { nil }
+
+        run_test!
+      end
+
+      response '404', 'goods nomenclature not found' do
+        let(:id) { '999999' }
+        let(:filter) { nil }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/swagger/api/v2/categorisation/themes_spec.rb
+++ b/spec/swagger/api/v2/categorisation/themes_spec.rb
@@ -1,0 +1,52 @@
+require 'swagger_helper'
+
+RSpec.describe 'Categorisation Themes', swagger_doc: 'v2/swagger.json', type: :request do
+  let(:accept) { 'application/vnd.hmrc.2.0+json' }
+
+  before { allow(TradeTariffBackend).to receive(:uk?).and_return(false) }
+
+  theme_schema = {
+    type: :object,
+    required: %w[id type attributes],
+    properties: {
+      id: { type: :string, description: 'Theme code, formatted as "{section}.{subsection}".' },
+      type: { type: :string, enum: %w[theme] },
+      attributes: {
+        type: :object,
+        properties: {
+          section: { type: :string, description: 'Same value as `id`.' },
+          theme: { type: :string, description: 'Theme description.' },
+          category: { type: :integer, description: 'Category assessment risk category (1, 2, or 3).' },
+        },
+      },
+    },
+  }.freeze
+
+  path '/api/categorisation/themes' do
+    parameter '$ref' => '#/components/parameters/accept_header'
+
+    get 'List Categorisation themes' do
+      tags 'Categorisation'
+      security [{ oauth2_client_credentials: ['tariff/categorisation'] }]
+      produces 'application/json'
+      description 'Returns all Categorisation (Green Lanes) themes, ordered by section and subsection. ' \
+                   'Available on the Northern Ireland (XI) service only.'
+      operationId 'getCategorisationThemes'
+
+      response '200', 'themes listed' do
+        schema type: :object,
+               required: %w[data],
+               properties: {
+                 data: {
+                   type: :array,
+                   items: theme_schema,
+                 },
+               }
+
+        before { create(:green_lanes_theme) }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -130,6 +130,7 @@ RSpec.configure do |config|
                 scopes: {
                   'tariff/read' => 'Read public Trade Tariff API data.',
                   'tariff/write' => 'Write Trade Tariff API data where an endpoint explicitly supports it.',
+                  'tariff/categorisation' => 'Read Categorisation API data (Northern Ireland only). Issued separately from tariff/read and tariff/write.',
                 },
               },
             },

--- a/spec/swagger_helper_spec.rb
+++ b/spec/swagger_helper_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe 'swagger helper configuration' do
           scopes: {
             'tariff/read' => 'Read public Trade Tariff API data.',
             'tariff/write' => 'Write Trade Tariff API data where an endpoint explicitly supports it.',
+            'tariff/categorisation' => 'Read Categorisation API data (Northern Ireland only). Issued separately from tariff/read and tariff/write.',
           },
         },
       },

--- a/swagger/v2/swagger.json
+++ b/swagger/v2/swagger.json
@@ -40,7 +40,8 @@
             "tokenUrl": "https://auth.id.trade-tariff.service.gov.uk/oauth2/token",
             "scopes": {
               "tariff/read": "Read public Trade Tariff API data.",
-              "tariff/write": "Write Trade Tariff API data where an endpoint explicitly supports it."
+              "tariff/write": "Write Trade Tariff API data where an endpoint explicitly supports it.",
+              "tariff/categorisation": "Read Categorisation API data (Northern Ireland only). Issued separately from tariff/read and tariff/write."
             }
           }
         }
@@ -482,6 +483,563 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/StandardErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/categorisation/faq_feedback": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/accept_header"
+        }
+      ],
+      "get": {
+        "summary": "List Categorisation FAQ feedback",
+        "tags": [
+          "Categorisation"
+        ],
+        "security": [
+          {
+            "oauth2_client_credentials": [
+              "tariff/categorisation"
+            ]
+          }
+        ],
+        "description": "Returns all submitted Categorisation (Green Lanes) FAQ feedback records. Available on the Northern Ireland (XI) service only.",
+        "operationId": "getCategorisationFaqFeedback",
+        "responses": {
+          "200": {
+            "description": "FAQ feedback listed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "id",
+                          "type",
+                          "attributes"
+                        ],
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "green_lanes_faq_feedback"
+                            ]
+                          },
+                          "attributes": {
+                            "type": "object",
+                            "properties": {
+                              "session_id": {
+                                "type": "string"
+                              },
+                              "category_id": {
+                                "type": "integer"
+                              },
+                              "question_id": {
+                                "type": "integer"
+                              },
+                              "useful": {
+                                "type": "boolean"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Submit Categorisation FAQ feedback",
+        "tags": [
+          "Categorisation"
+        ],
+        "security": [
+          {
+            "oauth2_client_credentials": [
+              "tariff/categorisation"
+            ]
+          }
+        ],
+        "description": "Records whether a Categorisation (Green Lanes) FAQ answer was useful. Available on the Northern Ireland (XI) service only.",
+        "operationId": "postCategorisationFaqFeedback",
+        "parameters": [],
+        "responses": {
+          "201": {
+            "description": "FAQ feedback recorded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "required": [
+                        "id",
+                        "type",
+                        "attributes"
+                      ],
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "green_lanes_faq_feedback"
+                          ]
+                        },
+                        "attributes": {
+                          "type": "object",
+                          "properties": {
+                            "session_id": {
+                              "type": "string"
+                            },
+                            "category_id": {
+                              "type": "integer"
+                            },
+                            "question_id": {
+                              "type": "integer"
+                            },
+                            "useful": {
+                              "type": "boolean"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "FAQ feedback invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "errors"
+                  ],
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "title": {
+                            "type": "string",
+                            "description": "Invalid attribute name."
+                          },
+                          "detail": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "description": "Validation messages for the attribute."
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "data"
+                ],
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "required": [
+                      "type",
+                      "attributes"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "green_lanes_faq_feedback"
+                        ]
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "required": [
+                          "session_id",
+                          "category_id",
+                          "question_id",
+                          "useful"
+                        ],
+                        "properties": {
+                          "session_id": {
+                            "type": "string",
+                            "description": "Opaque session identifier supplied by the client."
+                          },
+                          "category_id": {
+                            "type": "integer",
+                            "description": "FAQ category being rated."
+                          },
+                          "question_id": {
+                            "type": "integer",
+                            "description": "FAQ question being rated."
+                          },
+                          "useful": {
+                            "type": "boolean",
+                            "description": "Whether the FAQ answer was useful."
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "required": true,
+          "description": "JSON:API request body containing the feedback to record."
+        }
+      }
+    },
+    "/api/categorisation/goods_nomenclatures/{id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/accept_header"
+        },
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^\\d{4,10}$"
+          },
+          "description": "Goods nomenclature SID (4-10 digits). Available on the Northern Ireland (XI) service only."
+        },
+        {
+          "name": "filter",
+          "in": "query",
+          "required": false,
+          "style": "deepObject",
+          "explode": true,
+          "schema": {
+            "type": "object",
+            "properties": {
+              "geographical_area_id": {
+                "type": "string"
+              }
+            }
+          },
+          "description": "Optional `filter[geographical_area_id]` to scope applicable category assessments to a geographical area."
+        }
+      ],
+      "get": {
+        "summary": "Retrieve a Categorisation goods nomenclature by id",
+        "tags": [
+          "Categorisation"
+        ],
+        "security": [
+          {
+            "oauth2_client_credentials": [
+              "tariff/categorisation"
+            ]
+          }
+        ],
+        "description": "Returns a single goods nomenclature together with its applicable and descendant category assessments, licences, ancestors, and descendants. Available on the Northern Ireland (XI) service only.",
+        "operationId": "getCategorisationGoodsNomenclature",
+        "responses": {
+          "200": {
+            "description": "goods nomenclature found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "required": [
+                        "id",
+                        "type",
+                        "attributes"
+                      ],
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "Goods nomenclature SID."
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "goods_nomenclature"
+                          ]
+                        },
+                        "attributes": {
+                          "type": "object",
+                          "properties": {
+                            "goods_nomenclature_sid": {
+                              "type": "integer"
+                            },
+                            "goods_nomenclature_item_id": {
+                              "type": "string"
+                            },
+                            "description": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "formatted_description": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "validity_start_date": {
+                              "type": "string",
+                              "nullable": true,
+                              "format": "date-time"
+                            },
+                            "validity_end_date": {
+                              "type": "string",
+                              "nullable": true,
+                              "format": "date-time"
+                            },
+                            "description_plain": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "producline_suffix": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "parent_sid": {
+                              "type": "integer",
+                              "nullable": true
+                            },
+                            "supplementary_measure_unit": {
+                              "type": "string",
+                              "nullable": true
+                            }
+                          }
+                        },
+                        "relationships": {
+                          "type": "object",
+                          "properties": {
+                            "applicable_category_assessments": {
+                              "type": "object",
+                              "properties": {
+                                "data": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "descendant_category_assessments": {
+                              "type": "object",
+                              "properties": {
+                                "data": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "ancestors": {
+                              "type": "object",
+                              "properties": {
+                                "data": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "descendants": {
+                              "type": "object",
+                              "properties": {
+                                "data": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "licences": {
+                              "type": "object",
+                              "properties": {
+                                "data": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "included": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "goods nomenclature not found"
+          }
+        }
+      }
+    },
+    "/api/categorisation/themes": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/accept_header"
+        }
+      ],
+      "get": {
+        "summary": "List Categorisation themes",
+        "tags": [
+          "Categorisation"
+        ],
+        "security": [
+          {
+            "oauth2_client_credentials": [
+              "tariff/categorisation"
+            ]
+          }
+        ],
+        "description": "Returns all Categorisation (Green Lanes) themes, ordered by section and subsection. Available on the Northern Ireland (XI) service only.",
+        "operationId": "getCategorisationThemes",
+        "responses": {
+          "200": {
+            "description": "themes listed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "id",
+                          "type",
+                          "attributes"
+                        ],
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "description": "Theme code, formatted as \"{section}.{subsection}\"."
+                          },
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "theme"
+                            ]
+                          },
+                          "attributes": {
+                            "type": "object",
+                            "properties": {
+                              "section": {
+                                "type": "string",
+                                "description": "Same value as `id`."
+                              },
+                              "theme": {
+                                "type": "string",
+                                "description": "Theme description."
+                              },
+                              "category": {
+                                "type": "integer",
+                                "description": "Category assessment risk category (1, 2, or 3)."
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }


### PR DESCRIPTION
## What:

Add Categorisation API routes that will be routed through API gateway. It does not affect any green lanes routes currently in the system.

## Why:

So the categorisation API users have higher  usage limit.

## Ticket:

https://transformuk.atlassian.net/jira/software/c/projects/HMRC/boards/155?selectedIssue=HMRC-2476

## Risk:
**Risk level:** 🟢 

**Reason for rating:**

These are new routes and would not affect existing system.