### PR TITLE
Add trade-tariff-admin team to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
-*  @trade-tariff/trade-tariff-core
+*  @trade-tariff/trade-tariff-core @trade-tariff/trade-tariff-admin
 /terraform/  @trade-tariff/trade-tariff-platform


### PR DESCRIPTION
## What:
Add `@trade-tariff/trade-tariff-admin` as a code owner on the `*` rule in `CODEOWNERS`, alongside the existing owners.

## Why:
The trade-tariff-admin team should be included as a required reviewer across this repo, consistent with the other teams already listed.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:** Purely additive change to `CODEOWNERS` — adds a reviewer team, no code or infrastructure behaviour change.
