### PR TITLE
Route search alarms to production observability

### DIFF
--- a/terraform/degradation_alarms.tf
+++ b/terraform/degradation_alarms.tf
@@ -2,8 +2,6 @@ locals {
   log_group_name              = "platform-logs-${var.environment}"
   search_operations_dashboard = "SearchOperations-${var.environment}"
 
-  search_alert_actions = var.enable_observability_alerts ? [data.aws_sns_topic.slack_observability_topic[0].arn] : [data.aws_sns_topic.slack_topic.arn]
-
   # Keep legacy boundary events during rolling deployments and application rollbacks.
   # These count failure events, not requests: a stage and its retrieval leg can
   # both match, but share one alarm per component.
@@ -87,8 +85,8 @@ resource "aws_cloudwatch_metric_alarm" "search_degradation" {
   period      = each.value.period
   unit        = "Count"
 
-  alarm_actions = local.search_alert_actions
-  ok_actions    = local.search_alert_actions
+  alarm_actions = [data.aws_sns_topic.slack_observability_topic[0].arn]
+  ok_actions    = [data.aws_sns_topic.slack_observability_topic[0].arn]
 
   depends_on = [aws_cloudwatch_log_metric_filter.search_degradation]
 }

--- a/terraform/degradation_alarms.tf
+++ b/terraform/degradation_alarms.tf
@@ -2,6 +2,8 @@ locals {
   log_group_name              = "platform-logs-${var.environment}"
   search_operations_dashboard = "SearchOperations-${var.environment}"
 
+  search_alert_actions = var.enable_observability_alerts ? [data.aws_sns_topic.slack_observability_topic[0].arn] : [data.aws_sns_topic.slack_topic.arn]
+
   # Keep legacy boundary events during rolling deployments and application rollbacks.
   # These count failure events, not requests: a stage and its retrieval leg can
   # both match, but share one alarm per component.
@@ -85,8 +87,8 @@ resource "aws_cloudwatch_metric_alarm" "search_degradation" {
   period      = each.value.period
   unit        = "Count"
 
-  alarm_actions = [data.aws_sns_topic.slack_topic.arn]
-  ok_actions    = [data.aws_sns_topic.slack_topic.arn]
+  alarm_actions = local.search_alert_actions
+  ok_actions    = local.search_alert_actions
 
   depends_on = [aws_cloudwatch_log_metric_filter.search_degradation]
 }


### PR DESCRIPTION
## What:

- [x] Route OpenSearch, embedding, LLM and vector search alarm notifications through `slack-observability-topic`.
- [x] Reference that topic directly for both ALARM and OK notifications.

Validation: Terraform formatting, full configuration validation, TFLint and commit hooks passed.

## Why:

Search degradation notifications currently go to `#production-alerts`. Sending them through the existing observability topic directs them to `#production-observability`, where search dependency failures can be monitored. These alarms are enabled only in production, which already enables the observability topic lookup.

## Ticket:

N/A

## Risk:

**Risk level:** Green (low-risk)

**Reason for rating:** Only the notification destination changes. Alarm conditions and thresholds are preserved. A live AWS plan and delivery check have not been run locally.
