### PR TITLE
test: labeler / deploy-to-development race condition check

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,4 +1,5 @@
 # Add "needs-deployment" label to pull requests that should be deployed
+# test: labeler/deploy-to-development race condition check
 needs-deployment:
   - changed-files:
     - any-glob-to-any-file:


### PR DESCRIPTION
## Purpose
Test-only PR to check the timing between the `labeler.yml` workflow (runs on `pull_request_target`) and `deploy-to-development.yml` (runs on `pull_request: opened/synchronize/reopened/labeled/unlabeled`).

Hypothesis: the initial `opened` run of deploy-to-development.yml evaluates its `if: contains(..., 'needs-deployment')` condition before the labeler bot has had a chance to add the label, so that first run's `deploy` job is skipped. A follow-up run triggered by the `labeled` event (once the labeler adds `needs-deployment`) should then actually run the deploy job.

Change is a single comment line in `.github/labeler.yml`, which is itself in that file's own `needs-deployment` glob list — no functional/infra changes.

Will be closed once the run history is confirmed.