### PR TITLE
AI-1293: Add backend Puma capacity metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
             *.lock
             .github
 
-  puma-dashboard-test:
+  terraform-test:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,22 @@ jobs:
             *.lock
             .github
 
+  puma-dashboard-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: terraform/modules/puma_capacity_dashboard
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: 1.12.2
+      - run: terraform init -backend=false -input=false
+      - run: terraform test -no-color
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,3 +1,10 @@
+if ENV['PUMA_METRICS_ENABLED'] == 'true'
+  require_relative '../lib/puma_metrics'
+  ENV['PUMA_METRICS_SERVICE'] ||= "backend-#{ENV.fetch('SERVICE', 'uk')}"
+  Puma::Plugins.register('trade_tariff_metrics', PumaMetrics::Plugin)
+  plugin :trade_tariff_metrics
+end
+
 workers Integer(ENV['WEB_CONCURRENCY'] || 2)
 threads_count = Integer(ENV['MAX_THREADS'] || 6)
 threads threads_count, threads_count

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,8 @@ This directory is the starting point for understanding the Trade Tariff Backend 
 
 ## Operational Entry Points
 
+- [Puma request capacity metrics](puma-metrics.md) covers opt-in web worker occupancy, queue backlog and CloudWatch dashboards.
+
 - `README.md` covers local setup and daily update environment variables.
 - `config/sidekiq.yml` lists scheduled background jobs.
 - `lib/tasks/` contains operational Rake tasks for sync, reporting, OpenSearch, labels, self-texts, and other maintenance workflows.

--- a/docs/puma-metrics.md
+++ b/docs/puma-metrics.md
@@ -1,19 +1,18 @@
 # Puma request capacity metrics
 
 The opt-in `PumaMetrics::Plugin` reports web request thread occupancy and queue
-backlog. The implementation is kept identical in the frontend and backend
-repositories. Backend UK and XI report separately; Sidekiq does not run the
+backlog. Collector behaviour is kept aligned in the frontend and backend
+repositories; the plugin's application-environment lookup is repository-specific. Backend UK and XI report separately; Sidekiq does not run the
 Puma server configuration and does not start this reporter.
 
 ## Enable through the application configuration secret
 
-Add these string values to the existing **web application's configuration
+Add this string value to the existing **web application's configuration
 secret**, not to the Sidekiq worker secret:
 
 ```json
 {
-  "PUMA_METRICS_ENABLED": "true",
-  "PUMA_METRICS_ENVIRONMENT": "production"
+  "PUMA_METRICS_ENABLED": "true"
 }
 ```
 
@@ -22,8 +21,13 @@ required. `PUMA_METRICS_SERVICE` is optional: the Puma configuration defaults it
 to `frontend` or `backend-${SERVICE}` (UK when SERVICE is absent). If explicitly
 set, use `frontend`, `backend-uk` or `backend-xi` to match the dashboards.
 
-Set the environment explicitly: staging commonly uses `RAILS_ENV=production`,
-which would otherwise mislabel its metrics. In development use `development`.
+Environment comes from existing application configuration, not a separate
+telemetry setting or `RAILS_ENV`. Frontend uses `TradeTariffFrontend.environment`
+(the existing `ENVIRONMENT`, default `production`). Its config module can load
+in the Puma master without Rails. Backend reads the same existing `ENVIRONMENT`
+source and `local` fallback as `TradeTariffBackend.environment`, without booting
+Rails just to read it. Staging therefore keeps its staging label even when
+`RAILS_ENV=production`. No additional environment key is required.
 
 **Changing the secret alone does not change a running process.** Follow the
 normal deployment/configuration-refresh workflow so the secret values reach
@@ -146,7 +150,7 @@ response times before using these measurements as a go-live gate.
 ## Verification and rollout
 
 1. Deploy code and dashboard through the normal approved workflow, initially
-   outside production. Enable the two keys through the configuration secret.
+   outside production. Enable the reporter through the configuration secret.
 2. Confirm valid `event = "puma.metrics"` JSON records in `platform-logs-<env>`.
    Confirm EMF extraction produces `TradeTariff/Puma` metrics with the expected
    environment and service, not merely log records. Inspect EMF processing
@@ -182,7 +186,7 @@ provider, without AWS credentials or applying resources. These are structural
 assertions, not evidence of deployed EMF extraction or query execution.
 
 The RSpec integration tests launch real Puma in single and cluster modes, check
-default service labels and the explicit environment override, hold a request
+default service labels and existing application environment/defaults, hold a request
 open, then wait for idle recovery. They cover full master and phased worker
 restarts followed by serving and graceful shutdown. The phased scenario
 explicitly disables preloading, including in backend where ordinary phased
@@ -198,7 +202,7 @@ the focused checks in both repositories. No shared package is required.
 From the directory containing both checkouts, compare the shared sources:
 
 ```sh
-for file in lib/puma_metrics.rb spec/lib/puma_metrics_spec.rb \
+for file in spec/lib/puma_metrics_spec.rb \
   terraform/modules/puma_capacity_dashboard/main.tf \
   terraform/modules/puma_capacity_dashboard/variables.tf \
   terraform/modules/puma_capacity_dashboard/tests/dashboard.tftest.hcl; do
@@ -206,8 +210,10 @@ for file in lib/puma_metrics.rb spec/lib/puma_metrics_spec.rb \
 done
 ```
 
-Review the integration specs together: their expected service-label matrix is
-repository-specific; their lifecycle assertions should stay aligned. Keep this
-guide aligned too. Puma registration, dashboard callers and CI Terraform versions
+Review `lib/puma_metrics.rb` together: only the plugin environment lookup should
+differ; collector behaviour stays aligned. The integration specs' expected
+service/environment matrix is repository-specific; their lifecycle assertions
+should stay aligned. Keep this guide aligned too. Puma registration, dashboard
+callers and CI Terraform versions
 remain repository-specific. Compare explicit source files, not generated
 `.terraform` directories or module-local lockfiles.

--- a/docs/puma-metrics.md
+++ b/docs/puma-metrics.md
@@ -1,0 +1,158 @@
+# Puma request capacity metrics
+
+The opt-in `PumaMetrics::Plugin` reports web request thread occupancy and queue
+backlog. The implementation is kept identical in the frontend and backend
+repositories. Backend UK and XI report separately; Sidekiq does not run the
+Puma server configuration and does not start this reporter.
+
+## Enable through the application configuration secret
+
+Add these string values to the existing **web application's configuration
+secret**, not to the Sidekiq worker secret:
+
+```json
+{
+  "PUMA_METRICS_ENABLED": "true",
+  "PUMA_METRICS_ENVIRONMENT": "production"
+}
+```
+
+Apply this to frontend, backend UK API and backend XI API configuration as
+required. `PUMA_METRICS_SERVICE` is optional: the Puma configuration defaults it
+to `frontend` or `backend-${SERVICE}` (UK when SERVICE is absent). If explicitly
+set, use `frontend`, `backend-uk` or `backend-xi` to match the dashboards.
+
+Set the environment explicitly: staging commonly uses `RAILS_ENV=production`,
+which would otherwise mislabel its metrics. In development use `development`.
+
+**Changing the secret alone does not change a running process.** Follow the
+normal deployment/configuration-refresh workflow so the secret values reach
+the task definition and replacement tasks. These repositories currently read
+configuration secrets into task environment values during Terraform execution;
+a force-new-deployment of an unchanged task definition may retain old values.
+This change does not modify secrets or ECS environment wiring. To disable, set
+`PUMA_METRICS_ENABLED` to `false` and use the same refresh workflow.
+
+## How collection works
+
+- One background thread per Puma master, sampling every 10 seconds. In single
+  mode the sampler runs beside the request threads in the single process.
+- Uses `launcher.stats`, not a Rails endpoint, control socket, Sidekiq job or
+  per-request hook. No database, metadata endpoint or AWS SDK calls.
+- In cluster mode Puma already sends worker check-ins to the master. These are
+  cached snapshots, not instantaneous observations at emission time.
+- Unbooted/invalid workers are counted as unready. Workers with check-ins older
+  than 30 seconds (or three configured check-in intervals, whichever is larger)
+  are counted as stale, not as idle. Worker age is retained in the log record.
+- Emits one raw JSON line in CloudWatch Embedded Metric Format (EMF) to stdout.
+  The existing ECS log pipeline must preserve that JSON as the log message.
+  EMF extraction uses CloudWatch Logs; the application does not need
+  `cloudwatch:PutMetricData` permission or an additional SDK dependency.
+- Uses a nonblocking write with no retry or buffer. Backpressured, closed or
+  failing output drops the sample. Lines larger than 4 KiB are also dropped to
+  bound logging work; this comfortably covers the observed four-worker tasks.
+  Unusual worker counts or oversized labels need the event size reviewed before
+  enabling. On transports allowing partial writes, the affected log event may
+  be unusable; it is not retried. Missing telemetry must never imply idle capacity.
+- Shutdown/restart callbacks wake and stop the loop using a signal-safe queue.
+  Phased worker restarts retain the single master collector. Full master
+  restarts create a new collector identity.
+
+This adds a small, bounded amount of CPU and log volume, not zero overhead.
+Confirm ingestion and resource overhead in development/staging before production.
+
+## Metrics and interpretation
+
+Namespace: `TradeTariff/Puma`. Dimensions: **Environment, Service** only.
+Task/collector UUID and worker PID/index are log properties, not paid metric
+dimensions. Each metric therefore has bounded cardinality across task turnover.
+
+| Metric | Meaning | Useful statistic |
+|---|---|---|
+| `BusyThreads` | `max_threads - pool_capacity`: occupied slots, excluding queued requests | Maximum / Average |
+| `AvailableThreads` | Puma's available pool capacity | Minimum / Average |
+| `MaxThreads` | Configured request slots per worker | Maximum |
+| `Utilization` | Busy threads divided by maximum threads, percent | Maximum / Average |
+| `Backlog` | Requests in a worker's internal thread-pool queue at check-in | Maximum |
+| `BacklogMax` | Puma's recorded peak backlog since previous stats reads | Maximum |
+| `ExpectedWorkers` | Workers known to the master, including startup/restart workers | Maximum per task |
+| `ReportingWorkers` | Fresh workers included in this sample | Minimum per task |
+| `StaleWorkers` | Workers whose last check-in is too old | Maximum per task |
+| `UnreadyWorkers` | Workers not booted or without usable statistics | Maximum per task |
+| `SaturatedWorkers` | Fresh workers with no available request slots | Maximum per task |
+
+Worker metrics are EMF arrays: each worker contributes a sample. Coverage
+metrics are per-master scalars. **Do not use Sum over a time range for these
+gauges.** It adds repeated observations, not simultaneous capacity. An Average
+is a sample average, not necessarily capacity-weighted when workers differ.
+
+Puma 8's `busy_threads` includes backlog; `running` means spawned threads. Neither
+is used as the executing-request count. Puma stats reads reset its maxima;
+another stats consumer can shorten the interval represented by `BacklogMax`.
+
+These are **not queue-wait durations**. Backlog does not include every request
+waiting in kernel sockets, the load balancer or another application. A slow
+backend can occupy a frontend thread while the backend is still queueing.
+Therefore frontend and backend occupancy cannot be added into a single shared
+capacity figure. CPU, memory and downstream connection/provider limits still
+matter even when thread capacity is available.
+
+## Dashboards
+
+`terraform/puma_metrics.tf` creates a dedicated dashboard, without touching the
+existing manually managed dashboards or ECS settings:
+
+- `Puma-frontend-<environment>` in the frontend repository.
+- `Puma-backend-<environment>` in the backend repository (UK and XI sections).
+
+Charts show busiest-worker utilisation, minimum available threads, backlog,
+stale/unready coverage and ECS running/desired tasks. Fleet charts use Logs
+Insights to take one latest snapshot per collector per 10-second bucket before
+summing. These are sampled totals for **reporting workers only**, not exact
+instantaneous fleet measurements. Sampling boundaries, deployment overlap and
+missing records can distort totals; compare reporting coverage with ECS tasks.
+If all collectors disappear, there is no record to plot: a blank is not zero.
+
+Use a short window for 10-second log charts. Seven-day/month views should use
+coarser bins to avoid query/visualisation limits, with explicit treatment of
+collector turnover. CloudWatch high-resolution metric detail is retained for
+3 hours, 1-minute data for 15 days, 5-minute data for 63 days and 1-hour data for
+455 days. Maxima remain useful after aggregation, but historical sub-minute
+shape cannot be reconstructed. Retained raw log snapshots can support a
+separate offline analysis at their original resolution.
+
+Do not set arbitrary rollout alarms in this change. Establish a baseline,
+check coverage, and agree service-specific thresholds alongside normal-traffic
+response times before using these measurements as a go-live gate.
+
+## Verification and rollout
+
+1. Deploy code and dashboard through the normal approved workflow, initially
+   outside production. Enable the two keys through the configuration secret.
+2. Confirm valid `event = "puma.metrics"` JSON records in `platform-logs-<env>`.
+   Confirm EMF extraction produces `TradeTariff/Puma` metrics with the expected
+   environment and service, not merely log records. Inspect EMF processing
+   errors if logs arrive but metrics do not.
+3. Compare reporting workers/task coverage with actual Puma startup logs and
+   ECS task counts. Check that disabled applications and Sidekiq emit nothing.
+4. In a safe environment, hold requests open to occupy all threads; confirm
+   available capacity reaches zero and reports recover after release. Backlog
+   may remain outside Puma's internal queue, so do not expect every waiting
+   client to appear in `Backlog`.
+5. Check restarts and log backpressure do not break serving/shutdown. Compare
+   CPU/memory/log volume before and after enabling. No production load test is
+   authorised by the instrumentation change.
+
+Local checks (no AWS access or Rails/database boot required for these specs):
+
+```sh
+bundle exec rspec --options /dev/null spec/lib/puma_metrics_spec.rb spec/lib/puma_metrics_integration_spec.rb
+bundle exec rubocop lib/puma_metrics.rb config/puma.rb spec/lib/puma_metrics*_spec.rb
+terraform -chdir=terraform/modules/puma_capacity_dashboard init -backend=false
+terraform -chdir=terraform/modules/puma_capacity_dashboard validate
+terraform -chdir=terraform/modules/puma_capacity_dashboard test
+```
+
+The Terraform tests use a mock AWS provider and do not apply resources. The
+RSpec integration tests launch real Puma in single and cluster modes, hold a
+request open, inspect the emitted metrics and verify graceful shutdown.

--- a/docs/puma-metrics.md
+++ b/docs/puma-metrics.md
@@ -106,10 +106,27 @@ existing manually managed dashboards or ECS settings:
 - `Puma-frontend-<environment>` in the frontend repository.
 - `Puma-backend-<environment>` in the backend repository (UK and XI sections).
 
-Charts show busiest-worker utilisation, minimum available threads, backlog,
-stale/unready coverage and ECS running/desired tasks. Fleet charts use Logs
-Insights to take one latest snapshot per collector per 10-second bucket before
-summing. These are sampled totals for **reporting workers only**, not exact
+**Start here:** each service has an aligned summary row: queued requests in the
+busiest worker, threads in the least-spare worker, reporting collectors, then
+running/desired ECS tasks. Both backend service summaries appear before any
+diagnostics. The dashboards link to each other and to this guide; there is no
+new shared dashboard resource.
+
+Summary metrics and reporting-collector bins use 60 seconds. A collector seen
+at least once during that minute counts once, even if its workers are stale or
+unready. This is a task-coverage proxy, not an exact simultaneous task count:
+master restarts and rolling replacements can contribute multiple identities.
+Compare it with ECS counts and inspect worker reporting/expected/stale/unready
+coverage in the diagnostics before trusting spare capacity. Missing telemetry
+is not a measured zero; charts do not fill gaps or infer health from an empty
+internal queue. Extrema may come from different workers and different times,
+so matching queue and spare-thread extrema do not establish a correlation.
+
+Diagnostic charts separate thread totals from queued-request totals and use
+explicit worker/service scope. Capacity totals exclude records without worker
+capacity fields rather than aggregating missing capacity into a false zero.
+Fleet charts use Logs Insights to take one latest snapshot per collector per
+10-second bucket before summing. These are sampled totals for **reporting workers only**, not exact
 instantaneous fleet measurements. Sampling boundaries, deployment overlap and
 missing records can distort totals; compare reporting coverage with ECS tasks.
 If all collectors disappear, there is no record to plot: a blank is not zero.
@@ -135,7 +152,11 @@ response times before using these measurements as a go-live gate.
    environment and service, not merely log records. Inspect EMF processing
    errors if logs arrive but metrics do not.
 3. Execute the dashboard's Logs Insights queries and check time-series rendering,
-   not just their presence in the dashboard JSON.
+   not just their presence in the dashboard JSON. Capture staging screenshots for
+   idle, sustained saturation, recovery and missing/partial telemetry. Confirm
+   an operator can identify the affected service and any coverage gap without
+   reading application code. This requires an approved staging rollout; local
+   mock tests are structural checks, not rendered or ingestion evidence.
 4. Compare reporting workers/task coverage with actual Puma startup logs and
    ECS task counts. Check that disabled applications and Sidekiq emit nothing.
 5. In a safe environment, hold requests open to occupy all threads; confirm

--- a/docs/puma-metrics.md
+++ b/docs/puma-metrics.md
@@ -181,7 +181,7 @@ terraform -chdir=terraform/modules/puma_capacity_dashboard validate
 terraform -chdir=terraform/modules/puma_capacity_dashboard test
 ```
 
-The `puma-dashboard-test` CI job runs the Terraform tests using a mock AWS
+The `terraform-test` CI job runs the Terraform tests using a mock AWS
 provider, without AWS credentials or applying resources. These are structural
 assertions, not evidence of deployed EMF extraction or query execution.
 
@@ -209,6 +209,9 @@ for file in spec/lib/puma_metrics_spec.rb \
   cmp "trade-tariff-frontend/$file" "trade-tariff-backend/$file" || exit 1
 done
 ```
+
+The frontend collector and dashboard have separate operational guides; keep the
+shared interpretation and rollout requirements aligned across those guides.
 
 Review `lib/puma_metrics.rb` together: only the plugin environment lookup should
 differ; collector behaviour stays aligned. The integration specs' expected

--- a/docs/puma-metrics.md
+++ b/docs/puma-metrics.md
@@ -43,7 +43,8 @@ This change does not modify secrets or ECS environment wiring. To disable, set
   cached snapshots, not instantaneous observations at emission time.
 - Unbooted/invalid workers are counted as unready. Workers with check-ins older
   than 30 seconds (or three configured check-in intervals, whichever is larger)
-  are counted as stale, not as idle. Worker age is retained in the log record.
+  are counted as stale, not as idle. Only fresh workers retain PID/index and
+  check-in age in the log record; stale workers contribute to the count only.
 - Emits one raw JSON line in CloudWatch Embedded Metric Format (EMF) to stdout.
   The existing ECS log pipeline must preserve that JSON as the log message.
   EMF extraction uses CloudWatch Logs; the application does not need
@@ -54,9 +55,9 @@ This change does not modify secrets or ECS environment wiring. To disable, set
   Unusual worker counts or oversized labels need the event size reviewed before
   enabling. On transports allowing partial writes, the affected log event may
   be unusable; it is not retried. Missing telemetry must never imply idle capacity.
-- Shutdown/restart callbacks wake and stop the loop using a signal-safe queue.
+- The shutdown callback wakes and stops the loop using a signal-safe queue.
   Phased worker restarts retain the single master collector. Full master
-  restarts create a new collector identity.
+  restarts replace the process image and create a new collector identity.
 
 This adds a small, bounded amount of CPU and log volume, not zero overhead.
 Confirm ingestion and resource overhead in development/staging before production.
@@ -68,7 +69,7 @@ Task/collector UUID and worker PID/index are log properties, not paid metric
 dimensions. Each metric therefore has bounded cardinality across task turnover.
 
 | Metric | Meaning | Useful statistic |
-|---|---|---|
+| --- | --- | --- |
 | `BusyThreads` | `max_threads - pool_capacity`: occupied slots, excluding queued requests | Maximum / Average |
 | `AvailableThreads` | Puma's available pool capacity | Minimum / Average |
 | `MaxThreads` | Configured request slots per worker | Maximum |
@@ -133,13 +134,15 @@ response times before using these measurements as a go-live gate.
    Confirm EMF extraction produces `TradeTariff/Puma` metrics with the expected
    environment and service, not merely log records. Inspect EMF processing
    errors if logs arrive but metrics do not.
-3. Compare reporting workers/task coverage with actual Puma startup logs and
+3. Execute the dashboard's Logs Insights queries and check time-series rendering,
+   not just their presence in the dashboard JSON.
+4. Compare reporting workers/task coverage with actual Puma startup logs and
    ECS task counts. Check that disabled applications and Sidekiq emit nothing.
-4. In a safe environment, hold requests open to occupy all threads; confirm
+5. In a safe environment, hold requests open to occupy all threads; confirm
    available capacity reaches zero and reports recover after release. Backlog
    may remain outside Puma's internal queue, so do not expect every waiting
    client to appear in `Backlog`.
-5. Check restarts and log backpressure do not break serving/shutdown. Compare
+6. Check restarts and log backpressure do not break serving/shutdown. Compare
    CPU/memory/log volume before and after enabling. No production load test is
    authorised by the instrumentation change.
 
@@ -153,6 +156,37 @@ terraform -chdir=terraform/modules/puma_capacity_dashboard validate
 terraform -chdir=terraform/modules/puma_capacity_dashboard test
 ```
 
-The Terraform tests use a mock AWS provider and do not apply resources. The
-RSpec integration tests launch real Puma in single and cluster modes, hold a
-request open, inspect the emitted metrics and verify graceful shutdown.
+The `puma-dashboard-test` CI job runs the Terraform tests using a mock AWS
+provider, without AWS credentials or applying resources. These are structural
+assertions, not evidence of deployed EMF extraction or query execution.
+
+The RSpec integration tests launch real Puma in single and cluster modes, check
+default service labels and the explicit environment override, hold a request
+open, then wait for idle recovery. They cover full master and phased worker
+restarts followed by serving and graceful shutdown. The phased scenario
+explicitly disables preloading, including in backend where ordinary phased
+restarts otherwise fall back to a full restart. Only the test subprocess uses
+a shorter sampling interval.
+
+## Keeping the repository copies in sync
+
+Whoever changes this telemetry owns the paired update in frontend and backend.
+Neither copy is an independent fork: submit companion changes together and run
+the focused checks in both repositories. No shared package is required.
+
+From the directory containing both checkouts, compare the shared sources:
+
+```sh
+for file in lib/puma_metrics.rb spec/lib/puma_metrics_spec.rb \
+  terraform/modules/puma_capacity_dashboard/main.tf \
+  terraform/modules/puma_capacity_dashboard/variables.tf \
+  terraform/modules/puma_capacity_dashboard/tests/dashboard.tftest.hcl; do
+  cmp "trade-tariff-frontend/$file" "trade-tariff-backend/$file" || exit 1
+done
+```
+
+Review the integration specs together: their expected service-label matrix is
+repository-specific; their lifecycle assertions should stay aligned. Keep this
+guide aligned too. Puma registration, dashboard callers and CI Terraform versions
+remain repository-specific. Compare explicit source files, not generated
+`.terraform` directories or module-local lockfiles.

--- a/lib/puma_metrics.rb
+++ b/lib/puma_metrics.rb
@@ -153,8 +153,8 @@ private
         service: ENV.fetch('PUMA_METRICS_SERVICE'),
         stale_after: [30, launcher.options.fetch(:worker_check_interval, 5) * 3].max,
       )
+      # Stop only on shutdown: before_restart also fires for phased worker restarts.
       launcher.events.after_stopped { reporter.stop }
-      launcher.events.before_restart { reporter.stop }
       in_background { reporter.run }
     end
   end

--- a/lib/puma_metrics.rb
+++ b/lib/puma_metrics.rb
@@ -1,0 +1,161 @@
+require 'json'
+require 'securerandom'
+require 'time'
+require 'puma/plugin'
+
+# Kept identical in trade-tariff-frontend and trade-tariff-backend. No Rails,
+# network calls or request hooks: only the Puma master's cached worker stats.
+class PumaMetrics
+  INTERVAL = 10
+  MAX_SAMPLE_BYTES = 4096
+  WORKER_METRICS = %w[BusyThreads AvailableThreads MaxThreads Backlog BacklogMax Utilization].freeze
+  COVERAGE_METRICS = %w[ExpectedWorkers ReportingWorkers StaleWorkers UnreadyWorkers SaturatedWorkers].freeze
+
+  def initialize(stats:, environment:, service:, output: $stdout, stale_after: 30)
+    @stats = stats
+    @environment = environment
+    @service = service
+    @output = output
+    @stale_after = stale_after
+    @collector_id = SecureRandom.uuid
+    @stop = Queue.new
+  end
+
+  def run
+    loop do
+      @stop.pop(timeout: INTERVAL)
+      break if @stop.closed?
+
+      sample
+    end
+  end
+
+  def stop
+    # Puma invokes shutdown callbacks from signal traps. Queue#close is safe
+    # there, unlike Mutex#synchronize, and wakes the sleeping sampler.
+    @stop.close
+  end
+
+  # The master does not load Rails in non-preloaded deployments.
+  def sample(now: Process.clock_gettime(Process::CLOCK_REALTIME))
+    now = now.to_f
+    snapshot = @stats.call
+    workers = snapshot.fetch(:worker_status) do
+      [{ pid: Process.pid, index: 0, booted: true, last_checkin: now, last_status: snapshot }]
+    end
+    payload = build_payload(workers, snapshot.fetch(:workers, 1), now)
+    line = "#{JSON.generate(payload)}\n"
+    return false if line.bytesize > MAX_SAMPLE_BYTES
+
+    # Never wait on logging backpressure and never retry/buffer stale samples.
+    @output.write_nonblock(line, exception: false) == line.bytesize
+  rescue StandardError
+    # Telemetry failure must not interrupt Puma. Missing coverage is visible on
+    # the dashboard; deliberately avoid recursively writing to a failing logger.
+    false
+  end
+
+private
+
+  def build_payload(workers, expected, now)
+    stale = 0
+    unready = 0
+    samples = workers.filter_map do |worker|
+      if !worker[:booted] || !valid_pool?(worker[:last_status])
+        unready += 1
+        next
+      end
+      age = checkin_age(worker[:last_checkin], now)
+      unless age
+        unready += 1
+        next
+      end
+      if age.negative? || age > @stale_after
+        stale += 1
+        next
+      end
+      worker_sample(worker, age)
+    end
+
+    payload = {
+      event: 'puma.metrics',
+      Environment: @environment,
+      Service: @service,
+      collector_id: @collector_id,
+      workers: samples,
+      ExpectedWorkers: expected,
+      ReportingWorkers: samples.size,
+      StaleWorkers: stale,
+      UnreadyWorkers: unready,
+      SaturatedWorkers: samples.count { |s| s[:AvailableThreads].zero? },
+    }
+    unless samples.empty?
+      WORKER_METRICS.each { |name| payload[name] = samples.map { |s| s.fetch(name.to_sym) } }
+      payload.merge!(
+        task_busy_threads: samples.sum { |s| s[:BusyThreads] },
+        task_available_threads: samples.sum { |s| s[:AvailableThreads] },
+        task_max_threads: samples.sum { |s| s[:MaxThreads] },
+        task_backlog: samples.sum { |s| s[:Backlog] },
+      )
+    end
+    names = COVERAGE_METRICS + (samples.empty? ? [] : WORKER_METRICS)
+    payload[:_aws] = {
+      Timestamp: (now.to_f * 1000).to_i,
+      CloudWatchMetrics: [{
+        Namespace: 'TradeTariff/Puma',
+        Dimensions: [%w[Environment Service]],
+        Metrics: names.map { |name| { Name: name, Unit: name == 'Utilization' ? 'Percent' : 'Count', StorageResolution: 1 } },
+      }],
+    }
+    payload
+  end
+
+  def checkin_age(timestamp, now)
+    now - (timestamp.is_a?(Numeric) ? timestamp : Time.iso8601(timestamp).to_f)
+  rescue ArgumentError, TypeError
+    nil
+  end
+
+  def valid_pool?(pool)
+    return false unless pool.is_a?(Hash)
+
+    max = pool[:max_threads]
+    available = pool[:pool_capacity]
+    backlog = pool[:backlog]
+    max.is_a?(Integer) && max.positive? && available.is_a?(Integer) &&
+      available.between?(0, max) && backlog.is_a?(Integer) && backlog >= 0
+  end
+
+  def worker_sample(worker, age)
+    pool = worker.fetch(:last_status)
+    max = pool.fetch(:max_threads)
+    available = pool.fetch(:pool_capacity)
+    # Puma 8's busy_threads includes backlog; running means spawned threads.
+    busy = max - available
+    {
+      pid: worker[:pid],
+      index: worker[:index],
+      checkin_age_seconds: age.round(3),
+      BusyThreads: busy,
+      AvailableThreads: available,
+      MaxThreads: max,
+      Backlog: pool.fetch(:backlog),
+      BacklogMax: pool.fetch(:backlog_max, pool.fetch(:backlog)),
+      Utilization: (100.0 * busy / max).round(2),
+    }
+  end
+
+  class Plugin < Puma::Plugin
+    def start(launcher)
+      reporter = PumaMetrics.new(
+        stats: -> { launcher.stats },
+        environment: ENV.fetch('PUMA_METRICS_ENVIRONMENT', ENV.fetch('RAILS_ENV', 'development')),
+        service: ENV.fetch('PUMA_METRICS_SERVICE'),
+        stale_after: [30, launcher.options.fetch(:worker_check_interval, 5) * 3].max,
+      )
+      launcher.events.after_stopped { reporter.stop }
+      launcher.events.before_restart { reporter.stop }
+      in_background { reporter.run }
+    end
+  end
+end

--- a/lib/puma_metrics.rb
+++ b/lib/puma_metrics.rb
@@ -3,8 +3,8 @@ require 'securerandom'
 require 'time'
 require 'puma/plugin'
 
-# Kept identical in trade-tariff-frontend and trade-tariff-backend. No Rails,
-# network calls or request hooks: only the Puma master's cached worker stats.
+# Keep collector behaviour aligned in frontend and backend; only the plugin's
+# environment lookup differs. No Rails, network calls or request hooks.
 class PumaMetrics
   INTERVAL = 10
   MAX_SAMPLE_BYTES = 4096
@@ -149,7 +149,7 @@ private
     def start(launcher)
       reporter = PumaMetrics.new(
         stats: -> { launcher.stats },
-        environment: ENV.fetch('PUMA_METRICS_ENVIRONMENT', ENV.fetch('RAILS_ENV', 'development')),
+        environment: ENV.fetch('ENVIRONMENT', 'local'),
         service: ENV.fetch('PUMA_METRICS_SERVICE'),
         stale_after: [30, launcher.options.fetch(:worker_check_interval, 5) * 3].max,
       )

--- a/spec/lib/puma_metrics_integration_spec.rb
+++ b/spec/lib/puma_metrics_integration_spec.rb
@@ -1,0 +1,95 @@
+require 'rspec'
+require 'json'
+require 'socket'
+require 'tmpdir'
+require 'timeout'
+require 'rbconfig'
+require 'open3'
+require_relative '../../lib/puma_metrics'
+
+RSpec.describe PumaMetrics do
+  it 'does not load the disabled reporter' do
+    config = File.expand_path('../../config/puma.rb', __dir__)
+    script = <<~RUBY
+      require 'puma'
+      require 'puma/configuration'
+      Puma::Configuration.new(config_files: [ARGV.fetch(0)]).load
+      abort 'disabled reporter was loaded' if defined?(PumaMetrics)
+    RUBY
+    output, status = Open3.capture2e(
+      { 'PUMA_METRICS_ENABLED' => nil, 'RAILS_ENV' => 'test', 'SSL_CERT_PEM' => nil, 'SSL_KEY_PEM' => nil },
+      RbConfig.ruby, '-e', script, config
+    )
+    expect(status).to be_success, output
+  end
+
+  [0, 1].each do |worker_count|
+    context "with #{worker_count} cluster workers" do
+      it 'reports saturation and shuts down', :aggregate_failures do
+        Dir.mktmpdir('puma-metrics') do |dir|
+          socket_path = File.join(dir, 'puma.sock')
+          started = File.join(dir, 'request-started')
+          release = File.join(dir, 'release')
+          config = File.join(dir, 'puma.rb')
+          application_config = File.expand_path('../../config/puma.rb', __dir__)
+          File.write(config, <<~RUBY)
+            instance_eval(File.read(#{application_config.inspect}), #{application_config.inspect})
+            workers #{worker_count}
+            threads 1, 1
+            worker_check_interval 1
+            raise_exception_on_sigterm false
+            bind #{"unix://#{socket_path}".inspect}
+            app ->(_env) {
+              File.write(#{started.inspect}, 'started')
+              sleep 0.01 until File.exist?(#{release.inspect})
+              [200, { 'content-type' => 'text/plain' }, ['ok']]
+            }
+          RUBY
+          reader, writer = IO.pipe
+          pid = Process.spawn(
+            { 'PUMA_METRICS_ENABLED' => 'true', 'PUMA_METRICS_SERVICE' => 'test-app', 'PUMA_METRICS_ENVIRONMENT' => 'test', 'RAILS_ENV' => 'test', 'SSL_CERT_PEM' => nil, 'SSL_KEY_PEM' => nil },
+            RbConfig.ruby, '-S', 'puma', '-C', config,
+            out: writer, err: writer, pgroup: true
+          )
+          writer.close
+          Timeout.timeout(15) { sleep 0.01 until File.socket?(socket_path) }
+          client = UNIXSocket.new(socket_path)
+          client.write("GET /slow HTTP/1.0\r\n\r\n")
+          Timeout.timeout(15) { sleep 0.01 until File.exist?(started) }
+          sample = Timeout.timeout(25) do
+            loop do
+              line = reader.gets
+              raise 'Puma exited before reporting' unless line
+              next unless line.start_with?('{')
+
+              parsed = JSON.parse(line)
+              break parsed if parsed['BusyThreads'] == [1]
+            end
+          end
+          expect(sample).to include('AvailableThreads' => [0], 'MaxThreads' => [1], 'SaturatedWorkers' => 1, 'ReportingWorkers' => 1)
+          File.write(release, 'release')
+          expect(Timeout.timeout(5) { client.read }).to include('200 OK')
+          Process.kill('TERM', pid)
+          _, status = Timeout.timeout(10) { Process.wait2(pid) }
+          expect(status).to be_success, reader.read
+        rescue Timeout::Error => e
+          raise "#{e.message}: #{reader&.read_nonblock(16_384, exception: false)}"
+        ensure
+          client&.close
+          reader&.close
+          writer&.close unless writer&.closed?
+          begin
+            Process.kill('KILL', -pid) if pid
+          rescue Errno::ESRCH
+            nil
+          end
+          begin
+            Process.wait(pid) if pid
+          rescue Errno::ECHILD
+            nil
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/puma_metrics_integration_spec.rb
+++ b/spec/lib/puma_metrics_integration_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe PumaMetrics do
     expect(status).to be_success, output
   end
 
-  [[0, nil, 'backend-uk'], [1, 'uk', 'backend-uk'], [1, 'xi', 'backend-xi']].each do |worker_count, service, expected_service|
+  [[0, nil, 'backend-uk', 'local'], [1, 'uk', 'backend-uk', 'staging'], [1, 'xi', 'backend-xi', 'staging']].each do |worker_count, service, expected_service, expected_environment|
     context "with #{worker_count} cluster workers and SERVICE=#{service.inspect}" do
       it 'reports recovery across restarts', :aggregate_failures do
         Dir.mktmpdir('puma-metrics') do |dir|
@@ -34,6 +34,7 @@ RSpec.describe PumaMetrics do
           application_config = File.expand_path('../../config/puma.rb', __dir__)
           File.write(config, <<~RUBY)
             instance_eval(File.read(#{application_config.inspect}), #{application_config.inspect})
+            raise 'Metrics boot must not load Rails' if defined?(Rails)
             # Exercise phased restarts explicitly, including the normally preloaded backend.
             preload_app! false if #{(service == 'xi').inspect}
             PumaMetrics.send(:remove_const, :INTERVAL)
@@ -51,7 +52,7 @@ RSpec.describe PumaMetrics do
           RUBY
           reader, writer = IO.pipe
           pid = Process.spawn(
-            { 'PUMA_METRICS_ENABLED' => 'true', 'PUMA_METRICS_SERVICE' => nil, 'SERVICE' => service, 'PUMA_METRICS_ENVIRONMENT' => 'metrics-test', 'RAILS_ENV' => 'test', 'SSL_CERT_PEM' => nil, 'SSL_KEY_PEM' => nil },
+            { 'PUMA_METRICS_ENABLED' => 'true', 'PUMA_METRICS_SERVICE' => nil, 'SERVICE' => service, 'ENVIRONMENT' => service ? expected_environment : nil, 'RAILS_ENV' => 'test', 'SSL_CERT_PEM' => nil, 'SSL_KEY_PEM' => nil },
             RbConfig.ruby, '-S', 'puma', '-C', config,
             out: writer, err: writer, pgroup: true
           )
@@ -63,7 +64,7 @@ RSpec.describe PumaMetrics do
           sample = matching_sample(reader) { |event| event['BusyThreads'] == [1] }
           expect(sample).to include(
             'AvailableThreads' => [0], 'MaxThreads' => [1], 'SaturatedWorkers' => 1,
-            'ReportingWorkers' => 1, 'Service' => expected_service, 'Environment' => 'metrics-test'
+            'ReportingWorkers' => 1, 'Service' => expected_service, 'Environment' => expected_environment
           )
           File.write(release, 'release')
           expect(Timeout.timeout(5) { client.read }).to include('200 OK')
@@ -74,7 +75,7 @@ RSpec.describe PumaMetrics do
           restarted = matching_sample(reader) do |event|
             event['BusyThreads'] == [0] && (phased ? event.dig('workers', 0, 'pid') != sample.dig('workers', 0, 'pid') : event['collector_id'] != sample['collector_id'])
           end
-          expect(restarted).to include('Service' => expected_service, 'Environment' => 'metrics-test', 'ReportingWorkers' => 1)
+          expect(restarted).to include('Service' => expected_service, 'Environment' => expected_environment, 'ReportingWorkers' => 1)
           expect(restarted['collector_id']).to eq(sample['collector_id']) if phased
           client.close
           client = UNIXSocket.new(socket_path)

--- a/spec/lib/puma_metrics_integration_spec.rb
+++ b/spec/lib/puma_metrics_integration_spec.rb
@@ -23,9 +23,9 @@ RSpec.describe PumaMetrics do
     expect(status).to be_success, output
   end
 
-  [0, 1].each do |worker_count|
-    context "with #{worker_count} cluster workers" do
-      it 'reports saturation and shuts down', :aggregate_failures do
+  [[0, nil, 'backend-uk'], [1, 'uk', 'backend-uk'], [1, 'xi', 'backend-xi']].each do |worker_count, service, expected_service|
+    context "with #{worker_count} cluster workers and SERVICE=#{service.inspect}" do
+      it 'reports recovery across restarts', :aggregate_failures do
         Dir.mktmpdir('puma-metrics') do |dir|
           socket_path = File.join(dir, 'puma.sock')
           started = File.join(dir, 'request-started')
@@ -34,6 +34,10 @@ RSpec.describe PumaMetrics do
           application_config = File.expand_path('../../config/puma.rb', __dir__)
           File.write(config, <<~RUBY)
             instance_eval(File.read(#{application_config.inspect}), #{application_config.inspect})
+            # Exercise phased restarts explicitly, including the normally preloaded backend.
+            preload_app! false if #{(service == 'xi').inspect}
+            PumaMetrics.send(:remove_const, :INTERVAL)
+            PumaMetrics.const_set(:INTERVAL, 0.2) # Shorten only this subprocess's observation interval.
             workers #{worker_count}
             threads 1, 1
             worker_check_interval 1
@@ -47,7 +51,7 @@ RSpec.describe PumaMetrics do
           RUBY
           reader, writer = IO.pipe
           pid = Process.spawn(
-            { 'PUMA_METRICS_ENABLED' => 'true', 'PUMA_METRICS_SERVICE' => 'test-app', 'PUMA_METRICS_ENVIRONMENT' => 'test', 'RAILS_ENV' => 'test', 'SSL_CERT_PEM' => nil, 'SSL_KEY_PEM' => nil },
+            { 'PUMA_METRICS_ENABLED' => 'true', 'PUMA_METRICS_SERVICE' => nil, 'SERVICE' => service, 'PUMA_METRICS_ENVIRONMENT' => 'metrics-test', 'RAILS_ENV' => 'test', 'SSL_CERT_PEM' => nil, 'SSL_KEY_PEM' => nil },
             RbConfig.ruby, '-S', 'puma', '-C', config,
             out: writer, err: writer, pgroup: true
           )
@@ -56,18 +60,25 @@ RSpec.describe PumaMetrics do
           client = UNIXSocket.new(socket_path)
           client.write("GET /slow HTTP/1.0\r\n\r\n")
           Timeout.timeout(15) { sleep 0.01 until File.exist?(started) }
-          sample = Timeout.timeout(25) do
-            loop do
-              line = reader.gets
-              raise 'Puma exited before reporting' unless line
-              next unless line.start_with?('{')
-
-              parsed = JSON.parse(line)
-              break parsed if parsed['BusyThreads'] == [1]
-            end
-          end
-          expect(sample).to include('AvailableThreads' => [0], 'MaxThreads' => [1], 'SaturatedWorkers' => 1, 'ReportingWorkers' => 1)
+          sample = matching_sample(reader) { |event| event['BusyThreads'] == [1] }
+          expect(sample).to include(
+            'AvailableThreads' => [0], 'MaxThreads' => [1], 'SaturatedWorkers' => 1,
+            'ReportingWorkers' => 1, 'Service' => expected_service, 'Environment' => 'metrics-test'
+          )
           File.write(release, 'release')
+          expect(Timeout.timeout(5) { client.read }).to include('200 OK')
+          recovered = matching_sample(reader) { |event| event['BusyThreads'] == [0] }
+          expect(recovered).to include('AvailableThreads' => [1], 'Backlog' => [0], 'SaturatedWorkers' => 0)
+          phased = service == 'xi'
+          Process.kill(phased ? 'USR1' : 'USR2', pid)
+          restarted = matching_sample(reader) do |event|
+            event['BusyThreads'] == [0] && (phased ? event.dig('workers', 0, 'pid') != sample.dig('workers', 0, 'pid') : event['collector_id'] != sample['collector_id'])
+          end
+          expect(restarted).to include('Service' => expected_service, 'Environment' => 'metrics-test', 'ReportingWorkers' => 1)
+          expect(restarted['collector_id']).to eq(sample['collector_id']) if phased
+          client.close
+          client = UNIXSocket.new(socket_path)
+          client.write("GET /after-restart HTTP/1.0\r\n\r\n")
           expect(Timeout.timeout(5) { client.read }).to include('200 OK')
           Process.kill('TERM', pid)
           _, status = Timeout.timeout(10) { Process.wait2(pid) }
@@ -89,6 +100,19 @@ RSpec.describe PumaMetrics do
             nil
           end
         end
+      end
+    end
+  end
+
+  def matching_sample(reader)
+    Timeout.timeout(15) do
+      loop do
+        line = reader.gets
+        raise 'Puma exited before reporting' unless line
+        next unless line.start_with?('{')
+
+        parsed = JSON.parse(line)
+        return parsed if yield(parsed)
       end
     end
   end

--- a/spec/lib/puma_metrics_spec.rb
+++ b/spec/lib/puma_metrics_spec.rb
@@ -1,0 +1,187 @@
+require 'rspec'
+require 'json'
+require 'stringio'
+require_relative '../../lib/puma_metrics'
+
+RSpec.describe PumaMetrics do
+  subject(:reporter) do
+    described_class.new(stats: -> { stats }, environment: 'test', service: 'backend-uk', output: output)
+  end
+
+  let(:output) { instance_double(IO) }
+  let(:now) { Time.utc(2026, 9, 9, 12) }
+  let(:worker) do
+    {
+      pid: 123,
+      index: 0,
+      booted: true,
+      last_checkin: now.iso8601,
+      last_status: { max_threads: 6, pool_capacity: 2, busy_threads: 7, backlog: 3, backlog_max: 5, running: 6 },
+    }
+  end
+  let(:stats) { { workers: 1, worker_status: [worker] } }
+  let(:lines) { [] }
+
+  before do
+    allow(output).to receive(:write_nonblock) do |line, **|
+      lines << JSON.parse(line)
+      line.bytesize
+    end
+  end
+
+  describe '#sample' do
+    it 'separates executing and queued work' do
+      reporter.sample(now: now)
+      expect(lines.last).to include('BusyThreads' => [4], 'AvailableThreads' => [2], 'Backlog' => [3], 'BacklogMax' => [5], 'MaxThreads' => [6])
+    end
+
+    it 'reports the per-worker utilisation' do
+      reporter.sample(now: now)
+      expect(lines.last.fetch('Utilization').first).to be_within(0.01).of(66.67)
+    end
+
+    it 'bounds custom metric dimensions' do
+      reporter.sample(now: now)
+      expect(lines.last.dig('_aws', 'CloudWatchMetrics', 0, 'Dimensions')).to eq([%w[Environment Service]])
+    end
+
+    it 'uses high-resolution EMF metrics' do
+      reporter.sample(now: now)
+      expect(lines.last.dig('_aws', 'CloudWatchMetrics', 0, 'Metrics')).to all(include('StorageResolution' => 1))
+    end
+
+    it 'keeps identity outside dimensions' do
+      reporter.sample(now: now)
+      expect(lines.last).to include('collector_id' => a_kind_of(String), 'workers' => [include('pid' => 123, 'index' => 0)])
+    end
+
+    it 'reports coverage and task totals' do
+      reporter.sample(now: now)
+      expect(lines.last).to include('ReportingWorkers' => 1, 'ExpectedWorkers' => 1, 'StaleWorkers' => 0, 'task_busy_threads' => 4, 'task_available_threads' => 2, 'task_backlog' => 3)
+    end
+
+    context 'with multiple workers' do
+      let(:stats) { { workers: 2, worker_status: [worker, worker.merge(pid: 456, index: 1, last_status: worker[:last_status].merge(pool_capacity: 0))] } }
+
+      it 'retains individual worker samples' do
+        reporter.sample(now: now)
+        expect(lines.last).to include('BusyThreads' => [4, 6], 'AvailableThreads' => [2, 0], 'SaturatedWorkers' => 1, 'task_busy_threads' => 10)
+      end
+    end
+
+    context 'with a stale worker' do
+      let(:worker) { super().merge(last_checkin: (now - 31).iso8601) }
+
+      it 'reports missing coverage not idle', :aggregate_failures do
+        reporter.sample(now: now)
+        expect(lines.last).to include('ReportingWorkers' => 0, 'StaleWorkers' => 1)
+        expect(lines.last).not_to have_key('AvailableThreads')
+        expect(lines.last).not_to have_key('task_available_threads')
+      end
+    end
+
+    context 'with a missing check-in' do
+      let(:stats) { { workers: 2, worker_status: [worker, worker.merge(pid: 456, last_checkin: nil)] } }
+
+      it 'still reports the healthy worker' do
+        reporter.sample(now: now)
+        expect(lines.last).to include('ReportingWorkers' => 1, 'UnreadyWorkers' => 1, 'BusyThreads' => [4])
+      end
+    end
+
+    context 'with an oversized snapshot' do
+      let(:stats) { { workers: 100, worker_status: Array.new(100) { |i| worker.merge(pid: i, index: i) } } }
+
+      it 'drops rather than splits the event', :aggregate_failures do
+        expect(reporter.sample(now: now)).to be(false)
+        expect(output).not_to have_received(:write_nonblock)
+      end
+    end
+
+    context 'with an unbooted worker' do
+      let(:worker) { super().merge(booted: false, last_status: {}) }
+
+      it 'does not invent capacity' do
+        reporter.sample(now: now)
+        expect(lines.last).to include('ReportingWorkers' => 0, 'UnreadyWorkers' => 1)
+      end
+    end
+
+    context 'with invalid pool statistics' do
+      let(:worker) { super().tap { |value| value[:last_status][:pool_capacity] = 7 } }
+
+      it 'omits the invalid worker' do
+        reporter.sample(now: now)
+        expect(lines.last).to include('ReportingWorkers' => 0, 'UnreadyWorkers' => 1)
+      end
+    end
+
+    context 'with single mode' do
+      let(:stats) { worker[:last_status] }
+
+      it 'samples the single process' do
+        reporter.sample(now: now)
+        expect(lines.last).to include('ReportingWorkers' => 1, 'BusyThreads' => [4])
+      end
+    end
+
+    context 'when the single server is unready' do
+      let(:stats) { {} }
+
+      it 'reports missing coverage' do
+        reporter.sample(now: now)
+        expect(lines.last).to include('ReportingWorkers' => 0, 'UnreadyWorkers' => 1)
+      end
+    end
+
+    context 'when stdout is backpressured' do
+      before { allow(output).to receive(:write_nonblock).and_return(:wait_writable) }
+
+      it 'drops the sample without waiting' do
+        expect(reporter.sample(now: now)).to be(false)
+      end
+    end
+
+    context 'when stdout writes a partial line' do
+      before { allow(output).to receive(:write_nonblock).and_return(5) }
+
+      it 'drops partial writes without retry', :aggregate_failures do
+        expect(reporter.sample(now: now)).to be(false)
+        expect(output).to have_received(:write_nonblock).once
+      end
+    end
+
+    context 'when stdout is closed' do
+      before { allow(output).to receive(:write_nonblock).and_raise(IOError) }
+
+      it 'does not propagate the failure' do
+        expect(reporter.sample(now: now)).to be(false)
+      end
+    end
+
+    context 'when stats collection fails' do
+      let(:stats) { raise 'stats unavailable' }
+
+      it 'does not propagate the failure' do
+        expect(reporter.sample(now: now)).to be(false)
+      end
+    end
+
+    it 'recovers on the next sample' do
+      allow(output).to receive(:write_nonblock).and_raise(IOError)
+      reporter.sample(now: now)
+      allow(output).to receive(:write_nonblock) { |line, **| line.bytesize }
+      expect(reporter.sample(now: now)).to be(true)
+    end
+  end
+
+  describe '#stop' do
+    it 'wakes the sleeping reporter' do
+      thread = Thread.new { reporter.run }
+      reporter.stop
+      expect(thread.join(1)).to eq(thread)
+    ensure
+      thread&.kill
+    end
+  end
+end

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -25,6 +25,7 @@ Terraform to deploy the service into AWS.
 | <a name="module_backend_uk"></a> [backend\_uk](#module\_backend\_uk) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.2.1 |
 | <a name="module_backend_xi"></a> [backend\_xi](#module\_backend\_xi) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.2.1 |
 | <a name="module_label_generator_dashboard"></a> [label\_generator\_dashboard](#module\_label\_generator\_dashboard) | ./modules/label_generator_dashboard | n/a |
+| <a name="module_puma_capacity_dashboard"></a> [puma\_capacity\_dashboard](#module\_puma\_capacity\_dashboard) | ./modules/puma_capacity_dashboard | n/a |
 | <a name="module_search_dashboard"></a> [search\_dashboard](#module\_search\_dashboard) | ./modules/search_dashboard | n/a |
 | <a name="module_search_experiment_dashboard"></a> [search\_experiment\_dashboard](#module\_search\_experiment\_dashboard) | ./modules/search_experiment_dashboard | n/a |
 | <a name="module_search_operations_dashboard"></a> [search\_operations\_dashboard](#module\_search\_operations\_dashboard) | ./modules/search_operations_dashboard | n/a |
@@ -105,6 +106,7 @@ Terraform to deploy the service into AWS.
 | ---- | ----------- |
 | <a name="output_ai_costs_dashboard_url"></a> [ai\_costs\_dashboard\_url](#output\_ai\_costs\_dashboard\_url) | URL to the AI Costs CloudWatch dashboard |
 | <a name="output_label_generator_dashboard_url"></a> [label\_generator\_dashboard\_url](#output\_label\_generator\_dashboard\_url) | URL to the Label Generator CloudWatch dashboard |
+| <a name="output_puma_capacity_dashboard_name"></a> [puma\_capacity\_dashboard\_name](#output\_puma\_capacity\_dashboard\_name) | Dashboard for Puma web request capacity. |
 | <a name="output_search_dashboard_url"></a> [search\_dashboard\_url](#output\_search\_dashboard\_url) | URL to the Search CloudWatch dashboard |
 | <a name="output_search_experiment_dashboard_url"></a> [search\_experiment\_dashboard\_url](#output\_search\_experiment\_dashboard\_url) | URL to the Search Experiment CloudWatch dashboard |
 | <a name="output_search_operations_dashboard_url"></a> [search\_operations\_dashboard\_url](#output\_search\_operations\_dashboard\_url) | URL to the Search Operations CloudWatch dashboard |

--- a/terraform/modules/puma_capacity_dashboard/README.md
+++ b/terraform/modules/puma_capacity_dashboard/README.md
@@ -5,13 +5,14 @@
 
 | Name | Version |
 | ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.7 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5 |
 
 ## Providers
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.100.0 |
 
 ## Modules
 

--- a/terraform/modules/puma_capacity_dashboard/README.md
+++ b/terraform/modules/puma_capacity_dashboard/README.md
@@ -1,0 +1,40 @@
+# puma_capacity_dashboard
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [aws_cloudwatch_dashboard.puma_capacity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_dashboard) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_application"></a> [application](#input\_application) | Application name used in the dashboard name. | `string` | n/a | yes |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment dimension emitted by the reporter. | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | Region containing the application logs and metrics. | `string` | n/a | yes |
+| <a name="input_services"></a> [services](#input\_services) | Service dimensions emitted by the reporter (frontend, backend-uk, backend-xi). | `list(string)` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_puma_capacity_dashboard_name"></a> [puma\_capacity\_dashboard\_name](#output\_puma\_capacity\_dashboard\_name) | Puma capacity dashboard (metrics require manual enablement through the application configuration secret). |
+<!-- END_TF_DOCS -->

--- a/terraform/modules/puma_capacity_dashboard/main.tf
+++ b/terraform/modules/puma_capacity_dashboard/main.tf
@@ -1,12 +1,18 @@
 locals {
-  puma_worker_charts = [
-    { title = "Busiest worker utilisation (%)", metric = "Utilization", stat = "Maximum" },
-    { title = "Available threads per worker (minimum)", metric = "AvailableThreads", stat = "Minimum" },
-    { title = "Busy threads per worker (maximum)", metric = "BusyThreads", stat = "Maximum" },
-    { title = "Queued requests per worker (maximum)", metric = "Backlog", stat = "Maximum" },
-    { title = "Peak backlog since previous stats read", metric = "BacklogMax", stat = "Maximum" },
-    { title = "Stale workers per task (maximum)", metric = "StaleWorkers", stat = "Maximum" },
+  summary_charts = [
+    { title = "Queued requests: busiest worker", metric = "Backlog", stat = "Maximum", unit = "Requests" },
+    { title = "Available threads: least spare worker", metric = "AvailableThreads", stat = "Minimum", unit = "Threads" },
   ]
+  worker_charts = [
+    { title = "Utilisation: busiest worker (%)", metric = "Utilization", unit = "Percent" },
+    { title = "Busy threads: busiest worker", metric = "BusyThreads", unit = "Threads" },
+    { title = "Queued requests: peak since worker stats read", metric = "BacklogMax", unit = "Requests" },
+  ]
+  log_source      = "SOURCE 'platform-logs-${var.environment}'"
+  detail_y        = 7 + length(var.services) * 6
+  other_app       = var.application == "frontend" ? "backend" : "frontend"
+  other_dashboard = "https://${var.region}.console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=Puma-${local.other_app}-${var.environment}"
+  guide           = "https://github.com/trade-tariff/trade-tariff-${var.application}/blob/main/docs/puma-metrics.md"
 }
 
 resource "aws_cloudwatch_dashboard" "puma_capacity" {
@@ -16,64 +22,119 @@ resource "aws_cloudwatch_dashboard" "puma_capacity" {
     periodOverride = "inherit"
     widgets = concat([
       {
-        type = "text", x = 0, y = 0, width = 24, height = 3
+        type = "text", x = 0, y = 0, width = 24, height = 4
         properties = {
-          markdown = "# Puma request capacity\n10-second snapshots; worker check-ins can lag. These are thread-pool queues, NOT queue waiting time or Sidekiq. Never sum gauge samples over time. Missing/stale telemetry is NOT spare capacity. Fleet totals below include only reporting workers: check coverage before interpreting them. Task turnover and sampling boundaries can temporarily distort fleet totals. High-resolution metrics retain sub-minute detail for 3 hours; use 60s/300s periods for week/month views."
+          markdown = join("\n\n", [
+            "# Puma request capacity — ${var.environment}",
+            "**Start here:** compare queued requests and spare threads, then reporting collectors against ECS tasks. Check worker coverage below before trusting spare capacity. An empty internal queue does not prove service health.",
+            "**Missing telemetry is NOT zero or spare capacity.** Collectors seen per minute are a task-coverage proxy, not a concurrent task count; restart/rollout overlap can inflate it. Extrema may come from different workers and times.",
+            "[${local.other_app} dashboard](${local.other_dashboard}) | [Investigation and rollout guide](${local.guide})",
+          ])
         }
       }
       ], flatten([
         for service_index, service in var.services : concat([
-          for chart_index, chart in local.puma_worker_charts : {
-            type = "metric", x = (chart_index % 3) * 8, y = 3 + service_index * 24 + floor(chart_index / 3) * 6, width = 8, height = 6
+          for chart_index, chart in local.summary_charts : {
+            type = "metric", x = chart_index * 6, y = 4 + service_index * 6, width = 6, height = 6
             properties = {
               title   = "${service}: ${chart.title}", region = var.region, view = "timeSeries", period = 60
+              yAxis   = { left = { label = chart.unit, showUnits = false, min = 0 } }
               metrics = [["TradeTariff/Puma", chart.metric, "Environment", var.environment, "Service", service, { stat = chart.stat }]]
             }
           }
           ], [
           {
-            type = "log", x = 0, y = 15 + service_index * 24, width = 12, height = 6
+            type = "log", x = 12, y = 4 + service_index * 6, width = 6, height = 6
             properties = {
-              title = "${service}: sampled fleet slots (reporting workers only)", region = var.region, view = "timeSeries"
+              title = "${service}: Reporting collectors: seen per minute", region = var.region, view = "timeSeries"
               query = <<-QUERY
-              SOURCE 'platform-logs-${var.environment}'
+              ${local.log_source}
               | filter event = "puma.metrics" and Service = "${service}" and Environment = "${var.environment}"
-              | stats latest(task_busy_threads) as busy, latest(task_available_threads) as available, latest(task_backlog) as queued by collector_id, bin(10s) as sampled_at
-              | stats sum(busy) as busy_threads, sum(available) as available_threads, sum(queued) as backlog by sampled_at
+              | stats latest(ReportingWorkers) as reporting by collector_id, bin(60s) as sampled_at
+              | stats count(*) as reporting_collectors by sampled_at
               | sort sampled_at asc
             QUERY
             }
           },
           {
-            type = "log", x = 12, y = 15 + service_index * 24, width = 12, height = 6
+            type = "metric", x = 18, y = 4 + service_index * 6, width = 6, height = 6
             properties = {
-              title = "${service}: reporting coverage (compare with running tasks)", region = var.region, view = "timeSeries"
-              query = <<-QUERY
-              SOURCE 'platform-logs-${var.environment}'
-              | filter event = "puma.metrics" and Service = "${service}" and Environment = "${var.environment}"
-              | stats latest(ReportingWorkers) as reporting, latest(ExpectedWorkers) as expected, latest(StaleWorkers) as stale, latest(UnreadyWorkers) as unready by collector_id, bin(10s) as sampled_at
-              | stats count(*) as reporting_tasks, sum(reporting) as reporting_workers, sum(expected) as expected_workers, sum(stale) as stale_workers, sum(unready) as unready_workers by sampled_at
-              | sort sampled_at asc
-            QUERY
-            }
-          },
-          {
-            type = "metric", x = 0, y = 21 + service_index * 24, width = 12, height = 6
-            properties = {
-              title = "${service}: running and desired ECS tasks", region = var.region, view = "timeSeries", period = 60
+              title = "${service}: Running and desired ECS tasks", region = var.region, view = "timeSeries", period = 60
+              yAxis = { left = { label = "Tasks", showUnits = false, min = 0 } }
               metrics = [
-                ["ECS/ContainerInsights", "RunningTaskCount", "ServiceName", service, "ClusterName", "trade-tariff-cluster-${var.environment}", { stat = "Minimum" }],
-                ["ECS/ContainerInsights", "DesiredTaskCount", "ServiceName", service, "ClusterName", "trade-tariff-cluster-${var.environment}", { stat = "Maximum" }],
+                ["ECS/ContainerInsights", "RunningTaskCount", "ServiceName", service, "ClusterName", "trade-tariff-cluster-${var.environment}", { stat = "Minimum", label = "Running tasks: minimum" }],
+                ["ECS/ContainerInsights", "DesiredTaskCount", "ServiceName", service, "ClusterName", "trade-tariff-cluster-${var.environment}", { stat = "Maximum", label = "Desired tasks: maximum" }],
               ]
             }
           },
-          {
-            type = "metric", x = 12, y = 21 + service_index * 24, width = 12, height = 6
+        ])
+      ]), [
+      {
+        type = "text", x = 0, y = local.detail_y - 3, width = 24, height = 3
+        properties = {
+          markdown = "## Diagnostic detail\nService totals include reporting workers only; compare reporting with expected workers and stale/unready counts. Gauges must not be summed over time. Summary charts use 60s periods/bins; diagnostic log charts use 10s bins and incur query costs. Use short windows; see the [guide](${local.guide}) for longer-term analysis. Puma queues exclude socket/network waits and Sidekiq."
+        }
+      }
+      ], flatten([
+        for service_index, service in var.services : concat([
+          for chart_index, chart in local.worker_charts : {
+            type = "metric", x = chart_index * 8, y = local.detail_y + service_index * 18, width = 8, height = 6
             properties = {
-              title = "${service}: fully occupied / unready workers per task (maximum)", region = var.region, view = "timeSeries", period = 60
+              title   = "${service}: ${chart.title}", region = var.region, view = "timeSeries", period = 60
+              yAxis   = { left = { label = chart.unit, showUnits = false, min = 0 } }
+              metrics = [["TradeTariff/Puma", chart.metric, "Environment", var.environment, "Service", service, { stat = "Maximum" }]]
+            }
+          }
+          ], [
+          {
+            type = "log", x = 0, y = local.detail_y + 6 + service_index * 18, width = 12, height = 6
+            properties = {
+              title = "${service}: Threads: sampled service totals", region = var.region, view = "timeSeries"
+              query = <<-QUERY
+              ${local.log_source}
+              | filter event = "puma.metrics" and Service = "${service}" and Environment = "${var.environment}"
+              | filter ispresent(task_busy_threads)
+              | stats latest(task_busy_threads) as busy, latest(task_available_threads) as available by collector_id, bin(10s) as sampled_at
+              | stats sum(busy) as busy_threads, sum(available) as available_threads by sampled_at
+              | sort sampled_at asc
+            QUERY
+            }
+          },
+          {
+            type = "log", x = 12, y = local.detail_y + 6 + service_index * 18, width = 12, height = 6
+            properties = {
+              title = "${service}: Queued requests: sampled service total", region = var.region, view = "timeSeries"
+              query = <<-QUERY
+              ${local.log_source}
+              | filter event = "puma.metrics" and Service = "${service}" and Environment = "${var.environment}"
+              | filter ispresent(task_backlog)
+              | stats latest(task_backlog) as queued by collector_id, bin(10s) as sampled_at
+              | stats sum(queued) as queued_requests by sampled_at
+              | sort sampled_at asc
+            QUERY
+            }
+          },
+          {
+            type = "log", x = 0, y = local.detail_y + 12 + service_index * 18, width = 12, height = 6
+            properties = {
+              title = "${service}: Workers: sampled reporting coverage", region = var.region, view = "timeSeries"
+              query = <<-QUERY
+              ${local.log_source}
+              | filter event = "puma.metrics" and Service = "${service}" and Environment = "${var.environment}"
+              | stats latest(ReportingWorkers) as reporting, latest(ExpectedWorkers) as expected, latest(StaleWorkers) as stale, latest(UnreadyWorkers) as unready by collector_id, bin(10s) as sampled_at
+              | stats sum(reporting) as reporting_workers, sum(expected) as expected_workers, sum(stale) as stale_workers, sum(unready) as unready_workers by sampled_at
+              | sort sampled_at asc
+            QUERY
+            }
+          },
+          {
+            type = "metric", x = 12, y = local.detail_y + 12 + service_index * 18, width = 12, height = 6
+            properties = {
+              title = "${service}: Workers per task: maximum stale, unready or occupied", region = var.region, view = "timeSeries", period = 60
+              yAxis = { left = { label = "Workers", showUnits = false, min = 0 } }
               metrics = [
-                ["TradeTariff/Puma", "SaturatedWorkers", "Environment", var.environment, "Service", service, { stat = "Maximum" }],
-                ["TradeTariff/Puma", "UnreadyWorkers", "Environment", var.environment, "Service", service, { stat = "Maximum" }],
+                for metric in ["StaleWorkers", "UnreadyWorkers", "SaturatedWorkers"] :
+                ["TradeTariff/Puma", metric, "Environment", var.environment, "Service", service, { stat = "Maximum" }]
               ]
             }
           },

--- a/terraform/modules/puma_capacity_dashboard/main.tf
+++ b/terraform/modules/puma_capacity_dashboard/main.tf
@@ -1,0 +1,88 @@
+locals {
+  puma_worker_charts = [
+    { title = "Busiest worker utilisation (%)", metric = "Utilization", stat = "Maximum" },
+    { title = "Available threads per worker (minimum)", metric = "AvailableThreads", stat = "Minimum" },
+    { title = "Busy threads per worker (maximum)", metric = "BusyThreads", stat = "Maximum" },
+    { title = "Queued requests per worker (maximum)", metric = "Backlog", stat = "Maximum" },
+    { title = "Peak backlog since previous stats read", metric = "BacklogMax", stat = "Maximum" },
+    { title = "Stale workers per task (maximum)", metric = "StaleWorkers", stat = "Maximum" },
+  ]
+}
+
+resource "aws_cloudwatch_dashboard" "puma_capacity" {
+  dashboard_name = "Puma-${var.application}-${var.environment}"
+  dashboard_body = jsonencode({
+    start          = "-PT3H"
+    periodOverride = "inherit"
+    widgets = concat([
+      {
+        type = "text", x = 0, y = 0, width = 24, height = 3
+        properties = {
+          markdown = "# Puma request capacity\n10-second snapshots; worker check-ins can lag. These are thread-pool queues, NOT queue waiting time or Sidekiq. Never sum gauge samples over time. Missing/stale telemetry is NOT spare capacity. Fleet totals below include only reporting workers: check coverage before interpreting them. Task turnover and sampling boundaries can temporarily distort fleet totals. High-resolution metrics retain sub-minute detail for 3 hours; use 60s/300s periods for week/month views."
+        }
+      }
+      ], flatten([
+        for service_index, service in var.services : concat([
+          for chart_index, chart in local.puma_worker_charts : {
+            type = "metric", x = (chart_index % 3) * 8, y = 3 + service_index * 24 + floor(chart_index / 3) * 6, width = 8, height = 6
+            properties = {
+              title   = "${service}: ${chart.title}", region = var.region, view = "timeSeries", period = 60
+              metrics = [["TradeTariff/Puma", chart.metric, "Environment", var.environment, "Service", service, { stat = chart.stat }]]
+            }
+          }
+          ], [
+          {
+            type = "log", x = 0, y = 15 + service_index * 24, width = 12, height = 6
+            properties = {
+              title = "${service}: sampled fleet slots (reporting workers only)", region = var.region, view = "timeSeries"
+              query = <<-QUERY
+              SOURCE 'platform-logs-${var.environment}'
+              | filter event = "puma.metrics" and Service = "${service}" and Environment = "${var.environment}"
+              | stats latest(task_busy_threads) as busy, latest(task_available_threads) as available, latest(task_backlog) as queued by collector_id, bin(10s) as sampled_at
+              | stats sum(busy) as busy_threads, sum(available) as available_threads, sum(queued) as backlog by sampled_at
+              | sort sampled_at asc
+            QUERY
+            }
+          },
+          {
+            type = "log", x = 12, y = 15 + service_index * 24, width = 12, height = 6
+            properties = {
+              title = "${service}: reporting coverage (compare with running tasks)", region = var.region, view = "timeSeries"
+              query = <<-QUERY
+              SOURCE 'platform-logs-${var.environment}'
+              | filter event = "puma.metrics" and Service = "${service}" and Environment = "${var.environment}"
+              | stats latest(ReportingWorkers) as reporting, latest(ExpectedWorkers) as expected, latest(StaleWorkers) as stale, latest(UnreadyWorkers) as unready by collector_id, bin(10s) as sampled_at
+              | stats count(*) as reporting_tasks, sum(reporting) as reporting_workers, sum(expected) as expected_workers, sum(stale) as stale_workers, sum(unready) as unready_workers by sampled_at
+              | sort sampled_at asc
+            QUERY
+            }
+          },
+          {
+            type = "metric", x = 0, y = 21 + service_index * 24, width = 12, height = 6
+            properties = {
+              title = "${service}: running and desired ECS tasks", region = var.region, view = "timeSeries", period = 60
+              metrics = [
+                ["ECS/ContainerInsights", "RunningTaskCount", "ServiceName", service, "ClusterName", "trade-tariff-cluster-${var.environment}", { stat = "Minimum" }],
+                ["ECS/ContainerInsights", "DesiredTaskCount", "ServiceName", service, "ClusterName", "trade-tariff-cluster-${var.environment}", { stat = "Maximum" }],
+              ]
+            }
+          },
+          {
+            type = "metric", x = 12, y = 21 + service_index * 24, width = 12, height = 6
+            properties = {
+              title = "${service}: fully occupied / unready workers per task (maximum)", region = var.region, view = "timeSeries", period = 60
+              metrics = [
+                ["TradeTariff/Puma", "SaturatedWorkers", "Environment", var.environment, "Service", service, { stat = "Maximum" }],
+                ["TradeTariff/Puma", "UnreadyWorkers", "Environment", var.environment, "Service", service, { stat = "Maximum" }],
+              ]
+            }
+          },
+        ])
+    ]))
+  })
+}
+
+output "puma_capacity_dashboard_name" {
+  description = "Puma capacity dashboard (metrics require manual enablement through the application configuration secret)."
+  value       = aws_cloudwatch_dashboard.puma_capacity.dashboard_name
+}

--- a/terraform/modules/puma_capacity_dashboard/main.tf
+++ b/terraform/modules/puma_capacity_dashboard/main.tf
@@ -12,7 +12,8 @@ locals {
   detail_y        = 7 + length(var.services) * 6
   other_app       = var.application == "frontend" ? "backend" : "frontend"
   other_dashboard = "https://${var.region}.console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=Puma-${local.other_app}-${var.environment}"
-  guide           = "https://github.com/trade-tariff/trade-tariff-${var.application}/blob/main/docs/puma-metrics.md"
+  guide_file      = var.application == "frontend" ? "puma-capacity-dashboard.md" : "puma-metrics.md"
+  guide           = "https://github.com/trade-tariff/trade-tariff-${var.application}/blob/main/docs/${local.guide_file}"
 }
 
 resource "aws_cloudwatch_dashboard" "puma_capacity" {

--- a/terraform/modules/puma_capacity_dashboard/tests/dashboard.tftest.hcl
+++ b/terraform/modules/puma_capacity_dashboard/tests/dashboard.tftest.hcl
@@ -1,0 +1,54 @@
+mock_provider "aws" {}
+
+variables {
+  environment = "test"
+  region      = "eu-west-2"
+  application = "backend"
+  services    = ["backend-uk", "backend-xi"]
+}
+
+run "backend_dashboard" {
+  command = plan
+
+  assert {
+    condition     = aws_cloudwatch_dashboard.puma_capacity.dashboard_name == "Puma-backend-test"
+    error_message = "Backend dashboard must have a unique environment-specific name."
+  }
+
+  assert {
+    condition     = length(jsondecode(aws_cloudwatch_dashboard.puma_capacity.dashboard_body).widgets) == 21
+    error_message = "Both backend services must have capacity and coverage charts."
+  }
+
+  assert {
+    condition = alltrue(flatten([
+      for w in jsondecode(aws_cloudwatch_dashboard.puma_capacity.dashboard_body).widgets : [
+        for metric in try(w.properties.metrics, []) :
+        contains(["Minimum", "Maximum", "Average"], metric[length(metric) - 1].stat)
+      ]
+    ]))
+    error_message = "Gauge metrics must not sum samples over time."
+  }
+
+  assert {
+    condition = alltrue([
+      for w in jsondecode(aws_cloudwatch_dashboard.puma_capacity.dashboard_body).widgets :
+      can(regex("latest\\(", w.properties.query)) && can(regex("collector_id", w.properties.query))
+      if w.type == "log"
+    ])
+    error_message = "Fleet charts must deduplicate snapshots by collector before summing."
+  }
+}
+
+run "frontend_dashboard" {
+  command = plan
+  variables {
+    application = "frontend"
+    services    = ["frontend"]
+  }
+
+  assert {
+    condition     = aws_cloudwatch_dashboard.puma_capacity.dashboard_name == "Puma-frontend-test" && length(jsondecode(aws_cloudwatch_dashboard.puma_capacity.dashboard_body).widgets) == 11
+    error_message = "Frontend must have its own dashboard with one service."
+  }
+}

--- a/terraform/modules/puma_capacity_dashboard/tests/dashboard.tftest.hcl
+++ b/terraform/modules/puma_capacity_dashboard/tests/dashboard.tftest.hcl
@@ -16,8 +16,87 @@ run "backend_dashboard" {
   }
 
   assert {
-    condition     = length(jsondecode(aws_cloudwatch_dashboard.puma_capacity.dashboard_body).widgets) == 21
+    condition     = length(jsondecode(aws_cloudwatch_dashboard.puma_capacity.dashboard_body).widgets) == 24
     error_message = "Both backend services must have capacity and coverage charts."
+  }
+
+  assert {
+    condition = alltrue([
+      for i, service in var.services :
+      jsondecode(aws_cloudwatch_dashboard.puma_capacity.dashboard_body).widgets[1 + i * 4].properties.title == "${service}: Queued requests: busiest worker" &&
+      jsondecode(aws_cloudwatch_dashboard.puma_capacity.dashboard_body).widgets[2 + i * 4].properties.title == "${service}: Available threads: least spare worker" &&
+      jsondecode(aws_cloudwatch_dashboard.puma_capacity.dashboard_body).widgets[3 + i * 4].properties.title == "${service}: Reporting collectors: seen per minute" &&
+      jsondecode(aws_cloudwatch_dashboard.puma_capacity.dashboard_body).widgets[4 + i * 4].properties.title == "${service}: Running and desired ECS tasks" &&
+      alltrue([for j in range(4) :
+        jsondecode(aws_cloudwatch_dashboard.puma_capacity.dashboard_body).widgets[1 + i * 4 + j].x == j * 6 &&
+        jsondecode(aws_cloudwatch_dashboard.puma_capacity.dashboard_body).widgets[1 + i * 4 + j].y == 4 + i * 6
+      ])
+    ])
+    error_message = "All service summaries must align queue, spare threads, reporting collectors and ECS tasks in that order."
+  }
+
+  assert {
+    condition = alltrue([
+      for i in range(length(var.services)) :
+      jsondecode(aws_cloudwatch_dashboard.puma_capacity.dashboard_body).widgets[1 + i * 4].properties.metrics[0][1] == "Backlog" &&
+      jsondecode(aws_cloudwatch_dashboard.puma_capacity.dashboard_body).widgets[1 + i * 4].properties.metrics[0][6].stat == "Maximum" &&
+      jsondecode(aws_cloudwatch_dashboard.puma_capacity.dashboard_body).widgets[2 + i * 4].properties.metrics[0][1] == "AvailableThreads" &&
+      jsondecode(aws_cloudwatch_dashboard.puma_capacity.dashboard_body).widgets[2 + i * 4].properties.metrics[0][6].stat == "Minimum" &&
+      can(regex("bin\\(60s\\)", jsondecode(aws_cloudwatch_dashboard.puma_capacity.dashboard_body).widgets[3 + i * 4].properties.query))
+    ])
+    error_message = "Summary extrema must use the correct metrics/statistics with minute-binned collector coverage."
+  }
+
+  assert {
+    condition = (
+      alltrue([
+        for w in jsondecode(aws_cloudwatch_dashboard.puma_capacity.dashboard_body).widgets :
+        !(strcontains(try(w.properties.query, ""), "sum(queued)") && strcontains(try(w.properties.query, ""), "sum(available)"))
+      ]) &&
+      length([for w in jsondecode(aws_cloudwatch_dashboard.puma_capacity.dashboard_body).widgets : w if endswith(try(w.properties.title, ""), "Queued requests: sampled service total")]) == length(var.services)
+    )
+    error_message = "Service queue totals must be separate from thread totals."
+  }
+
+  assert {
+    condition = alltrue([
+      for w in jsondecode(aws_cloudwatch_dashboard.puma_capacity.dashboard_body).widgets :
+      w.properties.period == 60 && contains(["Requests", "Threads", "Tasks", "Workers", "Percent"], w.properties.yAxis.left.label)
+      if w.type == "metric"
+    ])
+    error_message = "Metric charts must use matching minute periods and explicit operator-facing units."
+  }
+
+  assert {
+    condition = alltrue([
+      for w in jsondecode(aws_cloudwatch_dashboard.puma_capacity.dashboard_body).widgets :
+      strcontains(w.properties.query, "filter ispresent(task_backlog)")
+      if endswith(try(w.properties.title, ""), "Queued requests: sampled service total")
+      ]) && alltrue([
+      for w in jsondecode(aws_cloudwatch_dashboard.puma_capacity.dashboard_body).widgets :
+      strcontains(w.properties.query, "filter ispresent(task_busy_threads)")
+      if endswith(try(w.properties.title, ""), "Threads: sampled service totals")
+    ])
+    error_message = "Missing worker capacity must be excluded from totals, not aggregated into false zeroes."
+  }
+
+  assert {
+    condition = alltrue(flatten([
+      for i, a in jsondecode(aws_cloudwatch_dashboard.puma_capacity.dashboard_body).widgets : [
+        for j, b in jsondecode(aws_cloudwatch_dashboard.puma_capacity.dashboard_body).widgets :
+        i == j || a.x + a.width <= b.x || b.x + b.width <= a.x || a.y + a.height <= b.y || b.y + b.height <= a.y
+      ]
+    ]))
+    error_message = "Summary and diagnostic widgets must not overlap."
+  }
+
+  assert {
+    condition = (
+      can(regex("Start here", jsondecode(aws_cloudwatch_dashboard.puma_capacity.dashboard_body).widgets[0].properties.markdown)) &&
+      can(regex("Missing telemetry is NOT zero", jsondecode(aws_cloudwatch_dashboard.puma_capacity.dashboard_body).widgets[0].properties.markdown)) &&
+      !can(regex("FILL\\(", aws_cloudwatch_dashboard.puma_capacity.dashboard_body))
+    )
+    error_message = "Start-here guidance must distinguish missing telemetry from zero without filling gaps."
   }
 
   assert {
@@ -48,7 +127,7 @@ run "frontend_dashboard" {
   }
 
   assert {
-    condition     = aws_cloudwatch_dashboard.puma_capacity.dashboard_name == "Puma-frontend-test" && length(jsondecode(aws_cloudwatch_dashboard.puma_capacity.dashboard_body).widgets) == 11
+    condition     = aws_cloudwatch_dashboard.puma_capacity.dashboard_name == "Puma-frontend-test" && length(jsondecode(aws_cloudwatch_dashboard.puma_capacity.dashboard_body).widgets) == 13
     error_message = "Frontend must have its own dashboard with one service."
   }
 }

--- a/terraform/modules/puma_capacity_dashboard/variables.tf
+++ b/terraform/modules/puma_capacity_dashboard/variables.tf
@@ -1,4 +1,6 @@
 terraform {
+  required_version = ">= 1.7"
+
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/terraform/modules/puma_capacity_dashboard/variables.tf
+++ b/terraform/modules/puma_capacity_dashboard/variables.tf
@@ -1,0 +1,28 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5"
+    }
+  }
+}
+
+variable "environment" {
+  description = "Environment dimension emitted by the reporter."
+  type        = string
+}
+
+variable "region" {
+  description = "Region containing the application logs and metrics."
+  type        = string
+}
+
+variable "application" {
+  description = "Application name used in the dashboard name."
+  type        = string
+}
+
+variable "services" {
+  description = "Service dimensions emitted by the reporter (frontend, backend-uk, backend-xi)."
+  type        = list(string)
+}

--- a/terraform/puma_metrics.tf
+++ b/terraform/puma_metrics.tf
@@ -1,0 +1,14 @@
+# Reporter enablement is managed manually through application configuration
+# secrets. This module creates a dashboard only; it does not change ECS tasks.
+module "puma_capacity_dashboard" {
+  source      = "./modules/puma_capacity_dashboard"
+  environment = var.environment
+  region      = var.region
+  application = "backend"
+  services    = ["backend-uk", "backend-xi"]
+}
+
+output "puma_capacity_dashboard_name" {
+  description = "Dashboard for Puma web request capacity."
+  value       = module.puma_capacity_dashboard.puma_capacity_dashboard_name
+}


### PR DESCRIPTION
## What:

- [x] Add an opt-in Puma master sampler for busy and available threads, request backlog and reporting coverage in the UK and XI web services.
- [x] Emit a bounded, nonblocking CloudWatch Embedded Metric Format log every 10 seconds, outside the request path and without AWS SDK or database calls.
- [x] Add the `Puma-backend-<environment>` dashboard with separate UK/XI busiest-worker, queue and sampled fleet-capacity views.
- [x] Document manual enablement through the existing API configuration secrets. Leave secrets, ECS environment wiring, IAM and Sidekiq services unchanged.
- [x] Cover disabled configuration, metric calculations, stale workers, logging failures and real Puma saturation, idle recovery, default service labels, existing application environments and defaults, full/phased restarts and shutdown. The 24 standalone focused specs, RuboCop and two mocked Terraform tests pass; pre-commit checks pass. The Rails-backed test runner is blocked locally by unavailable PostgreSQL. No RuboCop disables.

- [x] Keep the collector alive through phased worker restarts; stop it only on master shutdown.
- [x] Run the mocked dashboard assertions in the `terraform-test` CI job without AWS credentials, and document paired maintenance and fresh-only worker diagnostics. Declare the minimum Terraform version and commit generated root/module documentation.

- [x] Put aligned queue, spare-thread, reporting-collector and ECS-task summaries before diagnostic detail. Separate thread/queue totals, label scope and units, and protect layout and missing-data handling with Terraform assertions.

## Why:

Before exposing guided search to 10% of traders, we need to understand whether longer searches could occupy the backend capacity needed by ordinary tariff requests. Existing CPU, task-count and response-time dashboards do not show spare Puma threads or queued web requests.

```mermaid
flowchart TD
    WORKERS[Puma worker statistics] --> SAMPLER[Master background sampler]
    SAMPLER --> LOGS[Nonblocking EMF logs]
    LOGS --> METRICS[CloudWatch custom metrics]
    LOGS --> FLEET[Sampled fleet totals]
    METRICS --> DASHBOARD[Capacity dashboard]
    FLEET --> DASHBOARD
    classDef box stroke:#6366f1,stroke-width:2px
    class WORKERS,SAMPLER,LOGS,METRICS,FLEET,DASHBOARD box
```

The reporter is disabled by default. Enable with `PUMA_METRICS_ENABLED=true` through the UK/XI API configuration secrets and the normal configuration-refresh workflow. Backend uses the existing `ENVIRONMENT` source and `local` fallback of `TradeTariffBackend.environment`, without booting Rails in the collector. No separate telemetry environment setting is needed. Publishing valid EMF events creates the `TradeTariff/Puma` metric series; the dashboard definition alone does not create them. Confirm extraction and dimensions outside production before enabling live collection.

No API response or tariff-data changes. Queue size is not queue waiting time; missing or stale samples must not be interpreted as spare capacity. This instruments Puma web workers, not Sidekiq queues.

## Ticket:

[AI-1293](https://transformuk.atlassian.net/browse/AI-1293)

## Risk:

**Risk level:** 🟠 Medium

**Reason for rating:** Adds a runtime telemetry capability that transmits worker statistics into CloudWatch custom metrics. The collection architecture, log-to-metric extraction, metric availability and ongoing cost need socialising with the team before merging. Collection is opt-in and outside the request path, but production activation needs an agreed rollout and confirmed ingestion.