### PR TITLE
AI-1259: Remove vulnerable default resolv gem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,8 +60,11 @@ RUN apk add --no-cache \
     cp /usr/share/zoneinfo/Europe/London /etc/localtime && \
     echo "Europe/London" > /etc/timezone && \
     rm -f /usr/local/lib/ruby/gems/*/specifications/default/json-*.gemspec && \
+    rm -f /usr/local/lib/ruby/gems/*/specifications/default/resolv-*.gemspec && \
     rm -rf /usr/local/lib/ruby/gems/*/gems/json-* && \
-    rm -rf /usr/local/lib/ruby/*/json.rb /usr/local/lib/ruby/*/json /usr/local/lib/ruby/*/*-linux-musl/json
+    rm -rf /usr/local/lib/ruby/gems/*/gems/resolv-[0-9]* && \
+    rm -rf /usr/local/lib/ruby/*/json.rb /usr/local/lib/ruby/*/json /usr/local/lib/ruby/*/*-linux-musl/json && \
+    rm -f /usr/local/lib/ruby/*/resolv.rb
 
 RUN bundle config set without 'development test'
 


### PR DESCRIPTION
## What:

- [x] Remove the vulnerable `resolv 0.7.0` bundled with the Ruby 4.0.6 production image
- [x] Keep the application-pinned `resolv 0.7.2` as the runtime implementation
- [x] Build and scan the production image

## Why:

CVE-2026-80212 caused backend image publishing to fail even though the bundle already pins `resolv 0.7.2`. Trivy also detected the superseded default gem from the Ruby base image.

The production image now removes that stale copy, matching the existing `json` cleanup pattern. The rebuilt image loads `resolv 0.7.2` and reports zero HIGH/CRITICAL vulnerabilities.

## Ticket:

[AI-1259](https://transformuk.atlassian.net/browse/AI-1259)

## Risk:

**Risk level:** 🟢

**Reason for rating:**

The application already pins and loads `resolv 0.7.2`; this only removes the unused vulnerable default copy from the production image. Pre-commit and the production image vulnerability scan pass.