### PR TITLE
fix: news item error propagation

### DIFF
--- a/app/models/news/item.rb
+++ b/app/models/news/item.rb
@@ -47,21 +47,21 @@ module News
     end
 
     def validate
+      super
+
       validates_unique :slug
       validates_presence :precis if show_on_updates_page
       validates_presence :collection_ids, message: 'must include at least one collection'
 
-      unless valid_date?(start_date)
+      if !errors.on(:start_date) && !date_within_bounds?(start_date)
         errors.add(:start_date, "cannot be dated more than #{MAX_YEARS_IN_FUTURE} years in the future")
       end
 
-      if !end_date.nil? && (end_date < start_date)
+      if !end_date.nil? && !errors.on(:end_date) && (end_date < start_date)
         errors.add(:end_date, 'must be after start date')
       end
 
       errors.add(:chapters, 'have an invalid format') unless chapters.to_s.delete(' ').split(',').all? { |chapter| chapter.match?(/\A\d{2}\z/) }
-
-      super
     end
 
     def cache_key_with_version
@@ -173,7 +173,7 @@ module News
       slug.downcase.gsub(/\s+/, '-').gsub(/[^a-z0-9-]/, '').first(MAX_SLUG_LENGTH)
     end
 
-    def valid_date?(date)
+    def date_within_bounds?(date)
       return false unless date
 
       max_future_date = (Time.zone.today + MAX_YEARS_IN_FUTURE.years).to_date

--- a/spec/models/news/item_spec.rb
+++ b/spec/models/news/item_spec.rb
@@ -26,23 +26,34 @@ RSpec.describe News::Item do
     it { is_expected.to include(show_on_xi: ['is not present']) }
     it { is_expected.to include(show_on_updates_page: ['is not present']) }
     it { is_expected.to include(show_on_home_page: ['is not present']) }
-
-    it {
-      expect(errors[:start_date]).to contain_exactly('is not present', "cannot be dated more than #{described_class::MAX_YEARS_IN_FUTURE} years in the future")
-    }
-
+    it { is_expected.to include(start_date: ['is not present']) }
     it { is_expected.not_to include(end_date: ['is not present']) }
 
     context 'with malformed start date' do
-      let(:instance) { described_class.new start_date: (Time.zone.today + 10.years) }
+      # there cannot be a 30th of February
+      let(:instance) { described_class.new start_date: '2552-2-30' }
 
-      it { is_expected.to include(start_date: ['cannot be dated more than 2 years in the future']) }
+      # the invalid date takes precedence over the bounds check
+      it { is_expected.to include(start_date: ['is not a valid date']) }
+      it { is_expected.not_to include(start_date: ["cannot be dated more than #{described_class::MAX_YEARS_IN_FUTURE} years in the future"]) }
     end
 
     context 'with malformed end date' do
+      let(:instance) { described_class.new start_date: Time.zone.today, end_date: '2552-02-30' }
+
+      it { is_expected.to include(end_date: ['is not a valid date']) }
+    end
+
+    context 'with invalid end date' do
       let(:instance) { described_class.new start_date: Time.zone.today, end_date: Time.zone.yesterday }
 
       it { is_expected.to include(end_date: ['must be after start date']) }
+    end
+
+    context 'with out-of-bounds start date' do
+      let(:instance) { described_class.new start_date: (Time.zone.today + 10.years) }
+
+      it { is_expected.to include(start_date: ["cannot be dated more than #{described_class::MAX_YEARS_IN_FUTURE} years in the future"]) }
     end
 
     context 'with blank strings' do


### PR DESCRIPTION
## What:

- Updates the news item model validation method to check the date attributes against the database schema types before checking the date bounds.
- Move the `super` call to before our custom validations

## Why:

- The error validation added in #3653 introduced a regression, when a news item had an invalid start date, the bounds checking took precedence over the date being valid and presented a misleading error message
- The default auto-validations should take the highest precedence over custom validations in this model

## Ticket:
[HMRC-2635](https://transformuk.atlassian.net/browse/HMRC-2635)

## Risk:
**Risk level:** 🟢

**Reason for rating:**

Fixes a bug in error handling.