### PR TITLE
AI-1224: Mask team contact placeholders

### DIFF
--- a/app/models/enquiry_form/submission.rb
+++ b/app/models/enquiry_form/submission.rb
@@ -3,6 +3,7 @@ require 'mail'
 class EnquiryForm::Submission < Data.define(:form_data)
   HMRC_AUDIENCE = 'hmrc'.freeze
   TRADE_TARIFF_AUDIENCE = 'trade_tariff'.freeze
+  REDACTED_VALUE = '******'.freeze
   HMRC_AUDIENCES = [HMRC_AUDIENCE].freeze
   FLAGGED_AUDIENCES = [HMRC_AUDIENCE, TRADE_TARIFF_AUDIENCE].freeze
   TEAM_FIELDS = %i[
@@ -61,7 +62,7 @@ class EnquiryForm::Submission < Data.define(:form_data)
       Delivery.new(
         audience:,
         recipient: trade_tariff_recipient,
-        form_data: form_data.slice(*TEAM_FIELDS),
+        form_data: form_data.slice(*TEAM_FIELDS).merge(name: REDACTED_VALUE, email: REDACTED_VALUE),
         test_condition:,
       )
     else

--- a/spec/models/enquiry_form/submission_spec.rb
+++ b/spec/models/enquiry_form/submission_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe EnquiryForm::Submission do
     context 'with a feature flag' do
       let(:feature_flags) { %w[interactive_search] }
 
-      it 'uses the configured support recipient and redacts contact details for Trade Tariff' do
+      it 'uses the configured support recipient and masks contact details for Trade Tariff' do
         allow(TradeTariffBackend).to receive(:support_email)
           .and_return('Online Trade Tariff Support <team@example.com>')
 
@@ -62,8 +62,8 @@ RSpec.describe EnquiryForm::Submission do
         expect(delivery).to have_attributes(
           audience: described_class::TRADE_TARIFF_AUDIENCE,
           recipient: 'team@example.com',
+          form_data: hash_including(name: '******', email: '******'),
         )
-        expect(delivery.form_data).not_to include(:name, :email)
         expect(delivery.test_condition).to eq('Interactive search')
       end
 

--- a/spec/workers/enquiry_form/send_trade_tariff_submission_email_worker_spec.rb
+++ b/spec/workers/enquiry_form/send_trade_tariff_submission_email_worker_spec.rb
@@ -43,8 +43,8 @@ RSpec.describe EnquiryForm::SendTradeTariffSubmissionEmailWorker, type: :worker 
       'team@example.com',
       NOTIFY_CONFIGURATION.dig(:templates, :enquiry_form, :submission),
       hash_including(
-        name: nil,
-        email: nil,
+        name: '******',
+        email: '******',
         company_name: 'Doe & Co Inc.',
         test_condition: 'Interactive search',
       ),
@@ -52,7 +52,7 @@ RSpec.describe EnquiryForm::SendTradeTariffSubmissionEmailWorker, type: :worker 
       reference,
     )
     expect(StringIO).to have_received(:new).with(
-      "Reference,Submission date,Full name,Company name,Job title,Email address,What do you need help with?,How can we help?\nABC12345,2025-08-15 10:00,,Doe & Co Inc.,CEO,,Valuation,I have a question.\n",
+      "Reference,Submission date,Full name,Company name,Job title,Email address,What do you need help with?,How can we help?\nABC12345,2025-08-15 10:00,******,Doe & Co Inc.,CEO,******,Valuation,I have a question.\n",
     ).twice
   end
 


### PR DESCRIPTION
## What:

- [x] Supply masked name and email values for the Trade Tariff audience
- [x] Keep the same masked values in the attached CSV

## Why:

GOV.UK Notify requires values for every template placeholder. The PII-redacted Trade Tariff delivery omitted name and email, so Notify rejected the independently queued copy instead of sending it.

## Ticket:

[AI-1224](https://transformuk.atlassian.net/browse/AI-1224)

## Risk:
**Risk level:** 🟢

**Reason for rating:**
This is a small, covered correction limited to the already-redacted Trade Tariff copy. The HMRC delivery and routing conditions are unchanged.
