### PR TITLE
Remove @github-copilot from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
-*  @trade-tariff/trade-tariff-core @github-copilot
-/terraform/  @trade-tariff/trade-tariff-platform @github-copilot
+*  @trade-tariff/trade-tariff-core
+/terraform/  @trade-tariff/trade-tariff-platform


### PR DESCRIPTION
## What:
Remove the `@github-copilot` entry from CODEOWNERS.

## Why:
GitHub does not validate `@github-copilot` as a CODEOWNER and reports it as an unknown owner. Copilot Code Review is already enabled at the `trade-tariff` organisation level and this repository inherits that setting, with an active Copilot review ruleset configured. Copilot reviews are driven by those settings/rulesets, not by CODEOWNERS, so this entry is invalid and unnecessary.

## Ticket:
https://transformuk.atlassian.net/browse/HMRC-2630

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Text-only change to an ownership metadata file; no behaviour, permissions, or review automation change (Copilot reviews continue via the existing org-level rulesets).
