### PR TITLE
AI-1264: Exclude degraded requests from search overview and snapshots

### DIFF
--- a/.github/workflows/deploy-to-development.yml
+++ b/.github/workflows/deploy-to-development.yml
@@ -76,7 +76,19 @@ jobs:
           aws-region: eu-west-2
           role-to-assume: ${{ steps.environment-config.outputs.deploy-role-arn }}
 
+      - uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: 1.12.2
+          terraform_wrapper: false
+
+      - name: Render dashboard queries
+        env:
+          CLOUDWATCH_QUERY_VALIDATION_LOG_GROUP: ${{ steps.environment-config.outputs.log-group }}
+          CLOUDWATCH_DASHBOARD_QUERIES_FILE: /tmp/search-dashboard-queries.json
+        run: bundle exec rake search_analytics:render_dashboard_queries
+
       - name: Validate CloudWatch queries
         env:
+          CLOUDWATCH_DASHBOARD_QUERIES_FILE: /tmp/search-dashboard-queries.json
           CLOUDWATCH_QUERY_VALIDATION_LOG_GROUP: ${{ steps.environment-config.outputs.log-group }}
         run: bundle exec rake search_analytics:validate_cloudwatch_queries

--- a/app/services/search_analytics/cloudwatch_query_validator.rb
+++ b/app/services/search_analytics/cloudwatch_query_validator.rb
@@ -9,22 +9,23 @@ module SearchAnalytics
     ValidationError = Class.new(StandardError)
     QueryError = Class.new(StandardError)
 
-    def self.call(log_group_name:, client: Aws::CloudWatchLogs::Client.new, now: Time.current, output: $stdout)
-      new(log_group_name:, client:, now:, output:).call
+    def self.call(log_group_name:, client: Aws::CloudWatchLogs::Client.new, now: Time.current, output: $stdout, dashboard_queries: {})
+      new(log_group_name:, client:, now:, output:, dashboard_queries:).call
     end
 
-    def initialize(log_group_name:, client:, now:, output:)
+    def initialize(log_group_name:, client:, now:, output:, dashboard_queries:)
       @log_group_name = log_group_name
       @client = client
       @now = now
       @output = output
+      @dashboard_queries = dashboard_queries
     end
 
     def call
       failures = []
 
-      distinct_queries.each do |query_string, references|
-        validate_query(query_string)
+      distinct_queries.each do |query, references|
+        validate_query(query)
         output.puts("Validated #{references.join(', ')}")
       rescue Aws::CloudWatchLogs::Errors::MalformedQueryException => e
         failures << "#{references.join(', ')}: #{compile_error_message(e)}"
@@ -40,22 +41,31 @@ module SearchAnalytics
 
   private
 
-    attr_reader :log_group_name, :client, :now, :output
+    attr_reader :log_group_name, :client, :now, :output, :dashboard_queries
 
     def distinct_queries
-      @distinct_queries ||= SnapshotRefresh::PERIODS.each_with_object(Hash.new { |hash, query| hash[query] = [] }) do |period, queries|
-        CloudwatchSnapshotQuery.query_definitions(period:).each do |name, query_string|
-          queries[query_string] << "#{period}/#{name}"
+      @distinct_queries ||= SnapshotRefresh::PERIODS.each_with_object(Hash.new { |hash, query| hash[query] = [] }) { |period, queries|
+        CloudwatchSnapshotQuery.query_definitions(period:, log_group_name:).each do |name, query_string|
+          queries[{ query_string:, query_language: 'SQL' }] << "#{period}/#{name}"
         end
+      }.tap do |queries|
+        dashboard_queries.each { |name, query| queries[query.symbolize_keys] << name }
       end
     end
 
-    def validate_query(query_string)
+    def validate_query(query)
+      query_string = query.fetch(:query_string)
+      query_language = query.fetch(:query_language)
+      groups = query_string.scan(/\bFROM\s+`([^`]+)`|\bSOURCE\s+'([^']+)'/i).flatten.compact
+      raise QueryError, 'Query references a different log group' unless groups.all? { |group| group == log_group_name }
+
+      query_string = query_string.sub(/\A\s*SOURCE\s+'[^']+'\s*\|\s*/i, '')
+      source = query_language == 'SQL' ? {} : { log_group_name: }
       query_id = client.start_query(
-        log_group_name:,
+        **source,
         start_time: (now - LOOKBACK).to_i,
         end_time: now.to_i,
-        query_language: 'CWLI',
+        query_language:,
         query_string:,
       ).query_id
 

--- a/app/services/search_analytics/cloudwatch_snapshot_query.rb
+++ b/app/services/search_analytics/cloudwatch_snapshot_query.rb
@@ -35,16 +35,17 @@ module SearchAnalytics
     REQUEST_SOURCES = %w[frontend backend_only unknown].freeze
     QueryError = Class.new(StandardError)
 
-    def self.call(period:, client: self.client, now: Time.current) = new(period:, client:, now:).call
+    def self.call(period:, client: self.client, now: Time.current, log_group_name: SEARCH_LOG_GROUP_NAME) = new(period:, client:, now:, log_group_name:).call
 
-    def self.query_definitions(period:) = new(period:, client: nil).query_definitions
+    def self.query_definitions(period:, log_group_name: SEARCH_LOG_GROUP_NAME) = new(period:, client: nil, log_group_name:).query_definitions
 
     def self.client = @client ||= Aws::CloudWatchLogs::Client.new
 
-    def initialize(period:, client: self.class.client, now: Time.current)
+    def initialize(period:, client: self.class.client, now: Time.current, log_group_name: SEARCH_LOG_GROUP_NAME)
       @period = Period.for(period:, view: 'all')
       @client = client
       @now = now
+      @log_group_name = log_group_name
     end
 
     def call
@@ -95,11 +96,11 @@ module SearchAnalytics
 
   private
 
-    attr_reader :period, :client, :now
+    attr_reader :period, :client, :now, :log_group_name
 
     def run_query(query_string)
       query_id = client.start_query(
-        log_group_name: SEARCH_LOG_GROUP_NAME,
+        query_language: 'SQL',
         start_time: (now - period.duration).to_i,
         end_time: now.to_i,
         query_string: query_string,
@@ -129,214 +130,159 @@ module SearchAnalytics
       AGGREGATED_COST_FIELDS.fetch(field, field)
     end
 
-    def bucket_expression = period.bucket_size == 'hour' ? 'bin(1h)' : 'bin(1d)'
+    def bucket_expression = "DATE_TRUNC('#{bucket_period}', `@timestamp`)"
 
-    def bucket_period = period.bucket_size == 'hour' ? '1h' : '1d'
+    def bucket_period = period.bucket_size == 'hour' ? 'HOUR' : 'DAY'
 
-    def base_search_filter = 'filter service = "search" and event in ["search_completed", "search_failed"]'
+    def source = "`#{log_group_name}`"
 
-    def log_stream_filter = %(filter @logStream like "ecs/backend-#{TradeTariffBackend.service}/")
+    def base_search_filter = "service = 'search' AND event IN ('search_completed', 'search_failed')"
+
+    def log_stream_filter = "`@logStream` LIKE '%ecs/backend-#{TradeTariffBackend.service}/%'"
+
+    def request_exclusion_filter
+      Rails.root.join('app/services/search_analytics/request_exclusion_filter.sql.tftpl').read
+        .gsub('${log_group_name}', log_group_name)
+        .gsub('${scope_condition}', log_stream_filter)
+    end
 
     def volume_query
       <<~QUERY
-        fields @timestamp, event, search_type
-        | #{log_stream_filter}
-        | #{base_search_filter}
-        | fields if(ispresent(request_source), request_source, "unknown") as request_source
-        | stats count(*) as searches by #{bucket_expression}, search_type, event, request_source
+        SELECT #{bucket_expression} AS `@timestamp`, search_type, event,
+          COALESCE(request_source, 'unknown') AS request_source, COUNT(*) AS searches
+        FROM #{source} WHERE #{log_stream_filter} AND #{base_search_filter} AND #{request_exclusion_filter}
+        GROUP BY #{bucket_expression}, search_type, event, COALESCE(request_source, 'unknown')
       QUERY
     end
 
-    # Shared by classic + interactive dashboards and admin analytics.
-    #
-    # Classic empty commodity results = fuzzy/null with commodity_result_count = 0
-    # (empty "Best commodity matches"). That includes:
-    #   - completely empty results (result_count = 0)
-    #   - headings/chapters/other hits only (result_count > 0)
-    # Exact matches are never empty-commodity results.
-    #
-    # Interactive empty results = result_count = 0 (filter also accepts search_type=internal).
-    # Historical classic logs without commodity_result_count fall back to result_count = 0.
-    # Keep in sync with terraform/modules/search_*_dashboard zero_result_condition locals.
+    # Keep empty-commodity semantics in sync with terraform/modules/search_*_dashboard.
     def zero_result_condition
       <<~CONDITION.squish
-        (
-          (search_type = "classic" and (
-            (ispresent(commodity_result_count) and commodity_result_count = 0 and (not ispresent(results_type) or results_type != "exact_search"))
-            or
-            (not ispresent(commodity_result_count) and result_count = 0)
-          ))
-          or
-          ((search_type = "interactive" or search_type = "internal") and result_count = 0)
-        )
+        ((search_type = 'classic' AND (
+          (commodity_result_count IS NOT NULL AND commodity_result_count = 0 AND (results_type IS NULL OR results_type != 'exact_search'))
+          OR (commodity_result_count IS NULL AND result_count = 0)))
+        OR ((search_type = 'interactive' OR search_type = 'internal') AND result_count = 0))
       CONDITION
     end
 
     def zero_result_query
       <<~QUERY
-        fields @timestamp, event, search_type, result_count, commodity_result_count
-        | #{log_stream_filter}
-        | filter service = "search" and event = "search_completed" and #{zero_result_condition}
-        | fields if(ispresent(request_source), request_source, "unknown") as request_source
-        | stats count(*) as zero_results by #{bucket_expression}, search_type, request_source
+        SELECT #{bucket_expression} AS `@timestamp`, search_type,
+          COALESCE(request_source, 'unknown') AS request_source, COUNT(*) AS zero_results
+        FROM #{source} WHERE #{log_stream_filter} AND service = 'search' AND event = 'search_completed'
+          AND #{zero_result_condition} AND #{request_exclusion_filter}
+        GROUP BY #{bucket_expression}, search_type, COALESCE(request_source, 'unknown')
       QUERY
     end
 
-    def summary_all_latency_query
-      <<~QUERY
-        fields event, total_duration_ms
-        | #{log_stream_filter}
-        | #{base_search_filter} and ispresent(total_duration_ms)
-        | stats pct(total_duration_ms, 90) as p90_latency_ms
-      QUERY
-    end
+    def summary_all_latency_query = latency_query
 
-    def summary_view_latency_query
-      <<~QUERY
-        fields event, search_type, total_duration_ms
-        | #{log_stream_filter}
-        | #{base_search_filter} and ispresent(total_duration_ms)
-        | stats pct(total_duration_ms, 90) as p90_latency_ms by search_type
-      QUERY
-    end
+    def summary_view_latency_query = latency_query('search_type')
 
-    def source_all_latency_query
-      <<~QUERY
-        fields event, total_duration_ms
-        | #{log_stream_filter}
-        | #{base_search_filter} and ispresent(total_duration_ms)
-        | fields if(ispresent(request_source), request_source, "unknown") as request_source
-        | stats pct(total_duration_ms, 90) as p90_latency_ms by request_source
-      QUERY
-    end
+    def source_all_latency_query = latency_query("COALESCE(request_source, 'unknown') AS request_source")
 
-    def source_view_latency_query
+    def source_view_latency_query = latency_query("search_type, COALESCE(request_source, 'unknown') AS request_source")
+
+    def latency_query(dimensions = nil)
       <<~QUERY
-        fields event, search_type, total_duration_ms
-        | #{log_stream_filter}
-        | #{base_search_filter} and ispresent(total_duration_ms)
-        | fields if(ispresent(request_source), request_source, "unknown") as request_source
-        | stats pct(total_duration_ms, 90) as p90_latency_ms by search_type, request_source
+        SELECT PERCENTILE_APPROX(total_duration_ms, 0.9) AS p90_latency_ms#{", #{dimensions}" if dimensions}
+        FROM #{source} WHERE #{log_stream_filter} AND #{base_search_filter}
+          AND total_duration_ms IS NOT NULL AND #{request_exclusion_filter}
+        #{"GROUP BY #{dimensions.delete_suffix(' AS request_source')}" if dimensions}
       QUERY
     end
 
     def ai_cost_summary_query
       <<~QUERY
-        fields request_id, service, event, event_kind, total_tokens, total_cost_usd, pricing_known
-        | #{log_stream_filter}
-        | #{search_ai_cost_filter}
-        | fields if(pricing_known = true and ispresent(total_cost_usd), total_cost_usd, 0) as known_cost_usd
-        | fields if(pricing_known = true and ispresent(total_cost_usd), 1, 0) as priced
-        | fields if(pricing_known = true and ispresent(total_cost_usd), 0, 1) as unpriced
-        | stats sum(known_cost_usd) as request_cost_usd,
-            sum(priced) as request_priced_calls,
-            sum(unpriced) as request_unpriced_calls by request_id
-        | stats sum(request_cost_usd) as aggregated_total_cost_usd,
-            avg(request_cost_usd) as aggregated_average_cost_usd,
-            pct(request_cost_usd, 50) as aggregated_p50_cost_usd,
-            pct(request_cost_usd, 90) as aggregated_p90_cost_usd,
-            count(*) as aggregated_assisted_searches,
-            sum(request_priced_calls) as aggregated_priced_calls,
-            sum(request_unpriced_calls) as aggregated_unpriced_calls
+        SELECT SUM(request_cost_usd) AS aggregated_total_cost_usd,
+          AVG(request_cost_usd) AS aggregated_average_cost_usd,
+          PERCENTILE_APPROX(request_cost_usd, 0.5) AS aggregated_p50_cost_usd,
+          PERCENTILE_APPROX(request_cost_usd, 0.9) AS aggregated_p90_cost_usd,
+          COUNT(*) AS aggregated_assisted_searches,
+          SUM(request_priced_calls) AS aggregated_priced_calls,
+          SUM(request_unpriced_calls) AS aggregated_unpriced_calls
+        FROM (
+          SELECT request_id,
+            SUM(CASE WHEN pricing_known = true AND total_cost_usd IS NOT NULL THEN total_cost_usd ELSE 0 END) AS request_cost_usd,
+            SUM(CASE WHEN pricing_known = true AND total_cost_usd IS NOT NULL THEN 1 ELSE 0 END) AS request_priced_calls,
+            SUM(CASE WHEN pricing_known = true AND total_cost_usd IS NOT NULL THEN 0 ELSE 1 END) AS request_unpriced_calls
+          FROM #{source} WHERE #{log_stream_filter} AND #{search_ai_cost_filter}
+          GROUP BY request_id
+        ) AS request_costs
+        WHERE #{request_exclusion_filter}
       QUERY
     end
 
     def ai_cost_trend_query
       <<~QUERY
-        fields @timestamp, request_id, service, event, event_kind, input_tokens, cached_input_tokens, cache_write_input_tokens, output_tokens, total_tokens, input_cost_usd, cached_input_cost_usd, cache_write_input_cost_usd, output_cost_usd, total_cost_usd, pricing_known
-        | #{log_stream_filter}
-        | #{search_ai_cost_filter}
-        | fields if(pricing_known = true and service = "search", input_cost_usd, 0) as model_input_cost_usd
-        | fields if(pricing_known = true and service = "search", cached_input_cost_usd, 0) as model_cached_input_cost_usd
-        | fields if(pricing_known = true and service = "search", cache_write_input_cost_usd, 0) as model_cache_write_input_cost_usd
-        | fields if(pricing_known = true and service = "search", output_cost_usd, 0) as model_output_cost_usd
-        | fields if(pricing_known = true and service = "ai_usage", total_cost_usd, 0) as model_embedding_cost_usd
-        | fields if(pricing_known = true and ispresent(total_cost_usd), total_cost_usd, 0) as known_cost_usd
-        | fields if(pricing_known = true and ispresent(total_cost_usd), 1, 0) as priced_call
-        | fields if(pricing_known = true and ispresent(total_cost_usd), 0, 1) as unpriced_call
-        | stats sum(model_input_cost_usd) as aggregated_input_cost_usd,
-            sum(model_cached_input_cost_usd) as aggregated_cached_input_cost_usd,
-            sum(model_cache_write_input_cost_usd) as aggregated_cache_write_input_cost_usd,
-            sum(model_output_cost_usd) as aggregated_output_cost_usd,
-            sum(model_embedding_cost_usd) as aggregated_embedding_cost_usd,
-            sum(known_cost_usd) as aggregated_total_cost_usd,
-            sum(input_tokens) as aggregated_input_tokens,
-            sum(cached_input_tokens) as aggregated_cached_input_tokens,
-            sum(cache_write_input_tokens) as aggregated_cache_write_input_tokens,
-            sum(output_tokens) as aggregated_output_tokens,
-            sum(total_tokens) as aggregated_total_tokens,
-            count(*) as aggregated_calls,
-            sum(priced_call) as aggregated_priced_calls,
-            sum(unpriced_call) as aggregated_unpriced_calls by #{bucket_expression}, event_kind
+        SELECT #{bucket_expression} AS `@timestamp`, event_kind,
+          SUM(CASE WHEN pricing_known = true AND service = 'search' THEN input_cost_usd ELSE 0 END) AS aggregated_input_cost_usd,
+          SUM(CASE WHEN pricing_known = true AND service = 'search' THEN cached_input_cost_usd ELSE 0 END) AS aggregated_cached_input_cost_usd,
+          SUM(CASE WHEN pricing_known = true AND service = 'search' THEN cache_write_input_cost_usd ELSE 0 END) AS aggregated_cache_write_input_cost_usd,
+          SUM(CASE WHEN pricing_known = true AND service = 'search' THEN output_cost_usd ELSE 0 END) AS aggregated_output_cost_usd,
+          SUM(CASE WHEN pricing_known = true AND service = 'ai_usage' THEN total_cost_usd ELSE 0 END) AS aggregated_embedding_cost_usd,
+          SUM(CASE WHEN pricing_known = true AND total_cost_usd IS NOT NULL THEN total_cost_usd ELSE 0 END) AS aggregated_total_cost_usd,
+          SUM(input_tokens) AS aggregated_input_tokens, SUM(cached_input_tokens) AS aggregated_cached_input_tokens,
+          SUM(cache_write_input_tokens) AS aggregated_cache_write_input_tokens, SUM(output_tokens) AS aggregated_output_tokens,
+          SUM(total_tokens) AS aggregated_total_tokens, COUNT(*) AS aggregated_calls,
+          SUM(CASE WHEN pricing_known = true AND total_cost_usd IS NOT NULL THEN 1 ELSE 0 END) AS aggregated_priced_calls,
+          SUM(CASE WHEN pricing_known = true AND total_cost_usd IS NOT NULL THEN 0 ELSE 1 END) AS aggregated_unpriced_calls
+        FROM #{source} WHERE #{log_stream_filter} AND #{search_ai_cost_filter} AND #{request_exclusion_filter}
+        GROUP BY #{bucket_expression}, event_kind
       QUERY
     end
 
     def search_ai_cost_filter
       <<~FILTER.squish
-        filter ispresent(request_id) and ispresent(total_tokens) and
-          ((service = "search" and event = "api_call_completed") or
-          (service = "ai_usage" and event in ["embedding_api_call_completed", "embedding_api_call_failed"] and event_kind = "vector_search_query_embedding"))
+        request_id IS NOT NULL AND total_tokens IS NOT NULL
+        AND event IN ('api_call_completed', 'embedding_api_call_completed', 'embedding_api_call_failed')
+        AND ((service = 'search' AND event = 'api_call_completed') OR
+          (service = 'ai_usage' AND event IN ('embedding_api_call_completed', 'embedding_api_call_failed') AND event_kind = 'vector_search_query_embedding'))
       FILTER
     end
 
-    def selection_queries
+    def selection_queries(trend: false)
       {
-        'classic' => selection_query('search_type = "classic" and results_type = "fuzzy_search"'),
-        'internal' => selection_query('(search_type = "interactive" or search_type = "internal") and (results_type = "opensearch" or results_type = "vector" or results_type = "hybrid")'),
+        'classic' => selection_query("search_type = 'classic' AND results_type = 'fuzzy_search'", trend:),
+        'internal' => selection_query("search_type IN ('interactive', 'internal') AND results_type IN ('opensearch', 'vector', 'hybrid')", trend:),
       }
     end
 
-    def selection_query(selectable_condition)
+    # JSON extraction preserves request_source when SQL prunes fields outside GROUP BY.
+    def selection_query(selectable_condition, trend:)
+      dimension = trend ? "DATE_TRUNC('#{bucket_period}', latest_timestamp)" : 'source'
       <<~QUERY
-        fields request_id, event, search_type, result_count, results_type
-        | #{log_stream_filter}
-        | filter service = "search" and ispresent(request_id) and (event = "result_selected" or (event = "search_completed" and result_count > 0 and #{selectable_condition}))
-        | fields if(event = "result_selected", 1, 0) as result_selection_marker
-        | fields if(event = "search_completed" and result_count > 0 and #{selectable_condition}, 1, 0) as selectable_search_marker
-        | fields if(ispresent(request_source), request_source, "unknown") as request_source
-        | stats sum(result_selection_marker) as result_selections,
-            sum(selectable_search_marker) as selectable_searches,
-            earliest(request_source) as source by request_id
-        | filter selectable_searches > 0
-        | stats sum(result_selections) as selected, sum(selectable_searches) as selectable by source
+        SELECT SUM(result_selections) AS selected, SUM(selectable_searches) AS selectable,
+          #{dimension} AS #{trend ? '`@timestamp`' : 'source'}
+        FROM (
+          SELECT request_id, SUM(CASE WHEN event = 'result_selected' THEN 1 ELSE 0 END) AS result_selections,
+            SUM(CASE WHEN event = 'search_completed' AND result_count > 0 AND #{selectable_condition} THEN 1 ELSE 0 END) AS selectable_searches,
+            MIN_BY(COALESCE(GET_JSON_OBJECT(`@message`, '$.request_source'), 'unknown'), `@timestamp`) AS source, MAX(`@timestamp`) AS latest_timestamp
+          FROM #{source} WHERE #{log_stream_filter} AND service = 'search' AND request_id IS NOT NULL
+            AND (event = 'result_selected' OR (event = 'search_completed' AND result_count > 0 AND #{selectable_condition}))
+          GROUP BY request_id
+        ) AS request_selections
+        WHERE selectable_searches > 0 AND #{request_exclusion_filter}
+        GROUP BY #{dimension}
       QUERY
     end
 
-    def selection_trend_queries
-      selection_queries.transform_values do |query|
-        query
-          .sub(
-            'earliest(request_source) as source by request_id',
-            'earliest(request_source) as source, max(@timestamp) as @t by request_id',
-          )
-          .sub(
-            '| stats sum(result_selections) as selected, sum(selectable_searches) as selectable by source',
-            "| stats sum(result_selections) as selected by datefloor(@t, #{bucket_period}) as @timestamp",
-          )
-      end
-    end
+    def selection_trend_queries = selection_queries(trend: true)
 
     def improvement_term_queries
       {
-        'search_terms' => improvement_terms_query(term_filter: 'query not like /^[0-9 .-]+$/'),
-        'item_ids' => improvement_terms_query(term_filter: 'query like /^[0-9 .-]+$/'),
+        'search_terms' => improvement_terms_query(term_filter: "query NOT RLIKE '^[0-9 .-]+$'"),
+        'item_ids' => improvement_terms_query(term_filter: "query RLIKE '^[0-9 .-]+$'"),
       }
     end
 
-    def improvement_terms_query(term_filter: nil)
-      [
-        <<~QUERY,
-          fields query, search_type, result_count, commodity_result_count
-          | #{log_stream_filter}
-          | filter service = "search" and event = "search_completed" and #{zero_result_condition} and ispresent(query)
-        QUERY
-        ("| filter #{term_filter}\n" if term_filter.present?),
-        <<~QUERY,
-          | stats count(*) as zero_results by query, search_type
-          | sort zero_results desc
-          | limit #{IMPROVEMENT_TERM_LIMIT * VIEWS.size}
-        QUERY
-      ].compact.join
+    def improvement_terms_query(term_filter:)
+      <<~QUERY
+        SELECT query, search_type, COUNT(*) AS zero_results
+        FROM #{source} WHERE #{log_stream_filter} AND service = 'search' AND event = 'search_completed'
+          AND #{zero_result_condition} AND query IS NOT NULL AND #{term_filter} AND #{request_exclusion_filter}
+        GROUP BY query, search_type ORDER BY zero_results DESC LIMIT #{IMPROVEMENT_TERM_LIMIT * VIEWS.size}
+      QUERY
     end
 
     class Aggregate

--- a/app/services/search_analytics/cloudwatch_snapshot_query.rb
+++ b/app/services/search_analytics/cloudwatch_snapshot_query.rb
@@ -510,19 +510,14 @@ module SearchAnalytics
             'level' => 'neutral',
             'message' => 'Search volume is available for this period',
           },
-          'failure_rate' => status_for_failure_rate(current_summary.fetch('failure_rate')),
+          'failure_rate' => {
+            'level' => 'neutral',
+            'message' => 'Known failed or degraded requests are excluded',
+          },
           'zero_result_rate' => status_for_zero_result_rate(current_summary.fetch('zero_result_rate')),
           'selection_rate' => status_for_selection_rate(current_summary.fetch('selection_rate')),
           'p90_latency_ms' => status_for_latency(current_summary.fetch('p90_latency_ms')),
         }
-      end
-
-      def status_for_failure_rate(value)
-        case value
-        when 0...0.02 then { 'level' => 'good', 'message' => 'Failures are low' }
-        when 0.02...0.05 then { 'level' => 'watch', 'message' => 'Failures are slightly higher than usual' }
-        else { 'level' => 'problem', 'message' => 'Failures are higher than expected' }
-        end
       end
 
       def status_for_zero_result_rate(value)

--- a/app/services/search_analytics/dashboard_query_catalog.rb
+++ b/app/services/search_analytics/dashboard_query_catalog.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'open3'
+require 'tmpdir'
+
+module SearchAnalytics
+  class DashboardQueryCatalog
+    DASHBOARDS = %w[search_dashboard search_quality_dashboard search_experiment_dashboard search_operations_dashboard ai_costs_dashboard].freeze
+
+    def self.call(log_group_name:)
+      Dir.mktmpdir('search-dashboard-queries') do |directory|
+        configuration = {
+          terraform: { required_providers: { aws: { source: 'hashicorp/aws', version: '~> 5' } } },
+          module: DASHBOARDS.index_with do |name|
+            source = Rails.root.join('terraform/modules', name).relative_path_from(Pathname.new(directory)).to_s
+            { source:, environment: 'validation', log_group_name:, region: 'eu-west-2' }
+          end,
+        }
+        File.write(File.join(directory, 'main.tf.json'), configuration.to_json)
+        FileUtils.cp(Rails.root.join('terraform/.terraform.lock.hcl'), directory)
+        run(directory, 'init', '-backend=false', '-input=false', '-no-color')
+        run(directory, 'validate', '-no-color')
+        expression = DASHBOARDS.map { |name| "#{name} = module.#{name}.queries" }.join(', ')
+        rendered = run(directory, 'console', '-no-color', stdin_data: "jsonencode({#{expression}})\n")
+        JSON.parse(JSON.parse(rendered)).each_with_object({}) do |(dashboard, queries), catalog|
+          queries.each { |title, query| catalog["#{dashboard}/#{title}"] = query }
+        end
+      end
+    end
+
+    def self.run(directory, *arguments, **options)
+      output, error, status = Open3.capture3('terraform', "-chdir=#{directory}", *arguments, **options)
+      raise "Terraform dashboard rendering failed: #{error.presence || output}" unless status.success?
+
+      output
+    end
+    private_class_method :run
+  end
+end

--- a/app/services/search_analytics/request_exclusion_filter.sql.tftpl
+++ b/app/services/search_analytics/request_exclusion_filter.sql.tftpl
@@ -1,0 +1,6 @@
+(request_id IS NULL OR request_id = '' OR request_id NOT IN (
+  SELECT request_id FROM `${log_group_name}`
+  WHERE ${scope_condition}
+    AND service = 'search' AND request_id IS NOT NULL AND request_id != ''
+    AND (search_degraded = true OR event IN ('search_failed', 'search_stage_failed'))
+))

--- a/docs/architecture/search-and-indexing.md
+++ b/docs/architecture/search-and-indexing.md
@@ -144,3 +144,13 @@ input phrase => input phrase, lexical alternative
 ```
 
 Rules are matched case-insensitively against complete terms or phrases. Keep mappings contextual: prefer `HEPA filter` or `USB connector` to broad rules for `HEPA` or `USB`.
+
+### Search analytics SQL cohorts
+
+Admin analytics snapshots and Search Overview exclude every event for a request ID with a recorded `search_degraded: true`, `search_failed`, or `search_stage_failed` search event in the selected time window. The snapshot failure lookup uses the same UK/XI log stream as its metrics. Missing, null, and empty request IDs remain included, as do historical requests without a linked failure. Use the complete journey window: a failure outside that window cannot exclude an event inside it. Operations, Quality, Experiment, and general AI Costs retain their existing cohorts in this extraction.
+
+The shared `request_exclusion_filter.sql.tftpl` contains the SQL predicate used by Ruby and Terraform, with no inner row limit. Two-stage cost and selection queries place the failure lookup beside the request aggregation subquery to respect CloudWatch SQL's one-level nesting limit. Snapshot payload fields and millisecond units remain unchanged; Overview displays seconds. SQL percentiles use fractions and can differ slightly from QL's approximate percentiles.
+
+Development validation renders the real Terraform widget queries with `search_analytics:render_dashboard_queries`, then executes them and all distinct snapshot queries with `search_analytics:validate_cloudwatch_queries`. Both tasks use `CLOUDWATCH_QUERY_VALIDATION_LOG_GROUP`; `CLOUDWATCH_DASHBOARD_QUERIES_FILE` connects rendering to validation. Rendering does not access AWS. Validation preserves native QL query languages and uses SQL for migrated consumers. AWS documents SQL log widgets through [LogQueryLanguage](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_cloudwatch.LogQueryLanguage.html) and [LogQueryWidgetProps](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_cloudwatch.LogQueryWidgetProps.html).
+
+SQL dashboard widgets retain the `SOURCE 'group' |` envelope produced by the [AWS CDK implementation](https://github.com/aws/aws-cdk/issues/34482). The validator checks that source and every SQL FROM group, then removes only the leading dashboard envelope before StartQuery. Direct snapshot SQL obtains its group from FROM. Widget serialization follows that supported representation; validation does not publish a dashboard.

--- a/lib/tasks/search_analytics.rake
+++ b/lib/tasks/search_analytics.rake
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
 namespace :search_analytics do
+  desc 'Render the actual Terraform dashboard queries without AWS access'
+  task :render_dashboard_queries do # rubocop:disable Rails/RakeEnvironment
+    require Rails.root.join('app/services/search_analytics/dashboard_query_catalog')
+
+    catalog = SearchAnalytics::DashboardQueryCatalog.call(log_group_name: ENV.fetch('CLOUDWATCH_QUERY_VALIDATION_LOG_GROUP'))
+    File.write(ENV.fetch('CLOUDWATCH_DASHBOARD_QUERIES_FILE'), JSON.pretty_generate(catalog))
+  end # rubocop:enable Rails/RakeEnvironment
+
   desc 'Validate generated CloudWatch Logs Insights queries in AWS'
   # This CI task deliberately avoids booting the database-backed Rails environment.
   task :validate_cloudwatch_queries do # rubocop:disable Rails/RakeEnvironment
@@ -10,6 +18,7 @@ namespace :search_analytics do
 
     SearchAnalytics::CloudwatchQueryValidator.call(
       log_group_name: ENV.fetch('CLOUDWATCH_QUERY_VALIDATION_LOG_GROUP'),
+      dashboard_queries: ENV['CLOUDWATCH_DASHBOARD_QUERIES_FILE'] ? JSON.parse(File.read(ENV.fetch('CLOUDWATCH_DASHBOARD_QUERIES_FILE'))) : {},
     )
   end # rubocop:enable Rails/RakeEnvironment
 end

--- a/spec/services/search_analytics/cloudwatch_query_validator_spec.rb
+++ b/spec/services/search_analytics/cloudwatch_query_validator_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe SearchAnalytics::CloudwatchQueryValidator do
 
   before do
     allow(SearchAnalytics::CloudwatchSnapshotQuery).to receive(:query_definitions).and_return(
-      { 'volume' => 'fields event | stats count(*)' },
-      { 'volume' => 'fields event | stats count(*) by bin(1d)' },
-      { 'volume' => 'fields event | stats count(*) by bin(1d)' },
+      { 'volume' => 'SELECT COUNT(*) FROM `platform-logs-development`' },
+      { 'volume' => "SELECT COUNT(*) FROM `platform-logs-development` GROUP BY DATE_TRUNC('DAY', `@timestamp`)" },
+      { 'volume' => "SELECT COUNT(*) FROM `platform-logs-development` GROUP BY DATE_TRUNC('DAY', `@timestamp`)" },
     )
     allow(client).to receive_messages(
       start_query: instance_double(Aws::CloudWatchLogs::Types::StartQueryResponse, query_id: 'query-id'),
@@ -31,24 +31,48 @@ RSpec.describe SearchAnalytics::CloudwatchQueryValidator do
 
   it 'executes every distinct generated query against development AWS' do
     expect(validate).to be(true)
-    expect(SearchAnalytics::CloudwatchSnapshotQuery).to have_received(:query_definitions).with(period: '24h')
-    expect(SearchAnalytics::CloudwatchSnapshotQuery).to have_received(:query_definitions).with(period: '7d')
-    expect(SearchAnalytics::CloudwatchSnapshotQuery).to have_received(:query_definitions).with(period: '30d')
+    expect(SearchAnalytics::CloudwatchSnapshotQuery).to have_received(:query_definitions).with(period: '24h', log_group_name: 'platform-logs-development')
+    expect(SearchAnalytics::CloudwatchSnapshotQuery).to have_received(:query_definitions).with(period: '7d', log_group_name: 'platform-logs-development')
+    expect(SearchAnalytics::CloudwatchSnapshotQuery).to have_received(:query_definitions).with(period: '30d', log_group_name: 'platform-logs-development')
     expect(client).to have_received(:start_query).with(
-      log_group_name: 'platform-logs-development',
       start_time: (now - 5.minutes).to_i,
       end_time: now.to_i,
-      query_language: 'CWLI',
-      query_string: 'fields event | stats count(*)',
+      query_language: 'SQL',
+      query_string: 'SELECT COUNT(*) FROM `platform-logs-development`',
     ).once
     expect(client).to have_received(:start_query).with(
-      log_group_name: 'platform-logs-development',
       start_time: (now - 5.minutes).to_i,
       end_time: now.to_i,
-      query_language: 'CWLI',
-      query_string: 'fields event | stats count(*) by bin(1d)',
+      query_language: 'SQL',
+      query_string: "SELECT COUNT(*) FROM `platform-logs-development` GROUP BY DATE_TRUNC('DAY', `@timestamp`)",
     ).once
     expect(output.string).to include('Validated 2 distinct CloudWatch queries')
+  end
+
+  it 'validates rendered native dashboard queries alongside SQL snapshots' do
+    described_class.call(log_group_name: 'platform-logs-development', client:, now:, output:,
+                         dashboard_queries: { 'operations' => { 'query_language' => 'CWLI', 'query_string' => "SOURCE 'platform-logs-development' | stats count(*)" } })
+
+    expect(client).to have_received(:start_query).with(hash_including(
+                                                         log_group_name: 'platform-logs-development', query_language: 'CWLI', query_string: 'stats count(*)',
+                                                       ))
+  end
+
+  it 'strips the dashboard source envelope from SQL before calling StartQuery' do
+    described_class.call(log_group_name: 'platform-logs-development', client:, now:, output:,
+                         dashboard_queries: { 'overview' => { 'query_language' => 'SQL', 'query_string' => "SOURCE 'platform-logs-development' | SELECT COUNT(*) FROM `platform-logs-development`" } })
+
+    expect(client).to have_received(:start_query).with(hash_including(query_language: 'SQL', query_string: 'SELECT COUNT(*) FROM `platform-logs-development`')).twice
+    expect(client).not_to have_received(:start_query).with(hash_including(:log_group_name))
+  end
+
+  it 'rejects an unexpected inner SQL source before executing it' do
+    allow(SearchAnalytics::CloudwatchSnapshotQuery).to receive(:query_definitions).and_return(
+      { 'wrong' => 'SELECT request_id FROM `platform-logs-development` WHERE request_id NOT IN (SELECT request_id FROM `production`)' },
+    )
+
+    expect { validate }.to raise_error(described_class::ValidationError, /different log group/)
+    expect(client).not_to have_received(:start_query)
   end
 
   it 'polls until AWS completes the query' do

--- a/spec/services/search_analytics/cloudwatch_snapshot_query_spec.rb
+++ b/spec/services/search_analytics/cloudwatch_snapshot_query_spec.rb
@@ -147,6 +147,14 @@ RSpec.describe SearchAnalytics::CloudwatchSnapshotQuery do
       expect(definitions.values).to all(be_a(String).and(be_present))
     end
 
+    it 'excludes complete failed request cohorts within the selected backend stream' do
+      queries = described_class.query_definitions(period: '24h', log_group_name: 'validation-search')
+
+      expect(queries.values).to all(include('FROM `validation-search`', "request_id IS NULL OR request_id = '' OR request_id NOT IN ("))
+      expect(queries.values).to all(include("service = 'search'", "search_degraded = true OR event IN ('search_failed', 'search_stage_failed')"))
+      expect(queries.values.map { |query| query.scan("`@logStream` LIKE '%ecs/backend-uk/%'").size }).to all(eq(2))
+    end
+
     it 'defines zero results separately for classic and interactive/internal search' do
       expect(
         [
@@ -155,127 +163,34 @@ RSpec.describe SearchAnalytics::CloudwatchSnapshotQuery do
           definitions.fetch('item_id_improvements'),
         ],
       ).to all(include(
-                 'search_type = "classic"',
+                 "search_type = 'classic'",
                  'commodity_result_count = 0',
-                 'results_type != "exact_search"',
-                 'not ispresent(commodity_result_count) and result_count = 0',
-                 'search_type = "interactive" or search_type = "internal"',
+                 "results_type != 'exact_search'",
+                 'commodity_result_count IS NULL AND result_count = 0',
+                 "search_type = 'interactive' OR search_type = 'internal'",
                  'result_count = 0',
                ))
     end
   end
 
-  it 'uses aggregate CloudWatch stats queries for the period window' do
+  it 'executes SQL in the period window without an API log-group selector' do
     payloads
 
     expect(client).to have_received(:start_query).with(
-      hash_including(
-        start_time: (now - 24.hours).to_i,
-        end_time: now.to_i,
-        query_string: a_string_including('| stats'),
-      ),
-    ).at_least(:once)
-    expect(client).to have_received(:start_query).with(
-      hash_including(
-        query_string: a_string_including('filter @logStream like "ecs/backend-uk/"'),
-      ),
+      hash_including(start_time: (now - 24.hours).to_i, end_time: now.to_i, query_language: 'SQL'),
     ).exactly(14).times
-    expect(client).not_to have_received(:start_query).with(
-      hash_including(query_string: a_string_including('sort bin(')),
-    )
-    expect(client).to have_received(:start_query).with(
-      hash_including(
-        query_string: a_string_including('search_type = "classic" and results_type = "fuzzy_search"'),
-      ),
-    ).twice
-    expect(client).to have_received(:start_query).with(
-      hash_including(
-        query_string: a_string_including('event = "result_selected" or (event = "search_completed"'),
-      ),
-    ).exactly(4).times
-    expect(client).to have_received(:start_query).with(
-      hash_including(
-        query_string: a_string_including('results_type = "opensearch" or results_type = "vector" or results_type = "hybrid"'),
-      ),
-    ).twice
-    expect(client).to have_received(:start_query).with(
-      hash_including(
-        query_string: a_string_including('max(@timestamp) as @t by request_id'),
-      ),
-    ).twice
-    expect(client).to have_received(:start_query).with(
-      hash_including(
-        query_string: a_string_including('earliest(request_source) as source by request_id'),
-      ),
-    ).exactly(2).times
-    expect(client).to have_received(:start_query).with(
-      hash_including(
-        query_string: a_string_including('earliest(request_source) as source, max(@timestamp) as @t by request_id'),
-      ),
-    ).twice
-    expect(client).to have_received(:start_query).with(
-      hash_including(
-        query_string: a_string_including('| stats sum(result_selections) as selected, sum(selectable_searches) as selectable by source'),
-      ),
-    ).twice
-    expect(client).not_to have_received(:start_query).with(
-      hash_including(
-        query_string: a_string_including('| fields selected, selectable, source as request_source'),
-      ),
-    )
-    expect(client).to have_received(:start_query).with(
-      hash_including(
-        query_string: a_string_including(
-          'stats sum(request_cost_usd) as aggregated_total_cost_usd',
-          'avg(request_cost_usd) as aggregated_average_cost_usd',
-          'count(*) as aggregated_assisted_searches',
-        ),
-      ),
-    ).once
-    expect(client).to have_received(:start_query).with(
-      hash_including(
-        query_string: a_string_including('service = "ai_usage" and event in ["embedding_api_call_completed", "embedding_api_call_failed"] and event_kind = "vector_search_query_embedding"'),
-      ),
-    ).twice
-    expect(client).to have_received(:start_query).with(
-      hash_including(
-        query_string: a_string_including(
-          'as model_embedding_cost_usd',
-          'sum(model_embedding_cost_usd) as aggregated_embedding_cost_usd',
-          'sum(known_cost_usd) as aggregated_total_cost_usd',
-        ),
-      ),
-    ).once
-    expect(client).to have_received(:start_query).with(
-      hash_including(
-        query_string: a_string_including('datefloor(@t, 1h) as @timestamp'),
-      ),
-    ).twice
-    expect(client).not_to have_received(:start_query).with(
-      hash_including(
-        query_string: a_string_including('earliest(request_source) as request_source by request_id'),
-      ),
-    )
-    expect(client).not_to have_received(:start_query).with(
-      hash_including(
-        query_string: a_string_including('sum(selectable_searches) as selectable by request_source'),
-      ),
-    )
-    expect(client).to have_received(:start_query).with(
-      hash_including(
-        query_string: a_string_matching(/stats pct\(total_duration_ms, 90\) as p90_latency_ms\s*$/),
-      ),
-    ).once
-    expect(client).to have_received(:start_query).with(
-      hash_including(
-        query_string: a_string_including('stats pct(total_duration_ms, 90) as p90_latency_ms by request_source'),
-      ),
-    ).once
-    expect(client).not_to have_received(:start_query).with(
-      hash_including(
-        query_string: a_string_including('selected_count'),
-      ),
-    )
+    expect(client).not_to have_received(:start_query).with(hash_including(:log_group_name))
+  end
+
+  it 'keeps request-level cost and selection aggregates before cohort exclusion' do
+    queries = described_class.query_definitions(period: '24h')
+
+    expect(queries.fetch('ai_cost_summary')).to include('AS request_costs', 'aggregated_assisted_searches')
+    expect(queries.fetch('ai_cost_trend')).to include('aggregated_embedding_cost_usd', "DATE_TRUNC('HOUR', `@timestamp`)")
+    expect(queries.fetch('classic_selections')).to include("search_type = 'classic' AND results_type = 'fuzzy_search'", "GET_JSON_OBJECT(`@message`, '$.request_source')")
+    expect(queries.fetch('internal_selections')).to include("results_type IN ('opensearch', 'vector', 'hybrid')")
+    expect(queries.fetch('classic_selection_trend')).to include("DATE_TRUNC('HOUR', latest_timestamp) AS `@timestamp`")
+    expect(queries.fetch('classic_selections')).to match(/GROUP BY request_id\s+\) AS request_selections\s+WHERE selectable_searches > 0 AND \(request_id IS NULL/)
   end
 
   it 'scopes CloudWatch queries to the current backend service log stream' do
@@ -285,7 +200,7 @@ RSpec.describe SearchAnalytics::CloudwatchSnapshotQuery do
 
     expect(client).to have_received(:start_query).with(
       hash_including(
-        query_string: a_string_including('filter @logStream like "ecs/backend-xi/"'),
+        query_string: a_string_including("`@logStream` LIKE '%ecs/backend-xi/%'"),
       ),
     ).exactly(14).times
   end

--- a/spec/services/search_analytics/cloudwatch_snapshot_query_spec.rb
+++ b/spec/services/search_analytics/cloudwatch_snapshot_query_spec.rb
@@ -231,6 +231,12 @@ RSpec.describe SearchAnalytics::CloudwatchSnapshotQuery do
       'selection_rate' => 0.11,
       'p90_latency_ms' => 1000,
     )
+    payloads.each_value do |payload|
+      expect(payload.dig('summary_statuses', 'failure_rate')).to eq(
+        'level' => 'neutral',
+        'message' => 'Known failed or degraded requests are excluded',
+      )
+    end
     expect(payloads.dig('all', 'comparisons', 'classic')).to include(
       'searches' => 49,
       'zero_result_rate' => 0.11,

--- a/spec/services/search_analytics/dashboard_query_catalog_spec.rb
+++ b/spec/services/search_analytics/dashboard_query_catalog_spec.rb
@@ -1,0 +1,55 @@
+RSpec.describe SearchAnalytics::DashboardQueryCatalog do
+  describe '.call' do
+    subject(:catalog) { described_class.call(log_group_name: 'platform-logs-staging') }
+
+    let(:captured) { {} }
+    let(:status) { instance_double(Process::Status, success?: true) }
+    let(:stderr) { '' }
+    let(:rendered) do
+      {
+        'search_dashboard' => { 'Requests' => { 'query_language' => 'SQL', 'query_string' => "SOURCE 'platform-logs-staging' | SELECT COUNT(*) FROM `platform-logs-staging`" } },
+        'search_operations_dashboard' => { 'Requests' => { 'query_language' => 'CWLI', 'query_string' => "SOURCE 'platform-logs-staging' | stats count(*)" } },
+      }
+    end
+
+    before do
+      allow(Open3).to receive(:capture3) do |_executable, directory_option, *_arguments|
+        captured[:directory] = directory_option.delete_prefix('-chdir=')
+        captured[:configuration] = JSON.parse(File.read(File.join(captured[:directory], 'main.tf.json')))
+        captured[:lockfile] = File.read(File.join(captured[:directory], '.terraform.lock.hcl'))
+        [rendered.to_json.to_json, stderr, status]
+      end
+    end
+
+    it 'writes an isolated configuration for every dashboard with the selected log group' do
+      catalog
+
+      modules = captured[:configuration].fetch('module')
+      expect(modules.keys).to contain_exactly('search_dashboard', 'search_quality_dashboard', 'search_experiment_dashboard', 'search_operations_dashboard', 'ai_costs_dashboard')
+      modules.each do |name, configuration|
+        expect(configuration).to include('environment' => 'validation', 'log_group_name' => 'platform-logs-staging', 'region' => 'eu-west-2')
+        expect(File.expand_path(configuration.fetch('source'), captured[:directory])).to eq(Rails.root.join('terraform/modules', name).to_s)
+      end
+      expect(captured[:configuration].dig('terraform', 'required_providers', 'aws')).to eq('source' => 'hashicorp/aws', 'version' => '~> 5')
+      expect(captured[:lockfile]).to eq(Rails.root.join('terraform/.terraform.lock.hcl').read)
+      expect(File.exist?(captured[:directory])).to be(false)
+    end
+
+    it 'flattens Terraform console output without losing dashboard names, languages or source envelopes' do
+      expect(catalog).to eq(
+        'search_dashboard/Requests' => rendered.dig('search_dashboard', 'Requests'),
+        'search_operations_dashboard/Requests' => rendered.dig('search_operations_dashboard', 'Requests'),
+      )
+    end
+
+    context 'when Terraform exits unsuccessfully' do
+      let(:status) { instance_double(Process::Status, success?: false) }
+      let(:stderr) { 'Error: Failed to query available provider packages' }
+
+      it 'propagates the process error and removes its temporary configuration' do
+        expect { catalog }.to raise_error(RuntimeError, "Terraform dashboard rendering failed: #{stderr}")
+        expect(File.exist?(captured[:directory])).to be(false)
+      end
+    end
+  end
+end

--- a/spec/terraform/dashboard_latency_units_spec.rb
+++ b/spec/terraform/dashboard_latency_units_spec.rb
@@ -9,13 +9,13 @@ RSpec.describe 'CloudWatch dashboard latency units' do
     File.read(path).scan(
       /title\s+= "([^"]+)"(?:(?!title\s+=).)*?query\s+= <<-EOT\n(.*?)\n\s+EOT/m,
     ).filter_map do |title, query|
-      [path, title, query] if query.match?(/\| stats .*duration_ms/)
+      [path, title, query] if query.match?(/(?:\| stats|SELECT).*duration_ms/)
     end
   end
 
   it 'converts every aggregated millisecond duration to a human-scale unit' do
     aggregate_expressions = latency_widgets.flat_map do |_path, _title, query|
-      query.scan(/\b(?:pct|avg|max|min|median)\(([^)]*duration_ms[^)]*)\)/).flatten
+      query.scan(/\b(?:pct|percentile_approx|avg|max|min|median)\(([^)]*duration_ms[^)]*)\)/i).flatten
     end
 
     expect(aggregate_expressions).not_to be_empty
@@ -32,7 +32,7 @@ RSpec.describe 'CloudWatch dashboard latency units' do
   it 'states the unit in every aggregated latency or duration series name' do
     queries = latency_widgets.map { |_path, _title, query| query }
 
-    expect(queries).to all(match(/\bas \w+_(?:seconds|minutes)\b/))
-    expect(queries.join("\n")).not_to match(/\bas (?:p50|p90|p99|max|avg|avg_ms|avg_duration_ms)\b/)
+    expect(queries).to all(match(/\bas \w+_(?:seconds|minutes)\b/i))
+    expect(queries.join("\n")).not_to match(/\bas (?:p50|p90|p99|max|avg|avg_ms|avg_duration_ms)\b/i)
   end
 end

--- a/spec/terraform/search_quality_dashboard_spec.rb
+++ b/spec/terraform/search_quality_dashboard_spec.rb
@@ -27,7 +27,8 @@ RSpec.describe 'search quality dashboard Terraform' do
     overview_zero = expand_tf_local(overview_main_tf, 'zero_result_condition')
     experiment_zero = expand_tf_local(experiment_main_tf, 'zero_result_condition')
 
-    expect(quality_zero).to eq(overview_zero)
+    quality_sql = quality_zero.tr('"', "'").gsub(/not ispresent\((\w+)\)/, '\\1 IS NULL').gsub(/ispresent\((\w+)\)/, '\\1 IS NOT NULL')
+    expect(quality_sql).to eq(overview_zero)
     expect(quality_zero).to eq(experiment_zero)
     expect(quality_zero).to include('commodity_result_count = 0')
     expect(quality_zero).to include('results_type != "exact_search"')

--- a/terraform/modules/ai_costs_dashboard/README.md
+++ b/terraform/modules/ai_costs_dashboard/README.md
@@ -40,4 +40,5 @@ No modules.
 | <a name="output_dashboard_arn"></a> [dashboard\_arn](#output\_dashboard\_arn) | ARN of the CloudWatch dashboard |
 | <a name="output_dashboard_name"></a> [dashboard\_name](#output\_dashboard\_name) | Name of the CloudWatch dashboard |
 | <a name="output_dashboard_url"></a> [dashboard\_url](#output\_dashboard\_url) | URL to the CloudWatch dashboard |
+| <a name="output_queries"></a> [queries](#output\_queries) | Rendered queries and languages for read-only validation |
 <!-- END_TF_DOCS -->

--- a/terraform/modules/ai_costs_dashboard/main.tf
+++ b/terraform/modules/ai_costs_dashboard/main.tf
@@ -11,7 +11,11 @@ locals {
 resource "aws_cloudwatch_dashboard" "ai_costs" {
   dashboard_name = local.dashboard_name
 
-  dashboard_body = jsonencode({
+  dashboard_body = jsonencode(local.dashboard_body)
+}
+
+locals {
+  dashboard_body = {
     widgets = concat(
       [
         {
@@ -110,5 +114,5 @@ resource "aws_cloudwatch_dashboard" "ai_costs" {
         }
       ]
     )
-  })
+  }
 }

--- a/terraform/modules/ai_costs_dashboard/outputs.tf
+++ b/terraform/modules/ai_costs_dashboard/outputs.tf
@@ -12,3 +12,10 @@ output "dashboard_url" {
   description = "URL to the CloudWatch dashboard"
   value       = "https://${var.region}.console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=${local.dashboard_name}"
 }
+
+output "queries" {
+  description = "Rendered queries and languages for read-only validation"
+  value = { for widget in local.dashboard_body.widgets : widget.properties.title => {
+    query_string = widget.properties.query, query_language = lookup(widget.properties, "queryLanguage", "CWLI")
+  } if widget.type == "log" }
+}

--- a/terraform/modules/search_dashboard/README.md
+++ b/terraform/modules/search_dashboard/README.md
@@ -40,4 +40,5 @@ No modules.
 | <a name="output_dashboard_arn"></a> [dashboard\_arn](#output\_dashboard\_arn) | ARN of the CloudWatch dashboard |
 | <a name="output_dashboard_name"></a> [dashboard\_name](#output\_dashboard\_name) | Name of the CloudWatch dashboard |
 | <a name="output_dashboard_url"></a> [dashboard\_url](#output\_dashboard\_url) | URL to the CloudWatch dashboard |
+| <a name="output_queries"></a> [queries](#output\_queries) | Rendered queries and languages for read-only validation |
 <!-- END_TF_DOCS -->

--- a/terraform/modules/search_dashboard/main.tf
+++ b/terraform/modules/search_dashboard/main.tf
@@ -48,7 +48,7 @@ locals {
             markdown = join("\n", [
               "## Trade Tariff Search Overview",
               "Long-range search trends excluding every event for request IDs with a recorded search failure in the selected time range. Use the complete journey window; older and uncorrelated logs remain included when no failure can be linked. Operations retains all failures.",
-              "**Healthy:** p90 latency < 5s, hard failures stay low, empty commodity/empty result trends stable by search type, and selections broadly track search volume.",
+              "**Read these trends:** compare latency, empty results and selections within the retained cohort. Use Search Operations for failure counts and operational health; excluded failures cannot be assessed here.",
               "**Empty commodity results (classic):** fuzzy/null with zero commodity hits (empty Best commodity matches; includes fully empty and headings/chapters-only). **Empty results (interactive):** no returned results. See Search Quality for classic empty-kind pies and free-text rates.",
               "**Start here:** use this dashboard for 3-month trends. Open Operations for active troubleshooting and Quality for intercepts, empty commodity/empty result terms, and result behaviour.",
               "**Related:** [Search Operations](${local.search_operations_dashboard_url}) | [Search Quality](${local.search_quality_dashboard_url}) | [Search Experiments](${local.search_experiment_dashboard_url}) | [Label Generator](${local.label_dashboard_url}) | [Self-Text Generator](${local.self_text_dashboard_url})",

--- a/terraform/modules/search_dashboard/main.tf
+++ b/terraform/modules/search_dashboard/main.tf
@@ -1,15 +1,19 @@
 locals {
   dashboard_name = var.dashboard_name != null ? var.dashboard_name : "Search-${var.environment}"
-  source         = "SOURCE '${var.log_group_name}'"
-  service_filter = "filter service = \"search\""
+  source         = "FROM `${var.log_group_name}`"
+  service_filter = "service = 'search' AND ${local.request_exclusion_filter}"
+  request_exclusion_filter = templatefile("${path.module}/../../../app/services/search_analytics/request_exclusion_filter.sql.tftpl", {
+    log_group_name  = var.log_group_name
+    scope_condition = "1 = 1"
+  })
   # Classic empty commodity results: fuzzy/null with commodity_result_count = 0 (empty Best commodity matches).
   # Includes completely empty results and headings/chapters-only; excludes exact matches.
   # Interactive empty results: result_count = 0 (filter also accepts search_type=internal for forward-compat).
   # Historical classic falls back to result_count = 0.
   # Keep in sync with SearchAnalytics::CloudwatchSnapshotQuery#zero_result_condition
   # and the other search_*_dashboard modules.
-  classic_empty_commodity_condition = "(search_type = \"classic\" and ((ispresent(commodity_result_count) and commodity_result_count = 0 and (not ispresent(results_type) or results_type != \"exact_search\")) or (not ispresent(commodity_result_count) and result_count = 0)))"
-  interactive_no_results_condition  = "((search_type = \"interactive\" or search_type = \"internal\") and result_count = 0)"
+  classic_empty_commodity_condition = "(search_type = 'classic' and ((commodity_result_count IS NOT NULL and commodity_result_count = 0 and (results_type IS NULL or results_type != 'exact_search')) or (commodity_result_count IS NULL and result_count = 0)))"
+  interactive_no_results_condition  = "((search_type = 'interactive' or search_type = 'internal') and result_count = 0)"
   zero_result_condition             = "(${local.classic_empty_commodity_condition} or ${local.interactive_no_results_condition})"
 
   search_operations_dashboard_url = "https://${var.region}.console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=SearchOperations-${var.environment}"
@@ -22,7 +26,16 @@ locals {
 resource "aws_cloudwatch_dashboard" "search" {
   dashboard_name = local.dashboard_name
 
-  dashboard_body = jsonencode({
+  dashboard_body = jsonencode(local.rendered_dashboard_body)
+}
+
+locals {
+  rendered_dashboard_body = merge(local.dashboard_body, {
+    widgets = [for widget in local.dashboard_body.widgets : widget.type == "log" ? merge(widget, {
+      properties = merge(widget.properties, { queryLanguage = "SQL", query = "SOURCE '${var.log_group_name}' | ${widget.properties.query}" })
+    }) : widget]
+  })
+  dashboard_body = {
     widgets = concat(
       [
         {
@@ -34,7 +47,7 @@ resource "aws_cloudwatch_dashboard" "search" {
           properties = {
             markdown = join("\n", [
               "## Trade Tariff Search Overview",
-              "Long-range search health dashboard for quarter-scale trend viewing. Follows the RED method (Rate, Errors, Duration).",
+              "Long-range search trends excluding every event for request IDs with a recorded search failure in the selected time range. Use the complete journey window; older and uncorrelated logs remain included when no failure can be linked. Operations retains all failures.",
               "**Healthy:** p90 latency < 5s, hard failures stay low, empty commodity/empty result trends stable by search type, and selections broadly track search volume.",
               "**Empty commodity results (classic):** fuzzy/null with zero commodity hits (empty Best commodity matches; includes fully empty and headings/chapters-only). **Empty results (interactive):** no returned results. See Search Quality for classic empty-kind pies and free-text rates.",
               "**Start here:** use this dashboard for 3-month trends. Open Operations for active troubleshooting and Quality for intercepts, empty commodity/empty result terms, and result behaviour.",
@@ -55,10 +68,9 @@ resource "aws_cloudwatch_dashboard" "search" {
             region = var.region
             view   = "timeSeries"
             query  = <<-EOT
-              ${local.source}
-              | ${local.service_filter} and event in ["search_completed", "search_failed"]
-              | fields if(ispresent(request_source), request_source, "unknown") as request_source
-              | stats count(*) as searches by request_source, event, bin(1d)
+              SELECT DATE_TRUNC('DAY', `@timestamp`) AS bucket, COUNT(*) AS searches, COALESCE(request_source, 'unknown') AS request_source, event
+              ${local.source} WHERE ${local.service_filter} AND event IN ('search_completed', 'search_failed')
+              GROUP BY DATE_TRUNC('DAY', `@timestamp`), COALESCE(request_source, 'unknown'), event
             EOT
           }
         },
@@ -73,9 +85,9 @@ resource "aws_cloudwatch_dashboard" "search" {
             region = var.region
             view   = "timeSeries"
             query  = <<-EOT
-              ${local.source}
-              | ${local.service_filter} and event = "search_completed"
-              | stats count(*) as searches by search_type, bin(1d)
+              SELECT DATE_TRUNC('DAY', `@timestamp`) AS bucket, COUNT(*) AS searches, search_type
+              ${local.source} WHERE ${local.service_filter} AND event = 'search_completed'
+              GROUP BY DATE_TRUNC('DAY', `@timestamp`), search_type
             EOT
           }
         },
@@ -90,9 +102,9 @@ resource "aws_cloudwatch_dashboard" "search" {
             region = var.region
             view   = "timeSeries"
             query  = <<-EOT
-              ${local.source}
-              | ${local.service_filter} and event in ["search_completed", "search_failed"]
-              | stats count(*) as count by event, bin(1d)
+              SELECT DATE_TRUNC('DAY', `@timestamp`) AS bucket, COUNT(*) AS count, event
+              ${local.source} WHERE ${local.service_filter} AND event IN ('search_completed', 'search_failed')
+              GROUP BY DATE_TRUNC('DAY', `@timestamp`), event
             EOT
           }
         },
@@ -107,9 +119,9 @@ resource "aws_cloudwatch_dashboard" "search" {
             region = var.region
             view   = "timeSeries"
             query  = <<-EOT
-              ${local.source}
-              | ${local.service_filter} and event in ["search_completed", "result_selected"]
-              | stats count(*) as count by event, bin(1d)
+              SELECT DATE_TRUNC('DAY', `@timestamp`) AS bucket, COUNT(*) AS count, event
+              ${local.source} WHERE ${local.service_filter} AND event IN ('search_completed', 'result_selected')
+              GROUP BY DATE_TRUNC('DAY', `@timestamp`), event
             EOT
           }
         },
@@ -126,9 +138,9 @@ resource "aws_cloudwatch_dashboard" "search" {
             region = var.region
             view   = "timeSeries"
             query  = <<-EOT
-              ${local.source}
-              | ${local.service_filter} and event = "search_completed"
-              | stats pct(total_duration_ms / 1000, 50) as p50_seconds, pct(total_duration_ms / 1000, 90) as p90_seconds by bin(1d)
+              SELECT DATE_TRUNC('DAY', `@timestamp`) AS bucket, PERCENTILE_APPROX(total_duration_ms / 1000, 0.5) AS p50_seconds, PERCENTILE_APPROX(total_duration_ms / 1000, 0.9) AS p90_seconds
+              ${local.source} WHERE ${local.service_filter} AND event = 'search_completed'
+              GROUP BY DATE_TRUNC('DAY', `@timestamp`)
             EOT
           }
         },
@@ -143,9 +155,9 @@ resource "aws_cloudwatch_dashboard" "search" {
             region = var.region
             view   = "timeSeries"
             query  = <<-EOT
-              ${local.source}
-              | ${local.service_filter} and event = "api_call_completed"
-              | stats pct(duration_ms / 1000, 50) as p50_seconds, pct(duration_ms / 1000, 90) as p90_seconds by bin(1d)
+              SELECT DATE_TRUNC('DAY', `@timestamp`) AS bucket, PERCENTILE_APPROX(duration_ms / 1000, 0.5) AS p50_seconds, PERCENTILE_APPROX(duration_ms / 1000, 0.9) AS p90_seconds
+              ${local.source} WHERE ${local.service_filter} AND event = 'api_call_completed'
+              GROUP BY DATE_TRUNC('DAY', `@timestamp`)
             EOT
           }
         },
@@ -160,9 +172,9 @@ resource "aws_cloudwatch_dashboard" "search" {
             region = var.region
             view   = "timeSeries"
             query  = <<-EOT
-              ${local.source}
-              | ${local.service_filter} and event = "query_expanded"
-              | stats count(*) as expansions by bin(1d)
+              SELECT DATE_TRUNC('DAY', `@timestamp`) AS bucket, COUNT(*) AS expansions
+              ${local.source} WHERE ${local.service_filter} AND event = 'query_expanded'
+              GROUP BY DATE_TRUNC('DAY', `@timestamp`)
             EOT
           }
         },
@@ -179,9 +191,9 @@ resource "aws_cloudwatch_dashboard" "search" {
             region = var.region
             view   = "timeSeries"
             query  = <<-EOT
-              ${local.source}
-              | ${local.service_filter} and event = "search_completed" and ${local.zero_result_condition}
-              | stats count(*) as searches by search_type, bin(1d)
+              SELECT DATE_TRUNC('DAY', `@timestamp`) AS bucket, COUNT(*) AS searches, search_type
+              ${local.source} WHERE ${local.service_filter} AND event = 'search_completed' AND ${local.zero_result_condition}
+              GROUP BY DATE_TRUNC('DAY', `@timestamp`), search_type
             EOT
           }
         },
@@ -196,13 +208,13 @@ resource "aws_cloudwatch_dashboard" "search" {
             region = var.region
             view   = "timeSeries"
             query  = <<-EOT
-              ${local.source}
-              | ${local.service_filter} and event = "search_completed"
-              | stats avg(result_count) as avg_results, median(result_count) as median_results, avg(commodity_result_count) as avg_commodity_results by search_type, bin(1d)
+              SELECT DATE_TRUNC('DAY', `@timestamp`) AS bucket, AVG(result_count) AS avg_results, PERCENTILE_APPROX(result_count, 0.5) AS median_results, AVG(commodity_result_count) AS avg_commodity_results, search_type
+              ${local.source} WHERE ${local.service_filter} AND event = 'search_completed'
+              GROUP BY DATE_TRUNC('DAY', `@timestamp`), search_type
             EOT
           }
         },
       ]
     )
-  })
+  }
 }

--- a/terraform/modules/search_dashboard/outputs.tf
+++ b/terraform/modules/search_dashboard/outputs.tf
@@ -12,3 +12,10 @@ output "dashboard_url" {
   description = "URL to the CloudWatch dashboard"
   value       = "https://${var.region}.console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=${local.dashboard_name}"
 }
+
+output "queries" {
+  description = "Rendered queries and languages for read-only validation"
+  value = { for widget in local.rendered_dashboard_body.widgets : widget.properties.title => {
+    query_string = widget.properties.query, query_language = lookup(widget.properties, "queryLanguage", "CWLI")
+  } if widget.type == "log" }
+}

--- a/terraform/modules/search_experiment_dashboard/README.md
+++ b/terraform/modules/search_experiment_dashboard/README.md
@@ -46,4 +46,5 @@ No modules.
 | <a name="output_dashboard_arn"></a> [dashboard\_arn](#output\_dashboard\_arn) | ARN of the CloudWatch dashboard |
 | <a name="output_dashboard_name"></a> [dashboard\_name](#output\_dashboard\_name) | Name of the CloudWatch dashboard |
 | <a name="output_dashboard_url"></a> [dashboard\_url](#output\_dashboard\_url) | URL to the CloudWatch dashboard |
+| <a name="output_queries"></a> [queries](#output\_queries) | Rendered queries and languages for read-only validation |
 <!-- END_TF_DOCS -->

--- a/terraform/modules/search_experiment_dashboard/main.tf
+++ b/terraform/modules/search_experiment_dashboard/main.tf
@@ -22,7 +22,11 @@ locals {
 resource "aws_cloudwatch_dashboard" "search_experiment" {
   dashboard_name = local.dashboard_name
 
-  dashboard_body = jsonencode({
+  dashboard_body = jsonencode(local.dashboard_body)
+}
+
+locals {
+  dashboard_body = {
     variables = [
       {
         type         = "pattern"
@@ -501,5 +505,5 @@ resource "aws_cloudwatch_dashboard" "search_experiment" {
         },
       ]
     )
-  })
+  }
 }

--- a/terraform/modules/search_experiment_dashboard/outputs.tf
+++ b/terraform/modules/search_experiment_dashboard/outputs.tf
@@ -12,3 +12,10 @@ output "dashboard_url" {
   description = "URL to the CloudWatch dashboard"
   value       = "https://${var.region}.console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=${local.dashboard_name}"
 }
+
+output "queries" {
+  description = "Rendered queries and languages for read-only validation"
+  value = { for widget in local.dashboard_body.widgets : widget.properties.title => {
+    query_string = widget.properties.query, query_language = lookup(widget.properties, "queryLanguage", "CWLI")
+  } if widget.type == "log" }
+}

--- a/terraform/modules/search_operations_dashboard/README.md
+++ b/terraform/modules/search_operations_dashboard/README.md
@@ -40,4 +40,5 @@ No modules.
 | <a name="output_dashboard_arn"></a> [dashboard\_arn](#output\_dashboard\_arn) | ARN of the CloudWatch dashboard |
 | <a name="output_dashboard_name"></a> [dashboard\_name](#output\_dashboard\_name) | Name of the CloudWatch dashboard |
 | <a name="output_dashboard_url"></a> [dashboard\_url](#output\_dashboard\_url) | URL to the CloudWatch dashboard |
+| <a name="output_queries"></a> [queries](#output\_queries) | Rendered queries and languages for read-only validation |
 <!-- END_TF_DOCS -->

--- a/terraform/modules/search_operations_dashboard/main.tf
+++ b/terraform/modules/search_operations_dashboard/main.tf
@@ -10,7 +10,11 @@ locals {
 resource "aws_cloudwatch_dashboard" "search_operations" {
   dashboard_name = local.dashboard_name
 
-  dashboard_body = jsonencode({
+  dashboard_body = jsonencode(local.dashboard_body)
+}
+
+locals {
+  dashboard_body = {
     widgets = concat(
       [
         {
@@ -363,5 +367,5 @@ resource "aws_cloudwatch_dashboard" "search_operations" {
         },
       ]
     )
-  })
+  }
 }

--- a/terraform/modules/search_operations_dashboard/outputs.tf
+++ b/terraform/modules/search_operations_dashboard/outputs.tf
@@ -12,3 +12,10 @@ output "dashboard_url" {
   description = "URL to the CloudWatch dashboard"
   value       = "https://${var.region}.console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=${local.dashboard_name}"
 }
+
+output "queries" {
+  description = "Rendered queries and languages for read-only validation"
+  value = { for widget in local.dashboard_body.widgets : widget.properties.title => {
+    query_string = widget.properties.query, query_language = lookup(widget.properties, "queryLanguage", "CWLI")
+  } if widget.type == "log" }
+}

--- a/terraform/modules/search_quality_dashboard/README.md
+++ b/terraform/modules/search_quality_dashboard/README.md
@@ -40,4 +40,5 @@ No modules.
 | <a name="output_dashboard_arn"></a> [dashboard\_arn](#output\_dashboard\_arn) | ARN of the CloudWatch dashboard |
 | <a name="output_dashboard_name"></a> [dashboard\_name](#output\_dashboard\_name) | Name of the CloudWatch dashboard |
 | <a name="output_dashboard_url"></a> [dashboard\_url](#output\_dashboard\_url) | URL to the CloudWatch dashboard |
+| <a name="output_queries"></a> [queries](#output\_queries) | Rendered queries and languages for read-only validation |
 <!-- END_TF_DOCS -->

--- a/terraform/modules/search_quality_dashboard/main.tf
+++ b/terraform/modules/search_quality_dashboard/main.tf
@@ -47,7 +47,11 @@ locals {
 resource "aws_cloudwatch_dashboard" "search_quality" {
   dashboard_name = local.dashboard_name
 
-  dashboard_body = jsonencode({
+  dashboard_body = jsonencode(local.dashboard_body)
+}
+
+locals {
+  dashboard_body = {
     widgets = concat(
       [
         {
@@ -569,5 +573,5 @@ resource "aws_cloudwatch_dashboard" "search_quality" {
         },
       ]
     )
-  })
+  }
 }

--- a/terraform/modules/search_quality_dashboard/outputs.tf
+++ b/terraform/modules/search_quality_dashboard/outputs.tf
@@ -12,3 +12,10 @@ output "dashboard_url" {
   description = "URL to the CloudWatch dashboard"
   value       = "https://${var.region}.console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=${local.dashboard_name}"
 }
+
+output "queries" {
+  description = "Rendered queries and languages for read-only validation"
+  value = { for widget in local.dashboard_body.widgets : widget.properties.title => {
+    query_string = widget.properties.query, query_language = lookup(widget.properties, "queryLanguage", "CWLI")
+  } if widget.type == "log" }
+}


### PR DESCRIPTION
## What:

- [x] Exclude every event belonging to a degraded search from admin analytics snapshots and Search Overview within the selected time window.
- [x] Share one SQL predicate across Ruby and Terraform, preserving UK/XI snapshot scope and events without a usable request ID.
- [x] Render the actual dashboard queries and validate both SQL and native Logs Insights queries through the existing development check.
- [x] Explain that the filtered Overview cannot establish operational health; direct readers to Search Operations for failure counts.

## Why:

Experiment measurements need to exclude the whole degraded request, including events emitted before a failure. Filtering individual log rows leaves earlier latency, usage and selection events in the cohort.

Native Logs Insights correlation controls completed with incorrect exclusion counts. The SQL predicate passed mixed-request controls. Snapshot fields, units and widget layout are preserved; approximate percentile values can differ slightly between query engines. SQL also recognises priced calls that the previous native boolean comparison omitted, matching independently calculated usage totals. Grouped selection queries read source attribution from the original event to avoid CloudWatch SQL field pruning.

Operations and general AI Costs retain all failures. Quality and Experiment cohort exclusions follow separately.


## Ticket:

[AI-1264](https://transformuk.atlassian.net/browse/AI-1264)

## Risk:

**Risk level:** 🟢

**Reason for rating:** The affected assisted-search functionality is not live. This changes read-only analytics and extends the existing query validation check, without changing search responses, enabling features or adding infrastructure permissions.

Development retains seven days of logs, so its 30d checks do not establish production-volume timing. Production queries were not run with development credentials. CloudWatch dashboard deployment and query execution are verified; AWS console visual rendering remains unverified because the browser session requires sign-in.

Use only `needs-full-deployment` for this PR. Running both deployment labels concurrently caused a Terraform task-revision postcondition race; the duplicate backend-only run was cancelled and the full deployment passed.
