### PR TITLE
feat: log the originating client IP via CloudFront-Viewer-Address

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -50,6 +50,7 @@ protected
   def append_info_to_payload(payload)
     super
     payload[:request_id] = logged_request_id
+    payload[:remote_ip] = viewer_ip
     payload[:user_agent] = request_user_agent
     payload[:request_source] = TradeTariffRequest.request_source
     payload[:client_id] = TradeTariffRequest.client_id
@@ -166,5 +167,18 @@ private
 
   def request_user_agent
     request.headers['HTTP_X_ORIGINAL_USER_AGENT'].presence || request.env['HTTP_USER_AGENT']
+  end
+
+  # CloudFront-Viewer-Address is "ip:port" (IPv6 bracketed as "[ip]:port"),
+  # and reflects the true end-user IP rather than an untrusted-proxy hop -
+  # request.remote_ip alone would report a CloudFront edge node's IP here,
+  # since Rails' default trusted_proxies doesn't cover CloudFront's public
+  # edge IP ranges. Falls back to request.remote_ip for traffic that doesn't
+  # arrive via CloudFront (e.g. the API Gateway route).
+  def viewer_ip
+    viewer_address = request.headers['CloudFront-Viewer-Address']
+    return request.remote_ip if viewer_address.blank?
+
+    viewer_address.rpartition(':').first.delete_prefix('[').delete_suffix(']')
   end
 end

--- a/config/environments/production_environment_config.rb
+++ b/config/environments/production_environment_config.rb
@@ -49,6 +49,7 @@ module ProductionEnvironmentConfig
 
         {
           request_id: event.payload[:request_id],
+          remote_ip: event.payload[:remote_ip],
           auth_type: event.payload[:auth_type],
           client_id: event.payload[:client_id],
           accept: event.payload[:headers]&.[]('HTTP_ACCEPT'),

--- a/spec/config/environments/production_environment_config_spec.rb
+++ b/spec/config/environments/production_environment_config_spec.rb
@@ -111,6 +111,7 @@ RSpec.describe ProductionEnvironmentConfig do
         ActiveSupport::Notifications::Event,
         payload: {
           request_id: 'req-1',
+          remote_ip: '203.0.113.5',
           auth_type: 'token',
           client_id: 'client',
           headers: { 'HTTP_ACCEPT' => 'application/json' },
@@ -131,6 +132,7 @@ RSpec.describe ProductionEnvironmentConfig do
 
       expect(options).to include(
         request_id: 'req-1',
+        remote_ip: '203.0.113.5',
         auth_type: 'token',
         client_id: 'client',
         accept: 'application/json',

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -111,6 +111,33 @@ RSpec.describe ApplicationController, type: :request do
         expect(payload[:request_id]).to eq('search-request-id')
       end
 
+      it 'adds the originating client IP from CloudFront-Viewer-Address to the action controller payload' do
+        payload = process_action_payload_for(
+          params: {},
+          headers: { 'HTTP_CLOUDFRONT_VIEWER_ADDRESS' => '203.0.113.5:54321' },
+        )
+
+        expect(payload[:remote_ip]).to eq('203.0.113.5')
+      end
+
+      it 'strips the brackets from a bracketed IPv6 CloudFront-Viewer-Address' do
+        payload = process_action_payload_for(
+          params: {},
+          headers: { 'HTTP_CLOUDFRONT_VIEWER_ADDRESS' => '[2001:db8::1]:54321' },
+        )
+
+        expect(payload[:remote_ip]).to eq('2001:db8::1')
+      end
+
+      it 'falls back to request.remote_ip when CloudFront-Viewer-Address is absent' do
+        payload = process_action_payload_for(
+          params: {},
+          headers: { 'HTTP_X_FORWARDED_FOR' => '203.0.113.5' },
+        )
+
+        expect(payload[:remote_ip]).to eq('203.0.113.5')
+      end
+
       it 'adds the experiment label to the action controller payload' do
         payload = process_action_payload_for(params: { experiment: 'trstd-trdr' })
 


### PR DESCRIPTION
## What:
Adds the originating client IP to `platform-logs-production` (the shared Lograge output for backend UK/XI, workers, and backend_job) by reading `CloudFront-Viewer-Address` in `ApplicationController#append_info_to_payload`, falling back to `request.remote_ip` for traffic that doesn't arrive via CloudFront (e.g. the API Gateway route).

## Why:
`platform-logs-production` has never captured the client's IP, making per-IP request-rate analysis impossible without falling back to a raw WAF log scan of the shared CDN (which also mixes in frontend page/asset traffic, and costs real money to query at this log volume). `request.remote_ip` alone isn't usable behind this CDN: CloudFront appends its own edge-node IP to `X-Forwarded-For` when forwarding to a custom origin, and Rails' default `trusted_proxies` only covers RFC1918 ranges, not CloudFront's public edge IPs — so `remote_ip` would report a rotating CloudFront IP on every request, not the real client. `CloudFront-Viewer-Address` sidesteps that trusted-proxy ambiguity entirely.

**Companion PR required**: trade-tariff/trade-tariff-platform-aws-terraform#741 whitelists this header on the CloudFront origin request policy — without it, CloudFront won't forward the header to the origin and this will always hit the fallback.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:** Purely additive logging field with a safe fallback (`request.remote_ip`) if the header is ever absent — no behaviour change to responses, no new external contract, no schema change.