### PR TITLE
Return partial AI-assisted search results with failure metadata

### DIFF
--- a/app/controllers/api/internal/search_controller.rb
+++ b/app/controllers/api/internal/search_controller.rb
@@ -9,6 +9,16 @@ module Api
         else
           render json: result
         end
+      rescue HybridRetrievalService::AllLegsFailed
+        render json: {
+          errors: [
+            {
+              status: '500',
+              title: 'Search failed',
+              detail: 'Search is temporarily unavailable',
+            },
+          ],
+        }, status: :internal_server_error
       end
 
       def suggestions

--- a/app/controllers/api/v2/classification_search_controller.rb
+++ b/app/controllers/api/v2/classification_search_controller.rb
@@ -11,13 +11,13 @@ module Api
         else
           render json: result
         end
-      rescue HybridRetrievalService::AllLegsFailed => e
+      rescue HybridRetrievalService::AllLegsFailed
         render json: {
           errors: [
             {
               status: '500',
               title: 'Classification search failed',
-              detail: e.message,
+              detail: 'Classification search is temporarily unavailable',
             },
           ],
         }, status: :internal_server_error

--- a/app/lib/search/failure_codes.rb
+++ b/app/lib/search/failure_codes.rb
@@ -1,0 +1,17 @@
+module Search
+  module FailureCodes
+    QUERY_EXPANSION_FAILED = 'query_expansion_failed'.freeze
+    EMBEDDING_GENERATION_FAILED = 'embedding_generation_failed'.freeze
+    VECTOR_RETRIEVAL_FAILED = 'vector_retrieval_failed'.freeze
+    INTERACTIVE_SEARCH_FAILED = 'interactive_search_failed'.freeze
+    OPENSEARCH_FAILED = 'opensearch_failed'.freeze
+
+    ALL = [
+      QUERY_EXPANSION_FAILED,
+      EMBEDDING_GENERATION_FAILED,
+      VECTOR_RETRIEVAL_FAILED,
+      INTERACTIVE_SEARCH_FAILED,
+      OPENSEARCH_FAILED,
+    ].freeze
+  end
+end

--- a/app/lib/trade_tariff_request.rb
+++ b/app/lib/trade_tariff_request.rb
@@ -8,6 +8,7 @@ class TradeTariffRequest < ActiveSupport::CurrentAttributes
             :request_source,
             :client_id,
             :experiment,
+            :search_failures,
             :green_lanes,
             :time_machine_now,
             # Controls how TimeMachine filters associated records in queries.
@@ -20,6 +21,18 @@ class TradeTariffRequest < ActiveSupport::CurrentAttributes
             # Controls whether label fields (known_brands, colloquial_terms, synonyms)
             # are included in search suggestion queries
             :search_labels_enabled
+
+  def record_search_failure(code)
+    unless Search::FailureCodes::ALL.include?(code)
+      raise ArgumentError, "Unknown search failure: #{code}"
+    end
+
+    self.search_failures = Array(search_failures) | [code]
+  end
+
+  def search_failed?(code)
+    Array(search_failures).include?(code)
+  end
 
   def self.request_source_for_user_agent(user_agent)
     if user_agent.to_s.start_with?(FRONTEND_USER_AGENT_PREFIX)

--- a/app/services/api/internal/search_service.rb
+++ b/app/services/api/internal/search_service.rb
@@ -139,9 +139,10 @@ module Api
       end
 
       def preferred_fallback_results(retrieval)
-        retrieval.opensearch_results.presence ||
-          retrieval.vector_results.presence ||
-          retrieval.goods_nomenclatures
+        return retrieval.goods_nomenclatures unless retrieval.results_type == 'hybrid'
+        return retrieval.vector_results if TradeTariffRequest.search_failed?(::Search::FailureCodes::OPENSEARCH_FAILED)
+
+        retrieval.opensearch_results
       end
 
       def interactive_completion_payload(response, retrieval, interactive_result)

--- a/app/services/api/internal/search_service.rb
+++ b/app/services/api/internal/search_service.rb
@@ -3,7 +3,19 @@ module Api
     class SearchService
       include QueryProcessing
 
-      RetrievalResult = Data.define(:goods_nomenclatures, :max_score, :expanded_query, :results_type, :decision_results)
+      RetrievalResult = Data.define(
+        :goods_nomenclatures,
+        :max_score,
+        :expanded_query,
+        :results_type,
+        :decision_results,
+        :opensearch_results,
+        :vector_results,
+      ) do
+        def initialize(goods_nomenclatures:, max_score:, expanded_query:, results_type:, decision_results:, opensearch_results: [], vector_results: [])
+          super
+        end
+      end
 
       attr_reader :q, :as_of, :answers, :request_id, :description_intercept, :expanded_query
 
@@ -30,7 +42,7 @@ module Api
       def call
         return @sanitiser_errors if @sanitiser_errors
 
-        return { data: [] } if q.blank?
+        return empty_response if q.blank?
 
         @description_intercept = DescriptionIntercept.for_search(q, source: 'guided_search')
         ::Search::Instrumentation.description_intercept_checked(
@@ -75,7 +87,9 @@ module Api
         )
 
         [
-          with_description_intercept_meta(GoodsNomenclatureSearchSerializer.serialize([exact])),
+          with_search_failures_meta(
+            with_description_intercept_meta(GoodsNomenclatureSearchSerializer.serialize([exact])),
+          ),
           completion_payload(result_count: 1, results_type: 'exact_match'),
         ]
       end
@@ -85,7 +99,7 @@ module Api
       end
 
       def interactive_search_response(retrieval)
-        interactive_result = if @skip_question
+        interactive_result = if @skip_question || semantic_retrieval_failed?
                                nil
                              else
                                run_interactive_search(
@@ -94,14 +108,40 @@ module Api
                                )
                              end
 
+        response_results = if source_fallback_required?
+                             preferred_fallback_results(retrieval)
+                           else
+                             retrieval.goods_nomenclatures
+                           end
+        response_interactive_result = interactive_search_failed? ? nil : interactive_result
+
         response = build_response(
-          retrieval.goods_nomenclatures,
-          interactive_result,
+          response_results,
+          response_interactive_result,
           retrieval.expanded_query,
         )
         emit_evaluation_trace(retrieval:, interactive_result:)
 
         [response, interactive_completion_payload(response, retrieval, interactive_result)]
+      end
+
+      def semantic_retrieval_failed?
+        TradeTariffRequest.search_failed?(::Search::FailureCodes::EMBEDDING_GENERATION_FAILED) ||
+          TradeTariffRequest.search_failed?(::Search::FailureCodes::VECTOR_RETRIEVAL_FAILED)
+      end
+
+      def interactive_search_failed?
+        TradeTariffRequest.search_failed?(::Search::FailureCodes::INTERACTIVE_SEARCH_FAILED)
+      end
+
+      def source_fallback_required?
+        semantic_retrieval_failed? || interactive_search_failed?
+      end
+
+      def preferred_fallback_results(retrieval)
+        retrieval.opensearch_results.presence ||
+          retrieval.vector_results.presence ||
+          retrieval.goods_nomenclatures
       end
 
       def interactive_completion_payload(response, retrieval, interactive_result)
@@ -228,6 +268,7 @@ module Api
           expanded_query: search_expanded_query,
           results_type: 'vector',
           decision_results: goods_nomenclatures,
+          vector_results: goods_nomenclatures,
         )
       end
 
@@ -257,6 +298,7 @@ module Api
           expanded_query: search_expanded_query,
           results_type: 'opensearch',
           decision_results: result.results,
+          opensearch_results: result.results,
         )
       end
 
@@ -280,6 +322,8 @@ module Api
           expanded_query: result.expanded_query,
           results_type: 'hybrid',
           decision_results: hybrid_decision_results(result),
+          opensearch_results: result.opensearch_results,
+          vector_results: result.vector_results,
         )
       end
 
@@ -548,7 +592,7 @@ module Api
         response = GoodsNomenclatureSearchSerializer.serialize(results)
         meta = build_meta(interactive_result, expanded_query)
         response[:meta] = meta if meta.present?
-        response
+        with_search_failures_meta(response)
       end
 
       def build_results_with_confidence(goods_nomenclatures, interactive_result)
@@ -612,7 +656,11 @@ module Api
       end
 
       def empty_response
-        with_description_intercept_meta({ data: [] })
+        with_search_failures_meta(with_description_intercept_meta({ data: [] }))
+      end
+
+      def with_search_failures_meta(response)
+        response.merge(meta: (response[:meta] || {}).merge(search_failures: Array(TradeTariffRequest.search_failures)))
       end
 
       def with_description_intercept_meta(response)

--- a/app/services/api/internal/search_service.rb
+++ b/app/services/api/internal/search_service.rb
@@ -11,8 +11,9 @@ module Api
         :decision_results,
         :opensearch_results,
         :vector_results,
+        :failure_codes,
       ) do
-        def initialize(goods_nomenclatures:, max_score:, expanded_query:, results_type:, decision_results:, opensearch_results: [], vector_results: [])
+        def initialize(goods_nomenclatures:, max_score:, expanded_query:, results_type:, decision_results:, opensearch_results: [], vector_results: [], failure_codes: [])
           super
         end
       end
@@ -99,7 +100,7 @@ module Api
       end
 
       def interactive_search_response(retrieval)
-        interactive_result = if @skip_question || semantic_retrieval_failed?
+        interactive_result = if @skip_question || semantic_retrieval_failed?(retrieval)
                                nil
                              else
                                run_interactive_search(
@@ -108,7 +109,7 @@ module Api
                                )
                              end
 
-        response_results = if source_fallback_required?
+        response_results = if source_fallback_required?(retrieval)
                              preferred_fallback_results(retrieval)
                            else
                              retrieval.goods_nomenclatures
@@ -125,22 +126,24 @@ module Api
         [response, interactive_completion_payload(response, retrieval, interactive_result)]
       end
 
-      def semantic_retrieval_failed?
-        TradeTariffRequest.search_failed?(::Search::FailureCodes::EMBEDDING_GENERATION_FAILED) ||
-          TradeTariffRequest.search_failed?(::Search::FailureCodes::VECTOR_RETRIEVAL_FAILED)
+      def semantic_retrieval_failed?(retrieval)
+        retrieval.failure_codes.intersect?([
+          ::Search::FailureCodes::EMBEDDING_GENERATION_FAILED,
+          ::Search::FailureCodes::VECTOR_RETRIEVAL_FAILED,
+        ])
       end
 
       def interactive_search_failed?
         TradeTariffRequest.search_failed?(::Search::FailureCodes::INTERACTIVE_SEARCH_FAILED)
       end
 
-      def source_fallback_required?
-        semantic_retrieval_failed? || interactive_search_failed?
+      def source_fallback_required?(retrieval)
+        semantic_retrieval_failed?(retrieval) || interactive_search_failed?
       end
 
       def preferred_fallback_results(retrieval)
         return retrieval.goods_nomenclatures unless retrieval.results_type == 'hybrid'
-        return retrieval.vector_results if TradeTariffRequest.search_failed?(::Search::FailureCodes::OPENSEARCH_FAILED)
+        return retrieval.vector_results if retrieval.failure_codes.include?(::Search::FailureCodes::OPENSEARCH_FAILED)
 
         retrieval.opensearch_results
       end
@@ -325,6 +328,7 @@ module Api
           decision_results: hybrid_decision_results(result),
           opensearch_results: result.opensearch_results,
           vector_results: result.vector_results,
+          failure_codes: result.failure_codes,
         )
       end
 

--- a/app/services/api/v2/classification_search_service.rb
+++ b/app/services/api/v2/classification_search_service.rb
@@ -48,6 +48,7 @@ module Api
             expanded_query: expanded_query || @query,
             result_count: 0,
             max_score: nil,
+            search_failures: Array(TradeTariffRequest.search_failures),
           },
         }
       end
@@ -59,6 +60,7 @@ module Api
           expanded_query: result.expanded_query,
           result_count: result.results.size,
           max_score: result.results.map(&:score).compact.max,
+          search_failures: Array(TradeTariffRequest.search_failures),
         }
       end
 

--- a/app/services/expand_search_query_service.rb
+++ b/app/services/expand_search_query_service.rb
@@ -61,9 +61,11 @@ private
       Rails.cache.write(cache_key, result_hash, expires_in: CACHE_TTL)
       Result.new(**result_hash)
     else
+      TradeTariffRequest.record_search_failure(Search::FailureCodes::QUERY_EXPANSION_FAILED)
       unchanged_result
     end
   rescue OpenaiClient::DeadlineExceeded => e
+    TradeTariffRequest.record_search_failure(Search::FailureCodes::QUERY_EXPANSION_FAILED)
     Search::Instrumentation.query_expansion_timed_out(
       request_id:,
       timeout_ms: EXPANSION_TIMEOUT_MS,
@@ -73,6 +75,7 @@ private
     )
     unchanged_result
   rescue StandardError => e
+    TradeTariffRequest.record_search_failure(Search::FailureCodes::QUERY_EXPANSION_FAILED)
     Search::Instrumentation.search_failed(
       request_id:,
       error_type: e.class.name,

--- a/app/services/hybrid_retrieval_service.rb
+++ b/app/services/hybrid_retrieval_service.rb
@@ -1,7 +1,11 @@
 class HybridRetrievalService
   AllLegsFailed = Class.new(StandardError)
-  LegResult = Data.define(:value, :error)
-  Result = Data.define(:results, :expanded_query, :source_results)
+  LegResult = Data.define(:value, :error, :failure_code)
+  Result = Data.define(:results, :expanded_query, :source_results, :opensearch_results, :vector_results) do
+    def initialize(results:, expanded_query:, source_results:, opensearch_results: [], vector_results: [])
+      super
+    end
+  end
 
   def self.call(query:, as_of:, expanded_query: nil, retrieval_query: nil, request_id: nil, limit: 30, filter_prefixes: [], iteration: nil, search_type: 'interactive', rrf_k: nil, vector_score_threshold: nil, vector_ef_search: nil, search_non_declarables: nil)
     new(query:, as_of:, expanded_query:, retrieval_query:, request_id:, limit:, filter_prefixes:, iteration:, search_type:, rrf_k:, vector_score_threshold:, vector_ef_search:, search_non_declarables:).call
@@ -25,6 +29,9 @@ class HybridRetrievalService
 
   def call
     opensearch_leg, vector_leg = run_concurrent_retrievals
+    [opensearch_leg, vector_leg].filter_map(&:failure_code).each do |failure_code|
+      TradeTariffRequest.record_search_failure(failure_code)
+    end
     leg_errors = [opensearch_leg.error, vector_leg.error].compact
 
     if leg_errors.size == 2
@@ -35,7 +42,15 @@ class HybridRetrievalService
     vector_items = vector_leg.value&.results || []
 
     decision = query_guardrail_decision(vector_leg)
-    merged = decision[:accepted] ? rrf_merge(opensearch_items, vector_items) : []
+    merged = if vector_leg.error
+               opensearch_items
+             elsif opensearch_leg.error
+               vector_items
+             elsif decision[:accepted]
+               rrf_merge(opensearch_items, vector_items)
+             else
+               []
+             end
     Search::Instrumentation.query_guardrail_decided(
       request_id: @request_id,
       search_type: @search_type,
@@ -55,7 +70,13 @@ class HybridRetrievalService
       results: merged,
     )
 
-    Result.new(results: merged, expanded_query: @expanded_query, source_results: opensearch_items + vector_items)
+    Result.new(
+      results: merged,
+      expanded_query: @expanded_query,
+      source_results: opensearch_items + vector_items,
+      opensearch_results: opensearch_items,
+      vector_results: vector_items,
+    )
   end
 
 private
@@ -97,7 +118,7 @@ private
       results: result&.results || [],
     )
 
-    LegResult.new(value: result, error: nil)
+    LegResult.new(value: result, error: nil, failure_code: nil)
   rescue StandardError => e
     duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start) * 1000).round(2)
 
@@ -107,7 +128,14 @@ private
     )
 
     Rails.logger.error("HybridRetrievalService #{leg} leg failed: #{e.message}")
-    LegResult.new(value: nil, error: e)
+    LegResult.new(value: nil, error: e, failure_code: failure_code_for(leg, e))
+  end
+
+  def failure_code_for(leg, error)
+    return Search::FailureCodes::OPENSEARCH_FAILED if leg == :opensearch
+    return Search::FailureCodes::EMBEDDING_GENERATION_FAILED if error.is_a?(VectorRetrievalService::EmbeddingGenerationError)
+
+    Search::FailureCodes::VECTOR_RETRIEVAL_FAILED
   end
 
   def opensearch_args
@@ -172,7 +200,7 @@ private
                'below_threshold'
              end
 
-    { enabled:, accepted: reason == 'accepted', max_score:, threshold:, reason: }
+    { enabled:, accepted: reason.in?(%w[accepted vector_unavailable]), max_score:, threshold:, reason: }
   end
 
   def query_guardrail_threshold

--- a/app/services/hybrid_retrieval_service.rb
+++ b/app/services/hybrid_retrieval_service.rb
@@ -1,8 +1,8 @@
 class HybridRetrievalService
   AllLegsFailed = Class.new(StandardError)
   LegResult = Data.define(:value, :error, :failure_code)
-  Result = Data.define(:results, :expanded_query, :source_results, :opensearch_results, :vector_results) do
-    def initialize(results:, expanded_query:, source_results:, opensearch_results: [], vector_results: [])
+  Result = Data.define(:results, :expanded_query, :source_results, :opensearch_results, :vector_results, :failure_codes) do
+    def initialize(results:, expanded_query:, source_results:, opensearch_results: [], vector_results: [], failure_codes: [])
       super
     end
   end
@@ -29,7 +29,8 @@ class HybridRetrievalService
 
   def call
     opensearch_leg, vector_leg = run_concurrent_retrievals
-    [opensearch_leg, vector_leg].filter_map(&:failure_code).each do |failure_code|
+    failure_codes = [opensearch_leg, vector_leg].filter_map(&:failure_code)
+    failure_codes.each do |failure_code|
       TradeTariffRequest.record_search_failure(failure_code)
     end
     leg_errors = [opensearch_leg.error, vector_leg.error].compact
@@ -44,7 +45,7 @@ class HybridRetrievalService
     decision = query_guardrail_decision(vector_leg)
     merged = if vector_leg.error
                opensearch_items
-             elsif opensearch_leg.error
+             elsif opensearch_leg.error && decision[:accepted]
                vector_items
              elsif decision[:accepted]
                rrf_merge(opensearch_items, vector_items)
@@ -76,6 +77,7 @@ class HybridRetrievalService
       source_results: opensearch_items + vector_items,
       opensearch_results: opensearch_items,
       vector_results: vector_items,
+      failure_codes: failure_codes,
     )
   end
 

--- a/app/services/interactive_search_service.rb
+++ b/app/services/interactive_search_service.rb
@@ -448,7 +448,10 @@ private
     )
 
     if guard_result.duplicate?
-      return best_available_answers if duplicate_retry
+      if duplicate_retry
+        TradeTariffRequest.record_search_failure(Search::FailureCodes::INTERACTIVE_SEARCH_FAILED)
+        return best_available_answers
+      end
 
       return handle_parsed_response(
         parse_model_response(duplicate_retry_context(question, guard_result), operation: 'duplicate_question_retry'),

--- a/app/services/interactive_search_service.rb
+++ b/app/services/interactive_search_service.rb
@@ -42,6 +42,7 @@ class InteractiveSearchService
 
     handle_parsed_response(parse_model_response(build_context, operation: 'interactive_search'))
   rescue StandardError => e
+    record_failure
     Search::Instrumentation.search_failed(
       request_id: request_id,
       error_type: e.class.name,
@@ -312,7 +313,7 @@ private
     elsif parsed['error'].present?
       error_result(parsed['error'])
     else
-      best_available_answers
+      invalid_response_result
     end
   end
 
@@ -347,7 +348,7 @@ private
     elsif has_questions?(parsed)
       questions_result(parsed, duplicate_retry: duplicate_retry)
     else
-      best_available_answers
+      invalid_response_result
     end
   end
 
@@ -372,6 +373,7 @@ private
   end
 
   def error_result(message)
+    record_failure
     Result.new(
       type: :error,
       data: { message: message },
@@ -382,9 +384,20 @@ private
     )
   end
 
+  def invalid_response_result
+    error_result('Interactive search unavailable')
+  end
+
+  def record_failure
+    TradeTariffRequest.record_search_failure(Search::FailureCodes::INTERACTIVE_SEARCH_FAILED)
+  end
+
   def answers_result(ai_answers)
     filtered = filter_hallucinated_codes(ai_answers)
-    return best_available_answers(ranking_source: 'filtered_hallucinated_answers') if filtered.empty?
+    if filtered.empty?
+      record_failure
+      return best_available_answers(ranking_source: 'filtered_hallucinated_answers')
+    end
 
     limit = configured_result_limit
     normalized = filtered.map do |answer|
@@ -422,7 +435,7 @@ private
 
   def questions_result(parsed, duplicate_retry: false)
     questions = extract_questions(parsed)
-    return best_available_answers if questions.empty?
+    return invalid_response_result if questions.empty?
 
     question = questions.first
     guard_result = InteractiveSearch::DuplicateQuestionGuard.call(

--- a/app/services/vector_retrieval_service.rb
+++ b/app/services/vector_retrieval_service.rb
@@ -51,12 +51,15 @@ private
   end
 
   def generate_query_embedding
-    AiUsage::Instrumentation.embedding_api_call(
+    embedding = AiUsage::Instrumentation.embedding_api_call(
       event_kind: 'vector_search_query_embedding',
       batch_size: 1,
       model: EmbeddingService::MODEL,
       request_id: @request_id,
     ) { embedding_service.embed(@query, event_kind: 'vector_search_query_embedding') }
+    raise EmbeddingGenerationError, 'Embedding response was empty' unless embedding.is_a?(Array) && embedding.any?
+
+    embedding
   rescue StandardError => e
     raise EmbeddingGenerationError, e.message
   end

--- a/app/services/vector_retrieval_service.rb
+++ b/app/services/vector_retrieval_service.rb
@@ -1,4 +1,6 @@
 class VectorRetrievalService
+  EmbeddingGenerationError = Class.new(StandardError)
+  VectorRetrievalError = Class.new(StandardError)
   Result = Data.define(:results, :max_score)
 
   def self.call(query:, limit: 80, filter_prefixes: [], request_id: nil, vector_score_threshold: nil, vector_ef_search: nil, search_non_declarables: nil)
@@ -33,20 +35,30 @@ class VectorRetrievalService
     return Result.new(results: [], max_score:) if ranked_rows.empty?
 
     Result.new(results: build_results(ranked_rows), max_score:)
+  rescue EmbeddingGenerationError
+    raise
+  rescue StandardError => e
+    raise VectorRetrievalError, e.message
   end
 
 private
 
   def fetch_ranked_rows_for_query
-    query_embedding = AiUsage::Instrumentation.embedding_api_call(
+    query_embedding = generate_query_embedding
+    vector_literal = "'[#{query_embedding.join(',')}]'::vector"
+
+    fetch_ranked_sids(vector_literal)
+  end
+
+  def generate_query_embedding
+    AiUsage::Instrumentation.embedding_api_call(
       event_kind: 'vector_search_query_embedding',
       batch_size: 1,
       model: EmbeddingService::MODEL,
       request_id: @request_id,
     ) { embedding_service.embed(@query, event_kind: 'vector_search_query_embedding') }
-    vector_literal = "'[#{query_embedding.join(',')}]'::vector"
-
-    fetch_ranked_sids(vector_literal)
+  rescue StandardError => e
+    raise EmbeddingGenerationError, e.message
   end
 
   def build_results(ranked_rows, enforce_eligibility: false)

--- a/app/services/vector_retrieval_service.rb
+++ b/app/services/vector_retrieval_service.rb
@@ -1,4 +1,6 @@
 class VectorRetrievalService
+  EMBEDDING_DIMENSIONS = 1536
+
   EmbeddingGenerationError = Class.new(StandardError)
   VectorRetrievalError = Class.new(StandardError)
   Result = Data.define(:results, :max_score)
@@ -57,7 +59,10 @@ private
       model: EmbeddingService::MODEL,
       request_id: @request_id,
     ) { embedding_service.embed(@query, event_kind: 'vector_search_query_embedding') }
-    raise EmbeddingGenerationError, 'Embedding response was empty' unless embedding.is_a?(Array) && embedding.any?
+    valid_embedding = embedding.is_a?(Array) &&
+      embedding.size == EMBEDDING_DIMENSIONS &&
+      embedding.all? { |value| value.is_a?(Numeric) && value.real? && value.to_f.finite? }
+    raise EmbeddingGenerationError, 'Embedding response was malformed' unless valid_embedding
 
     embedding
   rescue StandardError => e

--- a/docs/architecture/search-and-indexing.md
+++ b/docs/architecture/search-and-indexing.md
@@ -64,7 +64,7 @@ The guardrail is controlled through admin configuration:
 - `hybrid_query_guardrail_enabled` defaults to off, preserving the existing hybrid behaviour.
 - `hybrid_query_guardrail_threshold` defaults to `32`, representing a similarity of `0.32`.
 
-When enabled, hybrid retrieval returns no suggestions if the maximum score is below the threshold, no eligible vector candidate exists, or the vector leg is unavailable. The `query_guardrail_decided.search` instrumentation event records the effective variant, score, threshold, outcome, and reason so A/B-test results can be attributed to the control.
+When enabled, hybrid retrieval returns no suggestions if the maximum score is below the threshold or no eligible vector candidate exists. If vector retrieval is unavailable, OpenSearch results remain available. If OpenSearch is unavailable, vector results are returned only when they pass the guardrail. The `query_guardrail_decided.search` instrumentation event records the effective variant, score, threshold, outcome, and reason so A/B-test results can be attributed to the control.
 
 Guided classification search can also attach bounded chapter- and section-note evidence to retrieved candidates. [Tariff knowledge notes](../tariff-knowledge-notes.md) documents extraction, graph edges, compressed-note materialisation and deduplication, prompt selection, and request-ID diagnostics.
 

--- a/spec/lib/search/failure_codes_spec.rb
+++ b/spec/lib/search/failure_codes_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe Search::FailureCodes do
+  describe '::ALL' do
+    it 'contains the stable response codes' do
+      expect(described_class::ALL).to eq(
+        %w[
+          query_expansion_failed
+          embedding_generation_failed
+          vector_retrieval_failed
+          interactive_search_failed
+          opensearch_failed
+        ],
+      )
+    end
+  end
+end

--- a/spec/lib/trade_tariff_request_spec.rb
+++ b/spec/lib/trade_tariff_request_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe TradeTariffRequest do
+  after { described_class.reset }
+
+  describe '.record_search_failure' do
+    it 'records each failure once' do
+      described_class.record_search_failure(Search::FailureCodes::OPENSEARCH_FAILED)
+      described_class.record_search_failure(Search::FailureCodes::OPENSEARCH_FAILED)
+
+      expect(described_class.search_failures).to eq(%w[opensearch_failed])
+    end
+
+    it 'rejects unknown codes' do
+      expect { described_class.record_search_failure('provider_broke') }
+        .to raise_error(ArgumentError, 'Unknown search failure: provider_broke')
+    end
+  end
+
+  describe '.search_failed?' do
+    it 'checks the stable failures recorded for the current request' do
+      described_class.record_search_failure(Search::FailureCodes::INTERACTIVE_SEARCH_FAILED)
+
+      expect(described_class.search_failed?(Search::FailureCodes::INTERACTIVE_SEARCH_FAILED)).to be(true)
+      expect(described_class.search_failed?(Search::FailureCodes::OPENSEARCH_FAILED)).to be(false)
+    end
+  end
+end

--- a/spec/requests/api/admin/search/evaluation/searches_controller_spec.rb
+++ b/spec/requests/api/admin/search/evaluation/searches_controller_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Api::Admin::Search::Evaluation::SearchesController, :admin do
       let(:params) { { q: '' } }
 
       it { is_expected.to have_http_status :success }
-      it { expect(json_response).to eq('data' => []) }
+      it { expect(json_response).to eq('data' => [], 'meta' => { 'search_failures' => [] }) }
     end
 
     context 'with a disallowed configuration_overrides key' do

--- a/spec/requests/api/internal/search_controller_spec.rb
+++ b/spec/requests/api/internal/search_controller_spec.rb
@@ -68,6 +68,7 @@ RSpec.describe Api::Internal::SearchController, :internal do
               },
             },
           ],
+          'meta' => { 'search_failures' => [] },
         }
       end
 
@@ -113,6 +114,7 @@ RSpec.describe Api::Internal::SearchController, :internal do
               },
             },
           ],
+          'meta' => { 'search_failures' => [] },
         }
       end
 
@@ -165,6 +167,7 @@ RSpec.describe Api::Internal::SearchController, :internal do
         payload = JSON.parse(response.body)
         expect(response).to have_http_status(:ok)
         expect(payload.dig('data', 0, 'attributes', 'goods_nomenclature_item_id')).to eq('8479899790')
+        expect(payload.dig('meta', 'search_failures')).to eq(%w[query_expansion_failed])
         expect(TradeTariffBackend.search_client).to have_received(:search).once
         expect(Search::Instrumentation).not_to have_received(:search_failed)
       end
@@ -204,6 +207,7 @@ RSpec.describe Api::Internal::SearchController, :internal do
               },
             },
           ],
+          'meta' => { 'search_failures' => [] },
         }
       end
 
@@ -217,7 +221,7 @@ RSpec.describe Api::Internal::SearchController, :internal do
 
     context 'when empty query' do
       let(:pattern) do
-        { 'data' => [] }
+        { 'data' => [], 'meta' => { 'search_failures' => [] } }
       end
 
       it 'returns an empty data array' do
@@ -225,6 +229,29 @@ RSpec.describe Api::Internal::SearchController, :internal do
 
         expect(response).to have_http_status(:ok)
         expect(response.body).to match_json_expression(pattern)
+      end
+    end
+
+    context 'when both hybrid retrieval legs fail' do
+      before do
+        service = instance_double(Api::Internal::SearchService)
+        allow(service).to receive(:call).and_raise(HybridRetrievalService::AllLegsFailed, 'provider details')
+        allow(Api::Internal::SearchService).to receive(:new).and_return(service)
+      end
+
+      it 'returns a controlled error without provider details' do
+        post api_search_path(format: :json), params: { q: 'horse' }
+
+        expect(response).to have_http_status(:internal_server_error)
+        expect(response.parsed_body).to eq(
+          'errors' => [
+            {
+              'status' => '500',
+              'title' => 'Search failed',
+              'detail' => 'Search is temporarily unavailable',
+            },
+          ],
+        )
       end
     end
 
@@ -254,6 +281,7 @@ RSpec.describe Api::Internal::SearchController, :internal do
               'guidance_location' => 'interstitial',
               'escalate_to_webchat' => true,
             },
+            'search_failures' => [],
           },
         }
       end
@@ -347,6 +375,7 @@ RSpec.describe Api::Internal::SearchController, :internal do
                 },
               ],
             },
+            'search_failures' => [],
           },
         }
       end

--- a/spec/requests/api/v2/classification_search_controller_spec.rb
+++ b/spec/requests/api/v2/classification_search_controller_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe 'Classification search API' do
           'expanded_query' => 'wireless headphones',
           'result_count' => 1,
           'max_score' => 0.03125,
+          'search_failures' => [],
         ),
       )
     end
@@ -80,7 +81,7 @@ RSpec.describe 'Classification search API' do
         expect(response).to have_http_status(:ok)
         expect(JSON.parse(response.body)).to include(
           'data' => [],
-          'meta' => include('retrieval_method' => 'hybrid', 'result_count' => 0),
+          'meta' => include('retrieval_method' => 'hybrid', 'result_count' => 0, 'search_failures' => []),
         )
       end
     end
@@ -110,7 +111,15 @@ RSpec.describe 'Classification search API' do
         make_request
 
         expect(response).to have_http_status(:internal_server_error)
-        expect(JSON.parse(response.body)).to include('errors' => [include('title' => 'Classification search failed')])
+        expect(JSON.parse(response.body)).to include(
+          'errors' => [
+            include(
+              'title' => 'Classification search failed',
+              'detail' => 'Classification search is temporarily unavailable',
+            ),
+          ],
+        )
+        expect(response.body).not_to include('all legs failed')
       end
     end
   end

--- a/spec/services/api/internal/search_service_spec.rb
+++ b/spec/services/api/internal/search_service_spec.rb
@@ -1631,6 +1631,25 @@ RSpec.describe Api::Internal::SearchService do
           expect(result[:meta]).to eq(search_failures: %w[interactive_search_failed])
         end
 
+        context 'when OpenSearch succeeded with no results' do
+          before do
+            allow(HybridRetrievalService).to receive(:call).and_return(
+              hybrid_result.with(
+                results: hybrid_vector_results,
+                opensearch_results: [],
+                vector_results: hybrid_vector_results,
+              ),
+            )
+          end
+
+          it 'does not mistake an empty OpenSearch result set for a failed leg' do
+            result = described_class.new(q: 'horses').call
+
+            expect(result[:data]).to be_empty
+            expect(result.dig(:meta, :search_failures)).to eq(%w[interactive_search_failed])
+          end
+        end
+
         context 'when OpenSearch also failed' do
           before do
             allow(HybridRetrievalService).to receive(:call) do

--- a/spec/services/api/internal/search_service_spec.rb
+++ b/spec/services/api/internal/search_service_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe Api::Internal::SearchService do
     )
   end
 
+  after { TradeTariffRequest.search_failures = nil }
+
   before do
     allow(AdminConfiguration).to receive(:option_value).and_call_original
     allow(AdminConfiguration).to receive(:option_value).with('retrieval_method').and_return('opensearch')
@@ -37,16 +39,16 @@ RSpec.describe Api::Internal::SearchService do
 
   describe '#call' do
     context 'when blank query' do
-      it 'returns empty data' do
+      it 'returns empty data with no failures' do
         result = described_class.new(q: '').call
-        expect(result).to eq(data: [])
+        expect(result).to eq(data: [], meta: { search_failures: [] })
       end
     end
 
     context 'when nil query' do
       it 'returns empty data' do
         result = described_class.new(q: nil).call
-        expect(result).to eq(data: [])
+        expect(result).to eq(data: [], meta: { search_failures: [] })
       end
     end
 
@@ -222,6 +224,7 @@ RSpec.describe Api::Internal::SearchService do
         expect(result[:data][0][:type]).to eq(:heading)
         expect(result[:data][0][:attributes][:goods_nomenclature_item_id]).to eq('0101000000')
         expect(result[:data][0][:attributes][:score]).to be_nil
+        expect(result.dig(:meta, :search_failures)).to eq([])
         expect(TradeTariffBackend.search_client).not_to have_received(:search)
       end
 
@@ -356,7 +359,7 @@ RSpec.describe Api::Internal::SearchService do
       it 'falls through to OpenSearch instead of returning exact match' do
         result = described_class.new(q: '98').call
 
-        expect(result).to eq(data: [])
+        expect(result).to eq(data: [], meta: { search_failures: [] })
         expect(TradeTariffBackend.search_client).to have_received(:search)
       end
     end
@@ -637,7 +640,7 @@ RSpec.describe Api::Internal::SearchService do
 
       it 'returns empty data array' do
         result = described_class.new(q: 'nonexistent').call
-        expect(result).to eq(data: [])
+        expect(result).to eq(data: [], meta: { search_failures: [] })
       end
     end
 
@@ -772,7 +775,7 @@ RSpec.describe Api::Internal::SearchService do
       it 'falls through to OpenSearch instead of returning an exact match' do
         result = described_class.new(q: 'horse').call
 
-        expect(result).to eq(data: [])
+        expect(result).to eq(data: [], meta: { search_failures: [] })
         expect(TradeTariffBackend.search_client).to have_received(:search)
       end
     end
@@ -1339,10 +1342,10 @@ RSpec.describe Api::Internal::SearchService do
         allow(InteractiveSearchService).to receive(:call).and_return(nil)
       end
 
-      it 'does not include interactive_search in meta' do
+      it 'returns no failures without interactive meta' do
         result = described_class.new(q: 'handbag').call
 
-        expect(result[:meta]).to be_nil
+        expect(result[:meta]).to eq(search_failures: [])
       end
 
       it 'does not instrument an evaluation trace' do
@@ -1383,7 +1386,7 @@ RSpec.describe Api::Internal::SearchService do
         result = described_class.new(q: 'handbag', skip_question: true).call
 
         expect(InteractiveSearchService).not_to have_received(:call)
-        expect(result[:meta]).to be_nil
+        expect(result[:meta]).to eq(search_failures: [])
       end
     end
 
@@ -1506,6 +1509,15 @@ RSpec.describe Api::Internal::SearchService do
           )
         end
       end
+      let(:hybrid_result) do
+        HybridRetrievalService::Result.new(
+          results: hybrid_results,
+          expanded_query: 'expanded horses',
+          source_results: hybrid_source_results,
+          opensearch_results: hybrid_opensearch_results,
+          vector_results: hybrid_vector_results,
+        )
+      end
 
       let(:hybrid_source_results) do
         hybrid_results.map.with_index do |result, index|
@@ -1513,13 +1525,12 @@ RSpec.describe Api::Internal::SearchService do
         end
       end
 
-      let(:hybrid_result) do
-        instance_double(
-          HybridRetrievalService::Result,
-          results: hybrid_results,
-          expanded_query: 'expanded horses',
-          source_results: hybrid_source_results,
-        )
+      def hybrid_opensearch_results
+        hybrid_results.first(2)
+      end
+
+      def hybrid_vector_results
+        hybrid_results.last(3)
       end
 
       before do
@@ -1561,6 +1572,101 @@ RSpec.describe Api::Internal::SearchService do
 
         expect(result[:data].length).to eq(5)
         expect(result[:data][0][:attributes][:goods_nomenclature_item_id]).to eq('0101210000')
+      end
+
+      context 'when vector retrieval fails' do
+        before do
+          allow(HybridRetrievalService).to receive(:call) do
+            TradeTariffRequest.record_search_failure(Search::FailureCodes::VECTOR_RETRIEVAL_FAILED)
+            hybrid_result.with(results: hybrid_opensearch_results, vector_results: [])
+          end
+        end
+
+        it 'returns OpenSearch results without attempting interactive search' do
+          result = described_class.new(q: 'horses').call
+
+          expect(InteractiveSearchService).not_to have_received(:call)
+          expect(result[:data].pluck(:attributes).pluck(:goods_nomenclature_item_id))
+            .to eq(hybrid_opensearch_results.map(&:goods_nomenclature_item_id))
+          expect(result.dig(:meta, :search_failures)).to eq(%w[vector_retrieval_failed])
+        end
+      end
+
+      context 'when embedding generation fails' do
+        before do
+          allow(HybridRetrievalService).to receive(:call) do
+            TradeTariffRequest.record_search_failure(Search::FailureCodes::EMBEDDING_GENERATION_FAILED)
+            hybrid_result.with(results: hybrid_opensearch_results, vector_results: [])
+          end
+        end
+
+        it 'returns OpenSearch results without attempting interactive search' do
+          result = described_class.new(q: 'horses').call
+
+          expect(InteractiveSearchService).not_to have_received(:call)
+          expect(result.dig(:meta, :search_failures)).to eq(%w[embedding_generation_failed])
+        end
+      end
+
+      context 'when interactive search fails' do
+        let(:interactive_error) do
+          InteractiveSearchService::Result.new(
+            type: :error, data: { message: 'provider detail' }, attempt: 1,
+            model: 'gpt-5.4', result_limit: 5, ranking_source: 'model_error'
+          )
+        end
+
+        before do
+          allow(InteractiveSearchService).to receive(:call) do
+            TradeTariffRequest.record_search_failure(Search::FailureCodes::INTERACTIVE_SEARCH_FAILED)
+            interactive_error
+          end
+        end
+
+        it 'returns unranked OpenSearch results and exposes only the stable failure code' do
+          result = described_class.new(q: 'horses').call
+
+          expect(result[:data].pluck(:attributes).pluck(:goods_nomenclature_item_id))
+            .to eq(hybrid_opensearch_results.map(&:goods_nomenclature_item_id))
+          expect(result[:meta]).to eq(search_failures: %w[interactive_search_failed])
+        end
+
+        context 'when OpenSearch also failed' do
+          before do
+            allow(HybridRetrievalService).to receive(:call) do
+              TradeTariffRequest.record_search_failure(Search::FailureCodes::OPENSEARCH_FAILED)
+              hybrid_result.with(results: hybrid_vector_results, opensearch_results: [])
+            end
+          end
+
+          it 'returns vector-only results with both failures' do
+            result = described_class.new(q: 'horses').call
+
+            expect(result[:data].pluck(:attributes).pluck(:goods_nomenclature_item_id))
+              .to eq(hybrid_vector_results.map(&:goods_nomenclature_item_id))
+            expect(result.dig(:meta, :search_failures)).to contain_exactly(
+              'opensearch_failed',
+              'interactive_search_failed',
+            )
+          end
+        end
+      end
+
+      context 'when only OpenSearch fails' do
+        before do
+          allow(HybridRetrievalService).to receive(:call) do
+            TradeTariffRequest.record_search_failure(Search::FailureCodes::OPENSEARCH_FAILED)
+            hybrid_result.with(results: hybrid_vector_results, opensearch_results: [])
+          end
+        end
+
+        it 'continues into interactive search with vector candidates' do
+          described_class.new(q: 'horses').call
+
+          expect(InteractiveSearchService).to have_received(:call).with(
+            hash_including(opensearch_results: hybrid_vector_results),
+          )
+        end
       end
 
       context 'when conditional expansion is enabled' do
@@ -1846,7 +1952,10 @@ RSpec.describe Api::Internal::SearchService do
       before do
         allow(AdminConfiguration).to receive(:option_value).with('retrieval_method').and_return('hybrid')
         allow(HybridRetrievalService).to receive(:call).and_return(
-          instance_double(HybridRetrievalService::Result, results: [], expanded_query: 'horses', source_results: []),
+          instance_double(
+            HybridRetrievalService::Result,
+            results: [], expanded_query: 'horses', source_results: [], opensearch_results: [], vector_results: [],
+          ),
         )
       end
 
@@ -1876,7 +1985,10 @@ RSpec.describe Api::Internal::SearchService do
       before do
         allow(AdminConfiguration).to receive(:option_value).with('retrieval_method').and_return('hybrid')
         allow(HybridRetrievalService).to receive(:call).and_return(
-          instance_double(HybridRetrievalService::Result, results: [], expanded_query: 'horses', source_results: []),
+          instance_double(
+            HybridRetrievalService::Result,
+            results: [], expanded_query: 'horses', source_results: [], opensearch_results: [], vector_results: [],
+          ),
         )
       end
 
@@ -1897,7 +2009,10 @@ RSpec.describe Api::Internal::SearchService do
       before do
         allow(AdminConfiguration).to receive(:option_value).with('retrieval_method').and_return('hybrid')
         allow(HybridRetrievalService).to receive(:call).and_return(
-          instance_double(HybridRetrievalService::Result, results: [], expanded_query: 'horses', source_results: []),
+          instance_double(
+            HybridRetrievalService::Result,
+            results: [], expanded_query: 'horses', source_results: [], opensearch_results: [], vector_results: [],
+          ),
         )
       end
 

--- a/spec/services/api/internal/search_service_spec.rb
+++ b/spec/services/api/internal/search_service_spec.rb
@@ -1578,7 +1578,11 @@ RSpec.describe Api::Internal::SearchService do
         before do
           allow(HybridRetrievalService).to receive(:call) do
             TradeTariffRequest.record_search_failure(Search::FailureCodes::VECTOR_RETRIEVAL_FAILED)
-            hybrid_result.with(results: hybrid_opensearch_results, vector_results: [])
+            hybrid_result.with(
+              results: hybrid_opensearch_results,
+              vector_results: [],
+              failure_codes: %w[vector_retrieval_failed],
+            )
           end
         end
 
@@ -1596,7 +1600,11 @@ RSpec.describe Api::Internal::SearchService do
         before do
           allow(HybridRetrievalService).to receive(:call) do
             TradeTariffRequest.record_search_failure(Search::FailureCodes::EMBEDDING_GENERATION_FAILED)
-            hybrid_result.with(results: hybrid_opensearch_results, vector_results: [])
+            hybrid_result.with(
+              results: hybrid_opensearch_results,
+              vector_results: [],
+              failure_codes: %w[embedding_generation_failed],
+            )
           end
         end
 
@@ -1654,7 +1662,11 @@ RSpec.describe Api::Internal::SearchService do
           before do
             allow(HybridRetrievalService).to receive(:call) do
               TradeTariffRequest.record_search_failure(Search::FailureCodes::OPENSEARCH_FAILED)
-              hybrid_result.with(results: hybrid_vector_results, opensearch_results: [])
+              hybrid_result.with(
+                results: hybrid_vector_results,
+                opensearch_results: [],
+                failure_codes: %w[opensearch_failed],
+              )
             end
           end
 
@@ -1675,7 +1687,11 @@ RSpec.describe Api::Internal::SearchService do
         before do
           allow(HybridRetrievalService).to receive(:call) do
             TradeTariffRequest.record_search_failure(Search::FailureCodes::OPENSEARCH_FAILED)
-            hybrid_result.with(results: hybrid_vector_results, opensearch_results: [])
+            hybrid_result.with(
+              results: hybrid_vector_results,
+              opensearch_results: [],
+              failure_codes: %w[opensearch_failed],
+            )
           end
         end
 
@@ -1710,6 +1726,34 @@ RSpec.describe Api::Internal::SearchService do
               max_score: 250.0,
             ),
           )
+        end
+
+        it 'uses the final retrieval attempt status for interactive search control' do
+          preliminary_result = hybrid_result.with(
+            results: hybrid_opensearch_results,
+            source_results: [hybrid_source_results.first.with(score: 1.0)],
+            vector_results: [],
+            failure_codes: %w[vector_retrieval_failed],
+          )
+          final_result = hybrid_result.with(failure_codes: [])
+          retrieval_attempt = 0
+          allow(HybridRetrievalService).to receive(:call) do
+            retrieval_attempt += 1
+            if retrieval_attempt == 1
+              TradeTariffRequest.record_search_failure(Search::FailureCodes::VECTOR_RETRIEVAL_FAILED)
+              preliminary_result
+            else
+              final_result
+            end
+          end
+
+          result = described_class.new(q: 'horses').call
+
+          expect(HybridRetrievalService).to have_received(:call).twice
+          expect(InteractiveSearchService).to have_received(:call).with(
+            hash_including(opensearch_results: hybrid_results),
+          )
+          expect(result.dig(:meta, :search_failures)).to eq(%w[vector_retrieval_failed])
         end
 
         context 'with the v2 decider' do
@@ -1973,7 +2017,7 @@ RSpec.describe Api::Internal::SearchService do
         allow(HybridRetrievalService).to receive(:call).and_return(
           instance_double(
             HybridRetrievalService::Result,
-            results: [], expanded_query: 'horses', source_results: [], opensearch_results: [], vector_results: [],
+            results: [], expanded_query: 'horses', source_results: [], opensearch_results: [], vector_results: [], failure_codes: [],
           ),
         )
       end
@@ -2006,7 +2050,7 @@ RSpec.describe Api::Internal::SearchService do
         allow(HybridRetrievalService).to receive(:call).and_return(
           instance_double(
             HybridRetrievalService::Result,
-            results: [], expanded_query: 'horses', source_results: [], opensearch_results: [], vector_results: [],
+            results: [], expanded_query: 'horses', source_results: [], opensearch_results: [], vector_results: [], failure_codes: [],
           ),
         )
       end
@@ -2030,7 +2074,7 @@ RSpec.describe Api::Internal::SearchService do
         allow(HybridRetrievalService).to receive(:call).and_return(
           instance_double(
             HybridRetrievalService::Result,
-            results: [], expanded_query: 'horses', source_results: [], opensearch_results: [], vector_results: [],
+            results: [], expanded_query: 'horses', source_results: [], opensearch_results: [], vector_results: [], failure_codes: [],
           ),
         )
       end

--- a/spec/services/api/v2/classification_search_service_spec.rb
+++ b/spec/services/api/v2/classification_search_service_spec.rb
@@ -1,0 +1,27 @@
+RSpec.describe Api::V2::ClassificationSearchService do
+  after { TradeTariffRequest.search_failures = nil }
+
+  describe '#call' do
+    it 'always returns the search failures array for an empty query' do
+      result = described_class.new(q: '', request_id: 'request-1').call
+
+      expect(result.dig(:meta, :search_failures)).to eq([])
+    end
+
+    it 'returns stable retrieval failures recorded by hybrid search' do
+      result = instance_double(
+        HybridRetrievalService::Result,
+        results: [],
+        expanded_query: 'horses',
+      )
+      allow(HybridRetrievalService).to receive(:call) do
+        TradeTariffRequest.record_search_failure(Search::FailureCodes::OPENSEARCH_FAILED)
+        result
+      end
+
+      response = described_class.new(q: 'horses', request_id: 'request-1').call
+
+      expect(response.dig(:meta, :search_failures)).to eq(%w[opensearch_failed])
+    end
+  end
+end

--- a/spec/services/expand_search_query_service_spec.rb
+++ b/spec/services/expand_search_query_service_spec.rb
@@ -1,6 +1,8 @@
 RSpec.describe ExpandSearchQueryService do
   subject(:result) { described_class.call(query, request_id: 'request-123') }
 
+  after { TradeTariffRequest.search_failures = nil }
+
   let(:ai_response) do
     {
       'expanded_query' => 'Portable automatic data-processing machines',
@@ -66,6 +68,12 @@ RSpec.describe ExpandSearchQueryService do
 
         expect(OpenaiClient).not_to have_received(:call)
       end
+
+      it 'does not record a failure for a stage that was not needed' do
+        result
+
+        expect(TradeTariffRequest.search_failures).to be_nil
+      end
     end
 
     context 'when the query is a short numeric code' do
@@ -121,6 +129,12 @@ RSpec.describe ExpandSearchQueryService do
       it 'returns nil reason' do
         expect(result.reason).to be_nil
       end
+
+      it 'records the expansion failure' do
+        result
+
+        expect(TradeTariffRequest.search_failures).to eq(%w[query_expansion_failed])
+      end
     end
 
     context 'when the AI returns an empty expanded_query' do
@@ -130,6 +144,22 @@ RSpec.describe ExpandSearchQueryService do
       it 'falls back to the original query' do
         expect(result.expanded_query).to eq('laptop')
       end
+
+      it 'records the malformed provider response as an expansion failure' do
+        result
+
+        expect(TradeTariffRequest.search_failures).to eq(%w[query_expansion_failed])
+      end
+    end
+
+    context 'when the AI validly returns the original query' do
+      let(:query) { 'laptop' }
+      let(:ai_response) { { 'expanded_query' => 'laptop', 'reason' => 'already tariff-ready' } }
+
+      it 'does not infer a failure from the unchanged value' do
+        expect(result.expanded_query).to eq('laptop')
+        expect(TradeTariffRequest.search_failures).to be_nil
+      end
     end
 
     context 'when the AI returns nil' do
@@ -138,6 +168,12 @@ RSpec.describe ExpandSearchQueryService do
 
       it 'falls back to the original query' do
         expect(result.expanded_query).to eq('laptop')
+      end
+
+      it 'records the malformed provider response as an expansion failure' do
+        result
+
+        expect(TradeTariffRequest.search_failures).to eq(%w[query_expansion_failed])
       end
     end
 
@@ -155,6 +191,12 @@ RSpec.describe ExpandSearchQueryService do
 
       it 'returns nil reason' do
         expect(result.reason).to be_nil
+      end
+
+      it 'records the expansion failure' do
+        result
+
+        expect(TradeTariffRequest.search_failures).to eq(%w[query_expansion_failed])
       end
 
       it 'emits a search_failed event' do
@@ -185,6 +227,12 @@ RSpec.describe ExpandSearchQueryService do
 
       it 'falls back to the original query' do
         expect(result.expanded_query).to eq('laptop')
+      end
+
+      it 'records the expansion failure' do
+        result
+
+        expect(TradeTariffRequest.search_failures).to eq(%w[query_expansion_failed])
       end
 
       it 'emits timeout telemetry' do

--- a/spec/services/hybrid_retrieval_service_spec.rb
+++ b/spec/services/hybrid_retrieval_service_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe HybridRetrievalService do
+  after { TradeTariffRequest.search_failures = nil }
+
   def make_result(sid:, item_id:, score:)
     GoodsNomenclatureResult.new(
       id: sid,
@@ -125,6 +127,13 @@ RSpec.describe HybridRetrievalService do
       result = described_class.call(query: 'horses', as_of: Time.zone.today)
 
       expect(result.source_results).to match_array(opensearch_results + vector_results)
+    end
+
+    it 'preserves each retrieval source' do
+      result = described_class.call(query: 'horses', as_of: Time.zone.today)
+
+      expect(result.opensearch_results).to eq(opensearch_results)
+      expect(result.vector_results).to eq(vector_results)
     end
 
     it 'ranks items in both lists higher than items in only one list' do
@@ -287,14 +296,14 @@ RSpec.describe HybridRetrievalService do
         )
       end
 
-      it 'fails closed when the vector score needed by the guardrail is unavailable' do
+      it 'keeps OpenSearch results when vector retrieval is unavailable' do
         allow(VectorRetrievalService).to receive(:call_with_diagnostics).and_raise(StandardError, 'vector down')
 
         result = described_class.call(query: 'horses', as_of: Time.zone.today)
 
-        expect(result.results).to be_empty
+        expect(result.results).to eq(opensearch_results)
         expect(Search::Instrumentation).to have_received(:query_guardrail_decided).with(
-          hash_including(accepted: false, max_score: nil, reason: 'vector_unavailable'),
+          hash_including(accepted: true, max_score: nil, reason: 'vector_unavailable'),
         )
       end
     end
@@ -336,6 +345,12 @@ RSpec.describe HybridRetrievalService do
         expect(sids).to eq([2, 4, 1])
       end
 
+      it 'records the OpenSearch failure' do
+        described_class.call(query: 'horses', as_of: Time.zone.today)
+
+        expect(TradeTariffRequest.search_failures).to eq(%w[opensearch_failed])
+      end
+
       it 'emits error status for opensearch leg' do
         described_class.call(query: 'horses', as_of: Time.zone.today)
 
@@ -360,6 +375,12 @@ RSpec.describe HybridRetrievalService do
         expect(sids).to eq([1, 2, 3])
       end
 
+      it 'records the vector retrieval failure' do
+        described_class.call(query: 'horses', as_of: Time.zone.today)
+
+        expect(TradeTariffRequest.search_failures).to eq(%w[vector_retrieval_failed])
+      end
+
       it 'still returns the expanded_query passed by internal search' do
         result = described_class.call(query: 'horses', expanded_query: expanded_query, as_of: Time.zone.today)
 
@@ -378,6 +399,19 @@ RSpec.describe HybridRetrievalService do
       end
     end
 
+    context 'when embedding generation fails' do
+      before do
+        allow(VectorRetrievalService).to receive(:call_with_diagnostics)
+          .and_raise(VectorRetrievalService::EmbeddingGenerationError, 'embedding down')
+      end
+
+      it 'records the embedding failure' do
+        described_class.call(query: 'horses', as_of: Time.zone.today)
+
+        expect(TradeTariffRequest.search_failures).to eq(%w[embedding_generation_failed])
+      end
+    end
+
     context 'when both legs fail' do
       before do
         allow(OpensearchRetrievalService).to receive(:call).and_raise(StandardError, 'opensearch down')
@@ -388,6 +422,17 @@ RSpec.describe HybridRetrievalService do
         expect {
           described_class.call(query: 'horses', as_of: Time.zone.today)
         }.to raise_error(described_class::AllLegsFailed, 'Hybrid retrieval failed for all legs: opensearch down; vector down')
+      end
+
+      it 'records both retrieval failures before raising' do
+        expect {
+          described_class.call(query: 'horses', as_of: Time.zone.today)
+        }.to raise_error(described_class::AllLegsFailed)
+
+        expect(TradeTariffRequest.search_failures).to contain_exactly(
+          'opensearch_failed',
+          'vector_retrieval_failed',
+        )
       end
 
       it 'emits error status for both legs' do

--- a/spec/services/hybrid_retrieval_service_spec.rb
+++ b/spec/services/hybrid_retrieval_service_spec.rb
@@ -343,6 +343,20 @@ RSpec.describe HybridRetrievalService do
 
         sids = result.results.map(&:goods_nomenclature_sid)
         expect(sids).to eq([2, 4, 1])
+        expect(result.failure_codes).to eq(%w[opensearch_failed])
+      end
+
+      context 'when the query guardrail rejects the vector results' do
+        before do
+          allow(AdminConfiguration).to receive(:enabled?).with('hybrid_query_guardrail_enabled').and_return(true)
+        end
+
+        it 'does not return the rejected vector results' do
+          result = described_class.call(query: 'horses', as_of: Time.zone.today)
+
+          expect(result.results).to be_empty
+          expect(result.failure_codes).to eq(%w[opensearch_failed])
+        end
       end
 
       it 'records the OpenSearch failure' do
@@ -373,6 +387,7 @@ RSpec.describe HybridRetrievalService do
 
         sids = result.results.map(&:goods_nomenclature_sid)
         expect(sids).to eq([1, 2, 3])
+        expect(result.failure_codes).to eq(%w[vector_retrieval_failed])
       end
 
       it 'records the vector retrieval failure' do

--- a/spec/services/interactive_search_service_spec.rb
+++ b/spec/services/interactive_search_service_spec.rb
@@ -445,6 +445,7 @@ RSpec.describe InteractiveSearchService do
 
         expect(result.type).to eq(:answers)
         expect(result.data.first).to eq({ commodity_code: '4202210000', confidence: 'good' })
+        expect(TradeTariffRequest.search_failures).to eq(%w[interactive_search_failed])
       end
 
       it 'returns the duplicate-looking question without retry when the guard is disabled' do

--- a/spec/services/interactive_search_service_spec.rb
+++ b/spec/services/interactive_search_service_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe InteractiveSearchService do
   let(:search_result_class) { Data.define(:goods_nomenclature_item_id, :description, :full_description, :score) }
   let(:params) { search_params }
 
+  after { TradeTariffRequest.search_failures = nil }
+
   def search_params(**overrides)
     {
       query: 'leather handbag',
@@ -198,6 +200,12 @@ RSpec.describe InteractiveSearchService do
         result
         expect(OpenaiClient).not_to have_received(:call)
       end
+
+      it 'does not record a failure' do
+        result
+
+        expect(TradeTariffRequest.search_failures).to be_nil
+      end
     end
 
     context 'when there is a single search result' do
@@ -280,13 +288,13 @@ RSpec.describe InteractiveSearchService do
         )
       end
 
-      it 'falls back to best available answers when AI returns questions' do
+      it 'records a failure when the final-answer response asks another question' do
         allow(OpenaiClient).to receive(:call).and_return(
           '{"questions": [{"question": "What colour?", "options": ["Red", "Blue"]}]}',
         )
 
-        expect(result.type).to eq(:answers)
-        expect(result.data.first[:confidence]).to eq('good')
+        expect(result.type).to eq(:error)
+        expect(TradeTariffRequest.search_failures).to eq(%w[interactive_search_failed])
       end
 
       it 'returns an error result when AI returns a structured error' do
@@ -517,6 +525,12 @@ RSpec.describe InteractiveSearchService do
         expect(result.type).to eq(:answers)
         expect(result.data.first[:commodity_code]).to eq('4202210000')
       end
+
+      it 'records the malformed answers as an interactive search failure' do
+        result
+
+        expect(TradeTariffRequest.search_failures).to eq(%w[interactive_search_failed])
+      end
     end
 
     context 'when AI returns an error' do
@@ -532,6 +546,12 @@ RSpec.describe InteractiveSearchService do
 
       it 'includes the error message' do
         expect(result.data[:message]).to eq('Contradictory answers given')
+      end
+
+      it 'records an interactive search failure' do
+        result
+
+        expect(TradeTariffRequest.search_failures).to eq(%w[interactive_search_failed])
       end
     end
 
@@ -550,6 +570,12 @@ RSpec.describe InteractiveSearchService do
           hash_including(error_type: 'Faraday::TimeoutError', search_type: 'interactive'),
         )
       end
+
+      it 'records an interactive search failure' do
+        result
+
+        expect(TradeTariffRequest.search_failures).to eq(%w[interactive_search_failed])
+      end
     end
 
     context 'when AI returns unparseable response' do
@@ -559,8 +585,9 @@ RSpec.describe InteractiveSearchService do
         allow(OpenaiClient).to receive(:call).and_return(ai_response)
       end
 
-      it 'falls back to best available answers' do
-        expect(result.type).to eq(:answers)
+      it 'returns an error and records an interactive search failure' do
+        expect(result.type).to eq(:error)
+        expect(TradeTariffRequest.search_failures).to eq(%w[interactive_search_failed])
       end
     end
 
@@ -615,6 +642,21 @@ RSpec.describe InteractiveSearchService do
 
       it 'removes uncertainty options but keeps Other as a catch-all option' do
         expect(result.data.first[:options]).to eq(%w[Leather Other])
+      end
+    end
+
+    context 'when AI returns a question without any usable options' do
+      let(:ai_response) do
+        %q({"questions": [{"question": "What is the material?", "options": ["I don't know", "Unknown"]}]})
+      end
+
+      before do
+        allow(OpenaiClient).to receive(:call).and_return(ai_response)
+      end
+
+      it 'records the malformed question as an interactive search failure' do
+        expect(result.type).to eq(:error)
+        expect(TradeTariffRequest.search_failures).to eq(%w[interactive_search_failed])
       end
     end
   end

--- a/spec/services/vector_retrieval_service_spec.rb
+++ b/spec/services/vector_retrieval_service_spec.rb
@@ -413,6 +413,17 @@ RSpec.describe VectorRetrievalService do
       end
     end
 
+    context 'when embedding generation returns no embedding' do
+      before do
+        allow(embedding_service).to receive(:embed).and_return(nil)
+      end
+
+      it 'identifies the malformed response at the embedding boundary' do
+        expect { service.call_with_diagnostics }
+          .to raise_error(described_class::EmbeddingGenerationError)
+      end
+    end
+
     context 'when vector retrieval fails' do
       before do
         allow(GoodsNomenclatureSelfText).to receive(:vector_search).and_raise(Sequel::DatabaseError)

--- a/spec/services/vector_retrieval_service_spec.rb
+++ b/spec/services/vector_retrieval_service_spec.rb
@@ -424,6 +424,28 @@ RSpec.describe VectorRetrievalService do
       end
     end
 
+    context 'when embedding generation returns the wrong dimensions' do
+      before do
+        allow(embedding_service).to receive(:embed).and_return([0.1])
+      end
+
+      it 'identifies the malformed response at the embedding boundary' do
+        expect { service.call_with_diagnostics }
+          .to raise_error(described_class::EmbeddingGenerationError)
+      end
+    end
+
+    context 'when embedding generation returns a non-numeric value' do
+      before do
+        allow(embedding_service).to receive(:embed).and_return(Array.new(1536, 'invalid'))
+      end
+
+      it 'identifies the malformed response at the embedding boundary' do
+        expect { service.call_with_diagnostics }
+          .to raise_error(described_class::EmbeddingGenerationError)
+      end
+    end
+
     context 'when vector retrieval fails' do
       before do
         allow(GoodsNomenclatureSelfText).to receive(:vector_search).and_raise(Sequel::DatabaseError)

--- a/spec/services/vector_retrieval_service_spec.rb
+++ b/spec/services/vector_retrieval_service_spec.rb
@@ -401,6 +401,30 @@ RSpec.describe VectorRetrievalService do
     end
   end
 
+  describe '#call_with_diagnostics' do
+    context 'when embedding generation fails' do
+      before do
+        allow(embedding_service).to receive(:embed).and_raise(Faraday::TimeoutError)
+      end
+
+      it 'identifies the embedding boundary' do
+        expect { service.call_with_diagnostics }
+          .to raise_error(described_class::EmbeddingGenerationError)
+      end
+    end
+
+    context 'when vector retrieval fails' do
+      before do
+        allow(GoodsNomenclatureSelfText).to receive(:vector_search).and_raise(Sequel::DatabaseError)
+      end
+
+      it 'identifies the retrieval boundary' do
+        expect { service.call_with_diagnostics }
+          .to raise_error(described_class::VectorRetrievalError)
+      end
+    end
+  end
+
 private
 
   def populate_search_embedding(sid, embedding)

--- a/spec/swagger/api/v2/classification_search_spec.rb
+++ b/spec/swagger/api/v2/classification_search_spec.rb
@@ -89,6 +89,27 @@ RSpec.describe 'Classification Search', skip: 'Draft MCP API docs are held back 
 
         run_test!
       end
+
+      response '500', 'classification search unavailable' do
+        schema type: :object,
+               required: %w[errors],
+               properties: {
+                 errors: {
+                   type: :array,
+                   items: {
+                     type: :object,
+                     required: %w[status title detail],
+                     properties: {
+                       status: { type: :string, enum: %w[500] },
+                       title: { type: :string, example: 'Classification search failed' },
+                       detail: { type: :string, example: 'Classification search is temporarily unavailable' },
+                     },
+                   },
+                 },
+               }
+
+        run_test!
+      end
     end
 
     post 'Post hybrid classification candidates' do
@@ -135,6 +156,27 @@ RSpec.describe 'Classification Search', skip: 'Draft MCP API docs are held back 
             instance_double(Api::V2::ClassificationSearchService, call: { data: [], meta: { request_id: 'test', retrieval_method: 'hybrid', expanded_query: 'wireless headphones', result_count: 0, max_score: nil, search_failures: [] } }),
           )
         end
+
+        run_test!
+      end
+
+      response '500', 'classification search unavailable' do
+        schema type: :object,
+               required: %w[errors],
+               properties: {
+                 errors: {
+                   type: :array,
+                   items: {
+                     type: :object,
+                     required: %w[status title detail],
+                     properties: {
+                       status: { type: :string, enum: %w[500] },
+                       title: { type: :string, example: 'Classification search failed' },
+                       detail: { type: :string, example: 'Classification search is temporarily unavailable' },
+                     },
+                   },
+                 },
+               }
 
         run_test!
       end

--- a/spec/swagger/api/v2/classification_search_spec.rb
+++ b/spec/swagger/api/v2/classification_search_spec.rb
@@ -59,12 +59,21 @@ RSpec.describe 'Classification Search', skip: 'Draft MCP API docs are held back 
                  },
                  meta: {
                    type: :object,
+                   required: %w[search_failures],
                    properties: {
                      request_id: { type: :string },
                      retrieval_method: { type: :string, enum: %w[hybrid] },
                      expanded_query: { type: :string, nullable: true },
                      result_count: { type: :integer },
                      max_score: { type: :number, nullable: true },
+                     search_failures: {
+                       type: :array,
+                       uniqueItems: true,
+                       items: {
+                         type: :string,
+                         enum: Search::FailureCodes::ALL,
+                       },
+                     },
                    },
                  },
                }
@@ -74,7 +83,7 @@ RSpec.describe 'Classification Search', skip: 'Draft MCP API docs are held back 
 
         before do
           allow(Api::V2::ClassificationSearchService).to receive(:new).and_return(
-            instance_double(Api::V2::ClassificationSearchService, call: { data: [], meta: { request_id: 'test', retrieval_method: 'hybrid', expanded_query: 'wireless headphones', result_count: 0, max_score: nil } }),
+            instance_double(Api::V2::ClassificationSearchService, call: { data: [], meta: { request_id: 'test', retrieval_method: 'hybrid', expanded_query: 'wireless headphones', result_count: 0, max_score: nil, search_failures: [] } }),
           )
         end
 
@@ -106,14 +115,24 @@ RSpec.describe 'Classification Search', skip: 'Draft MCP API docs are held back 
                required: %w[data meta],
                properties: {
                  data: { type: :array },
-                 meta: { type: :object },
+                 meta: {
+                   type: :object,
+                   required: %w[search_failures],
+                   properties: {
+                     search_failures: {
+                       type: :array,
+                       uniqueItems: true,
+                       items: { type: :string, enum: Search::FailureCodes::ALL },
+                     },
+                   },
+                 },
                }
 
         let(:body) { { q: 'wireless headphones', limit: 5 } }
 
         before do
           allow(Api::V2::ClassificationSearchService).to receive(:new).and_return(
-            instance_double(Api::V2::ClassificationSearchService, call: { data: [], meta: { request_id: 'test', retrieval_method: 'hybrid', expanded_query: 'wireless headphones', result_count: 0, max_score: nil } }),
+            instance_double(Api::V2::ClassificationSearchService, call: { data: [], meta: { request_id: 'test', retrieval_method: 'hybrid', expanded_query: 'wireless headphones', result_count: 0, max_score: nil, search_failures: [] } }),
           )
         end
 


### PR DESCRIPTION
## What:

- [x] Return a stable `meta.search_failures` array on successful internal and classification search responses
- [x] Distinguish query expansion, embedding, vector retrieval, interactive search and OpenSearch failures
- [x] Keep OpenSearch and vector candidates separate so degraded searches return the correct source
- [x] Return controlled 500 responses when both retrieval legs fail
- [x] Cover normal, partial and failed paths with service and request specs

## Why:

AI-assisted search currently degrades silently. A failed expansion, retrieval leg or interactive model call can look the same as a genuine empty result, which means the frontend cannot explain what happened.

Failures are now recorded at the boundary where they occur. Successful responses expose unique stable codes, while disabled or unnecessary stages remain non-failures. Hybrid search can return the usable source without leaking provider details or presenting vector-only results as an OpenSearch fallback.

## Ticket:

[AI-1263](https://transformuk.atlassian.net/browse/AI-1263)

## Risk:

**Risk level:** 🟢

**Reason for rating:**

The AI-assisted search journey is not currently in production use. The response metadata is additive, the fallback paths are covered by unit and request specs, and existing successful retrieval behaviour is preserved.

## Test evidence:

- `bundle exec rspec` across the affected service, request and Swagger specs: 319 examples, 0 failures, 2 intentionally pending draft Swagger examples
- `bundle exec rubocop` across all 21 changed files: no offences
- Commit hooks: passed

## Manual evidence:

Not applicable. This is backend response and fallback behaviour with no user interface change.

## Accessibility impact:

None.

## Backend, API and deployment implications:

Adds `meta.search_failures` to successful internal search and public V2 classification search responses. No migration, environment variable, feature flag or deployment-order dependency.