### PR TITLE
[HMRC-2224] Exposes semantic roles on measure types

### DIFF
--- a/app/models/measure_type.rb
+++ b/app/models/measure_type.rb
@@ -55,6 +55,17 @@ class MeasureType < Sequel::Model
     2 => 'both',
   }.freeze
 
+  SEMANTIC_ROLE_TYPES = {
+    'supplementary' => SUPPLEMENTARY_TYPES,
+    'supplementary_unit_import_only' => %w[110],
+    'safeguard' => %w[696],
+    'mfn_no_authorized_use' => %w[103],
+    'provides_unit_context' => %w[103 105 106 122 123 141 142 143 145 146],
+    'cds_proofs_of_origin' => %w[141 142 143 145 146 147],
+  }.freeze
+
+  PROHIBITIVE_SERIES = %w[A B].freeze
+
   set_primary_key [:measure_type_id]
 
   plugin :time_machine
@@ -143,5 +154,15 @@ class MeasureType < Sequel::Model
 
   def authorised_use_provisions_submission?
     measure_type_id.in?(AUTHORISED_USE_PROVISIONS_SUBMISSION)
+  end
+
+  def semantic_roles
+    roles = SEMANTIC_ROLE_TYPES.filter_map do |role, measure_type_ids|
+      role if measure_type_ids.include?(measure_type_id)
+    end
+
+    roles << 'prohibitive' if PROHIBITIVE_SERIES.include?(measure_type_series_id)
+
+    roles
   end
 end

--- a/app/serializers/api/v2/measures/measure_type_serializer.rb
+++ b/app/serializers/api/v2/measures/measure_type_serializer.rb
@@ -14,7 +14,8 @@ module Api
                    :order_number_capture_code,
                    :trade_movement_code,
                    :validity_end_date,
-                   :validity_start_date
+                   :validity_start_date,
+                   :semantic_roles
 
         attribute :id, &:measure_type_id
 

--- a/app/services/cached_commodity_service.rb
+++ b/app/services/cached_commodity_service.rb
@@ -2,7 +2,7 @@ class CachedCommodityService
   include DeclarableSerialization
   include JsonapiCacheKey
 
-  CACHE_VERSION = 6
+  CACHE_VERSION = 7
   RELATIONSHIP_FIELDS = %i[
     ancestors
     chapter

--- a/app/services/cached_subheading_service.rb
+++ b/app/services/cached_subheading_service.rb
@@ -2,7 +2,7 @@ class CachedSubheadingService
   include JsonapiCacheKey
 
   TTL = 23.hours # Expire just before the ETL job runs and prewarms expensive subheadings
-  CACHE_VERSION = 1
+  CACHE_VERSION = 2
   RELATIONSHIP_FIELDS = %i[
     ancestors
     chapter

--- a/app/services/heading_service/heading_serialization_service.rb
+++ b/app/services/heading_service/heading_serialization_service.rb
@@ -2,7 +2,7 @@ module HeadingService
   class HeadingSerializationService
     include JsonapiCacheKey
 
-    CACHE_VERSION = 'v1'.freeze
+    CACHE_VERSION = 'v2'.freeze
 
     class << self
       def cache_key(heading, actual_date, is_declarable, filters)

--- a/spec/models/measure_type_spec.rb
+++ b/spec/models/measure_type_spec.rb
@@ -229,4 +229,55 @@ RSpec.describe MeasureType do
       it { is_expected.not_to be_supplementary }
     end
   end
+
+  describe '#semantic_roles' do
+    {
+      '103' => %w[mfn_no_authorized_use provides_unit_context],
+      '105' => %w[provides_unit_context],
+      '106' => %w[provides_unit_context],
+      '109' => %w[supplementary],
+      '110' => %w[supplementary supplementary_unit_import_only],
+      '111' => %w[supplementary],
+      '122' => %w[provides_unit_context],
+      '123' => %w[provides_unit_context],
+      '141' => %w[provides_unit_context cds_proofs_of_origin],
+      '142' => %w[provides_unit_context cds_proofs_of_origin],
+      '143' => %w[provides_unit_context cds_proofs_of_origin],
+      '144' => [],
+      '145' => %w[provides_unit_context cds_proofs_of_origin],
+      '146' => %w[provides_unit_context cds_proofs_of_origin],
+      '147' => %w[cds_proofs_of_origin],
+      '306' => [],
+      '695' => [],
+      '696' => %w[safeguard],
+      '999' => [],
+    }.each do |measure_type_id, expected_roles|
+      it "returns the expected roles for measure type #{measure_type_id}" do
+        measure_type = build(
+          :measure_type,
+          measure_type_id:,
+          measure_type_series_id: 'C',
+        )
+
+        expect(measure_type.semantic_roles).to match_array(expected_roles)
+      end
+    end
+
+    {
+      'A' => %w[prohibitive],
+      'B' => %w[prohibitive],
+      'C' => [],
+      'Q' => [],
+    }.each do |series_id, expected_roles|
+      it "returns the expected roles for measure type series #{series_id}" do
+        measure_type = build(
+          :measure_type,
+          measure_type_id: '999',
+          measure_type_series_id: series_id,
+        )
+
+        expect(measure_type.semantic_roles).to match_array(expected_roles)
+      end
+    end
+  end
 end

--- a/spec/requests/api/v2/headings_controller_migrated_spec.rb
+++ b/spec/requests/api/v2/headings_controller_migrated_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Api::V2::HeadingsController, type: :request do
         api_response
 
         expected_hash = Digest::MD5.hexdigest('{}')
-        cache_suffix = '-v1'
+        cache_suffix = "-#{HeadingService::HeadingSerializationService::CACHE_VERSION}"
 
         expect(Rails.cache).to have_received(:fetch).with(
           "_heading-uk-#{heading.goods_nomenclature_sid}-#{Time.zone.today.iso8601}-false-#{expected_hash}#{cache_suffix}",
@@ -47,7 +47,7 @@ RSpec.describe Api::V2::HeadingsController, type: :request do
           api_response
 
           expected_hash = Digest::MD5.hexdigest(request_parameters[:filter].to_json)
-          cache_suffix = '-v1'
+          cache_suffix = "-#{HeadingService::HeadingSerializationService::CACHE_VERSION}"
 
           expect(Rails.cache).to have_received(:fetch).with(
             "_heading-uk-#{heading.goods_nomenclature_sid}-#{Time.zone.today.iso8601}-false-#{expected_hash}#{cache_suffix}",

--- a/spec/requests/api/v2/measure_types_controller_spec.rb
+++ b/spec/requests/api/v2/measure_types_controller_spec.rb
@@ -1,4 +1,15 @@
 RSpec.describe Api::V2::MeasureTypesController, type: :request do
+  let(:validity_end_date) { nil }
+
+  let(:measure_type) do
+    create(
+      :measure_type,
+      measure_type_id: '110',
+      measure_type_series_id: 'C',
+      validity_end_date:,
+    )
+  end
+
   describe '#index' do
     subject(:api_response) do
       make_request
@@ -9,8 +20,6 @@ RSpec.describe Api::V2::MeasureTypesController, type: :request do
       get '/uk/api/measure_types', headers: request_headers
     end
     let(:json_body) { JSON.parse(api_response.body)['data'] }
-    let(:validity_end_date) { nil }
-    let(:measure_type) { create(:measure_type, :with_measure_type_series_description, validity_end_date:) }
 
     before do
       measure_type
@@ -24,26 +33,15 @@ RSpec.describe Api::V2::MeasureTypesController, type: :request do
       expect(json_body.length).to eq 1
     end
 
+    it 'includes the semantic roles' do
+      expect(json_body.first.fetch('attributes').fetch('semantic_roles'))
+        .to contain_exactly('supplementary', 'supplementary_unit_import_only')
+    end
+
     context 'when the validity_end_date is set to a past date' do
       let(:validity_end_date) { 1.day.ago }
 
       it { expect(json_body).to eq [] }
-    end
-
-    context 'when the measure type has semantic roles' do
-      let(:measure_type) do
-        create(
-          :measure_type,
-          measure_type_id: '110',
-          measure_type_series_id: 'C',
-          validity_end_date:,
-        )
-      end
-
-      it 'includes the semantic roles' do
-        expect(json_body.first.fetch('attributes').fetch('semantic_roles'))
-          .to contain_exactly('supplementary', 'supplementary_unit_import_only')
-      end
     end
   end
 
@@ -72,27 +70,15 @@ RSpec.describe Api::V2::MeasureTypesController, type: :request do
         }
       end
 
-      let(:measure_type) { create(:measure_type, :with_measure_type_series_description) }
+      let(:json_body) { JSON.parse(api_response.body).fetch('data') }
 
       it { expect(api_response.body).to match_json_expression pattern }
 
       it { is_expected.to have_http_status :success }
 
-      context 'when the measure type has semantic roles' do
-        let(:measure_type) do
-          create(
-            :measure_type,
-            measure_type_id: '110',
-            measure_type_series_id: 'C',
-          )
-        end
-
-        let(:json_body) { JSON.parse(api_response.body).fetch('data') }
-
-        it 'includes the semantic roles' do
-          expect(json_body.fetch('attributes').fetch('semantic_roles'))
-            .to contain_exactly('supplementary', 'supplementary_unit_import_only')
-        end
+      it 'includes the semantic roles' do
+        expect(json_body.fetch('attributes').fetch('semantic_roles'))
+          .to contain_exactly('supplementary', 'supplementary_unit_import_only')
       end
     end
 

--- a/spec/requests/api/v2/measure_types_controller_spec.rb
+++ b/spec/requests/api/v2/measure_types_controller_spec.rb
@@ -10,9 +10,10 @@ RSpec.describe Api::V2::MeasureTypesController, type: :request do
     end
     let(:json_body) { JSON.parse(api_response.body)['data'] }
     let(:validity_end_date) { nil }
+    let(:measure_type) { create(:measure_type, :with_measure_type_series_description, validity_end_date:) }
 
     before do
-      create(:measure_type, :with_measure_type_series_description, validity_end_date:)
+      measure_type
 
       allow(TimeMachine).to receive(:at).and_call_original
     end
@@ -27,6 +28,22 @@ RSpec.describe Api::V2::MeasureTypesController, type: :request do
       let(:validity_end_date) { 1.day.ago }
 
       it { expect(json_body).to eq [] }
+    end
+
+    context 'when the measure type has semantic roles' do
+      let(:measure_type) do
+        create(
+          :measure_type,
+          measure_type_id: '110',
+          measure_type_series_id: 'C',
+          validity_end_date:,
+        )
+      end
+
+      it 'includes the semantic roles' do
+        expect(json_body.first.fetch('attributes').fetch('semantic_roles'))
+          .to contain_exactly('supplementary', 'supplementary_unit_import_only')
+      end
     end
   end
 
@@ -60,6 +77,23 @@ RSpec.describe Api::V2::MeasureTypesController, type: :request do
       it { expect(api_response.body).to match_json_expression pattern }
 
       it { is_expected.to have_http_status :success }
+
+      context 'when the measure type has semantic roles' do
+        let(:measure_type) do
+          create(
+            :measure_type,
+            measure_type_id: '110',
+            measure_type_series_id: 'C',
+          )
+        end
+
+        let(:json_body) { JSON.parse(api_response.body).fetch('data') }
+
+        it 'includes the semantic roles' do
+          expect(json_body.fetch('attributes').fetch('semantic_roles'))
+            .to contain_exactly('supplementary', 'supplementary_unit_import_only')
+        end
+      end
     end
 
     context 'when records are not present' do

--- a/spec/serializers/api/v2/measures/measure_type_serializer_spec.rb
+++ b/spec/serializers/api/v2/measures/measure_type_serializer_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Api::V2::Measures::MeasureTypeSerializer do
           trade_movement_code: measure_type.trade_movement_code,
           validity_end_date: measure_type.validity_end_date,
           validity_start_date: measure_type.validity_start_date,
+          semantic_roles: measure_type.semantic_roles,
         },
       },
     }

--- a/spec/services/cached_commodity_service_spec.rb
+++ b/spec/services/cached_commodity_service_spec.rb
@@ -91,6 +91,15 @@ RSpec.describe CachedCommodityService do
         expect(loaded_commodity.associations).to include(full_chemicals: be_present)
       end
 
+      it 'includes semantic roles on embedded measure types' do
+        measure_type = service.call.fetch(:included).find do |resource|
+          resource[:type].to_s == 'measure_type' && resource[:id] == '103'
+        end
+
+        expect(measure_type.fetch(:attributes).fetch(:semantic_roles))
+          .to contain_exactly('mfn_no_authorized_use', 'provides_unit_context')
+      end
+
       context 'with empty include and sparse fields that do not need eager-loaded associations' do
         around do |example|
           Thread.current[:jsonapi_query_options] = {

--- a/spec/services/cached_subheading_service_spec.rb
+++ b/spec/services/cached_subheading_service_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe CachedSubheadingService do
     it 'caches with the correct key' do
       allow(Rails.cache).to receive(:fetch).and_call_original
       service.call.to_json
-      expect(Rails.cache).to have_received(:fetch).with("_subheading-#{subheading.goods_nomenclature_sid}-2021-01-01-v1", expires_in: 23.hours)
+      expect(Rails.cache).to have_received(:fetch).with("_subheading-#{subheading.goods_nomenclature_sid}-2021-01-01-v2", expires_in: 23.hours)
     end
 
     context 'with empty include and sparse fields that do not need eager-loaded data' do

--- a/spec/swagger/api/v2/measure_types_spec.rb
+++ b/spec/swagger/api/v2/measure_types_spec.rb
@@ -20,6 +20,23 @@ RSpec.describe 'Measure Types', swagger_doc: 'v2/swagger.json', type: :request d
           validity_start_date: { type: :string, nullable: true, format: 'date-time' },
           validity_end_date: { type: :string, nullable: true, format: 'date-time' },
           measure_type_series_description: { type: :string, nullable: true },
+          semantic_roles: {
+            type: :array,
+            description: 'Behavioural roles of this measure type. Empty when none apply.',
+            items: {
+              type: :string,
+              enum: %w[
+                supplementary
+                supplementary_unit_import_only
+                safeguard
+                mfn_no_authorized_use
+                provides_unit_context
+                cds_proofs_of_origin
+                prohibitive
+              ],
+            },
+            example: %w[supplementary supplementary_unit_import_only],
+          },
         },
       },
     },

--- a/swagger/v2/swagger.json
+++ b/swagger/v2/swagger.json
@@ -5112,6 +5112,26 @@
                               "measure_type_series_description": {
                                 "type": "string",
                                 "nullable": true
+                              },
+                              "semantic_roles": {
+                                "type": "array",
+                                "description": "Behavioural roles of this measure type. Empty when none apply.",
+                                "items": {
+                                  "type": "string",
+                                  "enum": [
+                                    "supplementary",
+                                    "supplementary_unit_import_only",
+                                    "safeguard",
+                                    "mfn_no_authorized_use",
+                                    "provides_unit_context",
+                                    "cds_proofs_of_origin",
+                                    "prohibitive"
+                                  ]
+                                },
+                                "example": [
+                                  "supplementary",
+                                  "supplementary_unit_import_only"
+                                ]
                               }
                             }
                           }
@@ -5220,6 +5240,26 @@
                             "measure_type_series_description": {
                               "type": "string",
                               "nullable": true
+                            },
+                            "semantic_roles": {
+                              "type": "array",
+                              "description": "Behavioural roles of this measure type. Empty when none apply.",
+                              "items": {
+                                "type": "string",
+                                "enum": [
+                                  "supplementary",
+                                  "supplementary_unit_import_only",
+                                  "safeguard",
+                                  "mfn_no_authorized_use",
+                                  "provides_unit_context",
+                                  "cds_proofs_of_origin",
+                                  "prohibitive"
+                                ]
+                              },
+                              "example": [
+                                "supplementary",
+                                "supplementary_unit_import_only"
+                              ]
                             }
                           }
                         }


### PR DESCRIPTION
## What:
Exposes `semantic_roles` on measure-type endpoints and embedded measure types. 
Adds regression coverage, update Swagger documentation, and bump commodity, heading and subheading cache versions.

## Why:
Centralise measure-type classifications in the API so the frontend can remove its hardcoded role mappings in a follow-up PR.

## Ticket:
[HMRC-2224>](https://transformuk.atlassian.net/browse/HMRC-2224)

## Risk:
🟠 

**Reason for rating:**
Adds an API attribute and invalidates cached responses. Must be deployed and verify refreshed responses before merging the frontend follow-up PR.