### PR TITLE
AI-1314: Add queued internal search for asynchronous journey testing

### DIFF
--- a/app/controllers/api/internal/queued_searches_controller.rb
+++ b/app/controllers/api/internal/queued_searches_controller.rb
@@ -2,8 +2,6 @@ module Api
   module Internal
     class QueuedSearchesController < InternalController
       def create
-        return unavailable unless TradeTariffBackend.queued_search_enabled?
-
         search = QueuedSearch.create(params: search_params.to_h, context: search_context)
         unless QueuedSearchWorker.perform_async(search.id)
           search.delete

--- a/app/controllers/api/internal/queued_searches_controller.rb
+++ b/app/controllers/api/internal/queued_searches_controller.rb
@@ -2,6 +2,8 @@ module Api
   module Internal
     class QueuedSearchesController < InternalController
       def create
+        return unavailable unless TradeTariffBackend.queued_search_enabled?
+
         search = QueuedSearch.create(params: search_params.to_h, context: search_context)
         unless QueuedSearchWorker.perform_async(search.id)
           search.delete

--- a/app/controllers/api/internal/queued_searches_controller.rb
+++ b/app/controllers/api/internal/queued_searches_controller.rb
@@ -1,6 +1,8 @@
 module Api
   module Internal
     class QueuedSearchesController < InternalController
+      include QueryProcessing
+
       def create
         search = QueuedSearch.create(params: search_params.to_h, context: search_context)
         unless QueuedSearchWorker.perform_async(search.id)
@@ -30,7 +32,7 @@ module Api
 
       def search_context
         TradeTariffRequest.attributes.slice(:request_id, :request_source, :client_id, :experiment)
-          .merge(as_of: actual_date.iso8601)
+          .merge(as_of: actual_date.iso8601, search_as_of: parse_date(params[:as_of]).iso8601)
       end
 
       def unavailable

--- a/app/controllers/api/internal/queued_searches_controller.rb
+++ b/app/controllers/api/internal/queued_searches_controller.rb
@@ -1,0 +1,41 @@
+module Api
+  module Internal
+    class QueuedSearchesController < InternalController
+      def create
+        search = QueuedSearch.create(params: search_params.to_h, context: search_context)
+        unless QueuedSearchWorker.perform_async(search.id)
+          search.delete
+          return unavailable
+        end
+
+        render json: { id: search.id, status: 'queued' }, status: :accepted
+      rescue RedisClient::Error
+        unavailable
+      end
+
+      def show
+        payload = QueuedSearch.new(params[:id]).payload
+        return head :not_found unless payload
+
+        render json: payload.slice('id', 'status', 'created_at', 'updated_at', 'result', 'response_status')
+      rescue RedisClient::Error
+        unavailable
+      end
+
+    private
+
+      def search_params
+        params.permit(:q, :as_of, :request_id, :expanded_query, :skip_question, answers: %i[question answer options])
+      end
+
+      def search_context
+        TradeTariffRequest.attributes.slice(:request_id, :request_source, :client_id, :experiment)
+          .merge(as_of: actual_date.iso8601)
+      end
+
+      def unavailable
+        render json: { errors: [{ title: 'Queued search is temporarily unavailable' }] }, status: :service_unavailable
+      end
+    end
+  end
+end

--- a/app/engines/internal_api.rb
+++ b/app/engines/internal_api.rb
@@ -7,6 +7,7 @@ InternalApi.routes.draw do
       post 'search' => 'search#search'
       get 'search' => 'search#search'
       get 'search_suggestions' => 'search#suggestions'
+      resources :queued_searches, only: %i[create show]
 
       # ATaR rulings (and the gold queries generated from them) are a UK/HMRC-specific
       # data source — XI has no equivalent, so both stay behind the same UK-only guard.

--- a/app/lib/trade_tariff_backend/config/ai.rb
+++ b/app/lib/trade_tariff_backend/config/ai.rb
@@ -1,6 +1,10 @@
 module TradeTariffBackend
   module Config
     module Ai
+      def queued_search_enabled?
+        ENV.fetch('QUEUED_SEARCH_ENABLED', 'false') == 'true'
+      end
+
       def ai_model
         ENV.fetch('AI_MODEL', 'gpt-5.2')
       end

--- a/app/lib/trade_tariff_backend/config/ai.rb
+++ b/app/lib/trade_tariff_backend/config/ai.rb
@@ -1,10 +1,6 @@
 module TradeTariffBackend
   module Config
     module Ai
-      def queued_search_enabled?
-        ENV.fetch('QUEUED_SEARCH_ENABLED', 'false') == 'true'
-      end
-
       def ai_model
         ENV.fetch('AI_MODEL', 'gpt-5.2')
       end

--- a/app/models/queued_search.rb
+++ b/app/models/queued_search.rb
@@ -1,0 +1,65 @@
+class QueuedSearch
+  RETENTION = 1.hour
+
+  # Compare the full previous payload so duplicate workers cannot claim the same
+  # search or overwrite a terminal result. KEEPTTL prevents extending retention.
+  TRANSITION = <<~LUA.freeze
+    if redis.call('GET', KEYS[1]) == ARGV[1] then
+      redis.call('SET', KEYS[1], ARGV[2], 'KEEPTTL')
+      return 1
+    end
+    return 0
+  LUA
+
+  attr_reader :id
+
+  def self.create(params:, context:)
+    search = new(SecureRandom.uuid)
+    now = Time.current.iso8601
+    payload = { id: search.id, status: 'queued', params:, context:, created_at: now, updated_at: now }
+    Sidekiq.redis { |redis| redis.set(search.key, payload.to_json, ex: RETENTION.to_i) }
+    search
+  end
+
+  def initialize(id)
+    @id = id
+  end
+
+  def key
+    "queued_search:#{TradeTariffBackend.service}:#{id}"
+  end
+
+  def payload
+    stored = Sidekiq.redis { |redis| redis.get(key) }
+    JSON.parse(stored) if stored
+  end
+
+  def delete
+    Sidekiq.redis { |redis| redis.del(key) }
+  end
+
+  def claim
+    transition(from: 'queued', status: 'running')
+  end
+
+  def finish(result:, response_status:)
+    status = response_status == 200 ? 'completed' : 'failed'
+    transition(from: 'running', status:, result:, response_status:)
+  end
+
+private
+
+  def transition(from:, **attributes)
+    Sidekiq.redis do |redis|
+      previous = redis.get(key)
+      next unless previous
+
+      payload = JSON.parse(previous)
+      next unless payload['status'] == from
+
+      updated = payload.merge(attributes.stringify_keys).merge('updated_at' => Time.current.iso8601)
+      changed = redis.call('EVAL', TRANSITION, 1, key, previous, updated.to_json)
+      updated if changed == 1
+    end
+  end
+end

--- a/app/workers/queued_search_worker.rb
+++ b/app/workers/queued_search_worker.rb
@@ -29,7 +29,7 @@ private
     context = payload.fetch('context').symbolize_keys
     as_of = context.delete(:as_of)
     params = payload.fetch('params').with_indifferent_access
-    params[:as_of] = as_of if params[:as_of].blank?
+    params[:as_of] = context.delete(:search_as_of) || as_of
     context.merge!(search_failures: [], search_type: nil, search_labels_enabled: nil, time_machine_relevant: nil)
 
     TradeTariffRequest.set(context) do

--- a/app/workers/queued_search_worker.rb
+++ b/app/workers/queued_search_worker.rb
@@ -1,0 +1,41 @@
+class QueuedSearchWorker
+  include Sidekiq::Worker
+
+  # A failed search is terminal for the poller. Retrying requires a new submission,
+  # rather than letting expensive searches accumulate Sidekiq retries.
+  sidekiq_options queue: :default, retry: false
+
+  def perform(id)
+    search = QueuedSearch.new(id)
+    payload = search.claim
+    perform_search(search, payload) if payload
+  end
+
+private
+
+  def perform_search(search, payload)
+    result = execute_search(payload)
+    response_status = result.is_a?(Hash) && result[:errors] ? 422 : 200
+    search.finish(result:, response_status:)
+  rescue StandardError
+    search.finish(
+      result: { errors: [{ status: '500', title: 'Search failed', detail: 'Search is temporarily unavailable' }] },
+      response_status: 500,
+    )
+    raise
+  end
+
+  def execute_search(payload)
+    context = payload.fetch('context').symbolize_keys
+    as_of = context.delete(:as_of)
+    params = payload.fetch('params').with_indifferent_access
+    params[:as_of] = as_of if params[:as_of].blank?
+    context.merge!(search_failures: [], search_type: nil, search_labels_enabled: nil, time_machine_relevant: nil)
+
+    TradeTariffRequest.set(context) do
+      TimeMachine.at(as_of) do
+        Api::Internal::SearchService.new(params).call
+      end
+    end
+  end
+end

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -9,6 +9,7 @@ These pages give a code-level map of the Trade Tariff Backend. They describe sta
 - [Request routing](request-routing.md)
 - [Data import and sync](data-import-and-sync.md)
 - [Search and indexing](search-and-indexing.md)
+- [Queued internal search](queued-internal-search.md)
 - [Caching and background jobs](caching-and-background-jobs.md)
 - [API documentation](api-documentation.md)
 

--- a/docs/architecture/queued-internal-search.md
+++ b/docs/architecture/queued-internal-search.md
@@ -3,8 +3,7 @@
 The queued search API is an additive, backend-only interface for testing an
 asynchronous guided-search journey. Existing synchronous `/internal/search`
 callers and the frontend are unchanged. It reuses `Api::Internal::SearchService`
-rather than introducing a second search implementation. Submissions are disabled
-by default until operators explicitly enable them after the worker rollout.
+rather than introducing a second search implementation.
 
 ## API contract
 
@@ -13,12 +12,8 @@ backend's service mode. The examples below use UK.
 
 ### Submit
 
-`POST /uk/internal/queued_searches` requires `QUEUED_SEARCH_ENABLED=true` in the
-web process environment. Unset, `false` or any other value returns `503` before
-storing a payload or enqueueing a job. The gate does not affect polling or workers.
-
-When enabled, it accepts the same top-level inputs and strong parameter rules as
-the existing internal search endpoint:
+`POST /uk/internal/queued_searches` accepts the same top-level inputs and strong
+parameter rules as the existing internal search endpoint:
 
 - `q`
 - `as_of`
@@ -103,8 +98,7 @@ error, not the exception message, and are re-raised for Sidekiq error reporting.
   Future frontend poller          Backend web / Puma        Sidekiq worker
   ======================          ==================        ==============
 
-  POST queued_searches ----------> Check submission gate
-                                  Store payload in Redis
+  POST queued_searches ----------> Store payload in Redis
                                   Enqueue UUID ------------> Claim payload
   <--------------- 202 + UUID     Release request thread     Mark running
           |                                                       |
@@ -183,31 +177,21 @@ or recovery message. That frontend behaviour is not implemented here.
   an already-running search. The search service's existing downstream timeouts
   still apply, and late results are discarded.
 
-## Rollout and rollback
+## Rollout and integration
 
-Normal deployments can overlap old and new web and worker tasks. An old worker
-cannot load `QueuedSearchWorker` and can discard an accepted job because retries
-are disabled. The default-off gate prevents new web tasks from enqueueing during
-that initial mixed-version rollout.
+There is no runtime feature gate. Activation is controlled by introducing a
+caller: no existing frontend or other integration submits queued searches.
 
-1. Deploy this release with `QUEUED_SEARCH_ENABLED` unset or `false` on every web
-   task. Do not enable it in the initial deployment.
-2. Confirm that **all** workers consuming the relevant service's `default` queue
-   run a release containing `QueuedSearchWorker`, and that old worker tasks have
-   stopped. Verify UK and XI separately if enabling both.
-3. Set `QUEUED_SEARCH_ENABLED=true` in the intended web service's environment and
-   roll its tasks to apply the setting. Only then start controlled submissions.
-   No environment settings are enabled by this code change.
-4. Before rolling back workers to a release without the class, remove the setting
-   or set it to `false` and finish rolling **all** web tasks. Stop external test
-   producers too. Let accepted jobs finish while polling remains available, then
-   roll back workers. Do not roll back to an older web release that accepts
-   submissions without this gate.
+Deploy the backend and workers before enabling any caller, including manual test
+submissions. Confirm that all workers consuming the relevant service's `default`
+queue have `QueuedSearchWorker` and that old worker tasks have stopped. Check UK
+and XI separately where applicable. During a mixed-version rollout, an old
+worker can consume the new job class, fail to load it and discard it because
+retries are disabled, leaving the accepted payload queued until expiry.
 
-The gate is an operator-controlled rollout prerequisite, not automatic worker
-readiness detection. Retained payloads expire without a data migration. For local
-testing, start the matching Sidekiq release before starting the web process with
-`QUEUED_SEARCH_ENABLED=true`.
+For rollback, stop all callers and let accepted work drain before replacing
+workers with a release without the class. Any future integration must preserve
+this deployment ordering; the endpoint itself does not check worker readiness.
 
 ## Scope and operational limits
 
@@ -226,8 +210,9 @@ arbitrary submission rates.
 
 Production adoption still needs capacity/load measurements, suitable worker
 isolation, polling deadlines/backoff, abandoned-job handling and the frontend
-access/recovery journey. Follow the gated rollout and drain sequence above before
-changing which worker releases consume the queue.
+access/recovery journey. Stop test submissions and let work drain before rolling
+back to a release without the worker class; otherwise queued jobs reference an
+unknown class. The retained payloads expire without a data migration.
 
 ## Source and verification
 

--- a/docs/architecture/queued-internal-search.md
+++ b/docs/architecture/queued-internal-search.md
@@ -1,0 +1,216 @@
+# Queued internal search
+
+The queued search API is an additive, backend-only interface for testing an
+asynchronous guided-search journey. Existing synchronous `/internal/search`
+callers and the frontend are unchanged. It reuses `Api::Internal::SearchService`
+rather than introducing a second search implementation.
+
+## API contract
+
+Routes are mounted beneath `/uk/internal` or `/xi/internal`, according to the
+backend's service mode. The examples below use UK.
+
+### Submit
+
+`POST /uk/internal/queued_searches` accepts the same top-level inputs and strong
+parameter rules as the existing internal search endpoint:
+
+- `q`
+- `as_of`
+- `request_id` (the search journey's correlation ID, not the queued payload ID)
+- `expanded_query`
+- `skip_question`
+- `answers`, containing `question`, `answer` and `options`
+
+As in synchronous search, `options` can be a JSON-encoded array string. This
+endpoint does not expand the existing parameter contract or accept configuration
+overrides. Query sanitisation and search validation happen in the worker through
+the existing search service.
+
+Example body:
+
+```json
+{
+  "q": "horse",
+  "as_of": "2025-01-02",
+  "request_id": "journey-123",
+  "skip_question": false,
+  "answers": [
+    { "question": "Use?", "answer": "Racing", "options": "[\"Racing\",\"Breeding\"]" }
+  ]
+}
+```
+
+The backend stores the permitted inputs and request context in Sidekiq Redis,
+then enqueues `QueuedSearchWorker` with only the generated UUID. It returns
+`202 Accepted` only after enqueueing succeeds:
+
+```json
+{ "id": "d9b7a5ad-56a0-4abf-8a9b-5c1391f1c42f", "status": "queued" }
+```
+
+A Redis failure or rejected enqueue returns `503`, not an accepted ID. A rejected
+enqueue removes the payload. If a Redis connection fails during enqueueing, the
+outcome can be ambiguous: an orphaned payload expires automatically, and a job
+may already have been accepted before the connection failed. Submissions are not
+idempotent; each new submission creates a new ID.
+
+### Poll
+
+`GET /uk/internal/queued_searches/:id` reads state and returns immediately. It
+does not wait for a worker, run search, or enqueue more work.
+
+Existing payloads return `200` with `id`, `status`, `created_at` and `updated_at`.
+Terminal payloads also contain `response_status` and `result`:
+
+```json
+{
+  "id": "d9b7a5ad-56a0-4abf-8a9b-5c1391f1c42f",
+  "status": "completed",
+  "created_at": "2025-01-02T10:00:00Z",
+  "updated_at": "2025-01-02T10:00:04Z",
+  "response_status": 200,
+  "result": { "data": [], "meta": { "search_failures": [] } }
+}
+```
+
+`result` preserves the existing synchronous search response body, including
+interactive questions, fallback metadata or validation errors. `response_status`
+is the equivalent search HTTP status, not the polling request's HTTP status:
+
+| State | Poll HTTP status | Search response status | Poller action |
+| --- | --- | --- | --- |
+| `queued` | 200 | Absent | Wait, then poll again |
+| `running` | 200 | Absent | Wait, then poll again |
+| `completed` | 200 | 200 | Stop polling and serve `result` |
+| `failed` | 200 | 422 or 500 | Stop polling and show recovery |
+| Missing or expired | 404 | Absent | Stop polling; a new submission is required |
+| Redis unavailable | 503 | Absent | Use bounded retry/backoff, not a tight loop |
+
+Pending responses do not expose the submitted inputs or request context.
+Recoverable search fallbacks are still completed searches, with the existing
+`meta.search_failures` contract intact. Exceptions store a safe generic search
+error, not the exception message, and are re-raised for Sidekiq error reporting.
+
+## Flow
+
+```text
+  Future frontend poller          Backend web / Puma        Sidekiq worker
+  ======================          ==================        ==============
+
+  POST queued_searches ----------> Store payload in Redis
+                                  Enqueue UUID ------------> Claim payload
+  <--------------- 202 + UUID     Release request thread     Mark running
+          |                                                       |
+          |                                                       v
+          |                                               Existing search service
+          |                                               (slow work happens here)
+          |                                                       |
+          |                                                       v
+          |                                               Save result + status
+          |                                                       |
+          |                                                       v
+          |                     +---------------------------------------+
+          |                     | Sidekiq Redis: inputs, context, state, |
+          |                     | timestamps, result, response status    |
+          |                     +---------------------------------------+
+          |                                      |
+          |                                      | read only
+          v                                      v
+  GET queued_searches/:id -------> Return current state immediately
+  <------------------------------ No long-held web request
+          |
+          +-- queued/running --> wait, then repeat
+          +-- completed -------> stop and display result
+          +-- failed/404 ------> stop and show recovery
+```
+
+A future Stimulus controller should keep the existing throbber and loading
+message visible continuously while polling, then replace them with the result
+or recovery message. That frontend behaviour is not implemented here.
+
+## State machine
+
+```text
+                successful Redis write + enqueue
+                              |
+                              v
+                         +----------+
+                         |  queued  |
+                         +----+-----+
+                              |
+                              | atomic worker claim
+                              v
+                         +----------+
+                         | running  |
+                         +----+-----+
+                              |
+                 +------------+-------------+
+                 |                          |
+                 | normal result            | validation error / exception
+                 v                          v
+           +-----------+               +----------+
+           | completed |               |  failed  |
+           +-----------+               +----------+
+
+  Any stored state -- one-hour retention expires --> missing (GET returns 404)
+```
+
+- Payloads use `queued_search:<service>:<uuid>` keys in **Sidekiq Redis**, not
+  Rails cache. UK and XI payloads are separate even if Redis is shared.
+- Each JSON payload has a fixed one-hour TTL from submission. Polling and worker
+  transitions do not extend it. This is temporary job state, not search caching.
+- A Redis compare-and-set script makes claims and terminal writes atomic. Only a
+  queued payload can become running, and only a running payload can finish.
+  Duplicate deliveries do not execute an already-claimed search or overwrite a
+  terminal result. A late completion cannot recreate an expired key.
+- The result and terminal status are written together, so `completed` never
+  means a partially stored result.
+- Request ID, request source, client ID, experiment and the submission's effective
+  date are restored for search execution. Request-local search failure state is
+  isolated and restored afterwards. Missing `as_of` defaults to the submission
+  date, rather than the date a delayed worker eventually starts.
+- Automatic Sidekiq retries are disabled. A failed search requires a new
+  submission. If the process is killed after claiming, the payload stays running
+  until expiry; this version does not reclaim abandoned work.
+- Expiry bounds stored data retention, not execution time. It does not interrupt
+  an already-running search. The search service's existing downstream timeouts
+  still apply, and late results are discarded.
+
+## Scope and operational limits
+
+This API uses the existing internal routing/access boundary. UUIDs are opaque
+lookup handles, not authentication. There is no new browser/session ownership
+check: trusted internal clients possessing an ID can retrieve its result. Before
+connecting a public browser journey, the frontend must enforce the appropriate
+session ownership and must not expose internal API access directly.
+
+The worker uses the existing `default` queue. No queue topology, concurrency,
+frontend, infrastructure, public V2 API or synchronous search behaviour changes
+are included. Use controlled test traffic: this interface does **not** establish
+worker isolation, admission control, a payload-size limit, or protection against
+Redis/worker saturation. One-hour retention is not a bound on total memory at
+arbitrary submission rates.
+
+Production adoption still needs capacity/load measurements, suitable worker
+isolation, polling deadlines/backoff, abandoned-job handling and the frontend
+access/recovery journey. Stop test submissions and let work drain before rolling
+back to a release without the worker class; otherwise queued jobs reference an
+unknown class. The retained payloads expire without a data migration.
+
+## Source and verification
+
+- Routes: `app/engines/internal_api.rb`
+- Controller: `app/controllers/api/internal/queued_searches_controller.rb`
+- Payload lifecycle: `app/models/queued_search.rb`
+- Worker: `app/workers/queued_search_worker.rb`
+- Existing search: `app/services/api/internal/search_service.rb`
+- Existing payload precedent: `app/controllers/api/v2/enquiry_form/submissions_controller.rb`
+
+Run request, real-Redis lifecycle, worker and synchronous search regression
+coverage:
+
+```sh
+bundle exec rspec spec/requests/api/internal spec/services/api/internal \
+  spec/models/queued_search_spec.rb spec/workers/queued_search_worker_spec.rb
+```

--- a/docs/architecture/queued-internal-search.md
+++ b/docs/architecture/queued-internal-search.md
@@ -3,7 +3,8 @@
 The queued search API is an additive, backend-only interface for testing an
 asynchronous guided-search journey. Existing synchronous `/internal/search`
 callers and the frontend are unchanged. It reuses `Api::Internal::SearchService`
-rather than introducing a second search implementation.
+rather than introducing a second search implementation. Submissions are disabled
+by default until operators explicitly enable them after the worker rollout.
 
 ## API contract
 
@@ -12,8 +13,12 @@ backend's service mode. The examples below use UK.
 
 ### Submit
 
-`POST /uk/internal/queued_searches` accepts the same top-level inputs and strong
-parameter rules as the existing internal search endpoint:
+`POST /uk/internal/queued_searches` requires `QUEUED_SEARCH_ENABLED=true` in the
+web process environment. Unset, `false` or any other value returns `503` before
+storing a payload or enqueueing a job. The gate does not affect polling or workers.
+
+When enabled, it accepts the same top-level inputs and strong parameter rules as
+the existing internal search endpoint:
 
 - `q`
 - `as_of`
@@ -98,7 +103,8 @@ error, not the exception message, and are re-raised for Sidekiq error reporting.
   Future frontend poller          Backend web / Puma        Sidekiq worker
   ======================          ==================        ==============
 
-  POST queued_searches ----------> Store payload in Redis
+  POST queued_searches ----------> Check submission gate
+                                  Store payload in Redis
                                   Enqueue UUID ------------> Claim payload
   <--------------- 202 + UUID     Release request thread     Mark running
           |                                                       |
@@ -177,6 +183,32 @@ or recovery message. That frontend behaviour is not implemented here.
   an already-running search. The search service's existing downstream timeouts
   still apply, and late results are discarded.
 
+## Rollout and rollback
+
+Normal deployments can overlap old and new web and worker tasks. An old worker
+cannot load `QueuedSearchWorker` and can discard an accepted job because retries
+are disabled. The default-off gate prevents new web tasks from enqueueing during
+that initial mixed-version rollout.
+
+1. Deploy this release with `QUEUED_SEARCH_ENABLED` unset or `false` on every web
+   task. Do not enable it in the initial deployment.
+2. Confirm that **all** workers consuming the relevant service's `default` queue
+   run a release containing `QueuedSearchWorker`, and that old worker tasks have
+   stopped. Verify UK and XI separately if enabling both.
+3. Set `QUEUED_SEARCH_ENABLED=true` in the intended web service's environment and
+   roll its tasks to apply the setting. Only then start controlled submissions.
+   No environment settings are enabled by this code change.
+4. Before rolling back workers to a release without the class, remove the setting
+   or set it to `false` and finish rolling **all** web tasks. Stop external test
+   producers too. Let accepted jobs finish while polling remains available, then
+   roll back workers. Do not roll back to an older web release that accepts
+   submissions without this gate.
+
+The gate is an operator-controlled rollout prerequisite, not automatic worker
+readiness detection. Retained payloads expire without a data migration. For local
+testing, start the matching Sidekiq release before starting the web process with
+`QUEUED_SEARCH_ENABLED=true`.
+
 ## Scope and operational limits
 
 This API uses the existing internal routing/access boundary. UUIDs are opaque
@@ -194,9 +226,8 @@ arbitrary submission rates.
 
 Production adoption still needs capacity/load measurements, suitable worker
 isolation, polling deadlines/backoff, abandoned-job handling and the frontend
-access/recovery journey. Stop test submissions and let work drain before rolling
-back to a release without the worker class; otherwise queued jobs reference an
-unknown class. The retained payloads expire without a data migration.
+access/recovery journey. Follow the gated rollout and drain sequence above before
+changing which worker releases consume the queue.
 
 ## Source and verification
 

--- a/docs/architecture/queued-internal-search.md
+++ b/docs/architecture/queued-internal-search.md
@@ -166,10 +166,14 @@ or recovery message. That frontend behaviour is not implemented here.
   terminal result. A late completion cannot recreate an expired key.
 - The result and terminal status are written together, so `completed` never
   means a partially stored result.
-- Request ID, request source, client ID, experiment and the submission's effective
-  date are restored for search execution. Request-local search failure state is
-  isolated and restored afterwards. Missing `as_of` defaults to the submission
-  date, rather than the date a delayed worker eventually starts.
+- Request ID, request source, client ID and experiment are restored for search
+  execution. Request-local search failure state is isolated and restored afterwards.
+- Both date interpretations are captured at submission: `as_of` for the
+  controller's TimeMachine scope and `search_as_of` from the search service's
+  existing `QueryProcessing#parse_date` rules. The worker passes the captured
+  search date to the service instead of parsing the raw input again. Missing or
+  malformed dates therefore fall back to the submission date even across midnight,
+  while valid non-ISO dates retain the synchronous search service's behaviour.
 - Automatic Sidekiq retries are disabled. A failed search requires a new
   submission. If the process is killed after claiming, the payload stays running
   until expiry; this version does not reclaim abandoned work.

--- a/docs/architecture/search-and-indexing.md
+++ b/docs/architecture/search-and-indexing.md
@@ -4,6 +4,8 @@ Search combines direct code lookup, OpenSearch-backed fuzzy matching, search ref
 
 For trader outcomes, response metadata, combined failures and warning policy, use the canonical [AI-assisted search resilience contract](../search-resilience.md).
 
+For the backend-only asynchronous testing API, payload state machine and polling contract, see [Queued internal search](queued-internal-search.md). Existing synchronous search callers are unchanged.
+
 ## Request Flow
 
 Public search routes are defined in `app/engines/v2_api.rb`:

--- a/spec/models/queued_search_spec.rb
+++ b/spec/models/queued_search_spec.rb
@@ -1,0 +1,79 @@
+RSpec.describe QueuedSearch do
+  subject(:search) { described_class.create(params: { q: 'horse' }, context: {}) }
+
+  after { search.delete }
+
+  describe '.create' do
+    it 'stores an expiring queued payload' do
+      expect(search.payload).to include('id' => search.id, 'status' => 'queued', 'params' => { 'q' => 'horse' })
+      ttl = Sidekiq.redis { |redis| redis.ttl(search.key) }
+      expect(ttl).to be_between(1, 1.hour.to_i)
+    end
+  end
+
+  describe '#claim' do
+    it 'allows only one worker to claim work' do
+      expect(search.claim).to include('status' => 'running')
+      expect(described_class.new(search.id).claim).to be_nil
+    end
+
+    it 'claims once across concurrent workers' do
+      id = search.id
+      claims = Array.new(5) { Thread.new { described_class.new(id).claim } }.map(&:value)
+
+      expect(claims.compact.size).to eq(1)
+    end
+
+    it 'does not claim expired work' do
+      search.delete
+
+      expect(search.claim).to be_nil
+      expect(search.payload).to be_nil
+    end
+  end
+
+  describe '#payload' do
+    it 'isolates UK and XI payloads' do
+      id = search.id
+      allow(TradeTariffBackend).to receive(:service).and_return('xi')
+
+      expect(described_class.new(id).payload).to be_nil
+    ensure
+      allow(TradeTariffBackend).to receive(:service).and_call_original
+    end
+  end
+
+  describe '#finish' do
+    it 'preserves expiry through transitions' do
+      Sidekiq.redis { |redis| redis.expire(search.key, 60) }
+      search.claim
+      search.finish(result: { data: [] }, response_status: 200)
+
+      expect(search.payload).to include('status' => 'completed', 'result' => { 'data' => [] })
+      expect(Sidekiq.redis { |redis| redis.ttl(search.key) }).to be_between(1, 60)
+    end
+
+    it 'does not overwrite a terminal result' do
+      search.claim
+      search.finish(result: { data: [] }, response_status: 200)
+      search.finish(result: { errors: [] }, response_status: 500)
+
+      expect(search.payload).to include('status' => 'completed', 'response_status' => 200)
+    end
+
+    it 'does not resurrect expired work' do
+      search.claim
+      search.delete
+      search.finish(result: { data: [] }, response_status: 200)
+
+      expect(search.payload).to be_nil
+    end
+
+    it 'records a terminal failure' do
+      search.claim
+      search.finish(result: { errors: [{ title: 'Search failed' }] }, response_status: 500)
+
+      expect(search.payload).to include('status' => 'failed', 'response_status' => 500)
+    end
+  end
+end

--- a/spec/requests/api/internal/queued_searches_spec.rb
+++ b/spec/requests/api/internal/queued_searches_spec.rb
@@ -1,0 +1,152 @@
+RSpec.describe 'Queued internal searches', :internal do
+  let(:path) { '/uk/internal/queued_searches' }
+  let(:inputs) do
+    {
+      q: 'horse',
+      as_of: '2025-01-02',
+      request_id: 'search-journey',
+      expanded_query: 'live horse',
+      skip_question: false,
+      answers: [{ question: 'Use?', answer: 'Racing', options: '["Racing","Breeding"]' }],
+    }
+  end
+
+  after do
+    QueuedSearchWorker.jobs.each do |job|
+      QueuedSearch.new(job['args'].first).delete
+    end
+  end
+
+  describe 'POST /uk/internal/queued_searches' do
+    it 'stores inputs and queues only the id' do
+      post path, params: inputs.merge(configuration_overrides: { candidate_limit: 999 }), as: :json
+
+      expect(response).to have_http_status(:accepted)
+      expect(response.parsed_body).to include('id' => be_present, 'status' => 'queued')
+      id = response.parsed_body.fetch('id')
+      expect(QueuedSearchWorker.jobs.last['args']).to eq([id])
+      expect(QueuedSearch.new(id).payload.fetch('params')).to eq(inputs.deep_stringify_keys)
+    end
+
+    it 'does not execute search in the request' do
+      allow(Api::Internal::SearchService).to receive(:new)
+
+      post path, params: inputs, as: :json
+
+      expect(Api::Internal::SearchService).not_to have_received(:new)
+    end
+
+    it 'preserves request context for the worker' do
+      post path, params: inputs.merge(experiment: 'async-spike'),
+                 headers: { 'X-Client-Id' => 'test-client', 'HTTP_X_ORIGINAL_USER_AGENT' => 'TradeTariffFrontend/test' }, as: :json
+
+      payload = QueuedSearch.new(response.parsed_body.fetch('id')).payload
+      expect(payload.fetch('context')).to include(
+        'request_id' => 'search-journey', 'client_id' => 'test-client',
+        'request_source' => 'frontend', 'experiment' => 'async-spike', 'as_of' => '2025-01-02'
+      )
+    end
+
+    it 'does not accept a rejected enqueue' do
+      id = SecureRandom.uuid
+      allow(SecureRandom).to receive(:uuid).and_return(id)
+      allow(QueuedSearchWorker).to receive(:perform_async).and_return(nil)
+
+      post path, params: inputs, as: :json
+
+      expect(response).to have_http_status(:service_unavailable)
+      expect(response.parsed_body).not_to have_key('id')
+      expect(QueuedSearch.new(id).payload).to be_nil
+    end
+
+    it 'does not accept an enqueue connection failure' do
+      id = SecureRandom.uuid
+      allow(SecureRandom).to receive(:uuid).and_return(id)
+      allow(QueuedSearchWorker).to receive(:perform_async).and_raise(RedisClient::ConnectionError, 'unavailable')
+
+      post path, params: inputs, as: :json
+
+      expect(response).to have_http_status(:service_unavailable)
+      expect(response.parsed_body).not_to have_key('id')
+      expect(Sidekiq.redis { |redis| redis.ttl(QueuedSearch.new(id).key) }).to be_between(1, 3600)
+    ensure
+      QueuedSearch.new(id).delete
+    end
+
+    it 'does not accept a Redis outage' do
+      allow(Sidekiq).to receive(:redis).and_raise(RedisClient::ConnectionError, 'unavailable')
+
+      post path, params: inputs, as: :json
+
+      expect(response).to have_http_status(:service_unavailable)
+    end
+  end
+
+  describe 'GET /uk/internal/queued_searches/:id' do
+    it 'reports pending without exposing inputs' do
+      allow(Rails.configuration.action_controller).to receive(:perform_caching).and_return(true)
+      post path, params: inputs, as: :json
+      id = response.parsed_body.fetch('id')
+
+      get "#{path}/#{id}", headers: { 'HTTP_USER_AGENT' => 'TradeTariffFrontend/test' }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include('id' => id, 'status' => 'queued')
+      expect(response.parsed_body.keys).not_to include('params', 'context', 'result')
+      expect(response.headers['Cache-Control']).to include('no-store')
+    end
+
+    it 'returns the original completed response' do
+      # Empty queries exercise the real search service without external AI calls.
+      post path, params: { q: '' }, as: :json
+      id = response.parsed_body.fetch('id')
+      QueuedSearchWorker.new.perform(id)
+
+      get "#{path}/#{id}"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(
+        'status' => 'completed', 'response_status' => 200,
+        'result' => { 'data' => [], 'meta' => { 'search_failures' => [] } }
+      )
+    end
+
+    it 'serves terminal errors to the poller' do
+      post path, params: inputs, as: :json
+      id = response.parsed_body.fetch('id')
+      search = QueuedSearch.new(id)
+      search.claim
+      search.finish(result: { errors: [{ title: 'Invalid query' }] }, response_status: 422)
+
+      get "#{path}/#{id}"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include('status' => 'failed', 'response_status' => 422)
+      expect(response.parsed_body.fetch('result')).to eq('errors' => [{ 'title' => 'Invalid query' }])
+    end
+
+    it 'reports a polling Redis outage' do
+      allow(Sidekiq).to receive(:redis).and_raise(RedisClient::ConnectionError, 'unavailable')
+
+      get "#{path}/#{SecureRandom.uuid}"
+
+      expect(response).to have_http_status(:service_unavailable)
+    end
+
+    it 'returns not found for unknown ids' do
+      get "#{path}/#{SecureRandom.uuid}"
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'returns not found after expiry' do
+      post path, params: inputs, as: :json
+      id = response.parsed_body.fetch('id')
+      Sidekiq.redis { |redis| redis.expire(QueuedSearch.new(id).key, 0) }
+
+      get "#{path}/#{id}"
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/requests/api/internal/queued_searches_spec.rb
+++ b/spec/requests/api/internal/queued_searches_spec.rb
@@ -11,14 +11,6 @@ RSpec.describe 'Queued internal searches', :internal do
     }
   end
 
-  around do |example|
-    previous = ENV['QUEUED_SEARCH_ENABLED']
-    ENV['QUEUED_SEARCH_ENABLED'] = 'true'
-    example.run
-  ensure
-    ENV['QUEUED_SEARCH_ENABLED'] = previous
-  end
-
   after do
     QueuedSearchWorker.jobs.each do |job|
       QueuedSearch.new(job['args'].first).delete
@@ -26,22 +18,6 @@ RSpec.describe 'Queued internal searches', :internal do
   end
 
   describe 'POST /uk/internal/queued_searches' do
-    context 'when submissions are not enabled' do
-      [nil, 'false', 'invalid'].each do |value|
-        it "rejects without storing or queueing when configured as #{value.inspect}" do
-          ENV['QUEUED_SEARCH_ENABLED'] = value
-          allow(QueuedSearch).to receive(:create).and_call_original
-
-          post path, params: inputs, as: :json
-
-          expect(response).to have_http_status(:service_unavailable)
-          expect(response.parsed_body).not_to have_key('id')
-          expect(QueuedSearch).not_to have_received(:create)
-          expect(QueuedSearchWorker.jobs).to be_empty
-        end
-      end
-    end
-
     it 'stores inputs and queues only the id' do
       post path, params: inputs.merge(configuration_overrides: { candidate_limit: 999 }), as: :json
 
@@ -107,18 +83,6 @@ RSpec.describe 'Queued internal searches', :internal do
   end
 
   describe 'GET /uk/internal/queued_searches/:id' do
-    it 'allows work to finish after disabling submissions' do
-      post path, params: { q: '' }, as: :json
-      id = response.parsed_body.fetch('id')
-      ENV['QUEUED_SEARCH_ENABLED'] = 'false'
-      QueuedSearchWorker.new.perform(id)
-
-      get "#{path}/#{id}"
-
-      expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to include('id' => id, 'status' => 'completed')
-    end
-
     it 'reports pending without exposing inputs' do
       allow(Rails.configuration.action_controller).to receive(:perform_caching).and_return(true)
       post path, params: inputs, as: :json

--- a/spec/requests/api/internal/queued_searches_spec.rb
+++ b/spec/requests/api/internal/queued_searches_spec.rb
@@ -82,6 +82,27 @@ RSpec.describe 'Queued internal searches', :internal do
     end
   end
 
+  describe 'search dates across midnight' do
+    [nil, '', 'not-a-date', '2025-02-30', '2025-01-01', '1 Jan 2025', '9999-01-01'].each do |as_of|
+      it "preserves the synchronous search date for #{as_of.inspect}" do
+        search_dates = []
+        allow(Api::Internal::SearchService).to receive(:new).and_wrap_original do |original, params|
+          original.call(params).tap { |service| search_dates << service.as_of }
+        end
+        travel_to Time.zone.parse('2025-01-02 23:59:00')
+        post '/uk/internal/search', params: { q: '', as_of: }, as: :json
+        post path, params: { q: '', as_of: }, as: :json
+        id = response.parsed_body.fetch('id')
+
+        travel_to Time.zone.parse('2025-01-03 00:01:00')
+        QueuedSearchWorker.new.perform(id)
+
+        expect(search_dates.size).to eq(2)
+        expect(search_dates.last).to eq(search_dates.first)
+      end
+    end
+  end
+
   describe 'GET /uk/internal/queued_searches/:id' do
     it 'reports pending without exposing inputs' do
       allow(Rails.configuration.action_controller).to receive(:perform_caching).and_return(true)

--- a/spec/requests/api/internal/queued_searches_spec.rb
+++ b/spec/requests/api/internal/queued_searches_spec.rb
@@ -11,6 +11,14 @@ RSpec.describe 'Queued internal searches', :internal do
     }
   end
 
+  around do |example|
+    previous = ENV['QUEUED_SEARCH_ENABLED']
+    ENV['QUEUED_SEARCH_ENABLED'] = 'true'
+    example.run
+  ensure
+    ENV['QUEUED_SEARCH_ENABLED'] = previous
+  end
+
   after do
     QueuedSearchWorker.jobs.each do |job|
       QueuedSearch.new(job['args'].first).delete
@@ -18,6 +26,22 @@ RSpec.describe 'Queued internal searches', :internal do
   end
 
   describe 'POST /uk/internal/queued_searches' do
+    context 'when submissions are not enabled' do
+      [nil, 'false', 'invalid'].each do |value|
+        it "rejects without storing or queueing when configured as #{value.inspect}" do
+          ENV['QUEUED_SEARCH_ENABLED'] = value
+          allow(QueuedSearch).to receive(:create).and_call_original
+
+          post path, params: inputs, as: :json
+
+          expect(response).to have_http_status(:service_unavailable)
+          expect(response.parsed_body).not_to have_key('id')
+          expect(QueuedSearch).not_to have_received(:create)
+          expect(QueuedSearchWorker.jobs).to be_empty
+        end
+      end
+    end
+
     it 'stores inputs and queues only the id' do
       post path, params: inputs.merge(configuration_overrides: { candidate_limit: 999 }), as: :json
 
@@ -83,6 +107,18 @@ RSpec.describe 'Queued internal searches', :internal do
   end
 
   describe 'GET /uk/internal/queued_searches/:id' do
+    it 'allows work to finish after disabling submissions' do
+      post path, params: { q: '' }, as: :json
+      id = response.parsed_body.fetch('id')
+      ENV['QUEUED_SEARCH_ENABLED'] = 'false'
+      QueuedSearchWorker.new.perform(id)
+
+      get "#{path}/#{id}"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include('id' => id, 'status' => 'completed')
+    end
+
     it 'reports pending without exposing inputs' do
       allow(Rails.configuration.action_controller).to receive(:perform_caching).and_return(true)
       post path, params: inputs, as: :json

--- a/spec/workers/queued_search_worker_spec.rb
+++ b/spec/workers/queued_search_worker_spec.rb
@@ -1,0 +1,109 @@
+RSpec.describe QueuedSearchWorker, type: :worker do
+  subject(:worker) { described_class.new }
+
+  let(:inputs) { { q: 'horse', answers: [{ question: 'Use?', answer: 'Racing', options: '["Racing"]' }] } }
+  let(:context) do
+    { request_id: 'journey-id', client_id: 'test-client', request_source: 'frontend', experiment: 'async', as_of: '2025-01-02' }
+  end
+  let(:search) { QueuedSearch.create(params: inputs, context:) }
+  let(:service) { instance_double(Api::Internal::SearchService) }
+  let(:result) { { data: [], meta: { search_failures: [] } } }
+
+  before do
+    allow(Api::Internal::SearchService).to receive(:new).and_return(service)
+    allow(service).to receive(:call).and_return(result)
+  end
+
+  after { search.delete }
+
+  describe '#perform' do
+    it 'runs the search with stored inputs' do
+      worker.perform(search.id)
+
+      expect(Api::Internal::SearchService).to have_received(:new).with(inputs.merge(as_of: context[:as_of]).with_indifferent_access)
+      expect(search.payload).to include('status' => 'completed', 'result' => result.deep_stringify_keys, 'response_status' => 200)
+    end
+
+    it 'keeps the submission date across midnight' do
+      id = search.id
+      travel_to Time.zone.parse('2025-01-03 01:00:00')
+
+      worker.perform(id)
+
+      expect(Api::Internal::SearchService).to have_received(:new).with(hash_including(as_of: '2025-01-02'))
+    end
+
+    it 'exposes running until results are stored' do
+      allow(service).to receive(:call) do
+        expect(search.payload).to include('status' => 'running')
+        expect(search.payload).not_to have_key('result')
+        result
+      end
+
+      worker.perform(search.id)
+    end
+
+    it 'restores request and date context' do
+      allow(service).to receive(:call) do
+        expect(TradeTariffRequest.attributes).to include(context.except(:as_of))
+        expect(TimeMachine.point_in_time.to_date).to eq(Date.new(2025, 1, 2))
+        expect(TradeTariffRequest.search_failures).to eq([])
+        result
+      end
+
+      worker.perform(search.id)
+    end
+
+    it 'does not leak context after execution' do
+      previous = TradeTariffRequest.attributes.dup
+      allow(service).to receive(:call) do
+        TradeTariffRequest.record_search_failure(Search::FailureCodes::OPENSEARCH_FAILED)
+        result
+      end
+
+      worker.perform(search.id)
+
+      expect(TradeTariffRequest.attributes).to eq(previous)
+    end
+
+    it 'does not execute duplicate deliveries' do
+      worker.perform(search.id)
+      worker.perform(search.id)
+
+      expect(service).to have_received(:call).once
+    end
+
+    it 'skips missing or expired payloads' do
+      search.delete
+      worker.perform(search.id)
+
+      expect(service).not_to have_received(:call)
+    end
+
+    it 'preserves search validation errors' do
+      errors = { errors: [{ title: 'Invalid query' }] }
+      allow(service).to receive(:call).and_return(errors)
+
+      worker.perform(search.id)
+
+      expect(search.payload).to include('status' => 'failed', 'response_status' => 422, 'result' => errors.deep_stringify_keys)
+    end
+
+    it 'stores safe errors on search failure' do
+      allow(service).to receive(:call).and_raise(HybridRetrievalService::AllLegsFailed, 'private provider details')
+
+      expect { worker.perform(search.id) }.to raise_error(HybridRetrievalService::AllLegsFailed)
+
+      expect(search.payload).to include('status' => 'failed', 'response_status' => 500)
+      expect(search.payload.to_json).not_to include('private provider details')
+    end
+
+    it 'records unexpected errors as failures' do
+      allow(service).to receive(:call).and_raise(StandardError, 'private error')
+
+      expect { worker.perform(search.id) }.to raise_error(StandardError, 'private error')
+
+      expect(search.payload).to include('status' => 'failed', 'response_status' => 500)
+    end
+  end
+end

--- a/spec/workers/queued_search_worker_spec.rb
+++ b/spec/workers/queued_search_worker_spec.rb
@@ -55,7 +55,8 @@ RSpec.describe QueuedSearchWorker, type: :worker do
     end
 
     it 'does not leak context after execution' do
-      previous = TradeTariffRequest.attributes.dup
+      attributes = %i[request_id request_source client_id experiment search_failures search_type search_labels_enabled time_machine_now time_machine_relevant]
+      previous = attributes.index_with { |attribute| TradeTariffRequest.public_send(attribute) }
       allow(service).to receive(:call) do
         TradeTariffRequest.record_search_failure(Search::FailureCodes::OPENSEARCH_FAILED)
         result
@@ -63,7 +64,18 @@ RSpec.describe QueuedSearchWorker, type: :worker do
 
       worker.perform(search.id)
 
-      expect(TradeTariffRequest.attributes).to eq(previous)
+      expect(attributes.index_with { |attribute| TradeTariffRequest.public_send(attribute) }).to eq(previous)
+    end
+
+    it 'restores populated context on failure' do
+      previous = { request_id: 'previous-job', search_failures: [Search::FailureCodes::OPENSEARCH_FAILED] }
+      allow(service).to receive(:call).and_raise(StandardError, 'search error')
+
+      TradeTariffRequest.set(previous) do
+        expect { worker.perform(search.id) }.to raise_error(StandardError, 'search error')
+        expect(TradeTariffRequest.request_id).to eq('previous-job')
+        expect(TradeTariffRequest.search_failures).to eq(previous[:search_failures])
+      end
     end
 
     it 'does not execute duplicate deliveries' do


### PR DESCRIPTION
## What:

- [x] Add internal `POST /queued_searches` and `GET /queued_searches/:id` endpoints beneath the existing UK/XI mounts.
- [x] Accept the existing internal search inputs, store the complex payload in Sidekiq Redis for one hour, and enqueue only its UUID.
- [x] Reuse the existing search service in a worker with atomic `queued -> running -> completed/failed` transitions, preserved request/date context and no automatic retries.
- [x] Return the original search response when complete, safe terminal errors on failure, and 404 for missing/expired IDs. Prevent duplicate claims and late writes from resurrecting expired payloads.
- [x] Document the API, state machine, flow, rollout ordering and operational limits in `docs/architecture/queued-internal-search.md`.

## Why:

Long-running guided searches can occupy Puma request threads and delay unrelated requests. This gives us an additive internal API to test moving the slow work into Sidekiq without changing the frontend or existing synchronous callers.

```text
POST -> Redis payload -> enqueue UUID -> 202 Accepted
                              |
                              v
                    Worker claims queued payload
                              |
                           running
                              |
                    Existing search service
                              |
                     completed / failed
                              |
GET by UUID <--------- Redis state + result
```

No frontend, accessibility markup, public V2 API, infrastructure or environment-variable changes. This is a testing interface, not the completed frontend migration. There is no runtime feature gate: activation is introducing the caller integration, which is outside this PR.

## Ticket:

https://transformuk.atlassian.net/browse/AI-1314

## Risk:

**Risk level:** Low (green)

**Reason for rating:** Approved as low risk for an additive internal testing API with no existing consumers changed. It reuses existing Redis and the default Sidekiq queue, with no deployment topology or live journey change.

Deploy the backend and workers before introducing any caller, including manual submissions. Confirm all workers consuming the relevant default queue have `QueuedSearchWorker` and old tasks have stopped. An old worker can discard a job for the unknown class during a mixed-version rollout; the endpoint itself does not check readiness. Integration rollout is the activation boundary.

Use controlled traffic only: dedicated worker capacity, admission control and browser/session ownership enforcement are not included. A killed worker leaves the payload running until expiry; expiry does not interrupt executing work. Stop all callers and drain jobs before rolling back to a release without the worker class. This PR does not establish production-load safety.