### PR TITLE
fix: validate news item date attributes

### DIFF
--- a/app/models/news/item.rb
+++ b/app/models/news/item.rb
@@ -176,6 +176,9 @@ module News
     def valid_date?(date)
       max_future_date = (date + MAX_YEARS_IN_FUTURE.years).to_date
 
+      puts "date: #{date}"
+      puts "max_future_date: #{max_future_date}"
+
       date <= max_future_date
     end
   end

--- a/app/models/news/item.rb
+++ b/app/models/news/item.rb
@@ -51,7 +51,7 @@ module News
       validates_presence :precis if show_on_updates_page
       validates_presence :collection_ids, message: 'must include at least one collection'
 
-      if !start_date.nil? && valid_date?(start_date)
+      unless valid_date?(start_date)
         errors.add(:start_date, "cannot be dated more than #{MAX_YEARS_IN_FUTURE} years in the future")
       end
 
@@ -175,10 +175,6 @@ module News
 
     def valid_date?(date)
       max_future_date = (date + MAX_YEARS_IN_FUTURE.years).to_date
-
-      puts "date: #{date}"
-      puts "max_future_date: #{max_future_date}"
-
       date <= max_future_date
     end
   end

--- a/app/models/news/item.rb
+++ b/app/models/news/item.rb
@@ -5,6 +5,7 @@ module News
 
     DISPLAY_REGULAR = 0
     MAX_SLUG_LENGTH = 254
+    MAX_YEARS_IN_FUTURE = 2
 
     many_to_many :collections, join_table: :news_collections_news_items
     plugin :association_dependencies, collections: :nullify
@@ -49,6 +50,15 @@ module News
       validates_unique :slug
       validates_presence :precis if show_on_updates_page
       validates_presence :collection_ids, message: 'must include at least one collection'
+
+      if !start_date.nil? && valid_date?(start_date)
+        errors.add(:start_date, "cannot be dated more than #{MAX_YEARS_IN_FUTURE} years in the future")
+      end
+
+      if !end_date.nil? && (end_date < start_date)
+        errors.add(:end_date, 'must be after start date')
+      end
+
       errors.add(:chapters, 'have an invalid format') unless chapters.to_s.delete(' ').split(',').all? { |chapter| chapter.match?(/\A\d{2}\z/) }
 
       super
@@ -161,6 +171,12 @@ module News
 
     def normalise_slug(slug)
       slug.downcase.gsub(/\s+/, '-').gsub(/[^a-z0-9-]/, '').first(MAX_SLUG_LENGTH)
+    end
+
+    def valid_date?(date)
+      max_future_date = (date + MAX_YEARS_IN_FUTURE.years).to_date
+
+      date <= max_future_date
     end
   end
 end

--- a/app/models/news/item.rb
+++ b/app/models/news/item.rb
@@ -50,7 +50,6 @@ module News
       validates_unique :slug
       validates_presence :precis if show_on_updates_page
       validates_presence :collection_ids, message: 'must include at least one collection'
-      validates_presence :start_date
 
       unless valid_date?(start_date)
         errors.add(:start_date, "cannot be dated more than #{MAX_YEARS_IN_FUTURE} years in the future")
@@ -177,7 +176,7 @@ module News
     def valid_date?(date)
       return false unless date
 
-      max_future_date = (date + MAX_YEARS_IN_FUTURE.years).to_date
+      max_future_date = (Time.zone.today + MAX_YEARS_IN_FUTURE.years).to_date
       date <= max_future_date
     end
   end

--- a/app/models/news/item.rb
+++ b/app/models/news/item.rb
@@ -50,6 +50,7 @@ module News
       validates_unique :slug
       validates_presence :precis if show_on_updates_page
       validates_presence :collection_ids, message: 'must include at least one collection'
+      validates_presence :start_date
 
       unless valid_date?(start_date)
         errors.add(:start_date, "cannot be dated more than #{MAX_YEARS_IN_FUTURE} years in the future")
@@ -174,6 +175,8 @@ module News
     end
 
     def valid_date?(date)
+      return false unless date
+
       max_future_date = (date + MAX_YEARS_IN_FUTURE.years).to_date
       date <= max_future_date
     end

--- a/spec/models/news/item_spec.rb
+++ b/spec/models/news/item_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe News::Item do
     it { is_expected.not_to include(end_date: ['is not present']) }
 
     context 'with malformed start date' do
-      let(:instance) { described_class.new start_date: Date.new(3000, 1, 1) }
+      let(:instance) { described_class.new start_date: (Time.zone.today + 10.years) }
 
       it { is_expected.to include(start_date: ['cannot be dated more than 2 years in the future']) }
     end

--- a/spec/models/news/item_spec.rb
+++ b/spec/models/news/item_spec.rb
@@ -26,8 +26,27 @@ RSpec.describe News::Item do
     it { is_expected.to include(show_on_xi: ['is not present']) }
     it { is_expected.to include(show_on_updates_page: ['is not present']) }
     it { is_expected.to include(show_on_home_page: ['is not present']) }
-    it { is_expected.to include(start_date: ['is not present']) }
+
+    it {
+      expect(errors).to include(start_date: [
+        "cannot be dated more than #{described_class::MAX_YEARS_IN_FUTURE} years in the future",
+        'is not present',
+      ])
+    }
+
     it { is_expected.not_to include(end_date: ['is not present']) }
+
+    context 'with malformed start date' do
+      let(:instance) { described_class.new start_date: Date.new(3000, 1, 1) }
+
+      it { is_expected.to include(start_date: ['cannot be dated more than 2 years in the future']) }
+    end
+
+    context 'with malformed end date' do
+      let(:instance) { described_class.new start_date: Time.zone.today, end_date: Time.zone.yesterday }
+
+      it { is_expected.to include(end_date: ['must be after start date']) }
+    end
 
     context 'with blank strings' do
       let(:instance) { described_class.new title: '', content: '' }

--- a/spec/models/news/item_spec.rb
+++ b/spec/models/news/item_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe News::Item do
 
     it {
       expect(errors).to include(start_date: [
-        "cannot be dated more than #{described_class::MAX_YEARS_IN_FUTURE} years in the future",
         'is not present',
+        "cannot be dated more than #{described_class::MAX_YEARS_IN_FUTURE} years in the future",
       ])
     }
 

--- a/spec/models/news/item_spec.rb
+++ b/spec/models/news/item_spec.rb
@@ -28,10 +28,7 @@ RSpec.describe News::Item do
     it { is_expected.to include(show_on_home_page: ['is not present']) }
 
     it {
-      expect(errors).to include(start_date: [
-        'is not present',
-        "cannot be dated more than #{described_class::MAX_YEARS_IN_FUTURE} years in the future",
-      ])
+      expect(errors[:start_date]).to contain_exactly('is not present', "cannot be dated more than #{described_class::MAX_YEARS_IN_FUTURE} years in the future")
     }
 
     it { is_expected.not_to include(end_date: ['is not present']) }


### PR DESCRIPTION
## What:
- Adds custom validator to apply bounds checking to the start dates of news items.
- Adds a bounds check for end dates of news items so that they are on or after the start date.

## Why:
Currently the model accepts any valid Sequel Date object, so you could write a start date with a year of 20026 or another malformed thing and it would be accepted. This PR adds a `MAX_YEARS_IN_FUTURE` constant to the model that sets the maximum date in the future, so we aren't letting typos or something through.

The end date was also not checked to be on or after the start date, so I have added this check too.

I've intentionally not added maximum bounds checking to the end date; looking through the `news_items` database table I did find at least one entry that had an end date over 4 years from the start date, but in theory a news item might have an end date even longer than that. A further PR in the admin repo will limit the UI to only accept dates in the format `YYYY-MM-DD`, so for our admin tool users that check is probably enough.

## Ticket:
[HMRC-2635](https://transformuk.atlassian.net/browse/HMRC-2635)

## Risk:
**Risk level:** 🟠 

**Reason for rating:**

- Adds date validation to the news item model
- Making it Amber because I don't know if 2 years is right - this will affect end users writing news stories.