### PR TITLE
AI-1224: Default an unknown search request ID

### DIFF
--- a/app/workers/enquiry_form/send_submission_email_worker.rb
+++ b/app/workers/enquiry_form/send_submission_email_worker.rb
@@ -47,7 +47,7 @@ private
       enquiry_category: formatter.notify_category,
       enquiry_description: formatter.enquiry_description,
       reference_number: form_data[:reference_number],
-      search_request_id: form_data[:search_request_id],
+      search_request_id: form_data[:search_request_id].presence || 'unknown',
       test_condition: delivery.test_condition,
       created_at: formatted_created_at(form_data),
       csv_file: csv_file(form_data),

--- a/spec/workers/enquiry_form/send_submission_email_worker_spec.rb
+++ b/spec/workers/enquiry_form/send_submission_email_worker_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe EnquiryForm::SendSubmissionEmailWorker, type: :worker do
         expect(notifier_client).to have_received(:send_email).with(
           'support@example.com',
           NOTIFY_CONFIGURATION.dig(:templates, :enquiry_form, :submission),
-          hash_including(test_condition: 'none', search_request_id: nil),
+          hash_including(test_condition: 'none', search_request_id: 'unknown'),
           nil,
           'ABC12345',
         )


### PR DESCRIPTION
## What:

- [x] Send `unknown` to Notify when an enquiry has no Search Request ID
- [x] Preserve the real Search Request ID when one is available
- [x] Cover the missing-context path with a regression test

## Why:

The enquiry email template requires a Search Request ID personalisation. Enquiries that do not originate from a search legitimately omit that context, causing Notify to reject the email instead of sending it.

## Ticket:

[AI-1224](https://transformuk.atlassian.net/browse/AI-1224)

## Risk:
**Risk level:** 🟢

**Reason for rating:**
This is a small, covered fallback for a missing optional value. Known Search Request IDs, email routing, recipients, and contact-data handling are unchanged.