### PR TITLE
[ci skip] Add docs for a new route for categorisation API

### DIFF
--- a/docs/architecture/request-routing.md
+++ b/docs/architecture/request-routing.md
@@ -24,6 +24,8 @@ Routes are explicitly mounted under `/uk` and `/xi` where the service mode allow
 
 `app/engines/v2_api.rb` defines the public V2 API surface. It includes tariff hierarchy endpoints, measures, quotas, certificates, search, rules of origin, news, exchange rates, Green Lanes, changes, and error responses.
 
+Green Lanes (and its parallel `categorisation` namespace, added for the API Gateway OAuth migration) is the one V2 surface restricted to XI service mode at the controller level rather than just by mount point — see `docs/green-lanes.md#api-access--routing` for the mechanism and why no UK-side routing exists or is needed.
+
 Most V2 routes map to controllers under `app/controllers/api/v2/`. Serialisation usually flows through `app/serializers/api/v2/` and presenter classes under `app/presenters/api/v2/`.
 
 ## Admin, Internal, and User APIs

--- a/docs/green-lanes.md
+++ b/docs/green-lanes.md
@@ -60,6 +60,18 @@ _If the API consumer determines that no Category Assessments apply, then the Goo
 
 To achieve this the relevant measures are grouped together according to those with the same groups of exemptions (and geographical areas) and a separate CA is presented for each of these permutations.
 
+## API Access / Routing
+
+The Green Lanes/Categorisation API is XI-only. There is no UK equivalent and none is needed — the categorisation only has meaning for goods moving between GB and NI under the Windsor Framework, so there is nothing for a UK-side route to serve.
+
+This is enforced in code, not just by convention: `Api::V2::GreenLanes::BaseController#check_service` (`app/controllers/api/v2/green_lanes/base_controller.rb`) raises `ActionController::RoutingError` (404) whenever `TradeTariffBackend.uk?` is true, regardless of URL prefix (added in HOTT-4856, #1670).
+
+### Categorisation routes (API Gateway migration)
+
+`app/engines/v2_api.rb` also mounts a parallel `namespace :categorisation` alongside `namespace :green_lanes` (HMRC-2476, #3637). The `Api::V2::Categorisation::*` controllers subclass their `GreenLanes::*` equivalents and only `skip_before_action :authenticate` — auth is instead handled by API Gateway's `tariff/categorisation` OAuth scope in front of these routes, replacing the legacy static API key/token used by `green_lanes`. Because they subclass `GreenLanes::*`, they inherit `check_service`, so `/xi/api/categorisation/*` is XI-only for the same reason as `/xi/api/green_lanes/*`, with no extra guard needed.
+
+The `green_lanes` routes remain in place for backward compatibility and should be removed once existing consumers migrate to `categorisation`.
+
 ## Pseudo Measures and Pseudo Exemptions
 
 These are custom data points built by OTT to handle policies that don't explicitly appear in the EU tariff but are relevant under the Windsor Framework.


### PR DESCRIPTION
## What:
Add docs for a new route for categorisation API

## Why:

So we have a document of reason for changing and constraints like XI only.

## Ticket:
https://transformuk.atlassian.net/browse/HMRC-2476

## Risk:
**Risk level:** 🟢

**Reason for rating:**

Updated only docs so no real risk.