### PR TITLE
AI-1184: Make evaluation run creation retry-idempotent

### DIFF
--- a/app/controllers/api/admin/search/evaluation/runs_controller.rb
+++ b/app/controllers/api/admin/search/evaluation/runs_controller.rb
@@ -19,6 +19,7 @@ module Api
             evaluation_run = EvaluationRun.start!(
               experiment:,
               triggered_by: create_params[:triggered_by],
+              idempotency_key: idempotency_key!,
               run_time_overrides: create_params[:configuration_overrides] || {},
             )
 
@@ -55,6 +56,16 @@ module Api
 
           def run
             @run ||= EvaluationRun.with_pk!(params[:id])
+          end
+
+          # Required so retrying a create request (timeout, dropped response) can be
+          # told apart from a deliberate second run of the same experiment — see
+          # EvaluationRun.start!.
+          def idempotency_key!
+            key = request.headers['Idempotency-Key']
+            raise ActionController::BadRequest, 'Idempotency-Key header is required' if key.blank?
+
+            key
           end
 
           def create_params

--- a/app/controllers/api/admin/search/evaluation/runs_controller.rb
+++ b/app/controllers/api/admin/search/evaluation/runs_controller.rb
@@ -4,6 +4,13 @@ module Api
       module Evaluation
         class RunsController < AdminController
           RECONCILING_STATUSES = %w[completed partially_failed failed cancelled].freeze
+          # evaluation_runs.idempotency_key is an unbounded `text` column with a unique
+          # btree index on it — Postgres btree entries are capped at roughly a third of a
+          # page (~2.7KB on the default 8KB page size), so a sufficiently large header
+          # value would fail the INSERT with an unhandled 500 instead of a clean 400. 255
+          # is generous headroom for any real idempotency key (a UUID is 36 characters)
+          # while staying nowhere near that limit.
+          MAX_IDEMPOTENCY_KEY_LENGTH = 255
 
           def index
             render json: serialize(runs.all, is_collection: true, meta: pagination_meta)
@@ -64,6 +71,9 @@ module Api
           def idempotency_key!
             key = request.headers['Idempotency-Key']
             raise ActionController::BadRequest, 'Idempotency-Key header is required' if key.blank?
+            if key.length > MAX_IDEMPOTENCY_KEY_LENGTH
+              raise ActionController::BadRequest, "Idempotency-Key must be #{MAX_IDEMPOTENCY_KEY_LENGTH} characters or fewer"
+            end
 
             key
           end

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -29,6 +29,11 @@ module Api
       render json: serializer.serialized_errors({ error: exception.message, url: request.url }), status: :unprocessable_content
     end
 
+    rescue_from EvaluationRun::IdempotencyKeyConflict do |exception|
+      serializer = TradeTariffBackend.error_serializer(request)
+      render json: serializer.serialized_errors({ error: exception.message, url: request.url }), status: :conflict
+    end
+
   protected
 
     def current_page

--- a/app/models/evaluation_run.rb
+++ b/app/models/evaluation_run.rb
@@ -17,23 +17,35 @@ class EvaluationRun < Sequel::Model(Sequel[:evaluation_runs].qualify(:uk))
   # idempotency_key makes retrying a create request safe: the caller generates one key
   # per logical "start this run" attempt and resends the same value on any retry, so a
   # repeat request returns the run already created instead of inserting a duplicate. A
-  # key reused with a DIFFERENT experiment/triggered_by/configuration raises
+  # key reused with a DIFFERENT experiment/triggered_by/run_time_overrides raises
   # IdempotencyKeyConflict instead of silently returning the wrong run — the key is a
   # fingerprint of one specific request, not a bare token that returns whatever it last
   # pointed to.
+  #
+  # The reuse check compares ONLY the caller's literal request inputs — experiment_id,
+  # triggered_by, and run_time_overrides exactly as sent — never effective_configuration
+  # or configuration_digest. Those two are DERIVED from experiment.configuration_overrides
+  # and the admin-config baseline (EvaluationConfiguration::BaselineProvider), both of
+  # which an operator can edit at any time. A genuine retry — literally the same request,
+  # resent because the first response was lost — must return the original run even if an
+  # operator changed an unrelated admin setting in the meantime; comparing derived,
+  # time-varying state would wrongly reject that retry. Because of this, the reuse check
+  # runs BEFORE any configuration resolution, so a real replay does no config/baseline
+  # work at all.
+  #
   # The rescue covers the race where two requests carrying the same key both pass the
   # lookup below before either has inserted — the loser resolves against the winner's
   # row the same way the pre-insert lookup above would have.
   def self.start!(experiment:, triggered_by:, idempotency_key:, run_time_overrides: {})
+    existing = find_by_idempotency_key(idempotency_key)
+    return resolve_reused_key!(existing, idempotency_key:, experiment:, triggered_by:, run_time_overrides:) if existing
+
     overrides = EvaluationConfiguration::Merger.call(experiment.configuration_overrides, run_time_overrides)
     EvaluationConfiguration::AllowlistValidator.call(overrides)
 
     baseline = EvaluationConfiguration::BaselineProvider.call
     effective_configuration = EvaluationConfiguration::Merger.call(baseline, overrides)
     digest = EvaluationConfiguration::DigestCalculator.call(effective_configuration)
-
-    existing = find_by_idempotency_key(idempotency_key)
-    return resolve_reused_key!(existing, idempotency_key:, experiment:, triggered_by:, digest:) if existing
 
     create(
       evaluation_experiment: experiment,
@@ -44,26 +56,39 @@ class EvaluationRun < Sequel::Model(Sequel[:evaluation_runs].qualify(:uk))
       question_model: effective_configuration['question_model'],
       simulator_model: effective_configuration['simulator_model'],
       idempotency_key:,
+      run_time_overrides:,
     )
   rescue Sequel::UniqueConstraintViolation
     winner = find_by_idempotency_key(idempotency_key)
     raise unless winner
 
-    resolve_reused_key!(winner, idempotency_key:, experiment:, triggered_by:, digest:)
+    resolve_reused_key!(winner, idempotency_key:, experiment:, triggered_by:, run_time_overrides:)
   end
 
   def self.find_by_idempotency_key(idempotency_key)
     where(idempotency_key:).first
   end
 
-  # Returns `existing` if it was genuinely created by the same logical request
-  # (same experiment, same triggered_by, same resolved configuration); raises
-  # IdempotencyKeyConflict naming the mismatched field(s) otherwise.
-  def self.resolve_reused_key!(existing, idempotency_key:, experiment:, triggered_by:, digest:)
+  # Returns `existing` if it was genuinely created by the same logical request (same
+  # experiment, same triggered_by, same literal run_time_overrides — see start!'s comment
+  # for why this compares literal request inputs rather than any derived configuration);
+  # raises IdempotencyKeyConflict naming the mismatched field(s) otherwise.
+  def self.resolve_reused_key!(existing, idempotency_key:, experiment:, triggered_by:, run_time_overrides:)
     mismatches = []
     mismatches << "experiment_id (existing=#{existing.experiment_id}, requested=#{experiment.id})" if existing.experiment_id != experiment.id
     mismatches << "triggered_by (existing=#{existing.triggered_by.inspect}, requested=#{triggered_by.inspect})" if existing.triggered_by != triggered_by
-    mismatches << "configuration (existing digest=#{existing.configuration_digest}, requested digest=#{digest})" if existing.configuration_digest != digest
+    # JSON.parse(...to_json), not a bare Hash#== against run_time_overrides directly:
+    # existing.run_time_overrides is a plain, string-keyed Hash exactly as Postgres
+    # round-tripped it through jsonb. The incoming run_time_overrides may be an
+    # ActionController::Parameters-derived HashWithIndifferentAccess or contain Symbol
+    # keys, either of which can compare unequal to a plain Hash even with identical
+    # content. Round-tripping through the same JSON serialization jsonb itself uses
+    # guarantees both sides are compared in the exact representation that would be
+    # persisted, not an incidental Ruby object-equality quirk.
+    normalised_requested = JSON.parse(run_time_overrides.to_json)
+    if existing.run_time_overrides != normalised_requested
+      mismatches << "run_time_overrides (existing=#{existing.run_time_overrides.inspect}, requested=#{normalised_requested.inspect})"
+    end
 
     return existing if mismatches.empty?
 

--- a/app/models/evaluation_run.rb
+++ b/app/models/evaluation_run.rb
@@ -12,7 +12,16 @@ class EvaluationRun < Sequel::Model(Sequel[:evaluation_runs].qualify(:uk))
     validates_presence :experiment_id
   end
 
-  def self.start!(experiment:, triggered_by:, run_time_overrides: {})
+  # idempotency_key makes retrying a create request safe: the caller generates one key
+  # per logical "start this run" attempt and resends the same value on any retry, so a
+  # repeat request returns the run already created instead of inserting a duplicate.
+  # The rescue covers the race where two requests carrying the same key both pass the
+  # lookup below before either has inserted — the loser returns the winner's row instead
+  # of raising.
+  def self.start!(experiment:, triggered_by:, idempotency_key:, run_time_overrides: {})
+    existing = find_by_idempotency_key(idempotency_key)
+    return existing if existing
+
     overrides = EvaluationConfiguration::Merger.call(experiment.configuration_overrides, run_time_overrides)
     EvaluationConfiguration::AllowlistValidator.call(overrides)
 
@@ -28,7 +37,14 @@ class EvaluationRun < Sequel::Model(Sequel[:evaluation_runs].qualify(:uk))
       effective_configuration:,
       question_model: effective_configuration['question_model'],
       simulator_model: effective_configuration['simulator_model'],
+      idempotency_key:,
     )
+  rescue Sequel::UniqueConstraintViolation
+    find_by_idempotency_key(idempotency_key) || raise
+  end
+
+  def self.find_by_idempotency_key(idempotency_key)
+    where(idempotency_key:).first
   end
 
   def reconcile_aggregates!

--- a/app/models/evaluation_run.rb
+++ b/app/models/evaluation_run.rb
@@ -3,6 +3,8 @@ class EvaluationRun < Sequel::Model(Sequel[:evaluation_runs].qualify(:uk))
 
   STATUSES = %w[queued running completed partially_failed failed cancelled].freeze
 
+  IdempotencyKeyConflict = Class.new(StandardError)
+
   many_to_one :evaluation_experiment, key: :experiment_id
   one_to_many :evaluation_results, key: :run_id
 
@@ -14,20 +16,24 @@ class EvaluationRun < Sequel::Model(Sequel[:evaluation_runs].qualify(:uk))
 
   # idempotency_key makes retrying a create request safe: the caller generates one key
   # per logical "start this run" attempt and resends the same value on any retry, so a
-  # repeat request returns the run already created instead of inserting a duplicate.
+  # repeat request returns the run already created instead of inserting a duplicate. A
+  # key reused with a DIFFERENT experiment/triggered_by/configuration raises
+  # IdempotencyKeyConflict instead of silently returning the wrong run — the key is a
+  # fingerprint of one specific request, not a bare token that returns whatever it last
+  # pointed to.
   # The rescue covers the race where two requests carrying the same key both pass the
-  # lookup below before either has inserted — the loser returns the winner's row instead
-  # of raising.
+  # lookup below before either has inserted — the loser resolves against the winner's
+  # row the same way the pre-insert lookup above would have.
   def self.start!(experiment:, triggered_by:, idempotency_key:, run_time_overrides: {})
-    existing = find_by_idempotency_key(idempotency_key)
-    return existing if existing
-
     overrides = EvaluationConfiguration::Merger.call(experiment.configuration_overrides, run_time_overrides)
     EvaluationConfiguration::AllowlistValidator.call(overrides)
 
     baseline = EvaluationConfiguration::BaselineProvider.call
     effective_configuration = EvaluationConfiguration::Merger.call(baseline, overrides)
     digest = EvaluationConfiguration::DigestCalculator.call(effective_configuration)
+
+    existing = find_by_idempotency_key(idempotency_key)
+    return resolve_reused_key!(existing, idempotency_key:, experiment:, triggered_by:, digest:) if existing
 
     create(
       evaluation_experiment: experiment,
@@ -40,12 +46,30 @@ class EvaluationRun < Sequel::Model(Sequel[:evaluation_runs].qualify(:uk))
       idempotency_key:,
     )
   rescue Sequel::UniqueConstraintViolation
-    find_by_idempotency_key(idempotency_key) || raise
+    winner = find_by_idempotency_key(idempotency_key)
+    raise unless winner
+
+    resolve_reused_key!(winner, idempotency_key:, experiment:, triggered_by:, digest:)
   end
 
   def self.find_by_idempotency_key(idempotency_key)
     where(idempotency_key:).first
   end
+
+  # Returns `existing` if it was genuinely created by the same logical request
+  # (same experiment, same triggered_by, same resolved configuration); raises
+  # IdempotencyKeyConflict naming the mismatched field(s) otherwise.
+  def self.resolve_reused_key!(existing, idempotency_key:, experiment:, triggered_by:, digest:)
+    mismatches = []
+    mismatches << "experiment_id (existing=#{existing.experiment_id}, requested=#{experiment.id})" if existing.experiment_id != experiment.id
+    mismatches << "triggered_by (existing=#{existing.triggered_by.inspect}, requested=#{triggered_by.inspect})" if existing.triggered_by != triggered_by
+    mismatches << "configuration (existing digest=#{existing.configuration_digest}, requested digest=#{digest})" if existing.configuration_digest != digest
+
+    return existing if mismatches.empty?
+
+    raise IdempotencyKeyConflict, "Idempotency-Key #{idempotency_key} was already used for a different request: #{mismatches.join('; ')}"
+  end
+  private_class_method :resolve_reused_key!
 
   def reconcile_aggregates!
     results = evaluation_results_dataset

--- a/app/serializers/api/admin/search/evaluation/run_serializer.rb
+++ b/app/serializers/api/admin/search/evaluation/run_serializer.rb
@@ -24,7 +24,8 @@ module Api
                      :error_count,
                      :error_summary,
                      :aggregate_metrics,
-                     :created_at
+                     :created_at,
+                     :idempotency_key
         end
       end
     end

--- a/db/migrate/20260817163645_add_idempotency_key_to_evaluation_runs.rb
+++ b/db/migrate/20260817163645_add_idempotency_key_to_evaluation_runs.rb
@@ -1,0 +1,8 @@
+Sequel.migration do
+  change do
+    alter_table(:evaluation_runs) do
+      add_column :idempotency_key, String
+      add_index :idempotency_key, unique: true
+    end
+  end
+end

--- a/db/migrate/20260818120000_add_run_time_overrides_to_evaluation_runs.rb
+++ b/db/migrate/20260818120000_add_run_time_overrides_to_evaluation_runs.rb
@@ -1,0 +1,15 @@
+Sequel.migration do
+  change do
+    alter_table(:evaluation_runs) do
+      # Stores the literal run_time_overrides the caller sent, verbatim — distinct from
+      # effective_configuration/configuration_digest, which are DERIVED from this plus
+      # the (mutable) experiment.configuration_overrides and the (mutable) admin-config
+      # baseline. Idempotency-key replay detection must compare against something that
+      # cannot drift between the original request and a retry; the derived columns can
+      # drift if an operator edits the experiment or a baseline admin setting in between,
+      # so they are unsafe for that comparison. This column can't drift, because nothing
+      # ever updates it after creation.
+      add_column :run_time_overrides, :jsonb, null: false, default: '{}'
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2228,6 +2228,7 @@ CREATE TABLE uk.evaluation_runs (
     aggregate_metrics jsonb DEFAULT '{}'::jsonb NOT NULL,
     created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
     idempotency_key text,
+    run_time_overrides jsonb DEFAULT '{}'::jsonb NOT NULL,
     CONSTRAINT evaluation_runs_status_check CHECK ((status = ANY (ARRAY['queued'::text, 'running'::text, 'completed'::text, 'partially_failed'::text, 'failed'::text, 'cancelled'::text])))
 );
 
@@ -14995,3 +14996,4 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20260803000001_create_eval
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260803000002_create_evaluation_runs.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260803000003_create_evaluation_results.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260817163645_add_idempotency_key_to_evaluation_runs.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20260818120000_add_run_time_overrides_to_evaluation_runs.rb');

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2227,6 +2227,7 @@ CREATE TABLE uk.evaluation_runs (
     error_summary text,
     aggregate_metrics jsonb DEFAULT '{}'::jsonb NOT NULL,
     created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    idempotency_key text,
     CONSTRAINT evaluation_runs_status_check CHECK ((status = ANY (ARRAY['queued'::text, 'running'::text, 'completed'::text, 'partially_failed'::text, 'failed'::text, 'cancelled'::text])))
 );
 
@@ -11438,6 +11439,13 @@ CREATE INDEX evaluation_runs_experiment_id_index ON uk.evaluation_runs USING btr
 
 
 --
+-- Name: evaluation_runs_idempotency_key_index; Type: INDEX; Schema: uk; Owner: -
+--
+
+CREATE UNIQUE INDEX evaluation_runs_idempotency_key_index ON uk.evaluation_runs USING btree (idempotency_key);
+
+
+--
 -- Name: evaluation_runs_question_model_index; Type: INDEX; Schema: uk; Owner: -
 --
 
@@ -14986,3 +14994,4 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20260730140000_add_created
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260803000001_create_evaluation_experiments.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260803000002_create_evaluation_runs.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20260803000003_create_evaluation_results.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20260817163645_add_idempotency_key_to_evaluation_runs.rb');

--- a/spec/models/evaluation_run_spec.rb
+++ b/spec/models/evaluation_run_spec.rb
@@ -55,4 +55,53 @@ RSpec.describe EvaluationRun do
       )
     }.to raise_error(Sequel::CheckConstraintViolation)
   end
+
+  it 'enforces idempotency_key uniqueness at the database level' do
+    described_class.db[:evaluation_runs].insert(
+      experiment_id: experiment.id, status: 'queued', triggered_by: 'operator',
+      effective_configuration: Sequel.pg_jsonb({}), idempotency_key: 'dupe-key'
+    )
+
+    expect {
+      described_class.db[:evaluation_runs].insert(
+        experiment_id: experiment.id, status: 'queued', triggered_by: 'operator',
+        effective_configuration: Sequel.pg_jsonb({}), idempotency_key: 'dupe-key'
+      )
+    }.to raise_error(Sequel::UniqueConstraintViolation)
+  end
+
+  describe '.start!' do
+    it 'creates a new run and stores the idempotency_key' do
+      run = described_class.start!(experiment:, triggered_by: 'operator', idempotency_key: 'key-1')
+
+      expect(run.idempotency_key).to eq('key-1')
+      expect(described_class.count).to eq(1)
+    end
+
+    it 'returns the existing run instead of creating a second one when the key repeats' do
+      first_run = described_class.start!(experiment:, triggered_by: 'operator', idempotency_key: 'key-2')
+
+      second_run = described_class.start!(experiment:, triggered_by: 'operator', idempotency_key: 'key-2')
+
+      expect(second_run.id).to eq(first_run.id)
+      expect(described_class.count).to eq(1)
+    end
+
+    it 'creates a separate run for a different idempotency_key' do
+      described_class.start!(experiment:, triggered_by: 'operator', idempotency_key: 'key-3a')
+      described_class.start!(experiment:, triggered_by: 'operator', idempotency_key: 'key-3b')
+
+      expect(described_class.count).to eq(2)
+    end
+
+    it 'returns the racing request run instead of raising when a concurrent create wins the unique-constraint race' do
+      racing_run = create(:evaluation_run, evaluation_experiment: experiment, idempotency_key: 'race-key')
+      allow(described_class).to receive(:find_by_idempotency_key).and_return(nil, racing_run)
+      allow(described_class).to receive(:create).and_raise(Sequel::UniqueConstraintViolation.new('duplicate key'))
+
+      result = described_class.start!(experiment:, triggered_by: 'operator', idempotency_key: 'race-key')
+
+      expect(result).to eq(racing_run)
+    end
+  end
 end

--- a/spec/models/evaluation_run_spec.rb
+++ b/spec/models/evaluation_run_spec.rb
@@ -69,39 +69,4 @@ RSpec.describe EvaluationRun do
       )
     }.to raise_error(Sequel::UniqueConstraintViolation)
   end
-
-  describe '.start!' do
-    it 'creates a new run and stores the idempotency_key' do
-      run = described_class.start!(experiment:, triggered_by: 'operator', idempotency_key: 'key-1')
-
-      expect(run.idempotency_key).to eq('key-1')
-      expect(described_class.count).to eq(1)
-    end
-
-    it 'returns the existing run instead of creating a second one when the key repeats' do
-      first_run = described_class.start!(experiment:, triggered_by: 'operator', idempotency_key: 'key-2')
-
-      second_run = described_class.start!(experiment:, triggered_by: 'operator', idempotency_key: 'key-2')
-
-      expect(second_run.id).to eq(first_run.id)
-      expect(described_class.count).to eq(1)
-    end
-
-    it 'creates a separate run for a different idempotency_key' do
-      described_class.start!(experiment:, triggered_by: 'operator', idempotency_key: 'key-3a')
-      described_class.start!(experiment:, triggered_by: 'operator', idempotency_key: 'key-3b')
-
-      expect(described_class.count).to eq(2)
-    end
-
-    it 'returns the racing request run instead of raising when a concurrent create wins the unique-constraint race' do
-      racing_run = create(:evaluation_run, evaluation_experiment: experiment, idempotency_key: 'race-key')
-      allow(described_class).to receive(:find_by_idempotency_key).and_return(nil, racing_run)
-      allow(described_class).to receive(:create).and_raise(Sequel::UniqueConstraintViolation.new('duplicate key'))
-
-      result = described_class.start!(experiment:, triggered_by: 'operator', idempotency_key: 'race-key')
-
-      expect(result).to eq(racing_run)
-    end
-  end
 end

--- a/spec/models/evaluation_run_start_spec.rb
+++ b/spec/models/evaluation_run_start_spec.rb
@@ -11,13 +11,19 @@ RSpec.describe EvaluationRun do
     end
 
     it 'creates a run with an effective_configuration merging baseline and experiment overrides' do
-      run = described_class.start!(experiment:, triggered_by: 'operator')
+      run = described_class.start!(experiment:, triggered_by: 'operator', idempotency_key: SecureRandom.uuid)
       expect(run.effective_configuration['simulator_model']).to eq('gpt-4o-mini')
+    end
+
+    it 'stores the idempotency_key it was started with' do
+      key = SecureRandom.uuid
+      run = described_class.start!(experiment:, triggered_by: 'operator', idempotency_key: key)
+      expect(run.idempotency_key).to eq(key)
     end
 
     it 'applies run-time overrides on top of the experiment overrides' do
       run = described_class.start!(
-        experiment:, triggered_by: 'operator',
+        experiment:, triggered_by: 'operator', idempotency_key: SecureRandom.uuid,
         run_time_overrides: { 'simulator_model' => 'gpt-4o' }
       )
       expect(run.effective_configuration['simulator_model']).to eq('gpt-4o')
@@ -25,7 +31,7 @@ RSpec.describe EvaluationRun do
 
     it 'promotes simulator_model and question_model onto their own columns' do
       run = described_class.start!(
-        experiment:, triggered_by: 'operator',
+        experiment:, triggered_by: 'operator', idempotency_key: SecureRandom.uuid,
         run_time_overrides: { 'question_model' => 'gpt-4o' }
       )
       expect(run.simulator_model).to eq('gpt-4o-mini')
@@ -33,25 +39,26 @@ RSpec.describe EvaluationRun do
     end
 
     it 'stores a 16-character configuration_digest' do
-      run = described_class.start!(experiment:, triggered_by: 'operator')
+      run = described_class.start!(experiment:, triggered_by: 'operator', idempotency_key: SecureRandom.uuid)
       expect(run.configuration_digest).to match(/\A[0-9a-f]{16}\z/)
     end
 
-    it 'produces the same digest for two runs with identical effective configuration' do
-      run_a = described_class.start!(experiment:, triggered_by: 'operator')
-      run_b = described_class.start!(experiment:, triggered_by: 'operator')
+    it 'produces the same digest for two separately-keyed runs with identical effective configuration' do
+      run_a = described_class.start!(experiment:, triggered_by: 'operator', idempotency_key: SecureRandom.uuid)
+      run_b = described_class.start!(experiment:, triggered_by: 'operator', idempotency_key: SecureRandom.uuid)
+      expect(run_a.id).not_to eq(run_b.id)
       expect(run_a.configuration_digest).to eq(run_b.configuration_digest)
     end
 
     it 'starts in queued status' do
-      run = described_class.start!(experiment:, triggered_by: 'operator')
+      run = described_class.start!(experiment:, triggered_by: 'operator', idempotency_key: SecureRandom.uuid)
       expect(run.status).to eq('queued')
     end
 
     it 'refuses to start a run with a disallowed run-time override' do
       expect {
         described_class.start!(
-          experiment:, triggered_by: 'operator',
+          experiment:, triggered_by: 'operator', idempotency_key: SecureRandom.uuid,
           run_time_overrides: { 'use_kg_context' => true }
         )
       }.to raise_error(EvaluationConfiguration::OverrideValidationError)
@@ -64,8 +71,28 @@ RSpec.describe EvaluationRun do
         name: 'bad-experiment', configuration_overrides: { 'use_facts_vec' => true },
       )
       expect {
-        described_class.start!(experiment: bad_experiment, triggered_by: 'operator')
+        described_class.start!(experiment: bad_experiment, triggered_by: 'operator', idempotency_key: SecureRandom.uuid)
       }.to raise_error(EvaluationConfiguration::OverrideValidationError)
+    end
+
+    it 'returns the existing run instead of creating a second one when the idempotency_key repeats' do
+      key = SecureRandom.uuid
+      first_run = described_class.start!(experiment:, triggered_by: 'operator', idempotency_key: key)
+
+      second_run = described_class.start!(experiment:, triggered_by: 'operator', idempotency_key: key)
+
+      expect(second_run.id).to eq(first_run.id)
+      expect(described_class.where(evaluation_experiment: experiment).count).to eq(1)
+    end
+
+    it 'returns the racing request run instead of raising when a concurrent create wins the unique-constraint race' do
+      racing_run = create(:evaluation_run, evaluation_experiment: experiment, idempotency_key: 'race-key')
+      allow(described_class).to receive(:find_by_idempotency_key).and_return(nil, racing_run)
+      allow(described_class).to receive(:create).and_raise(Sequel::UniqueConstraintViolation.new('duplicate key'))
+
+      result = described_class.start!(experiment:, triggered_by: 'operator', idempotency_key: 'race-key')
+
+      expect(result).to eq(racing_run)
     end
   end
 end

--- a/spec/models/evaluation_run_start_spec.rb
+++ b/spec/models/evaluation_run_start_spec.rb
@@ -86,13 +86,60 @@ RSpec.describe EvaluationRun do
     end
 
     it 'returns the racing request run instead of raising when a concurrent create wins the unique-constraint race' do
-      racing_run = create(:evaluation_run, evaluation_experiment: experiment, idempotency_key: 'race-key')
+      racing_run = create(
+        :evaluation_run, evaluation_experiment: experiment, triggered_by: 'operator', idempotency_key: 'race-key',
+                         configuration_digest: EvaluationConfiguration::DigestCalculator.call(
+                           EvaluationConfiguration::Merger.call(EvaluationConfiguration::BaselineProvider.call, experiment.configuration_overrides),
+                         )
+      )
       allow(described_class).to receive(:find_by_idempotency_key).and_return(nil, racing_run)
       allow(described_class).to receive(:create).and_raise(Sequel::UniqueConstraintViolation.new('duplicate key'))
 
       result = described_class.start!(experiment:, triggered_by: 'operator', idempotency_key: 'race-key')
 
       expect(result).to eq(racing_run)
+    end
+
+    it 'raises IdempotencyKeyConflict instead of returning the wrong run when the key repeats with a different experiment' do
+      key = SecureRandom.uuid
+      described_class.start!(experiment:, triggered_by: 'operator', idempotency_key: key)
+      other_experiment = create(:evaluation_experiment, name: 'other-experiment')
+
+      expect {
+        described_class.start!(experiment: other_experiment, triggered_by: 'operator', idempotency_key: key)
+      }.to raise_error(EvaluationRun::IdempotencyKeyConflict, /experiment_id/)
+    end
+
+    it 'raises IdempotencyKeyConflict instead of returning the wrong run when the key repeats with a different triggered_by' do
+      key = SecureRandom.uuid
+      described_class.start!(experiment:, triggered_by: 'operator', idempotency_key: key)
+
+      expect {
+        described_class.start!(experiment:, triggered_by: 'scheduler', idempotency_key: key)
+      }.to raise_error(EvaluationRun::IdempotencyKeyConflict, /triggered_by/)
+    end
+
+    it 'raises IdempotencyKeyConflict instead of returning the wrong run when the key repeats with different run-time overrides' do
+      key = SecureRandom.uuid
+      described_class.start!(experiment:, triggered_by: 'operator', idempotency_key: key)
+
+      expect {
+        described_class.start!(
+          experiment:, triggered_by: 'operator', idempotency_key: key,
+          run_time_overrides: { 'simulator_model' => 'gpt-4o' }
+        )
+      }.to raise_error(EvaluationRun::IdempotencyKeyConflict, /configuration/)
+    end
+
+    it 'raises IdempotencyKeyConflict instead of returning the wrong run when a racing request actually differs' do
+      key = SecureRandom.uuid
+      racing_run = create(:evaluation_run, evaluation_experiment: experiment, triggered_by: 'scheduler', idempotency_key: key)
+      allow(described_class).to receive(:find_by_idempotency_key).and_return(nil, racing_run)
+      allow(described_class).to receive(:create).and_raise(Sequel::UniqueConstraintViolation.new('duplicate key'))
+
+      expect {
+        described_class.start!(experiment:, triggered_by: 'operator', idempotency_key: key)
+      }.to raise_error(EvaluationRun::IdempotencyKeyConflict, /triggered_by/)
     end
   end
 end

--- a/spec/models/evaluation_run_start_spec.rb
+++ b/spec/models/evaluation_run_start_spec.rb
@@ -86,12 +86,7 @@ RSpec.describe EvaluationRun do
     end
 
     it 'returns the racing request run instead of raising when a concurrent create wins the unique-constraint race' do
-      racing_run = create(
-        :evaluation_run, evaluation_experiment: experiment, triggered_by: 'operator', idempotency_key: 'race-key',
-                         configuration_digest: EvaluationConfiguration::DigestCalculator.call(
-                           EvaluationConfiguration::Merger.call(EvaluationConfiguration::BaselineProvider.call, experiment.configuration_overrides),
-                         )
-      )
+      racing_run = create(:evaluation_run, evaluation_experiment: experiment, triggered_by: 'operator', idempotency_key: 'race-key')
       allow(described_class).to receive(:find_by_idempotency_key).and_return(nil, racing_run)
       allow(described_class).to receive(:create).and_raise(Sequel::UniqueConstraintViolation.new('duplicate key'))
 
@@ -128,7 +123,39 @@ RSpec.describe EvaluationRun do
           experiment:, triggered_by: 'operator', idempotency_key: key,
           run_time_overrides: { 'simulator_model' => 'gpt-4o' }
         )
-      }.to raise_error(EvaluationRun::IdempotencyKeyConflict, /configuration/)
+      }.to raise_error(EvaluationRun::IdempotencyKeyConflict, /run_time_overrides/)
+    end
+
+    it 'returns the original run on retry even though the experiment configuration_overrides changed in between' do
+      key = SecureRandom.uuid
+      first_run = described_class.start!(experiment:, triggered_by: 'operator', idempotency_key: key)
+
+      # Simulates an operator editing the experiment (PATCH .../experiments/:id) between
+      # the original request and a retry of it — the retry itself sends the exact same
+      # inputs (same experiment_id, same triggered_by, same run_time_overrides), so it
+      # must still return the original run, not a conflict. Comparing anything DERIVED
+      # from experiment.configuration_overrides (effective_configuration/digest) would
+      # wrongly reject this, because that derived value has now changed underneath it.
+      experiment.update(configuration_overrides: { 'simulator_model' => 'gpt-4o' })
+
+      retried_run = described_class.start!(experiment: experiment.reload, triggered_by: 'operator', idempotency_key: key)
+
+      expect(retried_run.id).to eq(first_run.id)
+    end
+
+    it 'returns the original run on retry even though the admin-config baseline changed in between, and never re-resolves it' do
+      key = SecureRandom.uuid
+      baseline_a = { 'rrf_k' => 60 }
+      baseline_b = { 'rrf_k' => 120 }
+      allow(EvaluationConfiguration::BaselineProvider).to receive(:call).and_return(baseline_a, baseline_b)
+
+      first_run = described_class.start!(experiment:, triggered_by: 'operator', idempotency_key: key)
+      retried_run = described_class.start!(experiment:, triggered_by: 'operator', idempotency_key: key)
+
+      expect(retried_run.id).to eq(first_run.id)
+      # Only the FIRST call should ever resolve a baseline — a genuine replay is detected
+      # from literal request inputs alone and returns before touching the baseline at all.
+      expect(EvaluationConfiguration::BaselineProvider).to have_received(:call).once
     end
 
     it 'raises IdempotencyKeyConflict instead of returning the wrong run when a racing request actually differs' do

--- a/spec/requests/api/admin/search/evaluation/runs_controller_spec.rb
+++ b/spec/requests/api/admin/search/evaluation/runs_controller_spec.rb
@@ -54,6 +54,22 @@ RSpec.describe Api::Admin::Search::Evaluation::RunsController, :admin do
       end
     end
 
+    context 'when the same Idempotency-Key is reused for a different experiment' do
+      let(:params) { { data: { type: :run, attributes: { experiment_id: experiment.id, triggered_by: 'operator' } } } }
+
+      it 'returns 409 instead of the first run, and does not create a second one' do
+        api_response
+        other_experiment = create(:evaluation_experiment)
+
+        authenticated_post api_admin_search_evaluation_runs_path(format: :json),
+                           params: { data: { type: :run, attributes: { experiment_id: other_experiment.id, triggered_by: 'operator' } } },
+                           headers: { 'Idempotency-Key' => idempotency_key }
+
+        expect(response).to have_http_status(:conflict)
+        expect(EvaluationRun.count).to eq(1)
+      end
+    end
+
     context 'with a valid experiment and no run-time overrides' do
       let(:params) do
         { data: { type: :run, attributes: { experiment_id: experiment.id, triggered_by: 'operator' } } }

--- a/spec/requests/api/admin/search/evaluation/runs_controller_spec.rb
+++ b/spec/requests/api/admin/search/evaluation/runs_controller_spec.rb
@@ -10,7 +10,49 @@ RSpec.describe Api::Admin::Search::Evaluation::RunsController, :admin do
   let(:experiment) { create(:evaluation_experiment, configuration_overrides: { 'simulator_model' => 'gpt-4o-mini' }) }
 
   describe 'POST #create' do
-    let(:make_request) { authenticated_post api_admin_search_evaluation_runs_path(format: :json), params: params }
+    let(:idempotency_key) { SecureRandom.uuid }
+    let(:make_request) do
+      authenticated_post api_admin_search_evaluation_runs_path(format: :json),
+                         params: params, headers: { 'Idempotency-Key' => idempotency_key }
+    end
+
+    context 'without an Idempotency-Key header' do
+      let(:params) { { data: { type: :run, attributes: { experiment_id: experiment.id, triggered_by: 'operator' } } } }
+      let(:make_request) { authenticated_post api_admin_search_evaluation_runs_path(format: :json), params: params }
+
+      it { is_expected.to have_http_status :bad_request }
+      it { expect { api_response }.not_to change(EvaluationRun, :count) }
+    end
+
+    context 'when retried with the same Idempotency-Key' do
+      let(:params) { { data: { type: :run, attributes: { experiment_id: experiment.id, triggered_by: 'operator' } } } }
+
+      it 'returns the original run instead of creating a second one' do
+        api_response
+        first_id = json_response['data']['id']
+
+        authenticated_post api_admin_search_evaluation_runs_path(format: :json),
+                           params: params, headers: { 'Idempotency-Key' => idempotency_key }
+        second_id = JSON.parse(response.body)['data']['id']
+
+        expect(response).to have_http_status(:created)
+        expect(second_id).to eq(first_id)
+        expect(EvaluationRun.count).to eq(1)
+      end
+    end
+
+    context 'when sent twice with different Idempotency-Key values' do
+      let(:params) { { data: { type: :run, attributes: { experiment_id: experiment.id, triggered_by: 'operator' } } } }
+
+      it 'creates two separate runs' do
+        api_response
+
+        authenticated_post api_admin_search_evaluation_runs_path(format: :json),
+                           params: params, headers: { 'Idempotency-Key' => SecureRandom.uuid }
+
+        expect(EvaluationRun.count).to eq(2)
+      end
+    end
 
     context 'with a valid experiment and no run-time overrides' do
       let(:params) do

--- a/spec/requests/api/admin/search/evaluation/runs_controller_spec.rb
+++ b/spec/requests/api/admin/search/evaluation/runs_controller_spec.rb
@@ -70,6 +70,74 @@ RSpec.describe Api::Admin::Search::Evaluation::RunsController, :admin do
       end
     end
 
+    context 'when the same Idempotency-Key is reused with different run-time overrides' do
+      let(:params) { { data: { type: :run, attributes: { experiment_id: experiment.id, triggered_by: 'operator' } } } }
+
+      it 'returns 409 instead of the first run, and does not create a second one' do
+        api_response
+
+        authenticated_post api_admin_search_evaluation_runs_path(format: :json),
+                           params: {
+                             data: {
+                               type: :run,
+                               attributes: {
+                                 experiment_id: experiment.id,
+                                 triggered_by: 'operator',
+                                 configuration_overrides: { 'simulator_model' => 'gpt-4o' },
+                               },
+                             },
+                           },
+                           headers: { 'Idempotency-Key' => idempotency_key }
+
+        expect(response).to have_http_status(:conflict)
+        expect(EvaluationRun.count).to eq(1)
+      end
+    end
+
+    context 'when retried with the same Idempotency-Key and the same run-time overrides, after an unrelated admin setting changed' do
+      let(:params) do
+        {
+          data: {
+            type: :run,
+            attributes: {
+              experiment_id: experiment.id,
+              triggered_by: 'operator',
+              configuration_overrides: { 'simulator_model' => 'gpt-4o' },
+            },
+          },
+        }
+      end
+
+      it 'still returns the original run — the retry is identical, only unrelated server state changed' do
+        api_response
+        first_id = json_response['data']['id']
+
+        create(:admin_configuration, :integer, name: 'interactive_search_max_questions', value: 9)
+
+        authenticated_post api_admin_search_evaluation_runs_path(format: :json),
+                           params: params, headers: { 'Idempotency-Key' => idempotency_key }
+
+        expect(response).to have_http_status(:created)
+        expect(json_response['data']['id']).to eq(first_id)
+        expect(EvaluationRun.count).to eq(1)
+      end
+    end
+
+    context 'with an Idempotency-Key over 255 characters' do
+      let(:params) { { data: { type: :run, attributes: { experiment_id: experiment.id, triggered_by: 'operator' } } } }
+      let(:idempotency_key) { 'a' * 256 }
+
+      it { is_expected.to have_http_status :bad_request }
+      it { expect { api_response }.not_to change(EvaluationRun, :count) }
+    end
+
+    context 'with an Idempotency-Key of exactly 255 characters' do
+      let(:params) { { data: { type: :run, attributes: { experiment_id: experiment.id, triggered_by: 'operator' } } } }
+      let(:idempotency_key) { 'a' * 255 }
+
+      it { is_expected.to have_http_status :created }
+    end
+
     context 'with a valid experiment and no run-time overrides' do
       let(:params) do
         { data: { type: :run, attributes: { experiment_id: experiment.id, triggered_by: 'operator' } } }


### PR DESCRIPTION
## What:

This PR stops the "start an evaluation run" API from accidentally creating duplicate runs when a request gets retried.

Some background for anyone new to this part of the codebase: an "evaluation run" is one execution of a test experiment against our search — it's created by calling `POST /evaluation_runs`. Before this change, every single call to that endpoint created a brand new row in the database, no questions asked. That's a problem if the caller doesn't get a clean response back (say, the connection drops, or the request times out) — because the caller can't tell the difference between "my request never reached the server" and "it worked but I didn't hear back," the only safe thing for it to do is retry. And retrying meant creating a second, duplicate run for the exact same thing.

Changes:

- **New migration** — adds a `idempotency_key` column (nullable, with a uniqueness rule) to the `evaluation_runs` table.
- **`EvaluationRun.start!`** — now requires an `idempotency_key` argument. Before creating anything, it checks: "has a run already been made with this exact key?" If yes, it just returns that existing run instead of making a new one. There's also a small extra safety net for the rare case where two retries land on the server at almost exactly the same moment — whichever one loses that race gets handed back the winner's run instead of erroring out.
- **`RunsController#create`** — now requires the caller to send an `Idempotency-Key` header on the request. If it's missing, the API replies with a clear `400 Bad Request` immediately, rather than quietly accepting the request and going back to the old duplicate-creating behaviour.
- **`RunSerializer`** — the `idempotency_key` is now included in the API response, mainly so it's visible for debugging.

## Why:

**What's an "idempotency key" and why does the caller send it, not the server?** It's just a unique token (in practice, a UUID) that the *caller* generates once, right before it makes its first attempt to create a run. If it has to retry, it sends that exact same token again. This only works if the caller does the generating, because only the caller actually knows whether a given request is "the first attempt at this" or "a retry of something I already tried" — the server has no way to tell those apart on its own, since each incoming request looks the same to it in isolation.

We considered having the server try to spot duplicates itself (e.g. "if two requests come in for the same experiment with identical settings, treat the second one as a duplicate"), but rejected that — a person might genuinely want to run the exact same experiment twice in a row, and that approach would silently merge those into one, which is wrong. The idempotency-key approach doesn't have that problem, because it only matches requests that are *literally* retries of each other, not just similar-looking ones.

This was originally supposed to be covered when the evaluation API was first built (ticket AI-1065's own requirements said "API retries cannot create duplicate runs/results"), but it was missed at the time. It came up again during external review of PR #3648 (a different, unrelated piece of work) — confirmed as a real gap, but not caused by that PR, so it's been pulled out into its own ticket (this one) to fix properly.

One deliberate choice worth flagging: the header is *required*, not optional. That means if whoever eventually builds the client for this endpoint (tracked separately under AI-1073, not started yet) forgets to send it, they'll get an obvious, immediate error instead of the endpoint silently working in the old, duplicate-prone way. I've left a comment on that ticket explaining the contract so it isn't missed.

## Ticket:

[AI-1184](https://transformuk.atlassian.net/browse/AI-1184)

## Risk:
**Risk level:** 🟠

**Reason for rating:**
This changes the request contract of an existing API endpoint (`POST /evaluation_runs`) by making a new header mandatory — that's called out explicitly as an amber-risk change in our risk guide, since other services could consume this endpoint. In practice there's no live caller of this endpoint yet (the eval app client that will use it, AI-1073, hasn't been built), so nothing in production breaks today — but I'm rating it amber rather than green because it's still a real API contract change, not just an internal refactor.