### PR TITLE
AI-1251: Update escalation support template

### DIFF
--- a/app/models/admin_configuration.rb
+++ b/app/models/admin_configuration.rb
@@ -76,9 +76,13 @@ class AdminConfiguration < Sequel::Model(Sequel[:admin_configurations].qualify(:
 
     You should contact HMRC for help classifying this product.
 
-    **Webchat:** [Ask HMRC online]({{webchat_url}})
+    ### Webchat
 
-    **Email:** [{{enquiries_email}}](mailto:{{enquiries_email}})
+    [Ask HMRC online]({{webchat_url}})
+
+    ### Enquiry form
+
+    [Ask a classification question](/enquiry_form)
   MARKDOWN
 
   DEFAULTS = {

--- a/spec/lib/tasks/admin_configurations_rake_spec.rb
+++ b/spec/lib/tasks/admin_configurations_rake_spec.rb
@@ -91,8 +91,9 @@ RSpec.describe 'admin_configurations:seed' do
     )
     expect(config.value['escalation']['attributes']['message']).to include("The product you're searching for is difficult to classify.")
     expect(config.value['escalation']['attributes']['message']).not_to include('{{request_id}}')
-    expect(config.value['escalation']['attributes']['message']).to include('{{webchat_url}}')
-    expect(config.value['escalation']['attributes']['message']).to include('{{enquiries_email}}')
+    expect(config.value['escalation']['attributes']['message']).to include("### Webchat\n\n[Ask HMRC online]({{webchat_url}})")
+    expect(config.value['escalation']['attributes']['message']).to include("### Enquiry form\n\n[Ask a classification question](/enquiry_form)")
+    expect(config.value['escalation']['attributes']['message']).not_to include('{{enquiries_email}}')
   end
 
   it 'disables tariff-note and general-rule evidence by default', :aggregate_failures do

--- a/spec/models/admin_configuration_spec.rb
+++ b/spec/models/admin_configuration_spec.rb
@@ -515,9 +515,13 @@ RSpec.describe AdminConfiguration do
 
         You should contact HMRC for help classifying this product.
 
-        **Webchat:** [Ask HMRC online]({{webchat_url}})
+        ### Webchat
 
-        **Email:** [{{enquiries_email}}](mailto:{{enquiries_email}})
+        [Ask HMRC online]({{webchat_url}})
+
+        ### Enquiry form
+
+        [Ask a classification question](/enquiry_form)
       MARKDOWN
     end
 


### PR DESCRIPTION
## What:

- [x] Present Webchat under its own heading with the link on a separate line
- [x] Replace the classification email address with an Enquiry form heading
- [x] Link “Ask a classification question” to `/enquiry_form`
- [x] Update the default-template and seed-task coverage

## Why:

Escalation description intercepts should use the same classification support pattern as the other beta search screens. This updates the canonical template used when creating or re-importing intercepts; deployed admin configuration and existing intercept records will be updated separately.

## Ticket:

[AI-1251](https://transformuk.atlassian.net/browse/AI-1251)

## Risk:

**Risk level:** 🟢

**Reason for rating:** This is a covered copy and link-target change to the default description-intercept template. It does not modify search matching, API contracts, or existing deployed records.