### PR TITLE
HMRC-2694: look up subscriber emails over the private identity route

### DIFF
--- a/app/lib/identity_api_client.rb
+++ b/app/lib/identity_api_client.rb
@@ -1,11 +1,15 @@
 module IdentityApiClient
+  class LookupError < StandardError; end
+
   def self.get_email(username)
     return nil unless username
 
     response = user_request(:get, username)
-    if response.success?
-      JSON.parse(response.body)['user']['email']
-    end
+
+    return JSON.parse(response.body)['user']['email'] if response.success?
+    return nil if response.status == 404
+
+    raise LookupError, "Identity lookup for #{username} returned HTTP #{response.status}"
   end
 
   def self.delete_user(username)
@@ -17,9 +21,32 @@ module IdentityApiClient
 
   def self.user_request(method, username)
     url = URI.join(TradeTariffBackend.identity_api_host, '/api/users/', username).to_s
-    Faraday.public_send(method, url) do |req|
+
+    connection.public_send(method, url) do |req|
       req.headers['Authorization'] = "Token #{TradeTariffBackend.identity_api_key}"
       req.headers['Content-Type'] = 'application/json'
     end
+  end
+
+  def self.connection
+    pem = TradeTariffBackend.internal_ca_pem
+
+    if @connection.nil? || @connection_pem != pem
+      @connection_pem = pem
+      @connection = Faraday.new(ssl: ssl_options)
+    end
+
+    @connection
+  end
+
+  def self.ssl_options
+    pem = TradeTariffBackend.internal_ca_pem
+    return {} if pem.blank?
+
+    store = OpenSSL::X509::Store.new
+    store.set_default_paths
+    store.add_cert(OpenSSL::X509::Certificate.new(pem))
+
+    { cert_store: store }
   end
 end

--- a/app/lib/trade_tariff_backend/config/authentication.rb
+++ b/app/lib/trade_tariff_backend/config/authentication.rb
@@ -16,6 +16,10 @@ module TradeTariffBackend
       def identity_api_key
         ENV['IDENTITY_API_KEY']
       end
+
+      def internal_ca_pem
+        ENV['INTERNAL_CA_PEM'].presence&.gsub('\n', "\n")
+      end
     end
   end
 end

--- a/spec/lib/identity_api_client_spec.rb
+++ b/spec/lib/identity_api_client_spec.rb
@@ -27,13 +27,31 @@ RSpec.describe IdentityApiClient do
 
       it { is_expected.to eq 'email@example.com' }
 
+      context 'when the user does not exist' do
+        before do
+          stub_request(:get, "#{host}/api/users/#{username}")
+            .to_return(status: 404)
+        end
+
+        it { is_expected.to be_nil }
+      end
+
       context 'when api errors' do
         before do
           stub_request(:get, "#{host}/api/users/#{username}")
             .to_return(status: 500)
         end
 
-        it { is_expected.to be_nil }
+        it { expect { client }.to raise_error(IdentityApiClient::LookupError, /HTTP 500/) }
+      end
+
+      context 'when the request is rate limited' do
+        before do
+          stub_request(:get, "#{host}/api/users/#{username}")
+            .to_return(status: 429)
+        end
+
+        it { expect { client }.to raise_error(IdentityApiClient::LookupError, /HTTP 429/) }
       end
     end
   end
@@ -66,6 +84,52 @@ RSpec.describe IdentityApiClient do
         end
 
         it { is_expected.to be false }
+      end
+    end
+  end
+
+  describe '.ssl_options' do
+    subject(:ssl_options) { described_class.ssl_options }
+
+    context 'when no internal CA is configured' do
+      before { allow(TradeTariffBackend).to receive(:internal_ca_pem).and_return(nil) }
+
+      it { is_expected.to eq({}) }
+    end
+
+    context 'when an internal CA is configured' do
+      let(:certificate) do
+        key = OpenSSL::PKey::RSA.new(2048)
+        name = OpenSSL::X509::Name.parse('/CN=*.tariff.internal')
+
+        OpenSSL::X509::Certificate.new.tap do |cert|
+          cert.version = 2
+          cert.serial = 1
+          cert.subject = name
+          cert.issuer = name
+          cert.public_key = key.public_key
+          cert.not_before = Time.zone.now
+          cert.not_after = 1.hour.from_now
+          cert.sign(key, OpenSSL::Digest.new('SHA256'))
+        end
+      end
+
+      before { allow(TradeTariffBackend).to receive(:internal_ca_pem).and_return(certificate.to_pem) }
+
+      it { is_expected.to include(cert_store: an_instance_of(OpenSSL::X509::Store)) }
+
+      it 'trusts the internal certificate' do
+        expect(ssl_options[:cert_store].verify(certificate)).to be true
+      end
+
+      it 'still trusts the system CA bundle' do
+        bundle = OpenSSL::X509::DEFAULT_CERT_FILE
+        skip "no system CA bundle at #{bundle}" unless File.exist?(bundle)
+
+        pem = File.read(bundle)[/-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----/m]
+        skip "no certificates in #{bundle}" if pem.nil?
+
+        expect(ssl_options[:cert_store].verify(OpenSSL::X509::Certificate.new(pem))).to be true
       end
     end
   end

--- a/spec/lib/trade_tariff_backend/config_spec.rb
+++ b/spec/lib/trade_tariff_backend/config_spec.rb
@@ -599,6 +599,18 @@ RSpec.describe TradeTariffBackend::Config do
       end
     end
 
+    describe '.internal_ca_pem' do
+      it 'unescapes the newlines Secrets Manager stores' do
+        ENV['INTERNAL_CA_PEM'] = '-----BEGIN CERTIFICATE-----\nMIIC\n-----END CERTIFICATE-----'
+        expect(config.internal_ca_pem).to eq("-----BEGIN CERTIFICATE-----\nMIIC\n-----END CERTIFICATE-----")
+      end
+
+      it 'is nil when unset' do
+        ENV['INTERNAL_CA_PEM'] = nil
+        expect(config.internal_ca_pem).to be_nil
+      end
+    end
+
     describe '.cognito_user_pool_id' do
       it 'reads COGNITO_USER_POOL_ID from ENV' do
         ENV['COGNITO_USER_POOL_ID'] = 'pool-id'

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -21,6 +21,12 @@ locals {
     },
   ]
 
+  internal_ca_env_vars = [
+    {
+      name  = "INTERNAL_CA_PEM"
+      value = local.tls_secret.certificate
+    },
+  ]
 
   worker_uk_secret_value = try(data.aws_secretsmanager_secret_version.backend_uk_worker_configuration.secret_string, "{}")
   worker_uk_secret_map   = jsondecode(local.worker_uk_secret_value)
@@ -30,6 +36,7 @@ locals {
       value = value
     }
   ]
+  worker_uk_service_env_vars = concat(local.worker_uk_secret_env_vars, local.internal_ca_env_vars)
 
   backend_uk_secret_value = try(data.aws_secretsmanager_secret_version.backend_uk_api_configuration.secret_string, "{}")
   backend_uk_secret_map   = jsondecode(local.backend_uk_secret_value)

--- a/terraform/worker_uk.tf
+++ b/terraform/worker_uk.tf
@@ -31,7 +31,7 @@ module "worker_uk" {
   container_entrypoint = [""]
   container_command    = local.worker_command
 
-  service_environment_config = local.worker_uk_secret_env_vars
+  service_environment_config = local.worker_uk_service_env_vars
 
   has_autoscaler     = local.has_autoscaler
   min_capacity       = 1


### PR DESCRIPTION
## What:
Two changes to how the backend looks up subscriber emails:

1. `IdentityApiClient.get_email` raises `LookupError` on a non-2xx instead of returning `nil`. 404 still returns `nil` — that genuinely means no such user.
2. The client trusts the self-signed `*.tariff.internal` certificate via a new `INTERNAL_CA_PEM`, wired into `worker-uk` in Terraform, so `IDENTITY_API_HOST` can point at the private Cloud Map name.

Depends on trade-tariff/identity#349, which creates that name.

## Why:
`get_email` returned `nil` for every non-2xx, so a rate-limited lookup was indistinguishable from a subscriber with no address. `StopPressEmailWorker:16`, `MyCommoditiesEmailWorker:15` and `WatchListInvitationEmailWorker:13` all bail on a blank email, so large sends dropped 235-326 recipients each with no error anywhere — ongoing since late April. The ticket names the first two; the third has the same pattern and is fixed by the same change.

Raising makes it a Sidekiq retry and a visible failure. Every path into `get_email` is a worker via `PublicUsers::User#email`; the request path takes the email from the JWT payload and never calls the client, so no user-facing behaviour changes.

The private route removes the cause: internal calls stop leaving the VPC through NAT and CloudFront, where the WAF rate limit is keyed on the single shared NAT IP.

## Ticket:
https://transformuk.atlassian.net/browse/HMRC-2694

## Risk:
**Risk level:** 🟠

**Reason for rating:** Changes the failure behaviour of live email workers — previously silent failures now raise and retry. Terraform is additive (one env var, no resource recreation; the dev apply updated all four ECS services in place).

Notes for the reviewer:
- `terraform/locals.tf` and `worker_uk.tf` will conflict with HMRC-2677 — both add a `worker_uk_service_env_vars` local. Trivial to resolve, whichever lands second `concat`s both lists.
- `ssl_options` calls `set_default_paths` before adding the internal certificate, so the store trusts the public CAs *and* the internal one. This makes the change order independent: it can merge and sit safely on the public host until identity#349 is deployed and `IDENTITY_API_HOST` is flipped. Without that call the store would trust only the internal cert and every lookup would fail TLS on the public host.
- Activating the private route needs `IDENTITY_API_HOST=https://identity.tariff.internal:8443` in `backend-uk-worker-configuration`, plus a redeploy — the secret is read at terraform apply time and baked into the task definition, so a secret edit alone has no effect.
- Out of scope, worth its own ticket: `delete_user` still returns `response.success?`, so a non-2xx makes `ExternalUserDeletionWorker:21-23` skip the deletion and report success, leaving `external_id` set. Same bug class as `get_email`, with right-to-erasure rather than email consequences.
