### PR TITLE
Remove orphan show route from faq feedback controllers

### DIFF
--- a/app/engines/v2_api.rb
+++ b/app/engines/v2_api.rb
@@ -163,7 +163,7 @@ V2Api.routes.draw do
 
         resources :themes, only: %i[index]
 
-        resources :faq_feedback, only: %i[create index show]
+        resources :faq_feedback, only: %i[create index]
       end
 
       # Parallel route for the same Categorisation API, authenticated via API Gateway's
@@ -174,7 +174,7 @@ V2Api.routes.draw do
 
         resources :themes, only: %i[index]
 
-        resources :faq_feedback, only: %i[create index show]
+        resources :faq_feedback, only: %i[create index]
       end
 
       match '/400', to: 'errors#bad_request', via: :all


### PR DESCRIPTION
## What:
Removes the unused `show` action from faq feedback controllers.

## Why:
Discovered reviewing another PR, it seems this route is not used https://github.com/trade-tariff/trade-tariff-backend/pull/3637#pullrequestreview-4927020924

We should remove to keep the codebase clean and tidy

## Ticket:
N/A

## Risk:
**Risk level:** 🟢 

**Reason for rating:**
Removes a route with no action
