### PR TITLE
[skip ci] - Add documentation for sending email using notification service

### DIFF
--- a/docs/govuk-notify-guide.md
+++ b/docs/govuk-notify-guide.md
@@ -1,0 +1,27 @@
+# Sending email with GOV.UK Notify — quick reference
+
+- `GovukNotifier` (`app/services/govuk_notifier.rb`) wraps the `notifications-ruby-client`
+  gem — call `GovukNotifier.new.send_email(recipient, template_id, personalisation)`.
+- Template IDs live in `NOTIFY_CONFIGURATION` (`config/initializers/notify.rb`), per
+  environment, under `templates`.
+- Template content (subject/body/placeholders) is **not** in this repo — it's managed
+  in the Notify dashboard at https://www.notifications.service.gov.uk/your-services
+  (pick the service for the relevant environment). 
+- `GovukNotifierAudit` records every send (notification UUID, rendered subject/body, template info).
+
+## Steps
+
+1. Design the template: pick personalisation fields, write subject/body using
+   `((field))` / `((field??conditional text))`.
+2. Create the template in the Notify dashboard for each environment
+   (https://www.notifications.service.gov.uk/your-services) and copy each template ID.
+3. Add the ID(s) to `config/initializers/notify.rb` under `templates`.
+4. Call `GovukNotifier.new.send_email(email, TEMPLATE_ID, personalisation)` from your
+   code; rescue `Notifications::Client::RequestError` if a failed send shouldn't blow
+   up the caller.
+
+## Testing
+
+- **Manual (dev/staging)**: log into https://www.notifications.service.gov.uk/your-services for that environment's
+  service to get an API key, set `GOVUK_NOTIFY_API_KEY` locally (and optionally `OVERRIDE_NOTIFY_EMAIL` to redirect all sends to your own inbox), then trigger the
+  code (e.g. `bundle exec rails runner '...'`). Check the email arrives and cross-check the send in the dashboard's "sent messages" view.


### PR DESCRIPTION
## What:
Add documentation for sending email using notification service

## Why:
So it is easy for devs to have a reference when we forget steps after 6 months ;)

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
No code change
───────────────────────────────────────────────────

Rate the overall risk of deploying this change:

🟢 Green  – Low risk. Good to go, standard review applies.

🟠 Amber  – Medium risk. Socialise with the team before merging.

🔴 Red    – High risk. Requires explicit approval from Thor or Neil before merging.

───────────────────────────────────────────────────

🟢 GREEN – things that are typically low risk:
───────────────────────────────────────────────────
- Dependency bumps with no API changes (e.g. minor/patch gems, npm packages)
- Copy or content changes in GOV.UK-style UI components
- Adding or updating CloudWatch alarms or dashboards (read-only observability)
- New tests or improved test coverage with no production code changes
- Config/env var additions that are purely additive and have safe defaults
- Refactors with full test coverage and no behaviour change
- Terraform formatting or variable renaming with no resource recreation
- S3 lifecycle rule additions (non-destructive, time-delayed effect)

🟠 AMBER – things that need a team conversation first:
───────────────────────────────────────────────────
- Changes to commodity code lookups, measure type logic, or duty calculation
- Modifications to the search indexing pipeline (OpenSearch mappings, synonyms, stop words)
- Changes to declarable goods or quota logic
- New or modified API endpoints that other services (backend, frontend, admin) consume
- Adding or changing feature flags that affect live user journeys
- Infrastructure changes that alter networking, security groups, or IAM permissions in non-production first
- Terraform changes that will cause a resource replacement (check plan output carefully)
- Changes to CI/CD pipeline steps or deployment order dependencies
- S3 bucket policy or access control changes
- Removing or deprecating an endpoint or field that may still be consumed

🔴 RED – requires explicit approval from Thor or Neil:
───────────────────────────────────────────────────
- Dangerous database migrations, especially destructive ones (dropping columns/tables, removing indexes)
- Modifications to how measures, conditions, or footnotes are processed or surfaced
- Changes to the synchronisation mechanism from CDS or HMRC upstream data feeds
- Any change to production AWS infrastructure that cannot be easily rolled back (e.g. RDS parameter groups, KMS key policy, removal of resources)
- Secrets rotation or changes to how credentials are stored, scoped, or accessed
- Changes that affect trader-facing regulatory content or legally significant data (e.g. trade remedies, licensing, prohibitions)
- Significant architectural shifts (e.g. new service boundaries, queue/event topology changes)
