### PR TITLE
AI-1263: Fix search fallback diagnostics and usage accounting

### DIFF
--- a/app/controllers/api/admin/search/evaluation/searches_controller.rb
+++ b/app/controllers/api/admin/search/evaluation/searches_controller.rb
@@ -6,15 +6,16 @@ module Api
           # Matches both sources of per-search LLM/embedding usage:
           #   - api_call_completed.search: interactive-search LLM calls
           #     (Search::Instrumentation::ApiEvents#api_call)
-          #   - embedding_api_call_completed.ai_usage: the query-embedding call
+          #   - embedding_api_call_{completed,failed}.ai_usage: the query-embedding call
           #     vector/hybrid retrieval makes (AiUsage::Instrumentation#embedding_api_call,
           #     via VectorRetrievalService) -- without this, an eval run configured for
           #     vector/hybrid retrieval would silently omit its embedding cost from
           #     meta.usage, biasing cost comparisons against exactly the retrieval
-          #     strategies most worth benchmarking.
+          #     strategies most worth benchmarking. Malformed embedding responses can
+          #     still carry billed usage, so failed calls must also be collected.
           # A Regexp lets one .subscribed call listen to both: Fanout#subscribe only
           # accepts a String, Regexp, or nil pattern, not an array of patterns.
-          USAGE_EVENT_PATTERN = /\A(?:api_call_completed\.search|embedding_api_call_completed\.ai_usage)\z/
+          USAGE_EVENT_PATTERN = /\A(?:api_call_completed\.search|embedding_api_call_(?:completed|failed)\.ai_usage)\z/
 
           def create
             EvaluationConfiguration::AllowlistValidator.call(configuration_overrides)

--- a/app/lib/embedding_service.rb
+++ b/app/lib/embedding_service.rb
@@ -31,10 +31,6 @@ class EmbeddingService
   def embed(text, event_kind: nil)
     embeddings = embed_batch([text], event_kind:)
     embedding = embeddings.first
-    if embedding.nil? && text.present?
-      raise ApiError.new('Embedding response was malformed', ai_usage: AiUsage.metadata_from(embeddings))
-    end
-
     AiUsage.attach_metadata(embedding, AiUsage.metadata_from(embeddings)) if embedding
     embedding
   end
@@ -90,7 +86,12 @@ private
     raise TypeError unless data.is_a?(Array) && data.size == expected_size
     raise TypeError unless data.map { |entry| entry.fetch('index') }.sort.eql?((0...expected_size).to_a)
 
-    data.sort_by { |entry| entry['index'] }.map { |entry| entry['embedding'] }
+    data.sort_by { |entry| entry['index'] }.map do |entry|
+      embedding = entry.fetch('embedding')
+      raise TypeError unless embedding.is_a?(Array) && embedding.size == 1536 && embedding.all? { |value| value.is_a?(Numeric) && value.real? && value.to_f.finite? }
+
+      embedding
+    end
   rescue StandardError
     raise ApiError.new('Embedding response was malformed', ai_usage: usage)
   end

--- a/app/lib/embedding_service.rb
+++ b/app/lib/embedding_service.rb
@@ -69,9 +69,7 @@ class EmbeddingService
       if response.success?
         usage = AiUsage.merge_metadata(usage, usage_metadata(response.body, event_kind:))
 
-        batch_embeddings = response.body['data']
-          .sort_by { |d| d['index'] }
-          .map { |d| d['embedding'] }
+        batch_embeddings = extract_embeddings(response.body, usage:, expected_size: batch.size)
 
         batch_embeddings.each_with_index do |embedding, i|
           original_index = present_indices[slice_index * BATCH_SIZE + i]
@@ -86,6 +84,15 @@ class EmbeddingService
   end
 
 private
+
+  def extract_embeddings(body, usage:, expected_size:)
+    data = body.fetch('data')
+    raise TypeError unless data.is_a?(Array) && data.size == expected_size
+
+    data.sort_by { |entry| entry['index'] }.map { |entry| entry['embedding'] }
+  rescue StandardError
+    raise ApiError.new('Embedding response was malformed', ai_usage: usage)
+  end
 
   def usage_metadata(body, event_kind:)
     usage = body.to_h['usage']

--- a/app/lib/embedding_service.rb
+++ b/app/lib/embedding_service.rb
@@ -16,10 +16,11 @@ class EmbeddingService
   RETRYABLE_HTTP_STATUSES = [429, 500, 502, 503, 504].freeze
 
   class ApiError < StandardError
-    attr_reader :http_status
+    attr_reader :http_status, :ai_usage
 
-    def initialize(message, http_status: nil)
+    def initialize(message, http_status: nil, ai_usage: nil)
       @http_status = http_status
+      @ai_usage = ai_usage
       super(message)
     end
   end
@@ -30,6 +31,10 @@ class EmbeddingService
   def embed(text, event_kind: nil)
     embeddings = embed_batch([text], event_kind:)
     embedding = embeddings.first
+    if embedding.nil? && text.present?
+      raise ApiError.new('Embedding response was malformed', ai_usage: AiUsage.metadata_from(embeddings))
+    end
+
     AiUsage.attach_metadata(embedding, AiUsage.metadata_from(embeddings)) if embedding
     embedding
   end

--- a/app/lib/embedding_service.rb
+++ b/app/lib/embedding_service.rb
@@ -88,6 +88,7 @@ private
   def extract_embeddings(body, usage:, expected_size:)
     data = body.fetch('data')
     raise TypeError unless data.is_a?(Array) && data.size == expected_size
+    raise TypeError unless data.map { |entry| entry.fetch('index') }.sort.eql?((0...expected_size).to_a)
 
     data.sort_by { |entry| entry['index'] }.map { |entry| entry['embedding'] }
   rescue StandardError

--- a/app/lib/search/failure_codes.rb
+++ b/app/lib/search/failure_codes.rb
@@ -4,6 +4,7 @@ module Search
     EMBEDDING_GENERATION_FAILED = 'embedding_generation_failed'.freeze
     VECTOR_RETRIEVAL_FAILED = 'vector_retrieval_failed'.freeze
     INTERACTIVE_SEARCH_FAILED = 'interactive_search_failed'.freeze
+    DUPLICATE_QUESTION_VALIDATION_FAILED = 'duplicate_question_validation_failed'.freeze
     OPENSEARCH_FAILED = 'opensearch_failed'.freeze
 
     ALL = [
@@ -11,6 +12,7 @@ module Search
       EMBEDDING_GENERATION_FAILED,
       VECTOR_RETRIEVAL_FAILED,
       INTERACTIVE_SEARCH_FAILED,
+      DUPLICATE_QUESTION_VALIDATION_FAILED,
       OPENSEARCH_FAILED,
     ].freeze
   end

--- a/app/lib/search/instrumentation/api_events.rb
+++ b/app/lib/search/instrumentation/api_events.rb
@@ -1,7 +1,7 @@
 module Search
   module Instrumentation
     module ApiEvents
-      def api_call(request_id:, model:, attempt_number:, iteration: nil, effective_query: nil, operation: 'interactive_search', emit_search_failed: true)
+      def api_call(request_id:, model:, attempt_number:, iteration: nil, effective_query: nil, operation: 'interactive_search')
         start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         result = yield
         duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
@@ -47,7 +47,6 @@ module Search
             event_kind: operation,
           }.merge(truncate_error_payload(AiUsage.safe_error_message(e))).merge(AiUsage.payload_from_error(e)),
         )
-        search_failed(request_id:, error_type: e.class.name, error_message: AiUsage.safe_error_message(e), search_type: 'interactive') if emit_search_failed
         raise
       end
 

--- a/app/lib/search/instrumentation/core.rb
+++ b/app/lib/search/instrumentation/core.rb
@@ -9,11 +9,11 @@ module Search
         instrument('search_started', request_id:, query:, search_type:)
       end
 
-      def search(request_id:, query:, search_type:)
+      def search(request_id:, query:, search_type:, &block)
         search_started(request_id:, query:, search_type:)
         start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
-        result, completion_payload = yield
+        result, completion_payload = TradeTariffRequest.set(search_type:, &block)
 
         duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000).round(2)
         search_completed(request_id:, query:, search_type:, total_duration_ms: duration_ms, **(completion_payload || {}))

--- a/app/lib/search/instrumentation/core.rb
+++ b/app/lib/search/instrumentation/core.rb
@@ -34,6 +34,16 @@ module Search
           }.merge(truncate_error_payload(error_message)),
         )
       end
+
+      def search_stage_failed(request_id:, search_type:, failure_code:, error_type:, error_message:, operation: nil)
+        TradeTariffRequest.record_search_failure(failure_code)
+        instrument(
+          'search_stage_failed',
+          {
+            request_id:, search_type:, failure_code:, error_type:, operation:
+          }.compact.merge(truncate_error_payload(error_message)),
+        )
+      end
     end
   end
 end

--- a/app/lib/search/instrumentation/payload_helpers.rb
+++ b/app/lib/search/instrumentation/payload_helpers.rb
@@ -44,6 +44,7 @@ module Search
       end
 
       def with_request_context(payload)
+        payload = payload.merge(search_type: TradeTariffRequest.search_type) if TradeTariffRequest.search_type.present?
         return payload unless payload.key?(:request_id)
 
         payload

--- a/app/lib/search/instrumentation/result_events.rb
+++ b/app/lib/search/instrumentation/result_events.rb
@@ -89,7 +89,7 @@ module Search
         instrument('answer_returned', payload)
       end
 
-      def retrieval_leg_completed(request_id:, leg:, duration_ms:, result_count:, status:, error_message: nil)
+      def retrieval_leg_completed(request_id:, leg:, duration_ms:, result_count:, status:, error_message: nil, failure_code: nil, error_type: nil)
         instrument(
           'retrieval_leg_completed',
           {
@@ -99,7 +99,7 @@ module Search
             duration_ms:,
             result_count:,
             status:,
-          }.merge(truncate_error_payload(error_message)),
+          }.merge({ failure_code:, error_type: }.compact).merge(truncate_error_payload(error_message)),
         )
       end
 

--- a/app/lib/search/logger.rb
+++ b/app/lib/search/logger.rb
@@ -289,6 +289,7 @@ module Search
         result_count: event.payload[:result_count],
         status: event.payload[:status],
       }
+      data.merge!(event.payload.slice(:failure_code, :error_type))
       add_error_fields!(data, event)
       info log_entry(data, event)
     end
@@ -326,6 +327,19 @@ module Search
         error_type: event.payload[:error_type],
         search_type: event.payload[:search_type],
       }
+      add_error_fields!(data, event)
+      error log_entry(data, event)
+    end
+
+    def search_stage_failed(event)
+      data = {
+        event: 'search_stage_failed',
+        request_id: event.payload[:request_id],
+        search_type: event.payload[:search_type],
+        failure_code: event.payload[:failure_code],
+        operation: event.payload[:operation],
+        error_type: event.payload[:error_type],
+      }.compact
       add_error_fields!(data, event)
       error log_entry(data, event)
     end

--- a/app/lib/trade_tariff_request.rb
+++ b/app/lib/trade_tariff_request.rb
@@ -9,6 +9,7 @@ class TradeTariffRequest < ActiveSupport::CurrentAttributes
             :client_id,
             :experiment,
             :search_failures,
+            :search_type,
             :green_lanes,
             :time_machine_now,
             # Controls how TimeMachine filters associated records in queries.

--- a/app/services/expand_search_query_service.rb
+++ b/app/services/expand_search_query_service.rb
@@ -26,6 +26,11 @@ class ExpandSearchQueryService
     def clear_cache!
       Rails.cache.delete_matched('expand_search_query/*')
     end
+
+    def valid_response?(response)
+      response.is_a?(Hash) && response['expanded_query'].is_a?(String) &&
+        response['expanded_query'].present? && response['error'].blank?
+    end
   end
 
 private
@@ -38,14 +43,21 @@ private
 
   def expand_query
     cached = Rails.cache.read(cache_key)
-    return Result.new(**cached.symbolize_keys) if cached
+    if cached
+      cached_response = cached.is_a?(Hash) ? cached.stringify_keys : cached
+      if self.class.valid_response?(cached_response)
+        return Result.new(expanded_query: cached_response['expanded_query'], reason: cached_response['reason'])
+      end
+
+      record_failure('Cached query expansion was malformed')
+      Rails.cache.delete(cache_key)
+    end
 
     response = Search::Instrumentation.api_call(
       request_id:,
       model: configured_model,
       attempt_number: 1,
       operation: 'search_query_expansion',
-      emit_search_failed: false,
     ) do
       OpenaiClient.call(
         context_for(query),
@@ -56,12 +68,12 @@ private
       )
     end
 
-    if response.is_a?(Hash) && response['expanded_query'].present?
+    if self.class.valid_response?(response)
       result_hash = { expanded_query: response['expanded_query'], reason: response['reason'] }
       Rails.cache.write(cache_key, result_hash, expires_in: CACHE_TTL)
       Result.new(**result_hash)
     else
-      TradeTariffRequest.record_search_failure(Search::FailureCodes::QUERY_EXPANSION_FAILED)
+      record_failure('Query expansion response was malformed')
       unchanged_result
     end
   rescue OpenaiClient::DeadlineExceeded => e
@@ -75,14 +87,19 @@ private
     )
     unchanged_result
   rescue StandardError => e
-    TradeTariffRequest.record_search_failure(Search::FailureCodes::QUERY_EXPANSION_FAILED)
-    Search::Instrumentation.search_failed(
-      request_id:,
-      error_type: e.class.name,
-      error_message: e.message,
-      search_type: 'expand_query',
-    )
+    record_failure(e.message, error_type: e.class.name)
     unchanged_result
+  end
+
+  def record_failure(message, error_type: 'InvalidResponse')
+    Search::Instrumentation.search_stage_failed(
+      request_id:,
+      search_type: 'interactive',
+      failure_code: Search::FailureCodes::QUERY_EXPANSION_FAILED,
+      operation: 'search_query_expansion',
+      error_type:,
+      error_message: message,
+    )
   end
 
   def cache_key

--- a/app/services/hybrid_retrieval_service.rb
+++ b/app/services/hybrid_retrieval_service.rb
@@ -84,10 +84,20 @@ class HybridRetrievalService
 private
 
   def run_concurrent_retrievals
-    opensearch_thread = Thread.new { run_leg(:opensearch) }
-    vector_thread = Thread.new { run_leg(:vector) }
+    request_context = {
+      request_id: @request_id || TradeTariffRequest.request_id,
+      request_source: TradeTariffRequest.request_source,
+      client_id: TradeTariffRequest.client_id,
+      experiment: TradeTariffRequest.experiment,
+    }
+    search_failures = Array(TradeTariffRequest.search_failures)
+    threads = %i[opensearch vector].map do |leg|
+      Thread.new do
+        TradeTariffRequest.set(**request_context, search_failures: search_failures.dup) { run_leg(leg) }
+      end
+    end
 
-    [opensearch_thread.value, vector_thread.value]
+    threads.map(&:value)
   end
 
   def run_leg(leg)
@@ -123,14 +133,14 @@ private
     LegResult.new(value: result, error: nil, failure_code: nil)
   rescue StandardError => e
     duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start) * 1000).round(2)
+    failure_code = failure_code_for(leg, e)
 
     Search::Instrumentation.retrieval_leg_completed(
       request_id: @request_id, leg: leg, duration_ms: duration_ms, result_count: 0, status: 'error',
-      error_message: e.message
+      error_message: e.message, failure_code: failure_code, error_type: e.class.name
     )
 
-    Rails.logger.error("HybridRetrievalService #{leg} leg failed: #{e.message}")
-    LegResult.new(value: nil, error: e, failure_code: failure_code_for(leg, e))
+    LegResult.new(value: nil, error: e, failure_code: failure_code)
   end
 
   def failure_code_for(leg, error)

--- a/app/services/hybrid_retrieval_service.rb
+++ b/app/services/hybrid_retrieval_service.rb
@@ -89,6 +89,7 @@ private
       request_source: TradeTariffRequest.request_source,
       client_id: TradeTariffRequest.client_id,
       experiment: TradeTariffRequest.experiment,
+      search_type: @search_type,
     }
     search_failures = Array(TradeTariffRequest.search_failures)
     threads = %i[opensearch vector].map do |leg|

--- a/app/services/interactive_search/duplicate_question_guard.rb
+++ b/app/services/interactive_search/duplicate_question_guard.rb
@@ -120,7 +120,6 @@ module InteractiveSearch
         iteration: attempt_number,
         effective_query: effective_query,
         operation: 'duplicate_question_validator',
-        emit_search_failed: false,
       ) do
         OpenaiClient.call(
           validator_prompt,
@@ -130,9 +129,19 @@ module InteractiveSearch
         )
       end
       parsed = ExtractBottomJson.call(response)
+      record_validation_failure('Duplicate question validation was malformed') unless usable_validation?(parsed)
       parsed.is_a?(Hash) ? parsed : nil
-    rescue StandardError
+    rescue StandardError => e
+      record_validation_failure(e.message, error_type: e.class.name)
       nil
+    end
+
+    def record_validation_failure(message, error_type: 'InvalidResponse')
+      Search::Instrumentation.search_stage_failed(
+        request_id:, search_type: 'interactive',
+        failure_code: Search::FailureCodes::DUPLICATE_QUESTION_VALIDATION_FAILED,
+        operation: 'duplicate_question_validator', error_type:, error_message: message
+      )
     end
 
     def usable_validation?(validation)

--- a/app/services/interactive_search/duplicate_question_guard.rb
+++ b/app/services/interactive_search/duplicate_question_guard.rb
@@ -145,7 +145,7 @@ module InteractiveSearch
     end
 
     def usable_validation?(validation)
-      validation.is_a?(Hash) && [true, false].include?(validation['duplicate'])
+      validation.is_a?(Hash) && validation['error'].blank? && [true, false].include?(validation['duplicate'])
     end
 
     def validator_prompt

--- a/app/services/interactive_search_service.rb
+++ b/app/services/interactive_search_service.rb
@@ -386,6 +386,7 @@ private
     Search::Instrumentation.search_stage_failed(
       request_id:, search_type: @search_type,
       failure_code: Search::FailureCodes::INTERACTIVE_SEARCH_FAILED,
+      operation: 'interactive_search',
       error_type:, error_message: message
     )
   end

--- a/app/services/interactive_search_service.rb
+++ b/app/services/interactive_search_service.rb
@@ -42,13 +42,7 @@ class InteractiveSearchService
 
     handle_parsed_response(parse_model_response(build_context, operation: 'interactive_search'))
   rescue StandardError => e
-    record_failure
-    Search::Instrumentation.search_failed(
-      request_id: request_id,
-      error_type: e.class.name,
-      error_message: e.message,
-      search_type: @search_type,
-    )
+    record_failure(e.message, error_type: e.class.name)
     nil
   end
 
@@ -373,7 +367,7 @@ private
   end
 
   def error_result(message)
-    record_failure
+    record_failure(message)
     Result.new(
       type: :error,
       data: { message: message },
@@ -388,8 +382,12 @@ private
     error_result('Interactive search unavailable')
   end
 
-  def record_failure
-    TradeTariffRequest.record_search_failure(Search::FailureCodes::INTERACTIVE_SEARCH_FAILED)
+  def record_failure(message = 'Interactive search response was invalid', error_type: 'InvalidResponse')
+    Search::Instrumentation.search_stage_failed(
+      request_id:, search_type: @search_type,
+      failure_code: Search::FailureCodes::INTERACTIVE_SEARCH_FAILED,
+      error_type:, error_message: message
+    )
   end
 
   def answers_result(ai_answers)
@@ -449,7 +447,7 @@ private
 
     if guard_result.duplicate?
       if duplicate_retry
-        TradeTariffRequest.record_search_failure(Search::FailureCodes::INTERACTIVE_SEARCH_FAILED)
+        record_failure('Interactive search repeated a duplicate question')
         return best_available_answers
       end
 

--- a/app/services/opensearch_retrieval_service.rb
+++ b/app/services/opensearch_retrieval_service.rb
@@ -18,6 +18,13 @@ class OpensearchRetrievalService
   def call
     hits = run_search(@expanded_query)
     Result.new(results: hits.map { |h| build_result_from_hit(h) }, expanded_query: @expanded_query)
+  rescue StandardError => e
+    Search::Instrumentation.search_stage_failed(
+      request_id: @request_id, search_type: 'interactive',
+      failure_code: Search::FailureCodes::OPENSEARCH_FAILED,
+      operation: 'opensearch_retrieval', error_type: e.class.name, error_message: e.message
+    )
+    raise
   end
 
 private

--- a/app/services/search_analytics/cloudwatch_snapshot_query.rb
+++ b/app/services/search_analytics/cloudwatch_snapshot_query.rb
@@ -275,7 +275,7 @@ module SearchAnalytics
       <<~FILTER.squish
         filter ispresent(request_id) and ispresent(total_tokens) and
           ((service = "search" and event = "api_call_completed") or
-          (service = "ai_usage" and event = "embedding_api_call_completed" and event_kind = "vector_search_query_embedding"))
+          (service = "ai_usage" and event in ["embedding_api_call_completed", "embedding_api_call_failed"] and event_kind = "vector_search_query_embedding"))
       FILTER
     end
 

--- a/app/services/search_service/fuzzy_search.rb
+++ b/app/services/search_service/fuzzy_search.rb
@@ -9,8 +9,9 @@ class SearchService
 
       self
     rescue OpenSearch::Transport::Transport::Error => e
-      Search::Instrumentation.search_failed(
+      Search::Instrumentation.search_stage_failed(
         request_id: TradeTariffRequest.request_id,
+        failure_code: Search::FailureCodes::OPENSEARCH_FAILED,
         error_type: e.class.name,
         error_message: e.message,
         search_type: 'classic',

--- a/app/services/search_service/fuzzy_search.rb
+++ b/app/services/search_service/fuzzy_search.rb
@@ -15,6 +15,7 @@ class SearchService
         error_type: e.class.name,
         error_message: e.message,
         search_type: 'classic',
+        operation: 'opensearch_retrieval',
       )
       # OpenSearch transport failures should not prevent the blank-result fallback.
       @results = BLANK_RESULT

--- a/app/services/vector_retrieval_service.rb
+++ b/app/services/vector_retrieval_service.rb
@@ -1,7 +1,15 @@
 class VectorRetrievalService
   EMBEDDING_DIMENSIONS = 1536
 
-  EmbeddingGenerationError = Class.new(StandardError)
+  class EmbeddingGenerationError < StandardError
+    attr_reader :ai_usage
+
+    def initialize(message = nil, ai_usage: nil)
+      super(message)
+      @ai_usage = ai_usage
+    end
+  end
+
   VectorRetrievalError = Class.new(StandardError)
   Result = Data.define(:results, :max_score)
 
@@ -28,6 +36,11 @@ class VectorRetrievalService
     return [] if ranked_rows.empty?
 
     build_results(ranked_rows, enforce_eligibility: true)
+  rescue EmbeddingGenerationError
+    raise
+  rescue StandardError => e
+    record_failure(e, Search::FailureCodes::VECTOR_RETRIEVAL_FAILED, 'vector_retrieval')
+    raise
   end
 
   def call_with_diagnostics
@@ -40,6 +53,7 @@ class VectorRetrievalService
   rescue EmbeddingGenerationError
     raise
   rescue StandardError => e
+    record_failure(e, Search::FailureCodes::VECTOR_RETRIEVAL_FAILED, 'vector_retrieval')
     raise VectorRetrievalError, e.message
   end
 
@@ -53,20 +67,38 @@ private
   end
 
   def generate_query_embedding
-    embedding = AiUsage::Instrumentation.embedding_api_call(
+    AiUsage::Instrumentation.embedding_api_call(
       event_kind: 'vector_search_query_embedding',
       batch_size: 1,
       model: EmbeddingService::MODEL,
       request_id: @request_id,
-    ) { embedding_service.embed(@query, event_kind: 'vector_search_query_embedding') }
-    valid_embedding = embedding.is_a?(Array) &&
-      embedding.size == EMBEDDING_DIMENSIONS &&
-      embedding.all? { |value| value.is_a?(Numeric) && value.real? && value.to_f.finite? }
-    raise EmbeddingGenerationError, 'Embedding response was malformed' unless valid_embedding
+    ) do
+      embedding = embedding_service.embed(@query, event_kind: 'vector_search_query_embedding')
+      valid_embedding = embedding.is_a?(Array) &&
+        embedding.size == EMBEDDING_DIMENSIONS &&
+        embedding.all? { |value| value.is_a?(Numeric) && value.real? && value.to_f.finite? }
+      unless valid_embedding
+        raise EmbeddingGenerationError.new('Embedding response was malformed', ai_usage: AiUsage.metadata_from(embedding))
+      end
 
-    embedding
+      embedding
+    end
   rescue StandardError => e
-    raise EmbeddingGenerationError, e.message
+    record_failure(e, Search::FailureCodes::EMBEDDING_GENERATION_FAILED, 'embedding_generation')
+    raise if e.is_a?(EmbeddingGenerationError)
+
+    raise EmbeddingGenerationError.new(e.message, ai_usage: AiUsage.metadata_from(e))
+  end
+
+  def record_failure(error, failure_code, operation)
+    Search::Instrumentation.search_stage_failed(
+      request_id: @request_id,
+      search_type: 'interactive',
+      failure_code: failure_code,
+      error_type: error.class.name,
+      error_message: error.message,
+      operation: operation,
+    )
   end
 
   def build_results(ranked_rows, enforce_eligibility: false)

--- a/docs/architecture/search-and-indexing.md
+++ b/docs/architecture/search-and-indexing.md
@@ -68,6 +68,23 @@ When enabled, hybrid retrieval returns no suggestions if the maximum score is be
 
 Guided classification search can also attach bounded chapter- and section-note evidence to retrieved candidates. [Tariff knowledge notes](../tariff-knowledge-notes.md) documents extraction, graph edges, compressed-note materialisation and deduplication, prompt selection, and request-ID diagnostics.
 
+## Search Failure Diagnostics and Alarms
+
+Recoverable failures emit `search_stage_failed` with a scalar `failure_code`, the operation, the error type, and a bounded error message. They can be followed by `search_completed` when fallback succeeds. `search_failed` is reserved for a failure escaping the instrumented search boundary. Hybrid retrieval also records each leg's outcome and failure code. A successful retrieval returning no matches is not a retrieval failure.
+
+`terraform/degradation_alarms.tf` defines one alarm for each component when `enable_alarms` is enabled:
+
+| Component | Failure events counted |
+| --- | --- |
+| OpenSearch | `search_stage_failed` with `opensearch_failed`, including direct and classic search, or an unsuccessful OpenSearch retrieval leg |
+| Embedding generation | `embedding_api_call_failed` for `vector_search_query_embedding`, including malformed embedding responses |
+| LLM | An unsuccessful `api_call_completed`, or `search_stage_failed` with `query_expansion_failed`, `interactive_search_failed`, or `duplicate_question_validation_failed`, including unusable responses |
+| Vector database retrieval | `search_stage_failed` or an unsuccessful vector retrieval leg with `vector_retrieval_failed`; embedding failures belong to the separate embedding alarm |
+
+These alarms count failure events and trigger when any matching event occurs in a five-minute period. They are not degraded-request counts: correlated stage and leg/API events can count the same failure more than once. Embedding failures are matched only at their API boundary to avoid counting their vector-leg fallback again. Investigate with the Search Operations dashboard and the event's `request_id`, `failure_code`, `operation`, and error fields.
+
+The existing OpenSearch-leg and LLM API-error patterns remain alongside the new stage patterns so older application instances retain their alert coverage during a rolling deployment or rollback. The new vector alarm and unusable-response coverage require the corresponding new application events. Legacy vector errors cannot distinguish embedding generation from database retrieval and are not assigned to the database alarm.
+
 ## Query Expansion Deadline
 
 Uncached guided-search query expansion has a fixed five-second operation-specific deadline.

--- a/spec/lib/embedding_service_spec.rb
+++ b/spec/lib/embedding_service_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe EmbeddingService do
 
       before do
         stub_request(:post, "#{api_base_url}/embeddings")
-          .to_return(status: 200, body: response_body.to_json, headers: { 'Content-Type' => 'application/json' })
+          .to_return { { status: 200, body: response_body.to_json, headers: { 'Content-Type' => 'application/json' } } }
       end
 
       it 'returns embeddings for all texts' do
@@ -93,6 +93,13 @@ RSpec.describe EmbeddingService do
       it 'preserves order based on index' do
         result = service.embed_batch(%w[one two three])
         expect(result).to eq(embeddings)
+      end
+
+      it 'rejects duplicate indices with billed usage intact' do
+        response_body['data'][1]['index'] = 0
+        expect { service.embed_batch(%w[one two three]) }.to raise_error(EmbeddingService::ApiError) { |error|
+          expect(error.ai_usage.total_tokens).to eq(9)
+        }
       end
 
       it 'attaches batch usage metadata to the returned embeddings array' do

--- a/spec/lib/embedding_service_spec.rb
+++ b/spec/lib/embedding_service_spec.rb
@@ -95,11 +95,13 @@ RSpec.describe EmbeddingService do
         expect(result).to eq(embeddings)
       end
 
-      it 'rejects duplicate indices with billed usage intact' do
-        response_body['data'][1]['index'] = 0
-        expect { service.embed_batch(%w[one two three]) }.to raise_error(EmbeddingService::ApiError) { |error|
-          expect(error.ai_usage.total_tokens).to eq(9)
-        }
+      [{ 'index' => 0 }, { 'embedding' => nil }, { 'embedding' => 'invalid' }, { 'embedding' => [0.1] }].each do |invalid_entry|
+        it "rejects #{invalid_entry} with billed usage intact" do
+          response_body['data'][1].merge!(invalid_entry)
+          expect { service.embed_batch(%w[one two three]) }.to raise_error(EmbeddingService::ApiError) { |error|
+            expect(error.ai_usage.total_tokens).to eq(9)
+          }
+        end
       end
 
       it 'attaches batch usage metadata to the returned embeddings array' do

--- a/spec/lib/embedding_service_spec.rb
+++ b/spec/lib/embedding_service_spec.rb
@@ -27,6 +27,12 @@ RSpec.describe EmbeddingService do
       expect(result).to eq(embedding)
     end
 
+    it 'returns nil for blank text without calling the API' do
+      expect(service.embed('')).to be_nil
+      expect(service.embed(nil)).to be_nil
+      expect(WebMock).not_to have_requested(:post, "#{api_base_url}/embeddings")
+    end
+
     it 'sends the correct model' do
       service.embed('Live horses')
 

--- a/spec/lib/search/failure_codes_spec.rb
+++ b/spec/lib/search/failure_codes_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Search::FailureCodes do
           embedding_generation_failed
           vector_retrieval_failed
           interactive_search_failed
+          duplicate_question_validation_failed
           opensearch_failed
         ],
       )

--- a/spec/lib/search/instrumentation_spec.rb
+++ b/spec/lib/search/instrumentation_spec.rb
@@ -1,6 +1,31 @@
 RSpec.describe Search::Instrumentation do
   before { TradeTariffRequest.request_source = nil }
 
+  describe '.search_stage_failed' do
+    after { TradeTariffRequest.search_failures = nil }
+
+    it 'records bounded stage diagnostics', :aggregate_failures do
+      events = []
+      subscriber = ->(event) { events << event }
+
+      ActiveSupport::Notifications.subscribed(subscriber, /\.search\z/) do
+        described_class.search_stage_failed(
+          request_id: 'stage-failure', search_type: 'interactive',
+          failure_code: Search::FailureCodes::QUERY_EXPANSION_FAILED,
+          error_type: 'InvalidResponse', error_message: 'x' * 600,
+          operation: 'search_query_expansion'
+        )
+      end
+
+      expect(TradeTariffRequest.search_failures).to eq(%w[query_expansion_failed])
+      expect(events.map(&:name)).to eq(['search_stage_failed.search'])
+      expect(events.first.payload).to include(
+        failure_code: 'query_expansion_failed', operation: 'search_query_expansion',
+        error_type: 'InvalidResponse', error_message: 'x' * 500, error_message_truncated: true
+      )
+    end
+  end
+
   describe '.search_started' do
     it 'instruments the search_started event' do
       allow(ActiveSupport::Notifications).to receive(:instrument)
@@ -356,9 +381,8 @@ RSpec.describe Search::Instrumentation do
         'api_call_completed.search',
         hash_including(response_type: 'error'),
       )
-      expect(ActiveSupport::Notifications).to have_received(:instrument).with(
-        'search_failed.search',
-        hash_including(error_type: 'Faraday::TimeoutError'),
+      expect(ActiveSupport::Notifications).not_to have_received(:instrument).with(
+        'search_failed.search', anything
       )
     end
 

--- a/spec/lib/search/instrumentation_spec.rb
+++ b/spec/lib/search/instrumentation_spec.rb
@@ -2,9 +2,10 @@ RSpec.describe Search::Instrumentation do
   before { TradeTariffRequest.request_source = nil }
 
   describe '.search_stage_failed' do
-    after { TradeTariffRequest.search_failures = nil }
+    after { TradeTariffRequest.reset }
 
     it 'records bounded stage diagnostics', :aggregate_failures do
+      TradeTariffRequest.search_type = 'evaluation'
       events = []
       subscriber = ->(event) { events << event }
 
@@ -20,6 +21,7 @@ RSpec.describe Search::Instrumentation do
       expect(TradeTariffRequest.search_failures).to eq(%w[query_expansion_failed])
       expect(events.map(&:name)).to eq(['search_stage_failed.search'])
       expect(events.first.payload).to include(
+        search_type: 'evaluation',
         failure_code: 'query_expansion_failed', operation: 'search_query_expansion',
         error_type: 'InvalidResponse', error_message: 'x' * 500, error_message_truncated: true
       )

--- a/spec/lib/search/logger_spec.rb
+++ b/spec/lib/search/logger_spec.rb
@@ -610,6 +610,8 @@ RSpec.describe Search::Logger do
         status: 'error',
         error_message: 'vector down',
         error_message_truncated: false,
+        failure_code: 'vector_retrieval_failed',
+        error_type: 'Sequel::DatabaseError',
       }
     end
 
@@ -629,6 +631,8 @@ RSpec.describe Search::Logger do
       json = parsed_log_output
 
       expect(json['event']).to eq('retrieval_leg_completed')
+      expect(json['failure_code']).to eq('vector_retrieval_failed')
+      expect(json['error_type']).to eq('Sequel::DatabaseError')
       expect(json['leg']).to eq('vector')
       expect(json['status']).to eq('error')
       expect(json['error_message']).to eq('vector down')
@@ -685,6 +689,31 @@ RSpec.describe Search::Logger do
       expect(json['event']).to eq('result_selected')
       expect(json['goods_nomenclature_item_id']).to eq('4202210000')
       expect(json['goods_nomenclature_class']).to eq('Commodity')
+    end
+  end
+
+  describe '#search_stage_failed' do
+    it 'logs the failed component and bounded error with its request attribution' do
+      logger_instance.search_stage_failed(build_event('search_stage_failed', {
+        request_id: 'req-1',
+        search_type: 'interactive',
+        failure_code: 'query_expansion_failed',
+        operation: 'search_query_expansion',
+        error_type: 'InvalidResponse',
+        error_message: 'x' * 500,
+        error_message_truncated: true,
+      }))
+
+      expect(parsed_log_output).to include(
+        'event' => 'search_stage_failed',
+        'request_id' => 'req-1',
+        'search_type' => 'interactive',
+        'failure_code' => 'query_expansion_failed',
+        'operation' => 'search_query_expansion',
+        'error_type' => 'InvalidResponse',
+        'error_message' => 'x' * 500,
+        'error_message_truncated' => true,
+      )
     end
   end
 

--- a/spec/requests/api/admin/search/evaluation/searches_controller_spec.rb
+++ b/spec/requests/api/admin/search/evaluation/searches_controller_spec.rb
@@ -154,6 +154,29 @@ RSpec.describe Api::Admin::Search::Evaluation::SearchesController, :admin do
         expect(usage_meta).to have_key('total_cost_usd')
         expect(usage_meta).to have_key('duration_ms')
       end
+
+      context 'when the hybrid embedding is malformed' do
+        before do
+          allow(AdminConfiguration).to receive(:option_value).with('retrieval_method').and_return('hybrid')
+          embedding = AiUsage.attach_metadata(
+            [0.1],
+            AiUsage.metadata_for(
+              model: EmbeddingService::MODEL,
+              event_kind: 'vector_search_query_embedding',
+              usage: { 'prompt_tokens' => 42, 'total_tokens' => 42 },
+            ),
+          )
+          allow(EmbeddingService).to receive(:new).and_return(instance_double(EmbeddingService, embed: embedding))
+        end
+
+        it 'includes billed fallback usage' do
+          expect(api_response).to have_http_status(:success)
+          expect(json_response['data']).to be_present
+          expect(json_response.dig('meta', 'search_failures')).to eq(%w[embedding_generation_failed])
+          expect(json_response.dig('meta', 'usage')).to include('total_tokens' => 42, 'provider_calls' => 1)
+          expect(json_response.dig('meta', 'usage', 'total_cost_usd')).to be_positive
+        end
+      end
     end
 
     context 'when an unrelated concurrent search event fires during the request' do

--- a/spec/services/api/internal/search_service_resilience_spec.rb
+++ b/spec/services/api/internal/search_service_resilience_spec.rb
@@ -30,14 +30,14 @@ RSpec.describe Api::Internal::SearchService do
     events = []
     callback = ->(event) { events << event }
     response = ActiveSupport::Notifications.subscribed(callback, /\.search\z/) do
-      described_class.new(q: 'handbag', expanded_query: 'handbag', request_id:).call
+      described_class.new(q: 'handbag', expanded_query: 'handbag', request_id:, search_type: 'evaluation').call
     end
 
     expect(response[:data].size).to eq(2)
     expect(response.dig(:meta, :search_failures)).to eq(%w[interactive_search_failed])
     expect(events.map(&:name).grep(/search_(completed|failed)\.search/)).to eq(['search_completed.search'])
     expect(events.find { |event| event.name == 'search_stage_failed.search' }&.payload).to include(
-      failure_code: 'interactive_search_failed', error_type: 'Faraday::TimeoutError',
+      failure_code: 'interactive_search_failed', error_type: 'Faraday::TimeoutError', search_type: 'evaluation',
     )
   end
 

--- a/spec/services/api/internal/search_service_resilience_spec.rb
+++ b/spec/services/api/internal/search_service_resilience_spec.rb
@@ -1,0 +1,56 @@
+RSpec.describe Api::Internal::SearchService do
+  let(:request_id) { 'search-resilience-request' }
+  let(:candidates) do
+    (1..2).map do |sid|
+      GoodsNomenclatureResult.new(
+        id: sid, goods_nomenclature_sid: sid, goods_nomenclature_item_id: "420221000#{sid}",
+        producline_suffix: '80', goods_nomenclature_class: 'Commodity',
+        description: 'Handbag', formatted_description: 'Handbag', full_description: 'Handbag',
+        classification_description: 'Handbag', heading_description: nil, self_text: nil,
+        declarable: true, score: 10.0, confidence: nil
+      )
+    end
+  end
+
+  before do
+    allow(AdminConfiguration).to receive(:option_value).and_call_original
+    allow(AdminConfiguration).to receive(:option_value).with('retrieval_method').and_return('opensearch')
+    allow(AdminConfiguration).to receive(:enabled?).and_call_original
+    allow(AdminConfiguration).to receive(:enabled?).with('interactive_search_enabled').and_return(true)
+    allow(AdminConfiguration).to receive(:enabled?).with('search_compressed_notes_enabled').and_return(false)
+    allow(OpensearchRetrievalService).to receive(:call).and_return(
+      OpensearchRetrievalService::Result.new(results: candidates, expanded_query: 'handbag'),
+    )
+    allow(OpenaiClient).to receive(:call).and_raise(Faraday::TimeoutError, 'provider unavailable')
+  end
+
+  after { TradeTariffRequest.reset }
+
+  it 'emits one outcome for a fallback', :aggregate_failures do
+    events = []
+    callback = ->(event) { events << event }
+    response = ActiveSupport::Notifications.subscribed(callback, /\.search\z/) do
+      described_class.new(q: 'handbag', expanded_query: 'handbag', request_id:).call
+    end
+
+    expect(response[:data].size).to eq(2)
+    expect(response.dig(:meta, :search_failures)).to eq(%w[interactive_search_failed])
+    expect(events.map(&:name).grep(/search_(completed|failed)\.search/)).to eq(['search_completed.search'])
+    expect(events.find { |event| event.name == 'search_stage_failed.search' }&.payload).to include(
+      failure_code: 'interactive_search_failed', error_type: 'Faraday::TimeoutError',
+    )
+  end
+
+  it 'rejects malformed expansion safely', :aggregate_failures do
+    allow(AdminConfiguration).to receive(:enabled?).with('expand_search_enabled').and_return(true)
+    allow(AdminConfiguration).to receive(:enabled?).with('expand_search_when_needed_enabled').and_return(false)
+    allow(OpensearchRetrievalService).to receive(:call).and_call_original
+    allow(TradeTariffBackend.search_client).to receive(:search).and_return('hits' => { 'hits' => [] })
+    allow(OpenaiClient).to receive(:call).and_return('expanded_query' => 123)
+
+    response = described_class.new(q: 'handbag', request_id:).call
+
+    expect(response[:data]).to eq([])
+    expect(response.dig(:meta, :search_failures)).to eq(%w[query_expansion_failed])
+  end
+end

--- a/spec/services/expand_search_query_service_spec.rb
+++ b/spec/services/expand_search_query_service_spec.rb
@@ -162,6 +162,18 @@ RSpec.describe ExpandSearchQueryService do
       end
     end
 
+    [123, true, %w[laptop], { 'query' => 'laptop' }].each do |malformed_query|
+      context "when expanded_query is #{malformed_query.inspect}" do
+        let(:query) { 'laptop' }
+        let(:ai_response) { { 'expanded_query' => malformed_query } }
+
+        it 'returns the original query', :aggregate_failures do
+          expect(result.expanded_query).to eq('laptop')
+          expect(TradeTariffRequest.search_failures).to eq(%w[query_expansion_failed])
+        end
+      end
+    end
+
     context 'when the AI returns nil' do
       let(:query) { 'laptop' }
       let(:ai_response) { nil }
@@ -199,16 +211,18 @@ RSpec.describe ExpandSearchQueryService do
         expect(TradeTariffRequest.search_failures).to eq(%w[query_expansion_failed])
       end
 
-      it 'emits a search_failed event' do
-        allow(Search::Instrumentation).to receive(:search_failed)
+      it 'emits a search_stage_failed event' do
+        allow(Search::Instrumentation).to receive(:search_stage_failed)
 
         result
 
-        expect(Search::Instrumentation).to have_received(:search_failed).with(
+        expect(Search::Instrumentation).to have_received(:search_stage_failed).with(
           request_id: 'request-123',
           error_type: 'Faraday::TimeoutError',
           error_message: anything,
-          search_type: 'expand_query',
+          search_type: 'interactive',
+          failure_code: 'query_expansion_failed',
+          operation: 'search_query_expansion',
         )
       end
     end
@@ -343,6 +357,24 @@ RSpec.describe ExpandSearchQueryService do
 
       expect(second_result.expanded_query).to eq(first_result.expanded_query)
       expect(second_result.reason).to eq(first_result.reason)
+    end
+
+    it 'replaces malformed cached data', :aggregate_failures do
+      described_class.call(query)
+      allow(memory_store).to receive(:read).and_wrap_original do |original, key, **options|
+        original.call(key, **options).merge(expanded_query: 123)
+      end
+
+      expect(described_class.call(query).expanded_query).to eq(ai_response['expanded_query'])
+      expect(TradeTariffRequest.search_failures).to eq(%w[query_expansion_failed])
+      expect(OpenaiClient).to have_received(:call).twice
+    end
+
+    it 'does not cache malformed expansions' do
+      allow(OpenaiClient).to receive(:call).and_return({ 'expanded_query' => 123 }, ai_response)
+      described_class.call(query)
+
+      expect(described_class.call(query).expanded_query).to eq(ai_response['expanded_query'])
     end
 
     it 'treats queries case-insensitively' do

--- a/spec/services/hybrid_retrieval_service_spec.rb
+++ b/spec/services/hybrid_retrieval_service_spec.rb
@@ -63,6 +63,89 @@ RSpec.describe HybridRetrievalService do
   end
 
   describe '#call' do
+    context 'with request attribution' do
+      def request_context
+        {
+          request_id: 'parent-request',
+          experiment: 'search-experiment',
+          request_source: 'frontend',
+          client_id: 'search-client',
+          search_failures: %w[query_expansion_failed],
+        }
+      end
+
+      around do |example|
+        TradeTariffRequest.set(**request_context) { example.run }
+      end
+
+      it 'preserves context in both child threads' do
+        contexts = Queue.new
+        allow(OpensearchRetrievalService).to receive(:call) do
+          contexts << TradeTariffRequest.attributes.slice(*request_context.keys)
+          opensearch_result
+        end
+        allow(VectorRetrievalService).to receive(:call_with_diagnostics) do
+          contexts << TradeTariffRequest.attributes.slice(*request_context.keys)
+          vector_diagnostics
+        end
+
+        described_class.call(query: 'horses', as_of: Time.zone.today, request_id: 'explicit-request')
+
+        expect([contexts.pop, contexts.pop]).to all(eq(request_context.merge(request_id: 'explicit-request')))
+        expect(TradeTariffRequest.attributes.slice(*request_context.keys)).to eq(request_context)
+      end
+
+      it 'restores child context after a failure' do
+        contexts = Queue.new
+        allow(OpensearchRetrievalService).to receive(:call) do
+          contexts << TradeTariffRequest.instance
+          opensearch_result
+        end
+        allow(VectorRetrievalService).to receive(:call_with_diagnostics) do
+          contexts << TradeTariffRequest.instance
+          TradeTariffRequest.record_search_failure(Search::FailureCodes::EMBEDDING_GENERATION_FAILED)
+          raise VectorRetrievalService::EmbeddingGenerationError, 'embedding unavailable'
+        end
+
+        described_class.call(query: 'horses', as_of: Time.zone.today)
+
+        expect([contexts.pop, contexts.pop]).to all(
+          have_attributes(request_id: nil, experiment: nil, request_source: nil, client_id: nil, search_failures: nil),
+        )
+        expect(TradeTariffRequest.search_failures).to contain_exactly('query_expansion_failed', 'embedding_generation_failed')
+      end
+
+      it 'attributes embedding cost logs' do
+        usage = AiUsage.metadata_for(
+          model: EmbeddingService::MODEL,
+          event_kind: 'vector_search_query_embedding',
+          usage: { 'prompt_tokens' => 12, 'total_tokens' => 12 },
+        )
+        embedding = AiUsage.attach_metadata(Array.new(1536, 0.1), usage)
+        allow(EmbeddingService).to receive(:new).and_return(instance_double(EmbeddingService, embed: embedding))
+        allow(VectorRetrievalService).to receive(:call_with_diagnostics).and_call_original
+        logs = []
+        logger = AiUsage::Logger.new
+        allow(logger).to receive(:info) { |entry| logs << JSON.parse(entry) }
+        subscriber = ActiveSupport::Notifications.subscribe('embedding_api_call_completed.ai_usage') do |*args|
+          logger.embedding_api_call_completed(ActiveSupport::Notifications::Event.new(*args))
+        end
+
+        described_class.call(query: 'horses', as_of: Time.zone.today, request_id: 'explicit-request')
+
+        expect(logs).to contain_exactly(
+          hash_including(
+            'request_id' => 'explicit-request',
+            'experiment' => 'search-experiment',
+            'total_tokens' => 12,
+            'total_cost_usd' => be_positive,
+          ),
+        )
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+      end
+    end
+
     it 'runs both retrieval legs inside TimeMachine.at(as_of)' do
       as_of = Time.zone.today
       allow(TimeMachine).to receive(:at).with(as_of).and_yield
@@ -369,7 +452,13 @@ RSpec.describe HybridRetrievalService do
         described_class.call(query: 'horses', as_of: Time.zone.today)
 
         expect(Search::Instrumentation).to have_received(:retrieval_leg_completed).with(
-          hash_including(leg: :opensearch, status: 'error', error_message: 'opensearch down'),
+          hash_including(
+            leg: :opensearch,
+            status: 'error',
+            error_message: 'opensearch down',
+            failure_code: 'opensearch_failed',
+            error_type: 'StandardError',
+          ),
         )
         expect(Search::Instrumentation).to have_received(:retrieval_leg_completed).with(
           hash_including(leg: :vector, status: 'success'),
@@ -409,7 +498,13 @@ RSpec.describe HybridRetrievalService do
           hash_including(leg: :opensearch, status: 'success'),
         )
         expect(Search::Instrumentation).to have_received(:retrieval_leg_completed).with(
-          hash_including(leg: :vector, status: 'error', error_message: 'vector down'),
+          hash_including(
+            leg: :vector,
+            status: 'error',
+            error_message: 'vector down',
+            failure_code: 'vector_retrieval_failed',
+            error_type: 'StandardError',
+          ),
         )
       end
     end
@@ -424,6 +519,19 @@ RSpec.describe HybridRetrievalService do
         described_class.call(query: 'horses', as_of: Time.zone.today)
 
         expect(TradeTariffRequest.search_failures).to eq(%w[embedding_generation_failed])
+      end
+
+      it 'identifies the failed embedding leg' do
+        described_class.call(query: 'horses', as_of: Time.zone.today)
+
+        expect(Search::Instrumentation).to have_received(:retrieval_leg_completed).with(
+          hash_including(
+            leg: :vector,
+            status: 'error',
+            failure_code: 'embedding_generation_failed',
+            error_type: 'VectorRetrievalService::EmbeddingGenerationError',
+          ),
+        )
       end
     end
 

--- a/spec/services/hybrid_retrieval_service_spec.rb
+++ b/spec/services/hybrid_retrieval_service_spec.rb
@@ -70,6 +70,7 @@ RSpec.describe HybridRetrievalService do
           experiment: 'search-experiment',
           request_source: 'frontend',
           client_id: 'search-client',
+          search_type: 'evaluation',
           search_failures: %w[query_expansion_failed],
         }
       end
@@ -89,9 +90,9 @@ RSpec.describe HybridRetrievalService do
           vector_diagnostics
         end
 
-        described_class.call(query: 'horses', as_of: Time.zone.today, request_id: 'explicit-request')
+        described_class.call(query: 'horses', as_of: Time.zone.today, request_id: 'explicit-request', search_type: 'classification')
 
-        expect([contexts.pop, contexts.pop]).to all(eq(request_context.merge(request_id: 'explicit-request')))
+        expect([contexts.pop, contexts.pop]).to all(eq(request_context.merge(request_id: 'explicit-request', search_type: 'classification')))
         expect(TradeTariffRequest.attributes.slice(*request_context.keys)).to eq(request_context)
       end
 

--- a/spec/services/interactive_search/duplicate_question_guard_spec.rb
+++ b/spec/services/interactive_search/duplicate_question_guard_spec.rb
@@ -1,6 +1,8 @@
 RSpec.describe InteractiveSearch::DuplicateQuestionGuard do
   subject(:result) { described_class.call(**request) }
 
+  after { TradeTariffRequest.search_failures = nil }
+
   let(:request) { duplicate_question_request }
 
   def duplicate_question_request
@@ -305,6 +307,20 @@ RSpec.describe InteractiveSearch::DuplicateQuestionGuard do
     expect(result.suspicious).to be(true)
     expect(result.reason).to eq('validator_unparseable')
     expect(Search::Instrumentation).not_to have_received(:search_failed)
+  end
+
+  it 'records failed validation separately' do
+    allow(OpenaiClient).to receive(:call).and_raise(Faraday::TimeoutError)
+
+    expect(result).to be_allowed
+    expect(TradeTariffRequest.search_failures).to eq(%w[duplicate_question_validation_failed])
+  end
+
+  it 'records malformed validation' do
+    allow(OpenaiClient).to receive(:call).and_return('duplicate' => 'unknown')
+
+    expect(result).to be_allowed
+    expect(TradeTariffRequest.search_failures).to eq(%w[duplicate_question_validation_failed])
   end
 
   it 'allows continuation questions whose options include the previous other-like answer' do

--- a/spec/services/interactive_search/duplicate_question_guard_spec.rb
+++ b/spec/services/interactive_search/duplicate_question_guard_spec.rb
@@ -316,11 +316,13 @@ RSpec.describe InteractiveSearch::DuplicateQuestionGuard do
     expect(TradeTariffRequest.search_failures).to eq(%w[duplicate_question_validation_failed])
   end
 
-  it 'records malformed validation' do
-    allow(OpenaiClient).to receive(:call).and_return('duplicate' => 'unknown')
+  [{ 'duplicate' => 'unknown' }, { 'duplicate' => true, 'error' => 'unavailable' }].each do |validation|
+    it "records unusable validation #{validation}" do
+      allow(OpenaiClient).to receive(:call).and_return(validation)
 
-    expect(result).to be_allowed
-    expect(TradeTariffRequest.search_failures).to eq(%w[duplicate_question_validation_failed])
+      expect(result).to be_allowed
+      expect(TradeTariffRequest.search_failures).to eq(%w[duplicate_question_validation_failed])
+    end
   end
 
   it 'allows continuation questions whose options include the previous other-like answer' do

--- a/spec/services/interactive_search_service_spec.rb
+++ b/spec/services/interactive_search_service_spec.rb
@@ -569,7 +569,7 @@ RSpec.describe InteractiveSearchService do
         result
         expect(Search::Instrumentation).to have_received(:search_stage_failed).with(
           hash_including(failure_code: 'interactive_search_failed',
-                         error_type: 'Faraday::TimeoutError', search_type: 'interactive'),
+                         error_type: 'Faraday::TimeoutError', search_type: 'interactive', operation: 'interactive_search'),
         )
       end
 

--- a/spec/services/interactive_search_service_spec.rb
+++ b/spec/services/interactive_search_service_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe InteractiveSearchService do
     allow(Search::Instrumentation).to receive(:answer_returned)
     allow(Search::Instrumentation).to receive(:duplicate_question_guard_checked)
     allow(Search::Instrumentation).to receive(:note_evidence_evaluated)
-    allow(Search::Instrumentation).to receive(:search_failed)
+    allow(Search::Instrumentation).to receive(:search_stage_failed).and_call_original
     create(:admin_configuration, :boolean, name: 'interactive_search_enabled', value: true, area: 'classification')
     create(:admin_configuration, :integer, name: 'interactive_search_max_questions', value: 3, area: 'classification')
     create(:admin_configuration, name: 'search_context', value: default_search_context, area: 'classification')
@@ -162,11 +162,11 @@ RSpec.describe InteractiveSearchService do
     context 'when search_type is passed explicitly and the call raises' do
       it 'tags the failure instrumentation with the given search_type instead of the hardcoded default' do
         allow(OpenaiClient).to receive(:call).and_raise(StandardError, 'boom')
-        allow(Search::Instrumentation).to receive(:search_failed)
+        allow(Search::Instrumentation).to receive(:search_stage_failed).and_call_original
 
         described_class.call(**search_params(search_type: 'evaluation'))
 
-        expect(Search::Instrumentation).to have_received(:search_failed).with(
+        expect(Search::Instrumentation).to have_received(:search_stage_failed).with(
           hash_including(search_type: 'evaluation'),
         )
       end
@@ -175,11 +175,11 @@ RSpec.describe InteractiveSearchService do
     context 'when search_type is not given' do
       it 'still tags failure instrumentation as interactive, reproducing today\'s exact behaviour' do
         allow(OpenaiClient).to receive(:call).and_raise(StandardError, 'boom')
-        allow(Search::Instrumentation).to receive(:search_failed)
+        allow(Search::Instrumentation).to receive(:search_stage_failed).and_call_original
 
         described_class.call(**search_params)
 
-        expect(Search::Instrumentation).to have_received(:search_failed).with(
+        expect(Search::Instrumentation).to have_received(:search_stage_failed).with(
           hash_including(search_type: 'interactive'),
         )
       end
@@ -565,10 +565,11 @@ RSpec.describe InteractiveSearchService do
         expect(result).to be_nil
       end
 
-      it 'emits a search_failed event' do
+      it 'emits a stage failure event' do
         result
-        expect(Search::Instrumentation).to have_received(:search_failed).with(
-          hash_including(error_type: 'Faraday::TimeoutError', search_type: 'interactive'),
+        expect(Search::Instrumentation).to have_received(:search_stage_failed).with(
+          hash_including(failure_code: 'interactive_search_failed',
+                         error_type: 'Faraday::TimeoutError', search_type: 'interactive'),
         )
       end
 

--- a/spec/services/opensearch_retrieval_service_spec.rb
+++ b/spec/services/opensearch_retrieval_service_spec.rb
@@ -1,6 +1,15 @@
 RSpec.describe OpensearchRetrievalService do
+  after { TradeTariffRequest.search_failures = nil }
+
   before do
     allow(ExpandSearchQueryService).to receive(:call)
+  end
+
+  it 'records failed retrieval before raising' do
+    allow(TradeTariffBackend.search_client).to receive(:search).and_raise(Faraday::ConnectionFailed, 'unavailable')
+
+    expect { described_class.call(query: 'handbag', as_of: Time.zone.today) }.to raise_error(Faraday::ConnectionFailed)
+    expect(TradeTariffRequest.search_failures).to eq(%w[opensearch_failed])
   end
 
   describe '#call' do

--- a/spec/services/search_analytics/cloudwatch_snapshot_query_spec.rb
+++ b/spec/services/search_analytics/cloudwatch_snapshot_query_spec.rb
@@ -234,7 +234,7 @@ RSpec.describe SearchAnalytics::CloudwatchSnapshotQuery do
     ).once
     expect(client).to have_received(:start_query).with(
       hash_including(
-        query_string: a_string_including('service = "ai_usage" and event = "embedding_api_call_completed"'),
+        query_string: a_string_including('service = "ai_usage" and event in ["embedding_api_call_completed", "embedding_api_call_failed"] and event_kind = "vector_search_query_embedding"'),
       ),
     ).twice
     expect(client).to have_received(:start_query).with(

--- a/spec/services/search_service/fuzzy_search_spec.rb
+++ b/spec/services/search_service/fuzzy_search_spec.rb
@@ -170,6 +170,7 @@ RSpec.describe SearchService::FuzzySearch do
           error_type: 'OpenSearch::Transport::Transport::Error',
           error_message: 'OpenSearch timeout',
           search_type: 'classic',
+          operation: 'opensearch_retrieval',
         )
       end
     end

--- a/spec/services/search_service/fuzzy_search_spec.rb
+++ b/spec/services/search_service/fuzzy_search_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe SearchService::FuzzySearch do
+  after { TradeTariffRequest.search_failures = nil }
+
   let(:query_string) { 'apples' }
   let(:data_serializer) { Api::V2::SearchSerializationService.new }
 
@@ -147,7 +149,7 @@ RSpec.describe SearchService::FuzzySearch do
       end
 
       before do
-        allow(Search::Instrumentation).to receive(:search_failed)
+        allow(Search::Instrumentation).to receive(:search_stage_failed).and_call_original
         allow(TradeTariffBackend.search_client).to receive(:msearch)
           .and_raise(error)
       end
@@ -159,11 +161,12 @@ RSpec.describe SearchService::FuzzySearch do
         expect(results).to include(SearchService::BaseSearch::BLANK_RESULT)
       end
 
-      it 'emits a search_failed event' do
+      it 'emits a stage failure event' do
         fuzzy_search.serializable_hash
 
-        expect(Search::Instrumentation).to have_received(:search_failed).with(
+        expect(Search::Instrumentation).to have_received(:search_stage_failed).with(
           request_id: 'request-123',
+          failure_code: 'opensearch_failed',
           error_type: 'OpenSearch::Transport::Transport::Error',
           error_message: 'OpenSearch timeout',
           search_type: 'classic',

--- a/spec/services/vector_retrieval_service_spec.rb
+++ b/spec/services/vector_retrieval_service_spec.rb
@@ -472,15 +472,23 @@ RSpec.describe VectorRetrievalService do
   describe '#call_with_diagnostics' do
     include_examples 'records retrieval failures', :call_with_diagnostics, described_class::VectorRetrievalError
 
-    %w[missing malformed].each do |shape|
+    {
+      missing: [],
+      malformed: [{ index: 0, embedding: [0.1] }],
+      absent_data: nil,
+      invalid_data: {},
+      invalid_entry: [nil],
+      excess_data: [{}, {}],
+    }.each do |shape, data|
       context "when a billed embedding is #{shape}" do
         before do
           EmbeddingService.reset_client!
           allow(EmbeddingService).to receive(:new).and_call_original
-          data = shape == 'missing' ? [] : [{ index: 0, embedding: [0.1] }]
+          body = { data:, usage: { prompt_tokens: 12, total_tokens: 12 } }
+          body.delete(:data) if data.nil?
           stub_request(:post, 'https://api.openai.com/v1/embeddings').to_return(
             status: 200,
-            body: { data:, usage: { prompt_tokens: 12, total_tokens: 12 } }.to_json,
+            body: body.to_json,
             headers: { 'Content-Type' => 'application/json' },
           )
         end

--- a/spec/services/vector_retrieval_service_spec.rb
+++ b/spec/services/vector_retrieval_service_spec.rb
@@ -479,6 +479,8 @@ RSpec.describe VectorRetrievalService do
       invalid_data: {},
       invalid_entry: [nil],
       excess_data: [{}, {}],
+      missing_index: [{ embedding: Array.new(1536, 0.1) }],
+      invalid_index: [{ index: 1, embedding: Array.new(1536, 0.1) }],
     }.each do |shape, data|
       context "when a billed embedding is #{shape}" do
         before do

--- a/spec/services/vector_retrieval_service_spec.rb
+++ b/spec/services/vector_retrieval_service_spec.rb
@@ -472,30 +472,34 @@ RSpec.describe VectorRetrievalService do
   describe '#call_with_diagnostics' do
     include_examples 'records retrieval failures', :call_with_diagnostics, described_class::VectorRetrievalError
 
-    context 'when a malformed embedding has usage' do
-      let(:query_embedding) do
-        usage = AiUsage.metadata_for(
-          model: EmbeddingService::MODEL,
-          event_kind: 'vector_search_query_embedding',
-          usage: { 'prompt_tokens' => 12, 'total_tokens' => 12 },
-        )
-        AiUsage.attach_metadata([0.1], usage)
-      end
-
-      it 'retains the billed usage on failure' do
-        events = []
-        subscriber = ActiveSupport::Notifications.subscribe('embedding_api_call_failed.ai_usage') do |*args|
-          events << ActiveSupport::Notifications::Event.new(*args)
+    %w[missing malformed].each do |shape|
+      context "when a billed embedding is #{shape}" do
+        before do
+          EmbeddingService.reset_client!
+          allow(EmbeddingService).to receive(:new).and_call_original
+          data = shape == 'missing' ? [] : [{ index: 0, embedding: [0.1] }]
+          stub_request(:post, 'https://api.openai.com/v1/embeddings').to_return(
+            status: 200,
+            body: { data:, usage: { prompt_tokens: 12, total_tokens: 12 } }.to_json,
+            headers: { 'Content-Type' => 'application/json' },
+          )
         end
 
-        expect { service.call_with_diagnostics }
-          .to raise_error(described_class::EmbeddingGenerationError)
+        it 'retains the billed usage on failure' do
+          events = []
+          subscriber = ActiveSupport::Notifications.subscribe('embedding_api_call_failed.ai_usage') do |*args|
+            events << ActiveSupport::Notifications::Event.new(*args)
+          end
 
-        expect(events).to contain_exactly(
-          have_attributes(payload: hash_including(total_tokens: 12, total_cost_usd: be_positive)),
-        )
-      ensure
-        ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+          expect { service.call_with_diagnostics }
+            .to raise_error(described_class::EmbeddingGenerationError)
+
+          expect(events).to contain_exactly(
+            have_attributes(payload: hash_including(total_tokens: 12, total_cost_usd: be_positive)),
+          )
+        ensure
+          ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+        end
       end
     end
 

--- a/spec/services/vector_retrieval_service_spec.rb
+++ b/spec/services/vector_retrieval_service_spec.rb
@@ -9,7 +9,75 @@ RSpec.describe VectorRetrievalService do
     allow(embedding_service).to receive(:embed).with('live horses', event_kind: 'vector_search_query_embedding').and_return(query_embedding)
   end
 
+  around do |example|
+    TradeTariffRequest.set(search_failures: nil) { example.run }
+  end
+
+  shared_examples 'records retrieval failures' do |entrypoint, retrieval_error_class|
+    context 'when the embedding provider fails' do
+      before { allow(embedding_service).to receive(:embed).and_raise(Faraday::TimeoutError, 'embedding timed out') }
+
+      it 'records only the embedding failure' do
+        events = []
+        subscriber = ActiveSupport::Notifications.subscribe('search_stage_failed.search') do |*args|
+          events << ActiveSupport::Notifications::Event.new(*args)
+        end
+
+        expect { service.public_send(entrypoint) }.to raise_error(described_class::EmbeddingGenerationError)
+
+        expect(TradeTariffRequest.search_failures).to eq(%w[embedding_generation_failed])
+        expect(events).to contain_exactly(
+          have_attributes(payload: hash_including(
+            request_id: 'request-123',
+            failure_code: 'embedding_generation_failed',
+            operation: 'embedding_generation',
+            error_type: 'Faraday::TimeoutError',
+          )),
+        )
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+      end
+    end
+
+    context 'when the embedding is malformed' do
+      let(:query_embedding) { nil }
+
+      it 'records only the embedding failure' do
+        expect { service.public_send(entrypoint) }.to raise_error(described_class::EmbeddingGenerationError)
+
+        expect(TradeTariffRequest.search_failures).to eq(%w[embedding_generation_failed])
+      end
+    end
+
+    context 'when the vector database fails' do
+      before { allow(GoodsNomenclatureSelfText).to receive(:vector_search).and_raise(Sequel::DatabaseError, 'vector unavailable') }
+
+      it 'records only the vector failure' do
+        events = []
+        subscriber = ActiveSupport::Notifications.subscribe('search_stage_failed.search') do |*args|
+          events << ActiveSupport::Notifications::Event.new(*args)
+        end
+
+        expect { service.public_send(entrypoint) }.to raise_error(retrieval_error_class, 'vector unavailable')
+
+        expect(TradeTariffRequest.search_failures).to eq(%w[vector_retrieval_failed])
+        expect(events).to contain_exactly(
+          have_attributes(payload: hash_including(
+            request_id: 'request-123',
+            failure_code: 'vector_retrieval_failed',
+            operation: 'vector_retrieval',
+            error_type: 'Sequel::DatabaseError',
+          )),
+        )
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+      end
+    end
+  end
+
   describe '#call' do
+    include_examples 'records retrieval failures', :call, Sequel::DatabaseError
+
     it 'embeds the query text' do
       service.call
 
@@ -402,6 +470,35 @@ RSpec.describe VectorRetrievalService do
   end
 
   describe '#call_with_diagnostics' do
+    include_examples 'records retrieval failures', :call_with_diagnostics, described_class::VectorRetrievalError
+
+    context 'when a malformed embedding has usage' do
+      let(:query_embedding) do
+        usage = AiUsage.metadata_for(
+          model: EmbeddingService::MODEL,
+          event_kind: 'vector_search_query_embedding',
+          usage: { 'prompt_tokens' => 12, 'total_tokens' => 12 },
+        )
+        AiUsage.attach_metadata([0.1], usage)
+      end
+
+      it 'retains the billed usage on failure' do
+        events = []
+        subscriber = ActiveSupport::Notifications.subscribe('embedding_api_call_failed.ai_usage') do |*args|
+          events << ActiveSupport::Notifications::Event.new(*args)
+        end
+
+        expect { service.call_with_diagnostics }
+          .to raise_error(described_class::EmbeddingGenerationError)
+
+        expect(events).to contain_exactly(
+          have_attributes(payload: hash_including(total_tokens: 12, total_cost_usd: be_positive)),
+        )
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+      end
+    end
+
     context 'when embedding generation fails' do
       before do
         allow(embedding_service).to receive(:embed).and_raise(Faraday::TimeoutError)
@@ -413,36 +510,39 @@ RSpec.describe VectorRetrievalService do
       end
     end
 
-    context 'when embedding generation returns no embedding' do
-      before do
-        allow(embedding_service).to receive(:embed).and_return(nil)
-      end
+    {
+      'no embedding' => nil,
+      'the wrong dimensions' => [0.1],
+      'a non-numeric value' => Array.new(1536, 'invalid'),
+      'a non-real value' => Array.new(1536, Complex(1, 1)),
+      'a NaN value' => Array.new(1536, Float::NAN),
+      'an infinite value' => Array.new(1536, Float::INFINITY),
+    }.each do |description, embedding|
+      context "when embedding generation returns #{description}" do
+        let(:query_embedding) { embedding }
 
-      it 'identifies the malformed response at the embedding boundary' do
-        expect { service.call_with_diagnostics }
-          .to raise_error(described_class::EmbeddingGenerationError)
-      end
-    end
+        it 'emits only a failed embedding event' do
+          events = []
+          subscriber = ActiveSupport::Notifications.subscribe(/embedding_api_call_.*\.ai_usage/) do |*args|
+            events << ActiveSupport::Notifications::Event.new(*args)
+          end
 
-    context 'when embedding generation returns the wrong dimensions' do
-      before do
-        allow(embedding_service).to receive(:embed).and_return([0.1])
-      end
+          expect { service.call_with_diagnostics }
+            .to raise_error(described_class::EmbeddingGenerationError, 'Embedding response was malformed')
 
-      it 'identifies the malformed response at the embedding boundary' do
-        expect { service.call_with_diagnostics }
-          .to raise_error(described_class::EmbeddingGenerationError)
-      end
-    end
-
-    context 'when embedding generation returns a non-numeric value' do
-      before do
-        allow(embedding_service).to receive(:embed).and_return(Array.new(1536, 'invalid'))
-      end
-
-      it 'identifies the malformed response at the embedding boundary' do
-        expect { service.call_with_diagnostics }
-          .to raise_error(described_class::EmbeddingGenerationError)
+          expect(events).to contain_exactly(
+            have_attributes(
+              name: 'embedding_api_call_failed.ai_usage',
+              payload: hash_including(
+                event_kind: 'vector_search_query_embedding',
+                request_id: 'request-123',
+                error_class: 'VectorRetrievalService::EmbeddingGenerationError',
+              ),
+            ),
+          )
+        ensure
+          ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+        end
       end
     end
 

--- a/spec/terraform/search_experiment_dashboard_spec.rb
+++ b/spec/terraform/search_experiment_dashboard_spec.rb
@@ -46,8 +46,8 @@ RSpec.describe 'search experiment dashboard Terraform' do
   end
 
   it 'separates period cost and token totals and exposes incomplete pricing' do
-    expect(module_main_tf).to include('event in [\\"api_call_completed\\", \\"embedding_api_call_completed\\"]')
-    expect(module_main_tf).to include('service = \\"ai_usage\\" and event = \\"embedding_api_call_completed\\"')
+    expect(module_main_tf).to include('event in [\\"api_call_completed\\", \\"embedding_api_call_completed\\", \\"embedding_api_call_failed\\"]')
+    expect(module_main_tf).to include('service = \\"ai_usage\\" and event in [\\"embedding_api_call_completed\\", \\"embedding_api_call_failed\\"]')
     expect(module_main_tf).to include('event_kind = \\"vector_search_query_embedding\\"')
     expect(module_main_tf).to include('if(ispresent(operation), operation, event_kind) as ai_operation')
     expect(module_main_tf).to include('Total AI Cost by Operation')

--- a/terraform/degradation_alarms.tf
+++ b/terraform/degradation_alarms.tf
@@ -2,14 +2,16 @@ locals {
   log_group_name              = "platform-logs-${var.environment}"
   search_operations_dashboard = "SearchOperations-${var.environment}"
 
-  # One CloudWatch alarm per search component so a widespread outage pages once.
+  # Keep legacy boundary events during rolling deployments and application rollbacks.
+  # These count failure events, not requests: a stage and its retrieval leg can
+  # both match, but share one alarm per component.
   search_degradation_alarms = {
     opensearch = {
       filter_name         = "search-opensearch-error-${var.environment}"
-      pattern             = "{ $.service = \"search\" && $.event = \"retrieval_leg_completed\" && $.leg = \"opensearch\" && $.status = \"error\" }"
+      pattern             = "{ $.service = \"search\" && (($.event = \"search_stage_failed\" && $.failure_code = \"opensearch_failed\") || ($.event = \"retrieval_leg_completed\" && $.leg = \"opensearch\" && $.status = \"error\")) }"
       metric_name         = "SearchOpensearchErrorCount"
       alarm_name          = "search-opensearch-error-${var.environment}"
-      alarm_description   = "OpenSearch retrieval failed for AI-assisted search in ${var.environment}. Owner: Trade Tariff search. First action: dashboard ${local.search_operations_dashboard} Hybrid Leg Failures, then ${local.log_group_name} filtered by service=search event=retrieval_leg_completed leg=opensearch status=error. Use request_id and error_message to diagnose."
+      alarm_description   = "OpenSearch retrieval failed for search in ${var.environment}. Owner: Trade Tariff search. First action: dashboard ${local.search_operations_dashboard}, then ${local.log_group_name} filtered by service=search and failure_code=opensearch_failed, or event=retrieval_leg_completed leg=opensearch status=error. Use request_id, operation, error_type, and error_message to diagnose."
       threshold           = 0
       period              = 300
       evaluation_periods  = 1
@@ -20,7 +22,7 @@ locals {
       pattern             = "{ $.service = \"ai_usage\" && $.event = \"embedding_api_call_failed\" && $.event_kind = \"vector_search_query_embedding\" }"
       metric_name         = "SearchEmbeddingErrorCount"
       alarm_name          = "search-embedding-error-${var.environment}"
-      alarm_description   = "Query embedding calls failed for AI-assisted search in ${var.environment}. Owner: Trade Tariff search. First action: dashboard ${local.search_operations_dashboard}, then ${local.log_group_name} filtered by service=ai_usage event=embedding_api_call_failed event_kind=vector_search_query_embedding. Use request_id, error_class, and error_message to diagnose."
+      alarm_description   = "Query embedding calls failed or returned malformed embeddings for search in ${var.environment}. Owner: Trade Tariff search. First action: dashboard ${local.search_operations_dashboard}, then ${local.log_group_name} filtered by service=ai_usage event=embedding_api_call_failed event_kind=vector_search_query_embedding. Use request_id, error_class, and error_message to diagnose."
       threshold           = 0
       period              = 300
       evaluation_periods  = 1
@@ -28,10 +30,21 @@ locals {
     }
     llm = {
       filter_name         = "search-llm-error-${var.environment}"
-      pattern             = "{ $.service = \"search\" && $.event = \"api_call_completed\" && $.response_type = \"error\" }"
+      pattern             = "{ $.service = \"search\" && (($.event = \"api_call_completed\" && $.response_type = \"error\") || ($.event = \"search_stage_failed\" && ($.failure_code = \"query_expansion_failed\" || $.failure_code = \"interactive_search_failed\" || $.failure_code = \"duplicate_question_validation_failed\"))) }"
       metric_name         = "SearchLlmErrorCount"
       alarm_name          = "search-llm-error-${var.environment}"
-      alarm_description   = "LLM calls failed for AI-assisted search in ${var.environment} (interactive search, query expansion, or duplicate-question validation). Owner: Trade Tariff search. First action: dashboard ${local.search_operations_dashboard}, then ${local.log_group_name} filtered by service=search event=api_call_completed response_type=error. Use request_id, operation, and error_message to diagnose."
+      alarm_description   = "LLM calls failed or returned unusable responses for search in ${var.environment} (interactive search, query expansion, or duplicate-question validation). Owner: Trade Tariff search. First action: dashboard ${local.search_operations_dashboard}, then ${local.log_group_name} filtered by service=search and failure_code=query_expansion_failed, interactive_search_failed, or duplicate_question_validation_failed, or event=api_call_completed response_type=error. Use request_id, operation, error_type, and error_message to diagnose."
+      threshold           = 0
+      period              = 300
+      evaluation_periods  = 1
+      datapoints_to_alarm = 1
+    }
+    vector = {
+      filter_name         = "search-vector-error-${var.environment}"
+      pattern             = "{ $.service = \"search\" && $.failure_code = \"vector_retrieval_failed\" && ($.event = \"search_stage_failed\" || ($.event = \"retrieval_leg_completed\" && $.leg = \"vector\" && $.status = \"error\")) }"
+      metric_name         = "SearchVectorErrorCount"
+      alarm_name          = "search-vector-error-${var.environment}"
+      alarm_description   = "Vector database retrieval failed for search in ${var.environment}. Owner: Trade Tariff search. First action: dashboard ${local.search_operations_dashboard} Hybrid Leg Failures, then ${local.log_group_name} filtered by service=search failure_code=vector_retrieval_failed. Use request_id, operation, error_type, and error_message to diagnose. Embedding generation failures use the separate embedding alarm."
       threshold           = 0
       period              = 300
       evaluation_periods  = 1

--- a/terraform/modules/search_experiment_dashboard/main.tf
+++ b/terraform/modules/search_experiment_dashboard/main.tf
@@ -3,7 +3,7 @@ locals {
   source            = "SOURCE '${var.log_group_name}'"
   experiment_filter = "filter experiment = \"EXPERIMENT_LABEL\""
   search_filter     = "${local.experiment_filter} and service = \"search\""
-  ai_cost_filter    = "filter event in [\"api_call_completed\", \"embedding_api_call_completed\"]\n              | ${local.experiment_filter} and ((service = \"search\" and event = \"api_call_completed\") or (service = \"ai_usage\" and event = \"embedding_api_call_completed\" and event_kind = \"vector_search_query_embedding\"))"
+  ai_cost_filter    = "filter event in [\"api_call_completed\", \"embedding_api_call_completed\", \"embedding_api_call_failed\"]\n              | ${local.experiment_filter} and ((service = \"search\" and event = \"api_call_completed\") or (service = \"ai_usage\" and event in [\"embedding_api_call_completed\", \"embedding_api_call_failed\"] and event_kind = \"vector_search_query_embedding\"))"
   # Classic empty commodity results: fuzzy/null with commodity_result_count = 0 (empty Best commodity matches).
   # Includes completely empty results and headings/chapters-only; excludes exact matches.
   # Interactive empty results: result_count = 0 (filter also accepts search_type=internal for forward-compat).


### PR DESCRIPTION
## What:

- [x] Validate fresh and cached query expansion responses before retrieval, falling back safely when malformed.
- [x] Reserve terminal search failures for unrecovered errors and emit bounded component diagnostics for recovered failures.
- [x] Preserve experiment attribution across hybrid retrieval threads and retain billed usage when embeddings are malformed.
- [x] Cover direct retrieval, duplicate-question validation and vector database failures in instrumentation and component alarms.

## Why:

A malformed expansion could crash retrieval, recovered LLM errors could count as both failed and completed searches, and some retrieval failures and embedding costs were missing from diagnostics. Search now preserves its fallback behavior while reporting the failed stage and the final outcome separately.

Validation: 704 examples passed across embedding, search, AI usage, retrieval, API/request, analytics and Terraform specs. RuboCop and commit hooks passed for the review fixes. Terraform formatting and validation passed.

## Ticket:

[AI-1263](https://transformuk.atlassian.net/browse/AI-1263)

## Risk:

**Risk level:** 🟢

**Reason for rating:** The affected assisted-search functionality is not currently live. Regression coverage exercises fallback behavior and cost accounting; the remaining changes are read-only observability and additive alarm coverage. No feature flags are enabled.