### PR TITLE
AI-1264: Instrument search degradation and specific failure conditions

### DIFF
--- a/app/lib/ai_usage/instrumentation.rb
+++ b/app/lib/ai_usage/instrumentation.rb
@@ -6,6 +6,9 @@ module AiUsage
   module_function
 
     def instrument(event_name, payload = {}, &block)
+      if Search::FailureCodes.for_operation(payload[:event_kind])
+        payload = Search::Instrumentation.with_request_context(payload.merge(request_id: payload[:request_id]))
+      end
       ActiveSupport::Notifications.instrument("#{event_name}.ai_usage", payload, &block)
     end
 
@@ -41,6 +44,8 @@ module AiUsage
       )
       result
     rescue StandardError => e
+      failure_code = Search::FailureCodes.for_operation(event_kind)
+      TradeTariffRequest.record_search_failure(failure_code) if failure_code
       duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
       instrument(
         "#{event_prefix}_failed",

--- a/app/lib/ai_usage/logger.rb
+++ b/app/lib/ai_usage/logger.rb
@@ -28,13 +28,18 @@ module AiUsage
         duration_ms: event.payload[:duration_ms],
         request_id: event.payload[:request_id],
       }
+      if Search::FailureCodes.for_operation(event.payload[:event_kind])
+        data.merge!(Search::FailureCodes.logging_fields([]), event.payload.slice(*Search::FailureCodes::LOG_FIELDS))
+        data.merge!(event.payload.slice(:experiment, :request_source, :client_id, :search_type))
+      end
       add_ai_usage_fields!(data, event)
       data
     end
 
     def log_entry(data)
       entry = data.merge(service: 'ai_usage', timestamp: Time.current.iso8601)
-      entry[:experiment] = TradeTariffRequest.experiment if TradeTariffRequest.experiment.present?
+      experiment = data[:experiment].presence || TradeTariffRequest.experiment.presence
+      entry[:experiment] = experiment if experiment
       entry.to_json
     end
 

--- a/app/lib/search/failure_codes.rb
+++ b/app/lib/search/failure_codes.rb
@@ -15,5 +15,24 @@ module Search
       DUPLICATE_QUESTION_VALIDATION_FAILED,
       OPENSEARCH_FAILED,
     ].freeze
+
+    LOG_FIELDS = [:search_degraded, *ALL.map(&:to_sym)].freeze
+    OPERATIONS = {
+      'search_query_expansion' => QUERY_EXPANSION_FAILED,
+      'vector_search_query_embedding' => EMBEDDING_GENERATION_FAILED,
+      'interactive_search' => INTERACTIVE_SEARCH_FAILED,
+      'interactive_search_final_answer' => INTERACTIVE_SEARCH_FAILED,
+      'duplicate_question_retry' => INTERACTIVE_SEARCH_FAILED,
+      'duplicate_question_validator' => DUPLICATE_QUESTION_VALIDATION_FAILED,
+    }.freeze
+
+    def self.logging_fields(failure_codes)
+      failures = Array(failure_codes)
+      { search_degraded: failures.any? }.merge(ALL.index_with { |code| failures.include?(code) }.transform_keys(&:to_sym))
+    end
+
+    def self.for_operation(operation)
+      OPERATIONS[operation]
+    end
   end
 end

--- a/app/lib/search/instrumentation/api_events.rb
+++ b/app/lib/search/instrumentation/api_events.rb
@@ -5,6 +5,7 @@ module Search
         start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         result = yield
         duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
+        record_api_failure(operation) if determine_response_type(result) == 'error'
 
         instrument(
           # NOTE: Api::Admin::Search::Evaluation::SearchesController#create
@@ -29,6 +30,7 @@ module Search
 
         result
       rescue StandardError => e
+        record_api_failure(operation)
         duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
         instrument(
           # See the success-path instrument() call above for why this event
@@ -48,6 +50,11 @@ module Search
           }.merge(truncate_error_payload(AiUsage.safe_error_message(e))).merge(AiUsage.payload_from_error(e)),
         )
         raise
+      end
+
+      def record_api_failure(operation)
+        code = Search::FailureCodes.for_operation(operation)
+        TradeTariffRequest.record_search_failure(code) if code
       end
 
       def determine_response_type(result)

--- a/app/lib/search/instrumentation/core.rb
+++ b/app/lib/search/instrumentation/core.rb
@@ -9,19 +9,21 @@ module Search
         instrument('search_started', request_id:, query:, search_type:)
       end
 
-      def search(request_id:, query:, search_type:, &block)
-        search_started(request_id:, query:, search_type:)
-        start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      def search(request_id:, query:, search_type:)
+        TradeTariffRequest.set(search_type:) do
+          search_started(request_id:, query:, search_type:)
+          start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
-        result, completion_payload = TradeTariffRequest.set(search_type:, &block)
+          result, completion_payload = yield
 
-        duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000).round(2)
-        search_completed(request_id:, query:, search_type:, total_duration_ms: duration_ms, **(completion_payload || {}))
+          duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000).round(2)
+          search_completed(request_id:, query:, search_type:, total_duration_ms: duration_ms, **(completion_payload || {}))
 
-        result
-      rescue StandardError => e
-        search_failed(request_id:, error_type: e.class.name, error_message: e.message, search_type:)
-        raise
+          result
+        rescue StandardError => e
+          search_failed(request_id:, error_type: e.class.name, error_message: e.message, search_type:)
+          raise
+        end
       end
 
       def search_failed(request_id:, error_type:, error_message:, search_type:)
@@ -31,6 +33,7 @@ module Search
             request_id:,
             error_type:,
             search_type:,
+            search_degraded: true,
           }.merge(truncate_error_payload(error_message)),
         )
       end

--- a/app/lib/search/instrumentation/payload_helpers.rb
+++ b/app/lib/search/instrumentation/payload_helpers.rb
@@ -44,7 +44,13 @@ module Search
       end
 
       def with_request_context(payload)
-        payload = payload.merge(search_type: TradeTariffRequest.search_type) if TradeTariffRequest.search_type.present?
+        failure_fields = Search::FailureCodes.logging_fields(TradeTariffRequest.search_failures)
+        failure_fields[:search_degraded] ||= payload[:search_degraded] == true
+        payload = payload.merge(failure_fields).merge(
+          { experiment: TradeTariffRequest.experiment,
+            client_id: TradeTariffRequest.client_id,
+            search_type: TradeTariffRequest.search_type }.compact_blank,
+        )
         return payload unless payload.key?(:request_id)
 
         payload

--- a/app/lib/search/instrumentation/result_events.rb
+++ b/app/lib/search/instrumentation/result_events.rb
@@ -89,12 +89,12 @@ module Search
         instrument('answer_returned', payload)
       end
 
-      def retrieval_leg_completed(request_id:, leg:, duration_ms:, result_count:, status:, error_message: nil, failure_code: nil, error_type: nil)
+      def retrieval_leg_completed(request_id:, leg:, duration_ms:, result_count:, status:, error_message: nil, failure_code: nil, error_type: nil, search_type: 'interactive')
         instrument(
           'retrieval_leg_completed',
           {
             request_id:,
-            search_type: 'interactive',
+            search_type:,
             leg:,
             duration_ms:,
             result_count:,

--- a/app/lib/search/logger.rb
+++ b/app/lib/search/logger.rb
@@ -347,14 +347,15 @@ module Search
   private
 
     def log_entry(data, event)
-      entry = data.merge(
+      entry = data.merge(Search::FailureCodes.logging_fields([]), event.payload.slice(*Search::FailureCodes::LOG_FIELDS)).merge(
         service: 'search',
         timestamp: Time.current.iso8601,
       )
       entry[:request_source] = event.payload[:request_source] if event.payload[:request_source].present?
       client_id = event.payload[:client_id].presence || TradeTariffRequest.client_id.presence
       entry[:client_id] = client_id if client_id
-      entry[:experiment] = TradeTariffRequest.experiment if TradeTariffRequest.experiment.present?
+      experiment = event.payload[:experiment].presence || TradeTariffRequest.experiment.presence
+      entry[:experiment] = experiment if experiment
       entry.to_json
     end
 

--- a/app/services/api/v2/classification_search_service.rb
+++ b/app/services/api/v2/classification_search_service.rb
@@ -22,19 +22,27 @@ module Api
         return @sanitiser_errors if @sanitiser_errors
         return empty_response if @query.blank?
 
-        result = HybridRetrievalService.call(
-          query: @query,
-          expanded_query: expanded_query,
-          as_of: parse_date(@params[:as_of]),
-          request_id: request_id,
-          limit: limit,
-          search_type: 'classification',
-        )
+        ::Search::Instrumentation.search(request_id:, query: @query, search_type: 'classification') do
+          result = HybridRetrievalService.call(
+            query: @query,
+            expanded_query: expanded_query,
+            as_of: parse_date(@params[:as_of]),
+            request_id: request_id,
+            limit: limit,
+            search_type: 'classification',
+          )
 
-        ClassificationSearchResultSerializer.serialize(
-          result.results,
-          meta: response_meta(result),
-        )
+          response = ClassificationSearchResultSerializer.serialize(
+            result.results,
+            meta: response_meta(result),
+          )
+          completion = {
+            result_count: result.results.size,
+            results_type: 'hybrid',
+            max_score: result.results.map(&:score).compact.max,
+          }
+          [response, completion]
+        end
       end
 
     private

--- a/app/services/hybrid_retrieval_service.rb
+++ b/app/services/hybrid_retrieval_service.rb
@@ -1,6 +1,6 @@
 class HybridRetrievalService
   AllLegsFailed = Class.new(StandardError)
-  LegResult = Data.define(:value, :error, :failure_code)
+  LegResult = Data.define(:value, :error, :failure_code, :duration_ms, :failure_codes)
   Result = Data.define(:results, :expanded_query, :source_results, :opensearch_results, :vector_results, :failure_codes) do
     def initialize(results:, expanded_query:, source_results:, opensearch_results: [], vector_results: [], failure_codes: [])
       super
@@ -28,11 +28,15 @@ class HybridRetrievalService
   end
 
   def call
+    initial_failures = Array(TradeTariffRequest.search_failures)
     opensearch_leg, vector_leg = run_concurrent_retrievals
-    failure_codes = [opensearch_leg, vector_leg].filter_map(&:failure_code)
+    legs = [opensearch_leg, vector_leg]
+    failure_codes = (legs.flat_map(&:failure_codes).uniq - initial_failures) | legs.filter_map(&:failure_code)
     failure_codes.each do |failure_code|
       TradeTariffRequest.record_search_failure(failure_code)
     end
+    emit_leg_instrumentation(:opensearch, opensearch_leg)
+    emit_leg_instrumentation(:vector, vector_leg)
     leg_errors = [opensearch_leg.error, vector_leg.error].compact
 
     if leg_errors.size == 2
@@ -114,11 +118,27 @@ private
     end
 
     duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start) * 1000).round(2)
-    count = result&.results&.size || 0
+    LegResult.new(value: result, error: nil, failure_code: nil, duration_ms:, failure_codes: Array(TradeTariffRequest.search_failures))
+  rescue StandardError => e
+    duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start) * 1000).round(2)
+    LegResult.new(value: nil, error: e, failure_code: failure_code_for(leg, e), duration_ms:, failure_codes: Array(TradeTariffRequest.search_failures))
+  end
 
+  def emit_leg_instrumentation(leg, leg_result)
+    results = leg_result.value&.results || []
     Search::Instrumentation.retrieval_leg_completed(
-      request_id: @request_id, leg: leg, duration_ms: duration_ms, result_count: count, status: 'success',
+      request_id: @request_id,
+      search_type: @search_type,
+      leg: leg,
+      duration_ms: leg_result.duration_ms,
+      result_count: results.size,
+      status: leg_result.error ? 'error' : 'success',
+      error_message: leg_result.error&.message,
+      failure_code: leg_result.failure_code,
+      error_type: leg_result.error&.class&.name,
     )
+    return if leg_result.error
+
     Search::Instrumentation.retrieval_results_returned(
       request_id: @request_id,
       query: @query,
@@ -128,20 +148,8 @@ private
       stage: 'before_rrf',
       leg: leg,
       iteration: @iteration,
-      results: result&.results || [],
+      results: results,
     )
-
-    LegResult.new(value: result, error: nil, failure_code: nil)
-  rescue StandardError => e
-    duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start) * 1000).round(2)
-    failure_code = failure_code_for(leg, e)
-
-    Search::Instrumentation.retrieval_leg_completed(
-      request_id: @request_id, leg: leg, duration_ms: duration_ms, result_count: 0, status: 'error',
-      error_message: e.message, failure_code: failure_code, error_type: e.class.name
-    )
-
-    LegResult.new(value: nil, error: e, failure_code: failure_code)
   end
 
   def failure_code_for(leg, error)

--- a/docs/architecture/search-and-indexing.md
+++ b/docs/architecture/search-and-indexing.md
@@ -85,6 +85,16 @@ These alarms count failure events and trigger when any matching event occurs in 
 
 The existing OpenSearch-leg and LLM API-error patterns remain alongside the new stage patterns so older application instances retain their alert coverage during a rolling deployment or rollback. The new vector alarm and unusable-response coverage require the corresponding new application events. Legacy vector errors cannot distinguish embedding generation from database retrieval and are not assigned to the database alarm.
 
+## Search Failure Fields
+
+Search events and search-related AI usage events include `search_degraded` and six explicit boolean fields: `query_expansion_failed`, `embedding_generation_failed`, `vector_retrieval_failed`, `interactive_search_failed`, `duplicate_question_validation_failed`, and `opensearch_failed`. Each field is present as `true` or `false`. Duplicate-question validation failing open has its own code, separate from interactive inference failure. Disabled stages, successful empty results, and query-guardrail decisions do not mark a search as degraded.
+
+Flags describe failures known when each event is emitted. A later failure does not rewrite earlier events. Hybrid completion combines the retrieval legs' flags after both finish. An unclassified hard failure emits `search_failed` with `search_degraded: true` while all stage flags remain false.
+
+Search Operations keeps terminal and recovered stage failures visible in its existing Recent Error Log, including the failure code and operation. General AI cost accounting continues to include billed failures.
+
+To exclude degraded journeys from an experiment cohort, correlate all events sharing a `request_id` within the selected time window. Filtering individual events on `search_degraded` would retain costs and latency recorded before a later failure. The failure fields do not change dashboard cohorts by themselves.
+
 ## Query Expansion Deadline
 
 Uncached guided-search query expansion has a fixed five-second operation-specific deadline.

--- a/spec/lib/search/failure_logging_spec.rb
+++ b/spec/lib/search/failure_logging_spec.rb
@@ -1,0 +1,101 @@
+require 'stringio'
+
+RSpec.describe 'Search failure logging' do
+  after { TradeTariffRequest.reset }
+
+  def capture_logs(&block)
+    output = StringIO.new
+    logger = ActiveSupport::Logger.new(output)
+    subscribers = [Search::Logger, AiUsage::Logger].map do |klass|
+      klass.new.tap { |subscriber| subscriber.define_singleton_method(:logger) { logger } }
+    end
+    callback = lambda do |event|
+      subscriber = event.name.end_with?('.search') ? subscribers.first : subscribers.last
+      subscriber.public_send(event.name.split('.').first, event)
+    end
+    ActiveSupport::Notifications.subscribed(callback, /\.(search|ai_usage)\z/, &block)
+    output.string.lines.map { |line| JSON.parse(line) }
+  end
+
+  it 'retains the failure snapshot on each event while later failures accumulate' do
+    events = []
+    callback = ->(event) { events << event.payload }
+    TradeTariffRequest.experiment = 'failure-cohort'
+    ActiveSupport::Notifications.subscribed(callback, /\.search\z/) do
+      Search::Instrumentation.search(request_id: 'journey', query: 'horse', search_type: 'evaluation') do
+        Search::FailureCodes::ALL.each do |code|
+          Search::Instrumentation.search_stage_failed(
+            request_id: 'journey', search_type: 'interactive', failure_code: code,
+            error_type: 'InvalidResponse', error_message: 'bad response'
+          )
+        end
+        [[], { result_count: 0 }]
+      end
+    end
+
+    expect(events.first).to include(Search::FailureCodes::ALL.index_with { false }.transform_keys(&:to_sym))
+    expect(events.first).to include(search_degraded: false, experiment: 'failure-cohort', search_type: 'evaluation')
+    expect(events[1]).to include(search_degraded: true, query_expansion_failed: true, embedding_generation_failed: false)
+    expect(events.last).to include(Search::FailureCodes::ALL.index_with { true }.transform_keys(&:to_sym))
+    expect(events.last).to include(search_type: 'evaluation', result_count: 0)
+    expect(TradeTariffRequest.search_type).to be_nil
+  end
+
+  it 'logs embedding failure flags before the service rescue and retains provider cost' do
+    error = VectorRetrievalService::EmbeddingGenerationError.new(
+      'invalid embedding',
+      ai_usage: AiUsage.metadata_for(model: EmbeddingService::MODEL, event_kind: 'vector_search_query_embedding', usage: { 'total_tokens' => 42 }),
+    )
+    TradeTariffRequest.set(request_id: 'journey', experiment: 'failure-cohort', request_source: 'frontend', client_id: 'evaluation') do
+      TradeTariffRequest.record_search_failure(Search::FailureCodes::QUERY_EXPANSION_FAILED)
+      logs = capture_logs do
+        expect {
+          AiUsage::Instrumentation.embedding_api_call(event_kind: 'vector_search_query_embedding', batch_size: 1, model: EmbeddingService::MODEL) { raise error }
+        }.to raise_error(VectorRetrievalService::EmbeddingGenerationError)
+      end
+      expect(logs.last).to include(
+        'event' => 'embedding_api_call_failed', 'request_id' => 'journey', 'experiment' => 'failure-cohort',
+        'request_source' => 'frontend', 'client_id' => 'evaluation', 'total_tokens' => 42,
+        'search_degraded' => true, 'embedding_generation_failed' => true, 'query_expansion_failed' => true,
+        'vector_retrieval_failed' => false
+      )
+    end
+  end
+
+  {
+    'search_query_expansion' => 'query_expansion_failed',
+    'duplicate_question_validator' => 'duplicate_question_validation_failed',
+    'interactive_search' => 'interactive_search_failed',
+    'interactive_search_final_answer' => 'interactive_search_failed',
+    'duplicate_question_retry' => 'interactive_search_failed',
+  }.each do |operation, code|
+    it "flags #{operation} before logging its failed API call" do
+      logs = capture_logs do
+        expect {
+          Search::Instrumentation.api_call(request_id: 'journey', model: 'gpt-test', attempt_number: 1, operation:) { raise Faraday::TimeoutError }
+        }.to raise_error(Faraday::TimeoutError)
+      end
+      expect(logs.last).to include('event' => 'api_call_completed', 'search_degraded' => true, code => true)
+    end
+  end
+
+  it 'marks terminal failures without inventing a failed stage' do
+    logs = capture_logs do
+      expect {
+        Search::Instrumentation.search(request_id: 'journey', query: 'horse', search_type: 'evaluation') { raise StandardError, 'unknown failure' }
+      }.to raise_error(StandardError, 'unknown failure')
+    end
+    expect(logs.map { |entry| entry['event'] }).to eq(%w[search_started search_failed])
+    expect(logs.last).to include('search_degraded' => true)
+    expect(logs.last).to include(Search::FailureCodes::ALL.index_with { false })
+  end
+
+  it 'keeps healthy search usage and unrelated AI work distinguishable' do
+    logs = capture_logs do
+      AiUsage::Instrumentation.embedding_api_call(event_kind: 'vector_search_query_embedding', batch_size: 1, model: EmbeddingService::MODEL) { [] }
+      AiUsage::Instrumentation.api_call(event_kind: 'atar_fact_extraction', model: 'gpt-test') { {} }
+    end
+    expect(logs.first).to include('search_degraded' => false, 'embedding_generation_failed' => false)
+    expect(logs.last).not_to have_key('search_degraded')
+  end
+end

--- a/spec/lib/search/instrumentation_spec.rb
+++ b/spec/lib/search/instrumentation_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe Search::Instrumentation do
-  before { TradeTariffRequest.request_source = nil }
+  before { TradeTariffRequest.reset }
+  after { TradeTariffRequest.reset }
 
   describe '.search_stage_failed' do
     after { TradeTariffRequest.reset }
@@ -39,6 +40,7 @@ RSpec.describe Search::Instrumentation do
         request_id: 'req-1',
         query: 'horses',
         search_type: 'interactive',
+        **Search::FailureCodes.logging_fields([]),
       )
     end
 
@@ -53,6 +55,7 @@ RSpec.describe Search::Instrumentation do
         request_id: 'current-request-id',
         query: 'horses',
         search_type: 'interactive',
+        **Search::FailureCodes.logging_fields([]),
       )
     end
 
@@ -68,6 +71,7 @@ RSpec.describe Search::Instrumentation do
         query: 'horses',
         search_type: 'interactive',
         request_source: 'frontend',
+        **Search::FailureCodes.logging_fields([]),
       )
     end
   end
@@ -86,6 +90,7 @@ RSpec.describe Search::Instrumentation do
         request_id: 'req-1',
         query: 'horses',
         search_type: 'interactive',
+        **Search::FailureCodes.logging_fields([]),
       )
       expect(ActiveSupport::Notifications).to have_received(:instrument).with(
         'search_completed.search',
@@ -254,6 +259,7 @@ RSpec.describe Search::Instrumentation do
         answer_count: 1,
         added_answers: %w[Leather],
         iteration: 2,
+        **Search::FailureCodes.logging_fields([]),
       )
     end
   end
@@ -282,6 +288,7 @@ RSpec.describe Search::Instrumentation do
         decider_version: 'v1',
         result_count: 3,
         max_score: 4.5,
+        **Search::FailureCodes.logging_fields([]),
       )
     end
   end
@@ -306,6 +313,7 @@ RSpec.describe Search::Instrumentation do
         elapsed_ms: 5010.0,
         model: 'gpt-4.1-mini-2025-04-14',
         fallback_outcome: 'preliminary_results',
+        **Search::FailureCodes.logging_fields([]),
       )
     end
   end
@@ -756,6 +764,7 @@ RSpec.describe Search::Instrumentation do
         max_score: 0.31,
         threshold: 0.32,
         reason: 'below_threshold',
+        **Search::FailureCodes.logging_fields([]),
       )
     end
 
@@ -788,6 +797,7 @@ RSpec.describe Search::Instrumentation do
         max_score: 0.55,
         threshold: 0.32,
         reason: 'disabled',
+        **Search::FailureCodes.logging_fields([]),
       )
     end
   end
@@ -814,6 +824,7 @@ RSpec.describe Search::Instrumentation do
         iteration: 1,
         effective_query: 'horses',
         details: { questions: [{ question: 'Material?' }] },
+        **Search::FailureCodes.logging_fields([]),
       )
     end
   end
@@ -842,6 +853,7 @@ RSpec.describe Search::Instrumentation do
         iteration: 2,
         effective_query: 'handbag Leather',
         details: { answers: [{ commodity_code: '0101210000', confidence: 'strong' }] },
+        **Search::FailureCodes.logging_fields([]),
       )
     end
   end
@@ -954,6 +966,7 @@ RSpec.describe Search::Instrumentation do
         reason_truncated: false,
         duplicate_of_question: 'Which best describes the imported item itself?',
         duplicate_of_answer: 'Another electrical measuring or checking instrument',
+        **Search::FailureCodes.logging_fields([]),
       )
     end
 
@@ -997,6 +1010,7 @@ RSpec.describe Search::Instrumentation do
         search_type: 'interactive',
         query: 'horses',
         matched: false,
+        **Search::FailureCodes.logging_fields([]),
       )
     end
 
@@ -1031,6 +1045,7 @@ RSpec.describe Search::Instrumentation do
         guidance_level: 'warning',
         guidance_location: 'interstitial',
         escalate_to_webchat: true,
+        **Search::FailureCodes.logging_fields([]),
       )
     end
   end
@@ -1083,6 +1098,7 @@ RSpec.describe Search::Instrumentation do
         description_intercept_guidance_level: 'info',
         description_intercept_guidance_location: 'results',
         description_intercept_escalate_to_webchat: false,
+        **Search::FailureCodes.logging_fields([]),
       )
     end
 
@@ -1179,6 +1195,7 @@ RSpec.describe Search::Instrumentation do
         request_id: 'req-1',
         goods_nomenclature_item_id: '4202210000',
         goods_nomenclature_class: 'Commodity',
+        **Search::FailureCodes.logging_fields([]),
       )
     end
   end
@@ -1255,6 +1272,7 @@ RSpec.describe Search::Instrumentation do
         error_message: 'connection timed out',
         error_message_truncated: false,
         search_type: 'interactive',
+        **Search::FailureCodes.logging_fields([]).merge(search_degraded: true),
       )
     end
 

--- a/spec/services/api/v2/classification_search_service_spec.rb
+++ b/spec/services/api/v2/classification_search_service_spec.rb
@@ -1,7 +1,47 @@
 RSpec.describe Api::V2::ClassificationSearchService do
   after { TradeTariffRequest.search_failures = nil }
 
+  let(:events) { [] }
+
+  around do |example|
+    subscriber = ActiveSupport::Notifications.subscribe(/\A(?:search_started|search_completed|search_failed)\.search\z/) do |*args|
+      events << ActiveSupport::Notifications::Event.new(*args)
+    end
+    example.run
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+  end
+
   describe '#call' do
+    it 'completes a healthy empty retrieval' do
+      allow(HybridRetrievalService).to receive(:call).and_return(
+        HybridRetrievalService::Result.new(results: [], expanded_query: 'horses', source_results: []),
+      )
+
+      described_class.new(q: 'horses', request_id: 'request-1').call
+
+      expect(events.map(&:name)).to eq(%w[search_started.search search_completed.search])
+      expect(events.last.payload).to include(
+        request_id: 'request-1', search_type: 'classification', result_count: 0, results_type: 'hybrid', search_degraded: false,
+      )
+    end
+
+    it 'emits one terminal retrieval failure' do
+      allow(HybridRetrievalService).to receive(:call) do
+        TradeTariffRequest.record_search_failure(Search::FailureCodes::OPENSEARCH_FAILED)
+        TradeTariffRequest.record_search_failure(Search::FailureCodes::VECTOR_RETRIEVAL_FAILED)
+        raise HybridRetrievalService::AllLegsFailed, 'all legs failed'
+      end
+
+      expect { described_class.new(q: 'horses', request_id: 'request-1').call }.to raise_error(HybridRetrievalService::AllLegsFailed)
+
+      expect(events.map(&:name)).to eq(%w[search_started.search search_failed.search])
+      expect(events.last.payload).to include(
+        request_id: 'request-1', search_type: 'classification', search_degraded: true,
+        opensearch_failed: true, vector_retrieval_failed: true, error_type: 'HybridRetrievalService::AllLegsFailed'
+      )
+    end
+
     it 'always returns the search failures array for an empty query' do
       result = described_class.new(q: '', request_id: 'request-1').call
 
@@ -22,6 +62,10 @@ RSpec.describe Api::V2::ClassificationSearchService do
       response = described_class.new(q: 'horses', request_id: 'request-1').call
 
       expect(response.dig(:meta, :search_failures)).to eq(%w[opensearch_failed])
+      expect(events.last).to have_attributes(
+        name: 'search_completed.search',
+        payload: hash_including(search_type: 'classification', search_degraded: true, opensearch_failed: true),
+      )
     end
   end
 end

--- a/spec/services/hybrid_retrieval_service_spec.rb
+++ b/spec/services/hybrid_retrieval_service_spec.rb
@@ -63,6 +63,54 @@ RSpec.describe HybridRetrievalService do
   end
 
   describe '#call' do
+    context 'with consolidated failure diagnostics' do
+      before do
+        allow(Search::Instrumentation).to receive(:retrieval_leg_completed).and_call_original
+        allow(Search::Instrumentation).to receive(:retrieval_results_returned).and_call_original
+      end
+
+      it 'includes both legs and prior failures' do
+        TradeTariffRequest.record_search_failure(Search::FailureCodes::QUERY_EXPANSION_FAILED)
+        allow(OpensearchRetrievalService).to receive(:call).and_raise(StandardError, 'opensearch down')
+        allow(VectorRetrievalService).to receive(:call_with_diagnostics) do
+          TradeTariffRequest.record_search_failure(Search::FailureCodes::EMBEDDING_GENERATION_FAILED)
+          vector_diagnostics
+        end
+        events = []
+        subscriber = ActiveSupport::Notifications.subscribe(/\A(?:retrieval_leg_completed|retrieval_results_returned)\.search\z/) do |*args|
+          events << ActiveSupport::Notifications::Event.new(*args).payload
+        end
+
+        result = described_class.call(query: 'horses', as_of: Time.zone.today, search_type: 'evaluation')
+
+        expect(result.failure_codes).to contain_exactly('opensearch_failed', 'embedding_generation_failed')
+        expect(TradeTariffRequest.search_failures).to contain_exactly('query_expansion_failed', 'opensearch_failed', 'embedding_generation_failed')
+        expect(events.size).to eq(4)
+        expect(events).to all(
+          include(search_type: 'evaluation', search_degraded: true,
+                  query_expansion_failed: true, opensearch_failed: true, embedding_generation_failed: true),
+        )
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+      end
+
+      it 'emits both final snapshots before raising' do
+        allow(OpensearchRetrievalService).to receive(:call).and_raise(StandardError, 'opensearch down')
+        allow(VectorRetrievalService).to receive(:call_with_diagnostics).and_raise(StandardError, 'vector down')
+        events = []
+        subscriber = ActiveSupport::Notifications.subscribe('retrieval_leg_completed.search') do |*args|
+          events << ActiveSupport::Notifications::Event.new(*args).payload
+        end
+
+        expect { described_class.call(query: 'horses', as_of: Time.zone.today) }.to raise_error(described_class::AllLegsFailed)
+
+        expect(events.size).to eq(2)
+        expect(events).to all(include(search_degraded: true, opensearch_failed: true, vector_retrieval_failed: true))
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+      end
+    end
+
     context 'with request attribution' do
       def request_context
         {
@@ -111,7 +159,7 @@ RSpec.describe HybridRetrievalService do
         described_class.call(query: 'horses', as_of: Time.zone.today)
 
         expect([contexts.pop, contexts.pop]).to all(
-          have_attributes(request_id: nil, experiment: nil, request_source: nil, client_id: nil, search_failures: nil),
+          have_attributes(request_id: nil, experiment: nil, request_source: nil, client_id: nil, search_type: nil, search_failures: nil),
         )
         expect(TradeTariffRequest.search_failures).to contain_exactly('query_expansion_failed', 'embedding_generation_failed')
       end

--- a/spec/terraform/search_experiment_dashboard_spec.rb
+++ b/spec/terraform/search_experiment_dashboard_spec.rb
@@ -229,11 +229,11 @@ RSpec.describe 'search experiment dashboard Terraform' do
     recent_searches_query = operations_widget_query('Recent Searches')
 
     expect(recent_searches_query).to include(
-      'stats latest(@timestamp) as latest_timestamp, latest(query) as query,',
+      'stats latest(@timestamp) as latest_timestamp, latest(query) as latest_query,',
     )
     expect(recent_searches_query).to include('by request_id')
     expect(recent_searches_query).to include(
-      'display latest_timestamp, query, request_source, search_type, request_id',
+      'display latest_timestamp, latest_query, latest_request_source, latest_search_type, request_id',
     )
   end
 

--- a/terraform/modules/search_operations_dashboard/main.tf
+++ b/terraform/modules/search_operations_dashboard/main.tf
@@ -235,9 +235,9 @@ resource "aws_cloudwatch_dashboard" "search_operations" {
             region = var.region
             query  = <<-EOT
               ${local.source}
-              | ${local.service_filter} and event in ["search_failed", "search_completed"]
-              | filter event = "search_failed" or final_result_type = "error"
-              | fields @timestamp, event, request_source, search_type, error_type, final_result_type, error_message, request_id
+              | ${local.service_filter} and event in ["search_failed", "search_stage_failed", "search_completed"]
+              | filter event in ["search_failed", "search_stage_failed"] or final_result_type = "error"
+              | fields @timestamp, event, request_source, search_type, failure_code, operation, error_type, final_result_type, error_message, request_id
               | sort @timestamp desc
               | limit 20
             EOT
@@ -255,10 +255,10 @@ resource "aws_cloudwatch_dashboard" "search_operations" {
             query  = <<-EOT
               ${local.source}
               | ${local.service_filter} and event = "search_started"
-              | stats latest(@timestamp) as latest_timestamp, latest(query) as query,
-                  latest(request_source) as request_source, latest(search_type) as search_type
+              | stats latest(@timestamp) as latest_timestamp, latest(query) as latest_query,
+                  latest(request_source) as latest_request_source, latest(search_type) as latest_search_type
                 by request_id
-              | display latest_timestamp, query, request_source, search_type, request_id
+              | display latest_timestamp, latest_query, latest_request_source, latest_search_type, request_id
               | sort latest_timestamp desc
               | limit 30
             EOT


### PR DESCRIPTION
## What:

- Add a generic degradation flag and six explicit failure booleans to backend search and search-related AI usage events.
- Preserve request and experiment attribution, combine hybrid retrieval failures before completion diagnostics, and instrument classification search outcomes.
- Include recovered stage failures, failure codes and operations in the existing Operations error log, and repair its Recent Searches query aliases.

## Why:

Experiments need to distinguish successful searches from graceful fallbacks and identify the failed component. These fields provide that evidence while keeping billed failures and operational diagnostics visible.

Dashboard cohort exclusion is being handled in separate SQL follow-ups. Staging checks showed that native Logs Insights QL correlation queries can complete with incorrect exclusion counts; equivalent SQL passed whole-request and high-cardinality controls. This PR supplies the event data and does not change the main dashboard cohorts.

Validation: 718 examples passed on the merged main branch across search, AI usage, retrieval, API/request, analytics and Terraform specs. All 15 changed Ruby files passed RuboCop; Terraform formatting, validation and commit hooks passed. Independent extraction review completed. The two changed Operations queries also completed against 30 days of staging logs, returning existing errors and searches.

## Ticket:

[AI-1264](https://transformuk.atlassian.net/browse/AI-1264)

## Risk:

**Risk level:** 🟢

**Reason for rating:** The affected assisted-search functionality is not live. These are covered instrumentation changes and read-only operational dashboard updates, with no feature flags enabled or API response contract changes.