### PR TITLE
Rules of origin API: rescue 500 errors when invalid params passed and correct swagger docs

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -34,6 +34,11 @@ module Api
       render json: serializer.serialized_errors({ error: exception.message, url: request.url }), status: :conflict
     end
 
+    rescue_from RulesOfOrigin::Query::InvalidParams do |exception|
+      serializer = TradeTariffBackend.error_serializer(request)
+      render json: serializer.serialized_errors({ error: exception.message, url: request.url }), status: :bad_request
+    end
+
   protected
 
     def current_page

--- a/app/models/rules_of_origin/query.rb
+++ b/app/models/rules_of_origin/query.rb
@@ -81,8 +81,13 @@ module RulesOfOrigin
 
     def validate!
       if heading_code.present? || country_code.present?
-        raise InvalidParams unless HEADING_CHECKER.match?(heading_code)
-        raise InvalidParams unless COUNTRY_CHECKER.match?(country_code)
+        unless HEADING_CHECKER.match?(heading_code)
+          raise InvalidParams, "heading_code is invalid: expected a 6-digit code, got #{heading_code.inspect}"
+        end
+
+        unless COUNTRY_CHECKER.match?(country_code)
+          raise InvalidParams, "country_code is invalid: expected a 2-letter ISO code, got #{country_code.inspect}"
+        end
       end
     end
   end

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -1375,7 +1375,7 @@ RSpec.describe Measure do
       let(:certificate_type_code) { nil }
 
       it 'applies no filter' do
-        expect(dataset.pluck(:certificate_type_code)).to eq %w[Y N]
+        expect(dataset.pluck(:certificate_type_code)).to match_array(%w[Y N])
       end
     end
 

--- a/spec/requests/api/v2/rules_of_origin/schemes_controller_spec.rb
+++ b/spec/requests/api/v2/rules_of_origin/schemes_controller_spec.rb
@@ -30,6 +30,20 @@ RSpec.describe Api::V2::RulesOfOrigin::SchemesController, :v2 do
       it_behaves_like 'a successful jsonapi response'
     end
 
+    context 'with an invalid heading code' do
+      let(:heading_code) { '0101' }
+
+      it { expect(api_response).to have_http_status :bad_request }
+      it { expect(JSON.parse(api_response.body)['errors'].first['detail']).to include 'heading_code' }
+    end
+
+    context 'with an invalid country code' do
+      let(:country_code) { 'USA' }
+
+      it { expect(api_response).to have_http_status :bad_request }
+      it { expect(JSON.parse(api_response.body)['errors'].first['detail']).to include 'country_code' }
+    end
+
     context 'with path params' do
       let :make_request do
         api_get api_rules_of_origin_path(heading_code:, country_code:, format: :json)

--- a/spec/swagger/api/v2/rules_of_origin_spec.rb
+++ b/spec/swagger/api/v2/rules_of_origin_spec.rb
@@ -57,8 +57,8 @@ RSpec.describe 'Rules of Origin', swagger_doc: 'v2/swagger.json', type: :request
               schema: { type: :string, enum: ['application/vnd.hmrc.2.0+json'] },
               description: 'API version negotiation header'
     parameter name: :heading_code, in: :path, required: true,
-              schema: { type: :string },
-              description: 'Heading code (e.g. "0101")'
+              schema: { type: :string, pattern: '^\d{6}$' },
+              description: 'The 6 digit subheading of the goods being traded (e.g. "010121")'
     parameter name: :country_code, in: :path, required: true,
               schema: { type: :string },
               description: 'ISO 2-letter country code (e.g. "TR")'
@@ -81,6 +81,15 @@ RSpec.describe 'Rules of Origin', swagger_doc: 'v2/swagger.json', type: :request
                }
 
         let(:heading_code) { roo_heading_code }
+        let(:country_code) { roo_country_code }
+
+        run_test!
+      end
+
+      response '400', 'invalid heading_code — must be exactly 6 digits' do
+        schema '$ref' => '#/components/schemas/StandardErrorResponse'
+
+        let(:heading_code) { '0101' }
         let(:country_code) { roo_country_code }
 
         run_test!

--- a/swagger/v2/swagger.json
+++ b/swagger/v2/swagger.json
@@ -6248,9 +6248,10 @@
           "in": "path",
           "required": true,
           "schema": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^\\d{6}$"
           },
-          "description": "Heading code (e.g. \"0101\")"
+          "description": "The 6 digit subheading of the goods being traded (e.g. \"010121\")"
         },
         {
           "name": "country_code",
@@ -6318,6 +6319,16 @@
                       }
                     }
                   }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "invalid heading_code — must be exactly 6 digits",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StandardErrorResponse"
                 }
               }
             }


### PR DESCRIPTION
## What:

- [x] Rescue invalid request for rules or origin and returning 400 error response with correct error messages.
- [x] Update swagger docs to use correct six digit heading code.Align it with [Api docs](https://docs.trade-tariff.service.gov.uk/reference.html#rules-of-origin
)
- [x] Fix a flaky tests for measure_spec


## Why:

When sending invalid request the correct response is 400 bad request and not 500 error. Because it is not an error but intended behaviour where the client has to fix the request params. 

## Ticket:

https://transformuk.atlassian.net/jira/software/c/projects/HMRC/boards/155?selectedIssue=HMRC-2653

## Risk:
**Risk level:** 🟢 

**Reason for rating:**
Return correct response when client sends incorrect request so no real business logic change


