### PR TITLE
fix(security): pin resolv, clean json default gem, upgrade expat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,9 @@ RUN apk add --no-cache \
     tzdata && \
     cp /usr/share/zoneinfo/Europe/London /etc/localtime && \
     echo "Europe/London" > /etc/timezone && \
-    rm -f /usr/local/lib/ruby/gems/*/specifications/default/json-*.gemspec
+    rm -f /usr/local/lib/ruby/gems/*/specifications/default/json-*.gemspec && \
+    rm -rf /usr/local/lib/ruby/gems/*/gems/json-* && \
+    rm -rf /usr/local/lib/ruby/*/json.rb /usr/local/lib/ruby/*/json /usr/local/lib/ruby/*/*-linux-musl/json
 
 RUN bundle config set without 'development test'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,7 @@ RUN apk add --no-cache \
     socat \
     openssl-dev \
     tzdata && \
+    apk upgrade --no-cache expat && \
     cp /usr/share/zoneinfo/Europe/London /etc/localtime && \
     echo "Europe/London" > /etc/timezone && \
     rm -f /usr/local/lib/ruby/gems/*/specifications/default/json-*.gemspec && \

--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ gem 'logstash-event'
 gem 'newrelic_rpm'
 gem 'nokogiri'
 gem 'notifications-ruby-client'
+gem 'resolv', '~> 0.7.2'
 gem 'slack-notifier'
 
 # API related

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -357,6 +357,7 @@ GEM
       io-console (~> 0.5)
     request_store (1.7.0)
       rack (>= 1.4)
+    resolv (0.7.2)
     responders (3.2.0)
       actionpack (>= 7.0)
       railties (>= 7.0)
@@ -534,6 +535,7 @@ DEPENDENCIES
   redis
   redis-client
   redlock
+  resolv (~> 0.7.2)
   responders
   rspec-ctrf
   rspec-json_expectations

--- a/docs/govuk-notify-guide.md
+++ b/docs/govuk-notify-guide.md
@@ -6,7 +6,7 @@
   environment, under `templates`.
 - Template content (subject/body/placeholders) is **not** in this repo — it's managed
   in the Notify dashboard at https://www.notifications.service.gov.uk/your-services
-  (pick the service for the relevant environment). 
+  (pick the service for the relevant environment).
 - `GovukNotifierAudit` records every send (notification UUID, rendered subject/body, template info).
 
 ## Steps


### PR DESCRIPTION
## What:
Fixes five Amazon Inspector / AWS Security Hub CVE findings on the `tariff-backend-production` container image:

- CVE-2026-33210 (CRITICAL) / CVE-2026-54696 (LOW) — `json` gem
- CVE-2026-80212 (HIGH) / CVE-2026-80213 (MEDIUM) — `resolv` gem
- CVE-2026-76641 / CVE-2026-66046 (HIGH) / CVE-2026-76957 / CVE-2026-76956 (MEDIUM) — `expat` (Alpine OS package)

## Why:
`ruby:4.0.6-alpine` ships `json` and `resolv` as bundled "default gems" at old, vulnerable versions on disk (`/usr/local/lib/ruby/gems/4.0.0/gems/<name>-<version>/` plus the stdlib-loadable copy at `/usr/local/lib/ruby/4.0.0/<name>.rb` / `<name>/`). Trivy/Inspector fingerprint the version from those on-disk files regardless of whether the app actually loads them.

- **json**: `Gemfile.lock` already resolves `json (2.21.2)`, which is >= the fixed 2.19.9.0 — Bundler's own `GEM_HOME=/usr/local/bundle` overrides the default gem at runtime, so the app was never actually vulnerable. The production stage already removed the default gem's `.gemspec`, but left the actual `lib`/`gems` files behind for the scanner to fingerprint. Extended that cleanup to also remove `/usr/local/lib/ruby/gems/*/gems/json-*` and the stdlib copies (`json.rb`/`json/`), so no vulnerable version is discoverable on disk. Same pattern already verified via a full build+deploy on trade-tariff-frontend (PR #3308) and confirmed by this PR's own CI (`deploy / build` and `deploy / deploy` both passed).
- **resolv**: nothing in the Gemfile/Gemfile.lock pinned `resolv` at all, so a bare `require 'resolv'` anywhere in the dependency chain would load the base image's vulnerable 0.7.0 default-gem copy directly, with no Bundler override. Added `gem 'resolv', '~> 0.7.2'` to the Gemfile and ran `bundle install` to lock it in. Verified `require 'resolv'` resolves to `0.7.2` at runtime.
- **expat**: a new Security Hub finding (first observed 2026-09-02, unrelated to the two above) — the base Alpine image shipped `expat 2.8.3`, fixed in `2.8.4-r0`. Added `apk upgrade --no-cache expat` to the production stage.

Also fixed an unrelated pre-existing trailing-whitespace lint failure in `docs/govuk-notify-guide.md`, caught because the `lint` job runs `pre-commit --all-files` across the whole repo, not just this diff.

## Ticket:
BAU

## Risk:
**Risk level:** 🟢

**Reason for rating:** Dependency/image-hygiene fixes with no application behaviour change — a version pin for a gem nothing in the app directly configures, an Alpine package upgrade, and removal of unused on-disk files in the production image. CI's full pipeline (lint, test, `deploy / build`, `deploy / deploy`) has passed on this branch, confirming the image builds and boots correctly.
