### PR TITLE
fix: enable staging database replication

### DIFF
--- a/terraform/config_staging.tfvars
+++ b/terraform/config_staging.tfvars
@@ -5,3 +5,5 @@ memory        = 2048
 service_count = 4
 min_capacity  = 2
 max_capacity  = 8
+
+enable_database_replication = true


### PR DESCRIPTION
## What:

Enable database replication in staging.

## Why:

It was turned off (in https://github.com/trade-tariff/trade-tariff-backend/pull/3349) and staging is now quite out of date.

## Ticket:
n/a

## Risk:
**Risk level:** 🟢

**Reason for rating:**

Keeps the database in staging up to date, nothing else.