### PR TITLE
[HMRC-2568] Route tariff sync failures to production alerts slack channel

### DIFF
--- a/app/lib/tariff_synchronizer.rb
+++ b/app/lib/tariff_synchronizer.rb
@@ -92,7 +92,7 @@ module TariffSynchronizer
   def notify_slack_app(exception)
     SlackNotifierService.call(
       text: "Error #{exception.class}: #{exception.message}",
-      channel: TradeTariffBackend.slack_failures_channel
+      channel: TradeTariffBackend.slack_failures_channel,
     )
   end
 

--- a/app/lib/tariff_synchronizer.rb
+++ b/app/lib/tariff_synchronizer.rb
@@ -90,7 +90,10 @@ module TariffSynchronizer
   end
 
   def notify_slack_app(exception)
-    SlackNotifierService.call("Error #{exception.class}: #{exception.message}")
+    SlackNotifierService.call(
+      text: "Error #{exception.class}: #{exception.message}",
+      channel: TradeTariffBackend.slack_failures_channel
+    )
   end
 
   def check_sequence

--- a/spec/unit/cds_synchronizer_spec.rb
+++ b/spec/unit/cds_synchronizer_spec.rb
@@ -114,6 +114,15 @@ RSpec.describe CdsSynchronizer, :truncation do
       it 'sends email with the error' do
         expect { described_class.apply }.to raise_error(TariffSynchronizer::FailedUpdatesError)
       end
+
+      it "routes the failure notification to #production-alerts slack channel" do
+        expect { described_class.apply }.to raise_error(TariffSynchronizer::FailedUpdatesError)
+
+        expect(SlackNotifierService).to have_received(:call).with(
+          text: 'Error TariffSynchronizer::FailedUpdatesError: TariffSynchronizer::FailedUpdatesError',
+          channel: TradeTariffBackend.slack_failures_channel
+        )
+      end
     end
 
     context 'with only TARIC failed updates present' do

--- a/spec/unit/cds_synchronizer_spec.rb
+++ b/spec/unit/cds_synchronizer_spec.rb
@@ -116,6 +116,8 @@ RSpec.describe CdsSynchronizer, :truncation do
       end
 
       it 'routes the failure notification to #production-alerts slack channel' do
+        allow(SlackNotifierService).to receive(:call)
+
         expect { described_class.apply }.to raise_error(TariffSynchronizer::FailedUpdatesError)
 
         expect(SlackNotifierService).to have_received(:call).with(

--- a/spec/unit/cds_synchronizer_spec.rb
+++ b/spec/unit/cds_synchronizer_spec.rb
@@ -115,12 +115,12 @@ RSpec.describe CdsSynchronizer, :truncation do
         expect { described_class.apply }.to raise_error(TariffSynchronizer::FailedUpdatesError)
       end
 
-      it "routes the failure notification to #production-alerts slack channel" do
+      it 'routes the failure notification to #production-alerts slack channel' do
         expect { described_class.apply }.to raise_error(TariffSynchronizer::FailedUpdatesError)
 
         expect(SlackNotifierService).to have_received(:call).with(
           text: 'Error TariffSynchronizer::FailedUpdatesError: TariffSynchronizer::FailedUpdatesError',
-          channel: TradeTariffBackend.slack_failures_channel
+          channel: TradeTariffBackend.slack_failures_channel,
         )
       end
     end


### PR DESCRIPTION
## What:
Changes the `TariffSynchronizer::FailedUpdatesError` slack notification to go to the `#production-alerts` slack channel.

## Why:

Production tariff processing errors are currently reported to the #tariffs-etl Slack channel alongside routine ETL status messages. Operationally significant production failures, such as `TariffSynchronizer::FailedUpdatesError`, should instead be routed to #production-alerts to improve visibility and ensure appropriate incident response, while informational ETL notifications remain in #tariffs-etl.

## Ticket:
[HMRC-2568](https://transformuk.atlassian.net/browse/HMRC-2568)

## Risk:
**Risk level:** 🟢
**Reason for rating:**
Changes which slack channel the failure alert goes to