### PR TITLE
HMRC-2677: enable read-only root filesystem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,8 +82,10 @@ COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 
 RUN bundle config set without 'development test'
 
-RUN addgroup -S tariff && \
-  adduser -S tariff -G tariff && \
+# Pin uid/gid so the ecs-service module's writable-volume permissions init container
+# can chown the read-only-root-filesystem mounts to a known id (container_user).
+RUN addgroup -S -g 1000 tariff && \
+  adduser -S -u 1000 -G tariff tariff && \
   chown -R tariff:tariff /app && \
   chown -R tariff:tariff /usr/local/bundle
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -21,9 +21,9 @@ Terraform to deploy the service into AWS.
 | Name | Source | Version |
 | ---- | ------ | ------- |
 | <a name="module_ai_costs_dashboard"></a> [ai\_costs\_dashboard](#module\_ai\_costs\_dashboard) | ./modules/ai_costs_dashboard | n/a |
-| <a name="module_backend-job"></a> [backend-job](#module\_backend-job) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.2.1 |
-| <a name="module_backend_uk"></a> [backend\_uk](#module\_backend\_uk) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.2.1 |
-| <a name="module_backend_xi"></a> [backend\_xi](#module\_backend\_xi) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.2.1 |
+| <a name="module_backend-job"></a> [backend-job](#module\_backend-job) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | HMRC-2677-ecs-readonly-root-filesystem |
+| <a name="module_backend_uk"></a> [backend\_uk](#module\_backend\_uk) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | HMRC-2677-ecs-readonly-root-filesystem |
+| <a name="module_backend_xi"></a> [backend\_xi](#module\_backend\_xi) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | HMRC-2677-ecs-readonly-root-filesystem |
 | <a name="module_label_generator_dashboard"></a> [label\_generator\_dashboard](#module\_label\_generator\_dashboard) | ./modules/label_generator_dashboard | n/a |
 | <a name="module_search_dashboard"></a> [search\_dashboard](#module\_search\_dashboard) | ./modules/search_dashboard | n/a |
 | <a name="module_search_experiment_dashboard"></a> [search\_experiment\_dashboard](#module\_search\_experiment\_dashboard) | ./modules/search_experiment_dashboard | n/a |
@@ -32,8 +32,8 @@ Terraform to deploy the service into AWS.
 | <a name="module_self_text_generator_dashboard"></a> [self\_text\_generator\_dashboard](#module\_self\_text\_generator\_dashboard) | ./modules/self_text_generator_dashboard | n/a |
 | <a name="module_tariff_note_pipeline_dashboard"></a> [tariff\_note\_pipeline\_dashboard](#module\_tariff\_note\_pipeline\_dashboard) | ./modules/tariff_note_pipeline_dashboard | n/a |
 | <a name="module_tariff_sync_dashboard"></a> [tariff\_sync\_dashboard](#module\_tariff\_sync\_dashboard) | ./modules/tariff_sync_dashboard | n/a |
-| <a name="module_worker_uk"></a> [worker\_uk](#module\_worker\_uk) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.2.1 |
-| <a name="module_worker_xi"></a> [worker\_xi](#module\_worker\_xi) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.2.1 |
+| <a name="module_worker_uk"></a> [worker\_uk](#module\_worker\_uk) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | HMRC-2677-ecs-readonly-root-filesystem |
+| <a name="module_worker_xi"></a> [worker\_xi](#module\_worker\_xi) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | HMRC-2677-ecs-readonly-root-filesystem |
 
 ## Resources
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -21,9 +21,9 @@ Terraform to deploy the service into AWS.
 | Name | Source | Version |
 | ---- | ------ | ------- |
 | <a name="module_ai_costs_dashboard"></a> [ai\_costs\_dashboard](#module\_ai\_costs\_dashboard) | ./modules/ai_costs_dashboard | n/a |
-| <a name="module_backend-job"></a> [backend-job](#module\_backend-job) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | HMRC-2677-ecs-readonly-root-filesystem |
-| <a name="module_backend_uk"></a> [backend\_uk](#module\_backend\_uk) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | HMRC-2677-ecs-readonly-root-filesystem |
-| <a name="module_backend_xi"></a> [backend\_xi](#module\_backend\_xi) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | HMRC-2677-ecs-readonly-root-filesystem |
+| <a name="module_backend-job"></a> [backend-job](#module\_backend-job) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.3.0 |
+| <a name="module_backend_uk"></a> [backend\_uk](#module\_backend\_uk) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.3.0 |
+| <a name="module_backend_xi"></a> [backend\_xi](#module\_backend\_xi) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.3.0 |
 | <a name="module_label_generator_dashboard"></a> [label\_generator\_dashboard](#module\_label\_generator\_dashboard) | ./modules/label_generator_dashboard | n/a |
 | <a name="module_search_dashboard"></a> [search\_dashboard](#module\_search\_dashboard) | ./modules/search_dashboard | n/a |
 | <a name="module_search_experiment_dashboard"></a> [search\_experiment\_dashboard](#module\_search\_experiment\_dashboard) | ./modules/search_experiment_dashboard | n/a |
@@ -32,8 +32,8 @@ Terraform to deploy the service into AWS.
 | <a name="module_self_text_generator_dashboard"></a> [self\_text\_generator\_dashboard](#module\_self\_text\_generator\_dashboard) | ./modules/self_text_generator_dashboard | n/a |
 | <a name="module_tariff_note_pipeline_dashboard"></a> [tariff\_note\_pipeline\_dashboard](#module\_tariff\_note\_pipeline\_dashboard) | ./modules/tariff_note_pipeline_dashboard | n/a |
 | <a name="module_tariff_sync_dashboard"></a> [tariff\_sync\_dashboard](#module\_tariff\_sync\_dashboard) | ./modules/tariff_sync_dashboard | n/a |
-| <a name="module_worker_uk"></a> [worker\_uk](#module\_worker\_uk) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | HMRC-2677-ecs-readonly-root-filesystem |
-| <a name="module_worker_xi"></a> [worker\_xi](#module\_worker\_xi) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | HMRC-2677-ecs-readonly-root-filesystem |
+| <a name="module_worker_uk"></a> [worker\_uk](#module\_worker\_uk) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.3.0 |
+| <a name="module_worker_xi"></a> [worker\_xi](#module\_worker\_xi) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.3.0 |
 
 ## Resources
 

--- a/terraform/backend_job.tf
+++ b/terraform/backend_job.tf
@@ -1,5 +1,5 @@
 module "backend-job" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v3.2.1"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=HMRC-2677-ecs-readonly-root-filesystem"
 
   region = var.region
 
@@ -23,6 +23,10 @@ module "backend-job" {
   service_environment_config = local.backend_job_secret_env_vars
 
   enable_ecs_exec = true
+
+  readonly_root_filesystem = true
+  writable_paths           = local.writable_paths
+  container_user           = local.container_user
 
   has_autoscaler     = false
   max_capacity       = 1

--- a/terraform/backend_job.tf
+++ b/terraform/backend_job.tf
@@ -1,5 +1,5 @@
 module "backend-job" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=HMRC-2677-ecs-readonly-root-filesystem"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v3.3.0"
 
   region = var.region
 

--- a/terraform/backend_uk.tf
+++ b/terraform/backend_uk.tf
@@ -1,5 +1,5 @@
 module "backend_uk" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v3.2.1"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=HMRC-2677-ecs-readonly-root-filesystem"
 
   region = var.region
 
@@ -30,6 +30,10 @@ module "backend_uk" {
   service_environment_config = local.backend_uk_service_env_vars
 
   enable_ecs_exec = true
+
+  readonly_root_filesystem = true
+  writable_paths           = local.writable_paths
+  container_user           = local.container_user
 
   has_autoscaler     = local.has_autoscaler
   min_capacity       = var.min_capacity

--- a/terraform/backend_uk.tf
+++ b/terraform/backend_uk.tf
@@ -1,5 +1,5 @@
 module "backend_uk" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=HMRC-2677-ecs-readonly-root-filesystem"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v3.3.0"
 
   region = var.region
 

--- a/terraform/backend_xi.tf
+++ b/terraform/backend_xi.tf
@@ -1,5 +1,5 @@
 module "backend_xi" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v3.2.1"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=HMRC-2677-ecs-readonly-root-filesystem"
 
   region = var.region
 
@@ -30,6 +30,10 @@ module "backend_xi" {
   service_environment_config = local.backend_xi_service_env_vars
 
   enable_ecs_exec = true
+
+  readonly_root_filesystem = true
+  writable_paths           = local.writable_paths
+  container_user           = local.container_user
 
   has_autoscaler     = local.has_autoscaler
   min_capacity       = var.min_capacity

--- a/terraform/backend_xi.tf
+++ b/terraform/backend_xi.tf
@@ -1,5 +1,5 @@
 module "backend_xi" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=HMRC-2677-ecs-readonly-root-filesystem"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v3.3.0"
 
   region = var.region
 

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -69,4 +69,25 @@ locals {
     }
   ]
   ecr_repo = "382373577178.dkr.ecr.eu-west-2.amazonaws.com/tariff-backend-production"
+
+  # Paths the image must still be able to write to under a read-only root filesystem.
+  # WORKDIR is /app, so Rails.root-relative paths resolve there.
+  #   /tmp      - Tempfile (CustomsTariffImporter::NotesExtractor) and general scratch
+  #   /app/tmp  - bootsnap, loaded in config/boot.rb; without it the app fails to boot
+  #   /app/log  - the New Relic agent's own log file (newrelic.yml sets no log_file)
+  #
+  # NOT /app/data: it ships eight tracked runtime files (guides.csv,
+  # preference_codes.json, CN2026_SelfText_EN_DE_FR.csv, green_lanes/themes.html, ...)
+  # and an ephemeral volume mounted there would mask all of them.
+  writable_paths = ["/tmp", "/app/tmp", "/app/log"]
+
+  # CdsImporter::ExcelWriter writes "CDS updates <date>.xlsx" into data/cds_updates with
+  # no Rails.env guard, driven by CdsUpdateNotificationWorker — so only the Sidekiq
+  # workers need it. Mounted at the subdirectory to leave the sibling files visible.
+  worker_writable_paths = concat(local.writable_paths, ["/app/data/cds_updates"])
+
+  # Matches the uid/gid pinned in the Dockerfile. The ecs-service module adds an init
+  # container that chowns the writable mounts to this user, because Fargate mounts them
+  # root-owned and the app runs as the non-root `tariff`.
+  container_user = "1000:1000"
 }

--- a/terraform/worker_uk.tf
+++ b/terraform/worker_uk.tf
@@ -1,5 +1,5 @@
 module "worker_uk" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v3.2.1"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=HMRC-2677-ecs-readonly-root-filesystem"
 
   service_name = "worker-uk"
   region       = var.region
@@ -23,6 +23,10 @@ module "worker_uk" {
   task_role_policy_arns = [aws_iam_policy.task.arn]
 
   enable_ecs_exec = true
+
+  readonly_root_filesystem = true
+  writable_paths           = local.worker_writable_paths
+  container_user           = local.container_user
 
   container_entrypoint = [""]
   container_command    = local.worker_command

--- a/terraform/worker_uk.tf
+++ b/terraform/worker_uk.tf
@@ -1,5 +1,5 @@
 module "worker_uk" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=HMRC-2677-ecs-readonly-root-filesystem"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v3.3.0"
 
   service_name = "worker-uk"
   region       = var.region

--- a/terraform/worker_xi.tf
+++ b/terraform/worker_xi.tf
@@ -1,5 +1,5 @@
 module "worker_xi" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v3.2.1"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=HMRC-2677-ecs-readonly-root-filesystem"
 
   service_name = "worker-xi"
   region       = var.region
@@ -23,6 +23,10 @@ module "worker_xi" {
   task_role_policy_arns = [aws_iam_policy.task.arn]
 
   enable_ecs_exec = true
+
+  readonly_root_filesystem = true
+  writable_paths           = local.worker_writable_paths
+  container_user           = local.container_user
 
   container_entrypoint = [""]
   container_command    = local.worker_command

--- a/terraform/worker_xi.tf
+++ b/terraform/worker_xi.tf
@@ -1,5 +1,5 @@
 module "worker_xi" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=HMRC-2677-ecs-readonly-root-filesystem"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v3.3.0"
 
   service_name = "worker-xi"
   region       = var.region


### PR DESCRIPTION
## What:

Enables `readonly_root_filesystem` across all five `ecs-service` instances (backend-uk, backend-xi, backend-job, worker-uk, worker-xi) and pins the container uid/gid to `1000` in the Dockerfile. Shared `writable_paths` in `locals.tf`:

- all: `["/tmp", "/app/tmp", "/app/log"]`
- workers also: `["/app/data/cds_updates"]`

## Why:

Security Hub control ECS.5.

- `/app/tmp` — bootsnap, or the app fails to boot
- `/app/log` — New Relic agent log
- `/tmp` — `Tempfile` in `NotesExtractor`, general scratch
- `/app/data/cds_updates` — `CdsImporter::ExcelWriter` writes `.xlsx` files here with **no `Rails.env` guard**, driven by `CdsUpdateNotificationWorker` (workers only)

`/app/data` itself is **not** mounted — it ships tracked runtime files (`guides.csv`, `preference_codes.json`, …) that a volume would mask, so only the `cds_updates` subdirectory is mounted. `DUMP_CDS_DATA_AS_JSON=true` would also need `/app/data/cds_dumps`; it defaults to `false`.

## Ticket:

HMRC-2677 — module PR: trade-tariff/trade-tariff-platform-terraform-modules#107

## Risk:

**Risk level:** 🟠

**Reason for rating:**
Infrastructure change across five services — each gets a new task definition revision with a read-only root filesystem and an init container (deploy-order dependency). Riskiest consumer of the module.

**Validated in development** (all five instances, 2026-09-08):

- All 4 long-running services reached steady state; init container exits 0; 0 restarts
- Read-only enforced (`touch /nope` → `Read-only file system`); `/app/tmp`, `/app/log`, `/tmp` and (workers) `/app/data/cds_updates` all owned by `tariff` and writable as `tariff`
- `/app/data` siblings not masked; bootsnap cache present
- backend-uk serving live API traffic; ALB target healthy; Sidekiq running
- No `EROFS` / `EACCES` in logs
- `aws ecs execute-command` works

The `/app/data/cds_updates` write was verified directly (`touch` as `tariff`); a real CDS sync exercising `ExcelWriter` still hasn't run, but the path and permissions are confirmed.
