### PR TITLE
Add 'open' and 'suspended' status filters to the Quotas search API and refactor

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -34,7 +34,7 @@ module Api
       render json: serializer.serialized_errors({ error: exception.message, url: request.url }), status: :conflict
     end
 
-    rescue_from RulesOfOrigin::Query::InvalidParams do |exception|
+    rescue_from RulesOfOrigin::Query::InvalidParams, QuotaDefinitionsQuery::InvalidStatus do |exception|
       serializer = TradeTariffBackend.error_serializer(request)
       render json: serializer.serialized_errors({ error: exception.message, url: request.url }), status: :bad_request
     end

--- a/app/models/quota_definition.rb
+++ b/app/models/quota_definition.rb
@@ -115,9 +115,9 @@ class QuotaDefinition < Sequel::Model
   #
   #       Status (pending a discussion) should be determined by active events and be prioritised in the following order:
   #
+  #       - exhausted
   #       - suspended
   #       - blocked
-  #       - exhausted
   #       - critical
   #       - open events
   #

--- a/app/models/quota_event.rb
+++ b/app/models/quota_event.rb
@@ -20,6 +20,11 @@ class QuotaEvent
     end
   end
 
+  # Scalar subquery selecting just the latest event_type for embedding in SQL.
+  def self.latest_event_type_dataset(quota_sid, point_in_time)
+    for_quota_definition(quota_sid, point_in_time).select(:event_type).limit(1)
+  end
+
   def self.for_event(event_type, quota_sid, point_in_time)
     event_class_for(event_type).select(:quota_definition_sid,
                                        :occurrence_timestamp,

--- a/app/queries/quota_definitions_query.rb
+++ b/app/queries/quota_definitions_query.rb
@@ -1,0 +1,195 @@
+# Builds the filtered dataset of Measures used to look up quota definitions.
+
+class QuotaDefinitionsQuery
+  STATUS_VALUES = %w[blocked exhausted not_blocked not_exhausted suspended not_suspended open].freeze
+
+  class InvalidStatus < StandardError; end
+
+  attr_reader :goods_nomenclature_item_id, :geographical_area_id, :order_number,
+              :critical, :status, :date
+
+  def initialize(attributes, date)
+    status_value = attributes['status']&.gsub(/[+ ]/, '_')
+    if status_value.present? && STATUS_VALUES.exclude?(status_value)
+      raise InvalidStatus, "invalid status: #{attributes['status']}"
+    end
+
+    @status = ActiveSupport::StringInquirer.new(status_value || '')
+    @goods_nomenclature_item_id = attributes['goods_nomenclature_item_id']
+    @geographical_area_id = attributes['geographical_area_id']
+    @order_number = attributes['order_number']
+    @critical = attributes['critical']
+    @date = date
+  end
+
+  def eager_quota_exhaustion_events?
+    status.exhausted? || status.not_exhausted?
+  end
+
+  def apply(scope)
+    scope = apply_quota_definition_filter(scope)
+    scope = apply_goods_nomenclature_item_id_filter(scope) if goods_nomenclature_item_id.present?
+    scope = apply_geographical_area_id_filter(scope) if geographical_area_id.present?
+    scope = apply_order_number_filter(scope) if order_number.present?
+
+    scope
+  end
+
+private
+
+  def apply_goods_nomenclature_item_id_filter(scope)
+    ancestors = FindAncestorsService.new(goods_nomenclature_item_id).call
+
+    if ancestors.present?
+      scope.where(goods_nomenclature_item_id: ancestors)
+    else
+      scope.where(Sequel.like(:measures__goods_nomenclature_item_id, "#{goods_nomenclature_item_id}%"))
+    end
+  end
+
+  def apply_geographical_area_id_filter(scope)
+    geographical_area_ids = GeographicalArea.where(geographical_area_id:).actual.take.included_geographical_areas.pluck(:geographical_area_id)
+    geographical_area_ids << geographical_area_id
+
+    scope.where(measures__geographical_area_id: geographical_area_ids)
+  end
+
+  def apply_order_number_filter(scope)
+    scope.where(measures__ordernumber: order_number)
+  end
+
+  def apply_quota_definition_filter(scope)
+    critical_condition = critical.present? ? 'AND quota_definitions."critical_state" = \'Y\'' : ''
+    args = [date, date]
+    if status.present?
+      status_filter = send("apply_#{status}_filter")
+      status_condition = "AND #{status_filter.str}"
+      args.push(*status_filter.args)
+    end
+
+    sql = Sequel.lit(
+      <<~SQL, *args
+        EXISTS (
+          SELECT 1
+          FROM "quota_definitions" quota_definitions
+          WHERE quota_definitions."quota_order_number_id" = "measures"."ordernumber"
+            AND quota_definitions."validity_start_date" <= ?
+            AND (quota_definitions."validity_end_date" >= ? OR quota_definitions."validity_end_date" IS NULL)
+            #{critical_condition}
+            #{status_condition}
+          LIMIT 1
+        )
+      SQL
+    )
+
+    scope.where(sql)
+  end
+
+  def apply_exhausted_filter
+    Sequel.lit(
+      <<~SQL, QuotaDefinition.point_in_time
+        EXISTS (
+        SELECT *
+          FROM "quota_exhaustion_events"
+         WHERE "quota_exhaustion_events"."quota_definition_sid" = "quota_definitions"."quota_definition_sid" AND
+               "quota_exhaustion_events"."occurrence_timestamp" <= ?
+         LIMIT 1
+        )
+      SQL
+    )
+  end
+
+  def apply_not_exhausted_filter
+    Sequel.lit(
+      <<~SQL, QuotaDefinition.point_in_time
+        NOT EXISTS (
+        SELECT *
+          FROM "quota_exhaustion_events"
+         WHERE "quota_exhaustion_events"."quota_definition_sid" = "quota_definitions"."quota_definition_sid" AND
+               "quota_exhaustion_events"."occurrence_timestamp" <= ?
+         LIMIT 1
+        )
+      SQL
+    )
+  end
+
+  def apply_blocked_filter
+    Sequel.lit(
+      <<~SQL, QuotaDefinition.point_in_time, QuotaDefinition.point_in_time
+        EXISTS (
+        SELECT *
+          FROM "quota_blocking_periods"
+         WHERE "quota_blocking_periods"."quota_definition_sid" = "quota_definitions"."quota_definition_sid" AND
+               ("quota_blocking_periods"."blocking_start_date" <= ? AND
+               ("quota_blocking_periods"."blocking_end_date" >= ? OR
+                "quota_blocking_periods"."blocking_end_date" IS NULL))
+         LIMIT 1
+        )
+      SQL
+    )
+  end
+
+  def apply_not_blocked_filter
+    Sequel.lit(
+      <<~SQL, QuotaDefinition.point_in_time, QuotaDefinition.point_in_time
+        NOT EXISTS (
+        SELECT *
+          FROM "quota_blocking_periods"
+         WHERE "quota_blocking_periods"."quota_definition_sid" = "quota_definitions"."quota_definition_sid" AND
+               ("quota_blocking_periods"."blocking_start_date" <= ? AND
+               ("quota_blocking_periods"."blocking_end_date" >= ? OR
+                "quota_blocking_periods"."blocking_end_date" IS NULL))
+         LIMIT 1
+        )
+      SQL
+    )
+  end
+
+  def apply_suspended_filter
+    Sequel.lit(
+      <<~SQL, QuotaDefinition.point_in_time, QuotaDefinition.point_in_time
+        EXISTS (
+        SELECT *
+          FROM "quota_suspension_periods"
+         WHERE "quota_suspension_periods"."quota_definition_sid" = "quota_definitions"."quota_definition_sid" AND
+               ("quota_suspension_periods"."suspension_start_date" <= ? AND
+               ("quota_suspension_periods"."suspension_end_date" >= ? OR
+                "quota_suspension_periods"."suspension_end_date" IS NULL))
+         LIMIT 1
+        )
+      SQL
+    )
+  end
+
+  def apply_not_suspended_filter
+    Sequel.lit(
+      <<~SQL, QuotaDefinition.point_in_time, QuotaDefinition.point_in_time
+        NOT EXISTS (
+        SELECT *
+          FROM "quota_suspension_periods"
+         WHERE "quota_suspension_periods"."quota_definition_sid" = "quota_definitions"."quota_definition_sid" AND
+               ("quota_suspension_periods"."suspension_start_date" <= ? AND
+               ("quota_suspension_periods"."suspension_end_date" >= ? OR
+                "quota_suspension_periods"."suspension_end_date" IS NULL))
+         LIMIT 1
+        )
+      SQL
+    )
+  end
+
+  # A quota definition is "Open" when it has no exhausted event, is not
+  # currently suspended, is not currently blocked, and isn't flagged as
+  # critical.
+  def apply_open_filter
+    not_exhausted = apply_not_exhausted_filter
+    not_suspended = apply_not_suspended_filter
+    not_blocked = apply_not_blocked_filter
+
+    Sequel.lit(
+      "#{not_exhausted.str} AND #{not_suspended.str} AND #{not_blocked.str} AND \"quota_definitions\".\"critical_state\" != 'Y'",
+      *not_exhausted.args,
+      *not_suspended.args,
+      *not_blocked.args,
+    )
+  end
+end

--- a/app/queries/quota_definitions_query.rb
+++ b/app/queries/quota_definitions_query.rb
@@ -85,32 +85,50 @@ private
     scope.where(sql)
   end
 
-  def apply_exhausted_filter
+  # QuotaDefinition#status considers a quota "Exhausted" only when the most
+  # recent quota event (across all event types - exhaustion, balance,
+  # critical, reopening, unblocking, unsuspension) is an exhaustion event
+  # (see QuotaEvent.last_for / QuotaDefinition#has_exhausted_event?). A
+  # historical exhaustion event that has since been superseded by a newer
+  # reopening or balance event must NOT be treated as exhausted, so we
+  # replicate that "latest event wins" semantics here rather than just
+  # checking whether an exhaustion event exists at all.
+  def latest_quota_event_type_sql
+    unions = QuotaEvent::EVENTS.map { |event_type|
+      table = "quota_#{event_type}_events"
+
+      <<~SQL
+        SELECT '#{event_type}' AS event_type, "#{table}"."occurrence_timestamp"
+          FROM "#{table}"
+         WHERE "#{table}"."quota_definition_sid" = "quota_definitions"."quota_definition_sid"
+           AND "#{table}"."occurrence_timestamp" <= ?
+      SQL
+    }.join("UNION ALL\n")
+
     Sequel.lit(
-      <<~SQL, QuotaDefinition.point_in_time
-        EXISTS (
-        SELECT *
-          FROM "quota_exhaustion_events"
-         WHERE "quota_exhaustion_events"."quota_definition_sid" = "quota_definitions"."quota_definition_sid" AND
-               "quota_exhaustion_events"."occurrence_timestamp" <= ?
-         LIMIT 1
+      <<~SQL, *([QuotaDefinition.point_in_time] * QuotaEvent::EVENTS.length)
+        (
+          SELECT event_type
+            FROM (
+              #{unions}
+            ) latest_quota_events
+           ORDER BY occurrence_timestamp DESC, event_type DESC
+           LIMIT 1
         )
       SQL
     )
   end
 
+  def apply_exhausted_filter
+    latest_event_type = latest_quota_event_type_sql
+
+    Sequel.lit("#{latest_event_type.str} = 'exhaustion'", *latest_event_type.args)
+  end
+
   def apply_not_exhausted_filter
-    Sequel.lit(
-      <<~SQL, QuotaDefinition.point_in_time
-        NOT EXISTS (
-        SELECT *
-          FROM "quota_exhaustion_events"
-         WHERE "quota_exhaustion_events"."quota_definition_sid" = "quota_definitions"."quota_definition_sid" AND
-               "quota_exhaustion_events"."occurrence_timestamp" <= ?
-         LIMIT 1
-        )
-      SQL
-    )
+    latest_event_type = latest_quota_event_type_sql
+
+    Sequel.lit("#{latest_event_type.str} IS DISTINCT FROM 'exhaustion'", *latest_event_type.args)
   end
 
   def apply_blocked_filter

--- a/app/queries/quota_definitions_query.rb
+++ b/app/queries/quota_definitions_query.rb
@@ -5,6 +5,8 @@ class QuotaDefinitionsQuery
 
   class InvalidStatus < StandardError; end
 
+  SqlFragment = Struct.new(:str, :args)
+
   attr_reader :goods_nomenclature_item_id, :geographical_area_id, :order_number,
               :critical, :status, :date
 
@@ -48,7 +50,8 @@ private
   end
 
   def apply_geographical_area_id_filter(scope)
-    geographical_area_ids = GeographicalArea.where(geographical_area_id:).actual.take.included_geographical_areas.pluck(:geographical_area_id)
+    area = GeographicalArea.where(geographical_area_id:).actual.first
+    geographical_area_ids = area&.included_geographical_areas&.pluck(:geographical_area_id).to_a
     geographical_area_ids << geographical_area_id
 
     scope.where(measures__geographical_area_id: geographical_area_ids)
@@ -61,6 +64,7 @@ private
   def apply_quota_definition_filter(scope)
     critical_condition = critical.present? ? 'AND quota_definitions."critical_state" = \'Y\'' : ''
     args = [date, date]
+    status_condition = ''
     if status.present?
       status_filter = send("apply_#{status}_filter")
       status_condition = "AND #{status_filter.str}"
@@ -85,129 +89,52 @@ private
     scope.where(sql)
   end
 
-  # QuotaDefinition#status considers a quota "Exhausted" only when the most
-  # recent quota event (across all event types - exhaustion, balance,
-  # critical, reopening, unblocking, unsuspension) is an exhaustion event
-  # (see QuotaEvent.last_for / QuotaDefinition#has_exhausted_event?). A
-  # historical exhaustion event that has since been superseded by a newer
-  # reopening or balance event must NOT be treated as exhausted, so we
-  # replicate that "latest event wins" semantics here rather than just
-  # checking whether an exhaustion event exists at all.
-  def latest_quota_event_type_sql
-    unions = QuotaEvent::EVENTS.map { |event_type|
-      table = "quota_#{event_type}_events"
-
-      <<~SQL
-        SELECT '#{event_type}' AS event_type, "#{table}"."occurrence_timestamp"
-          FROM "#{table}"
-         WHERE "#{table}"."quota_definition_sid" = "quota_definitions"."quota_definition_sid"
-           AND "#{table}"."occurrence_timestamp" <= ?
-      SQL
-    }.join("UNION ALL\n")
-
-    Sequel.lit(
-      <<~SQL, *([QuotaDefinition.point_in_time] * QuotaEvent::EVENTS.length)
-        (
-          SELECT event_type
-            FROM (
-              #{unions}
-            ) latest_quota_events
-           ORDER BY occurrence_timestamp DESC, event_type DESC
-           LIMIT 1
-        )
-      SQL
-    )
-  end
-
   def apply_exhausted_filter
-    latest_event_type = latest_quota_event_type_sql
-
-    Sequel.lit("#{latest_event_type.str} = 'exhaustion'", *latest_event_type.args)
+    status_equals(QuotaDefinition::STATUS_EXHAUSTED)
   end
 
   def apply_not_exhausted_filter
-    latest_event_type = latest_quota_event_type_sql
-
-    Sequel.lit("#{latest_event_type.str} IS DISTINCT FROM 'exhaustion'", *latest_event_type.args)
+    status_not_equals(QuotaDefinition::STATUS_EXHAUSTED)
   end
 
   def apply_blocked_filter
-    Sequel.lit(
-      <<~SQL, QuotaDefinition.point_in_time, QuotaDefinition.point_in_time
-        EXISTS (
-        SELECT *
-          FROM "quota_blocking_periods"
-         WHERE "quota_blocking_periods"."quota_definition_sid" = "quota_definitions"."quota_definition_sid" AND
-               ("quota_blocking_periods"."blocking_start_date" <= ? AND
-               ("quota_blocking_periods"."blocking_end_date" >= ? OR
-                "quota_blocking_periods"."blocking_end_date" IS NULL))
-         LIMIT 1
-        )
-      SQL
-    )
+    status_equals(QuotaDefinition::STATUS_BLOCKED)
   end
 
   def apply_not_blocked_filter
-    Sequel.lit(
-      <<~SQL, QuotaDefinition.point_in_time, QuotaDefinition.point_in_time
-        NOT EXISTS (
-        SELECT *
-          FROM "quota_blocking_periods"
-         WHERE "quota_blocking_periods"."quota_definition_sid" = "quota_definitions"."quota_definition_sid" AND
-               ("quota_blocking_periods"."blocking_start_date" <= ? AND
-               ("quota_blocking_periods"."blocking_end_date" >= ? OR
-                "quota_blocking_periods"."blocking_end_date" IS NULL))
-         LIMIT 1
-        )
-      SQL
-    )
+    status_not_equals(QuotaDefinition::STATUS_BLOCKED)
   end
 
   def apply_suspended_filter
-    Sequel.lit(
-      <<~SQL, QuotaDefinition.point_in_time, QuotaDefinition.point_in_time
-        EXISTS (
-        SELECT *
-          FROM "quota_suspension_periods"
-         WHERE "quota_suspension_periods"."quota_definition_sid" = "quota_definitions"."quota_definition_sid" AND
-               ("quota_suspension_periods"."suspension_start_date" <= ? AND
-               ("quota_suspension_periods"."suspension_end_date" >= ? OR
-                "quota_suspension_periods"."suspension_end_date" IS NULL))
-         LIMIT 1
-        )
-      SQL
-    )
+    status_equals(QuotaDefinition::STATUS_SUSPENDED)
   end
 
   def apply_not_suspended_filter
-    Sequel.lit(
-      <<~SQL, QuotaDefinition.point_in_time, QuotaDefinition.point_in_time
-        NOT EXISTS (
-        SELECT *
-          FROM "quota_suspension_periods"
-         WHERE "quota_suspension_periods"."quota_definition_sid" = "quota_definitions"."quota_definition_sid" AND
-               ("quota_suspension_periods"."suspension_start_date" <= ? AND
-               ("quota_suspension_periods"."suspension_end_date" >= ? OR
-                "quota_suspension_periods"."suspension_end_date" IS NULL))
-         LIMIT 1
-        )
-      SQL
-    )
+    status_not_equals(QuotaDefinition::STATUS_SUSPENDED)
   end
 
-  # A quota definition is "Open" when it has no exhausted event, is not
-  # currently suspended, is not currently blocked, and isn't flagged as
-  # critical.
   def apply_open_filter
-    not_exhausted = apply_not_exhausted_filter
-    not_suspended = apply_not_suspended_filter
-    not_blocked = apply_not_blocked_filter
+    status_equals(QuotaDefinition::STATUS_OPEN)
+  end
 
-    Sequel.lit(
-      "#{not_exhausted.str} AND #{not_suspended.str} AND #{not_blocked.str} AND \"quota_definitions\".\"critical_state\" != 'Y'",
-      *not_exhausted.args,
-      *not_suspended.args,
-      *not_blocked.args,
-    )
+  def status_sql_fragment
+    @status_sql_fragment ||= QuotaStatusSql.new(
+      definition_table: :quota_definitions,
+      point_in_time: date,
+    ).to_fragment
+  end
+
+  def status_equals(status_value)
+    fragment = status_sql_fragment
+    sql_fragment("(#{fragment.str}) = '#{status_value}'", *fragment.args)
+  end
+
+  def status_not_equals(status_value)
+    fragment = status_sql_fragment
+    sql_fragment("(#{fragment.str}) IS DISTINCT FROM '#{status_value}'", *fragment.args)
+  end
+
+  def sql_fragment(str, *args)
+    SqlFragment.new(str, args)
   end
 end

--- a/app/queries/quota_status_sql.rb
+++ b/app/queries/quota_status_sql.rb
@@ -1,0 +1,100 @@
+# Builds the SQL expression that computes quota status precedence for a
+# single quota definition row.
+class QuotaStatusSql
+  OPEN_EVENT_TYPES = %w[balance reopening unblocking unsuspension].freeze
+
+  Fragment = Struct.new(:str, :args)
+
+  def initialize(definition_table:, point_in_time:)
+    @definition_table = definition_table.to_s
+    @point_in_time = point_in_time
+  end
+
+  def to_fragment
+    latest_event_type = latest_event_type_sql
+    latest_critical_state = latest_critical_state_sql
+    suspended = active_suspension_sql
+    blocked = active_blocking_sql
+
+    sql = <<~SQL
+      CASE
+        WHEN (#{latest_event_type}) = 'exhaustion' THEN '#{QuotaDefinition::STATUS_EXHAUSTED}'
+        WHEN #{suspended.str} THEN '#{QuotaDefinition::STATUS_SUSPENDED}'
+        WHEN #{blocked.str} THEN '#{QuotaDefinition::STATUS_BLOCKED}'
+        WHEN (#{latest_event_type}) = 'critical' THEN '#{QuotaDefinition::STATUS_CRITICAL}'
+        WHEN (#{latest_event_type}) IN (#{open_event_types_sql})
+          AND (#{latest_critical_state.str}) = '#{QuotaCriticalEvent::ACTIVE_CRITICAL_STATE}' THEN '#{QuotaDefinition::STATUS_CRITICAL}'
+        WHEN (#{latest_event_type}) IS NOT NULL THEN '#{QuotaDefinition::STATUS_OPEN}'
+        ELSE CASE
+               WHEN "#{definition_table}"."critical_state" = '#{QuotaDefinition::DEFINITION_CRITICAL_STATE}' THEN '#{QuotaDefinition::STATUS_CRITICAL}'
+               ELSE '#{QuotaDefinition::STATUS_OPEN}'
+             END
+      END
+    SQL
+
+    Fragment.new(sql, suspended.args + blocked.args + latest_critical_state.args)
+  end
+
+private
+
+  attr_reader :definition_table, :point_in_time
+
+  def latest_event_type_sql
+    QuotaEvent.latest_event_type_dataset(
+      Sequel[definition_table.to_sym][:quota_definition_sid],
+      point_in_time,
+    ).sql
+  end
+
+  def latest_critical_state_sql
+    Fragment.new(
+      <<~SQL,
+        SELECT "quota_critical_events"."critical_state"
+          FROM "quota_critical_events"
+         WHERE "quota_critical_events"."quota_definition_sid" = "#{definition_table}"."quota_definition_sid"
+           AND "quota_critical_events"."occurrence_timestamp" <= ?
+         ORDER BY "quota_critical_events"."occurrence_timestamp" DESC
+         LIMIT 1
+      SQL
+      [point_in_time],
+    )
+  end
+
+  def active_suspension_sql
+    Fragment.new(
+      <<~SQL,
+        EXISTS (
+          SELECT 1
+            FROM "quota_suspension_periods"
+           WHERE "quota_suspension_periods"."quota_definition_sid" = "#{definition_table}"."quota_definition_sid"
+             AND ("quota_suspension_periods"."suspension_start_date" <= ?
+             AND ("quota_suspension_periods"."suspension_end_date" >= ?
+             OR "quota_suspension_periods"."suspension_end_date" IS NULL))
+           LIMIT 1
+        )
+      SQL
+      [point_in_time, point_in_time],
+    )
+  end
+
+  def active_blocking_sql
+    Fragment.new(
+      <<~SQL,
+        EXISTS (
+          SELECT 1
+            FROM "quota_blocking_periods"
+           WHERE "quota_blocking_periods"."quota_definition_sid" = "#{definition_table}"."quota_definition_sid"
+             AND ("quota_blocking_periods"."blocking_start_date" <= ?
+             AND ("quota_blocking_periods"."blocking_end_date" >= ?
+             OR "quota_blocking_periods"."blocking_end_date" IS NULL))
+           LIMIT 1
+        )
+      SQL
+      [point_in_time, point_in_time],
+    )
+  end
+
+  def open_event_types_sql
+    OPEN_EVENT_TYPES.map { |event_type| "'#{event_type}'" }.join(', ')
+  end
+end

--- a/app/services/quota_search_service.rb
+++ b/app/services/quota_search_service.rb
@@ -1,5 +1,4 @@
 class QuotaSearchService
-  STATUS_VALUES = %w[blocked exhausted not_blocked not_exhausted].freeze
   DEFAULT_EAGER_LOAD_GRAPH = {
     quota_order_number: [
       { quota_order_number_origins: [{ geographical_area: :geographical_area_descriptions }] },
@@ -25,18 +24,12 @@ class QuotaSearchService
     ],
   }.freeze
 
-  attr_reader :scope, :goods_nomenclature_item_id, :geographical_area_id, :order_number,
-              :critical, :years, :status, :current_page, :per_page, :date, :include_quota_balance_events
+  attr_reader :scope, :current_page, :per_page, :date, :include_quota_balance_events
+
+  delegate :status, to: :query
 
   def initialize(attributes, current_page, per_page, date, include_quota_balance_events: false)
-    @attributes = attributes
-    status_value = attributes['status']&.gsub(/[+ ]/, '_')
-    status_value = '' unless STATUS_VALUES.include?(status_value)
-    @status = ActiveSupport::StringInquirer.new(status_value || '')
-    @goods_nomenclature_item_id = attributes['goods_nomenclature_item_id']
-    @geographical_area_id = attributes['geographical_area_id']
-    @order_number = attributes['order_number']
-    @critical = attributes['critical']
+    @query = QuotaDefinitionsQuery.new(attributes, date)
     @current_page = current_page
     @per_page = per_page
     @date = date
@@ -46,18 +39,14 @@ class QuotaSearchService
   def call
     record_count = pagination_record_count
 
-    @scope = Measure
-               .actual
-               .eager(eager_load_graph)
-               .distinct(:measures__ordernumber)
-               .select(Sequel.expr(:measures).*)
-               .order(:measures__ordernumber)
-
-    apply_quota_definition
-
-    apply_goods_nomenclature_item_id_filter if goods_nomenclature_item_id.present?
-    apply_geographical_area_id_filter if geographical_area_id.present?
-    apply_order_number_filter if order_number.present?
+    @scope = query.apply(
+      Measure
+        .actual
+        .eager(eager_load_graph)
+        .distinct(:measures__ordernumber)
+        .select(Sequel.expr(:measures).*)
+        .order(:measures__ordernumber),
+    )
 
     @scope = @scope.paginate(current_page, per_page, record_count)
 
@@ -70,18 +59,10 @@ class QuotaSearchService
 
 private
 
-  attr_reader :attributes
+  attr_reader :query
 
   def count_total_records
-    @scope = Measure.actual
-
-    apply_quota_definition
-
-    apply_goods_nomenclature_item_id_filter if goods_nomenclature_item_id.present?
-    apply_geographical_area_id_filter if geographical_area_id.present?
-    apply_order_number_filter if order_number.present?
-
-    @scope.count(Sequel.lit('DISTINCT ordernumber'))
+    query.apply(Measure.actual).count(Sequel.lit('DISTINCT ordernumber'))
   end
 
   def eager_load_graph
@@ -90,116 +71,8 @@ private
     eager_load[:quota_definition] << :latest_quota_balance_event
     eager_load[:quota_definition] << :quota_balance_events if include_quota_balance_events
 
-    eager_load[:quota_definition] << :quota_exhaustion_events if status.exhausted? || status.not_exhausted?
+    eager_load[:quota_definition] << :quota_exhaustion_events if query.eager_quota_exhaustion_events?
 
     eager_load
-  end
-
-  def apply_goods_nomenclature_item_id_filter
-    ancestors = FindAncestorsService.new(goods_nomenclature_item_id).call
-
-    @scope = if ancestors.present?
-               @scope.where(goods_nomenclature_item_id: ancestors)
-             else
-               @scope.where(Sequel.like(:measures__goods_nomenclature_item_id, "#{goods_nomenclature_item_id}%"))
-             end
-  end
-
-  def apply_geographical_area_id_filter
-    geographical_area_ids = GeographicalArea.where(geographical_area_id:).actual.take.included_geographical_areas.pluck(:geographical_area_id)
-    geographical_area_ids << geographical_area_id
-
-    @scope = scope.where(measures__geographical_area_id: geographical_area_ids)
-  end
-
-  def apply_order_number_filter
-    @scope = scope.where(measures__ordernumber: order_number)
-  end
-
-  def apply_quota_definition
-    critical_condition = critical.present? ? 'AND quota_definitions."critical_state" = \'Y\'' : ''
-    args = [date, date]
-    if status.present?
-      status_filter = send("apply_#{status}_filter")
-      status_condition = "AND #{status_filter.str}"
-      args.push(*status_filter.args)
-    end
-
-    sql = Sequel.lit(
-      <<~SQL, *args
-        EXISTS (
-          SELECT 1
-          FROM "quota_definitions" quota_definitions
-          WHERE quota_definitions."quota_order_number_id" = "measures"."ordernumber"
-            AND quota_definitions."validity_start_date" <= ?
-            AND (quota_definitions."validity_end_date" >= ? OR quota_definitions."validity_end_date" IS NULL)
-            #{critical_condition}
-            #{status_condition}
-          LIMIT 1
-        )
-      SQL
-    )
-
-    @scope = scope.where(sql)
-  end
-
-  def apply_exhausted_filter
-    Sequel.lit(
-      <<~SQL, QuotaDefinition.point_in_time
-        EXISTS (
-        SELECT *
-          FROM "quota_exhaustion_events"
-         WHERE "quota_exhaustion_events"."quota_definition_sid" = "quota_definitions"."quota_definition_sid" AND
-               "quota_exhaustion_events"."occurrence_timestamp" <= ?
-         LIMIT 1
-        )
-      SQL
-    )
-  end
-
-  def apply_not_exhausted_filter
-    Sequel.lit(
-      <<~SQL, QuotaDefinition.point_in_time
-        NOT EXISTS (
-        SELECT *
-          FROM "quota_exhaustion_events"
-         WHERE "quota_exhaustion_events"."quota_definition_sid" = "quota_definitions"."quota_definition_sid" AND
-               "quota_exhaustion_events"."occurrence_timestamp" <= ?
-         LIMIT 1
-        )
-      SQL
-    )
-  end
-
-  def apply_blocked_filter
-    Sequel.lit(
-      <<~SQL, QuotaDefinition.point_in_time, QuotaDefinition.point_in_time
-        EXISTS (
-        SELECT *
-          FROM "quota_blocking_periods"
-         WHERE "quota_blocking_periods"."quota_definition_sid" = "quota_definitions"."quota_definition_sid" AND
-               ("quota_blocking_periods"."blocking_start_date" <= ? AND
-               ("quota_blocking_periods"."blocking_end_date" >= ? OR
-                "quota_blocking_periods"."blocking_end_date" IS NULL))
-         LIMIT 1
-        )
-      SQL
-    )
-  end
-
-  def apply_not_blocked_filter
-    Sequel.lit(
-      <<~SQL, QuotaDefinition.point_in_time, QuotaDefinition.point_in_time
-        NOT EXISTS (
-        SELECT *
-          FROM "quota_blocking_periods"
-         WHERE "quota_blocking_periods"."quota_definition_sid" = "quota_definitions"."quota_definition_sid" AND
-               ("quota_blocking_periods"."blocking_start_date" <= ? AND
-               ("quota_blocking_periods"."blocking_end_date" >= ? OR
-                "quota_blocking_periods"."blocking_end_date" IS NULL))
-         LIMIT 1
-        )
-      SQL
-    )
   end
 end

--- a/spec/models/quota_definition_spec.rb
+++ b/spec/models/quota_definition_spec.rb
@@ -58,6 +58,18 @@ RSpec.describe QuotaDefinition do
       it { is_expected.to eq QuotaDefinition::STATUS_CRITICAL }
     end
 
+    context 'when latest event is reopening and there is an active critical event' do
+      subject(:status) do
+        quota_definition = create(:quota_definition)
+        create(:quota_critical_event, :active, quota_definition:, occurrence_timestamp: 2.days.ago)
+        create(:quota_reopening_event, quota_definition:, occurrence_timestamp: 1.day.ago)
+
+        quota_definition.reload.status
+      end
+
+      it { is_expected.to eq QuotaDefinition::STATUS_CRITICAL }
+    end
+
     context 'when there are balance events and an inactive critical event' do
       subject(:status) { build(:quota_definition, :with_quota_balance_and_inactive_critical_events).status }
 
@@ -92,6 +104,37 @@ RSpec.describe QuotaDefinition do
       subject(:status) { create(:quota_definition, :with_expired_quota_blocking_period).reload.status }
 
       it { is_expected.to eq QuotaDefinition::STATUS_OPEN }
+    end
+
+    context 'when an exhaustion event occurs after point_in_time' do
+      subject(:status) do
+        quota_definition = create(:quota_definition, critical_state: 'N')
+        create(:quota_exhaustion_event, quota_definition:, occurrence_timestamp: 1.day.from_now)
+
+        quota_definition.reload.status
+      end
+
+      it 'ignores the future event' do
+        expect(status).to eq(QuotaDefinition::STATUS_OPEN)
+      end
+    end
+
+    context 'when a suspension period starts after point_in_time' do
+      subject(:status) do
+        quota_definition = create(:quota_definition, critical_state: 'N')
+        create(
+          :quota_suspension_period,
+          quota_definition_sid: quota_definition.quota_definition_sid,
+          suspension_start_date: Date.tomorrow,
+          suspension_end_date: 1.year.from_now.to_date,
+        )
+
+        quota_definition.reload.status
+      end
+
+      it 'ignores the future period' do
+        expect(status).to eq(QuotaDefinition::STATUS_OPEN)
+      end
     end
   end
 

--- a/spec/queries/quota_definitions_query_spec.rb
+++ b/spec/queries/quota_definitions_query_spec.rb
@@ -1,0 +1,60 @@
+RSpec.describe QuotaDefinitionsQuery do
+  subject(:query) { described_class.new(attributes, Time.zone.today) }
+
+  around do |example|
+    TimeMachine.now { example.run }
+  end
+
+  describe '#initialize' do
+    context 'when status is not one of the allowed values' do
+      let(:attributes) { { 'status' => 'not_a_real_status' } }
+
+      it 'raises QuotaDefinitionsQuery::InvalidStatus' do
+        expect { query }.to raise_error(described_class::InvalidStatus)
+      end
+    end
+
+    context 'when status is valid' do
+      let(:attributes) { { 'status' => 'not+exhausted' } }
+
+      it 'unescapes the status value' do
+        expect(query.status).to eq('not_exhausted')
+      end
+    end
+
+    context 'when status is blank' do
+      let(:attributes) { {} }
+
+      it 'defaults to an empty status' do
+        expect(query.status).to eq('')
+      end
+    end
+  end
+
+  describe '#apply' do
+    let(:attributes) { { 'order_number' => quota_order_number.quota_order_number_id } }
+    let(:quota_order_number) { create :quota_order_number }
+    let(:measure) do
+      create(
+        :measure,
+        ordernumber: quota_order_number.quota_order_number_id,
+        validity_start_date: Time.zone.yesterday,
+      )
+    end
+
+    before do
+      measure
+      create(:measure, validity_start_date: Time.zone.yesterday)
+      create(
+        :quota_definition,
+        quota_order_number_sid: quota_order_number.quota_order_number_sid,
+        quota_order_number_id: quota_order_number.quota_order_number_id,
+        validity_start_date: Time.zone.yesterday,
+      )
+    end
+
+    it 'is reusable against any Measure-based scope, applying the configured filters' do
+      expect(query.apply(Measure.actual).all).to contain_exactly(measure)
+    end
+  end
+end

--- a/spec/queries/quota_definitions_query_spec.rb
+++ b/spec/queries/quota_definitions_query_spec.rb
@@ -56,6 +56,15 @@ RSpec.describe QuotaDefinitionsQuery do
     it 'is reusable against any Measure-based scope, applying the configured filters' do
       expect(query.apply(Measure.actual).all).to contain_exactly(measure)
     end
+
+    context 'when geographical_area_id does not exist' do
+      let(:attributes) { { 'geographical_area_id' => 'UNKNOWN_AREA' } }
+
+      it 'returns an empty result without raising' do
+        expect { query.apply(Measure.actual).all }.not_to raise_error
+        expect(query.apply(Measure.actual).all).to be_empty
+      end
+    end
   end
 
   describe 'status=exhausted / status=not_exhausted / status=open parity with QuotaDefinition#status' do
@@ -149,6 +158,131 @@ RSpec.describe QuotaDefinitionsQuery do
         expect(open_query.apply(Measure.actual).all).to contain_exactly(measure)
         expect(not_exhausted_query.apply(Measure.actual).all).to contain_exactly(measure)
         expect(exhausted_query.apply(Measure.actual).all).to be_empty
+      end
+    end
+
+    context 'when a quota is both blocked and suspended' do
+      let(:attributes) { { 'order_number' => order_number.quota_order_number_id } }
+
+      before do
+        create(:quota_balance_event, quota_definition: definition, occurrence_timestamp: 3.days.ago)
+        create(
+          :quota_blocking_period,
+          quota_definition_sid: definition.quota_definition_sid,
+          blocking_start_date: 2.days.ago.to_date,
+          blocking_end_date: 2.days.from_now.to_date,
+        )
+        create(
+          :quota_suspension_period,
+          quota_definition_sid: definition.quota_definition_sid,
+          suspension_start_date: 1.day.ago.to_date,
+          suspension_end_date: 1.day.from_now.to_date,
+        )
+      end
+
+      it 'reports Suspended, and is matched by status=suspended but not status=blocked' do
+        suspended_query = described_class.new(attributes.merge('status' => 'suspended'), Time.zone.today)
+        blocked_query = described_class.new(attributes.merge('status' => 'blocked'), Time.zone.today)
+
+        expect(definition.reload.status).to eq(QuotaDefinition::STATUS_SUSPENDED)
+        expect(suspended_query.apply(Measure.actual).all).to contain_exactly(measure)
+        expect(blocked_query.apply(Measure.actual).all).to be_empty
+      end
+    end
+
+    context 'when a quota is both exhausted and blocked' do
+      let(:attributes) { { 'order_number' => order_number.quota_order_number_id } }
+
+      before do
+        create(:quota_exhaustion_event, quota_definition: definition, occurrence_timestamp: 1.day.ago)
+        create(
+          :quota_blocking_period,
+          quota_definition_sid: definition.quota_definition_sid,
+          blocking_start_date: 2.days.ago.to_date,
+          blocking_end_date: 2.days.from_now.to_date,
+        )
+      end
+
+      it 'reports Exhausted, and is matched by status=exhausted but not status=blocked' do
+        exhausted_query = described_class.new(attributes.merge('status' => 'exhausted'), Time.zone.today)
+        blocked_query = described_class.new(attributes.merge('status' => 'blocked'), Time.zone.today)
+
+        expect(definition.reload.status).to eq(QuotaDefinition::STATUS_EXHAUSTED)
+        expect(exhausted_query.apply(Measure.actual).all).to contain_exactly(measure)
+        expect(blocked_query.apply(Measure.actual).all).to be_empty
+      end
+    end
+
+    context 'when latest event is balance and latest critical event is active' do
+      let(:attributes) { { 'order_number' => order_number.quota_order_number_id } }
+
+      before do
+        create(:quota_balance_event, quota_definition: definition, occurrence_timestamp: 2.days.ago)
+        create(:quota_critical_event, :active, quota_definition: definition, occurrence_timestamp: 1.day.ago)
+      end
+
+      it 'reports Critical and is excluded by status=open' do
+        open_query = described_class.new(attributes.merge('status' => 'open'), Time.zone.today)
+
+        expect(definition.reload.status).to eq(QuotaDefinition::STATUS_CRITICAL)
+        expect(open_query.apply(Measure.actual).all).to be_empty
+      end
+    end
+
+    context 'when query date is before a later reopening event' do
+      let(:attributes) { { 'order_number' => order_number.quota_order_number_id } }
+      let(:query_date) { 36.hours.ago }
+
+      before do
+        create(:quota_exhaustion_event, quota_definition: definition, occurrence_timestamp: 2.days.ago)
+        create(:quota_reopening_event, quota_definition: definition, occurrence_timestamp: 1.day.ago)
+      end
+
+      it 'uses the passed date for status event cut-off' do
+        exhausted_query = described_class.new(attributes.merge('status' => 'exhausted'), query_date)
+        open_query = described_class.new(attributes.merge('status' => 'open'), query_date)
+
+        expect(exhausted_query.apply(Measure.actual).all).to contain_exactly(measure)
+        expect(open_query.apply(Measure.actual).all).to be_empty
+      end
+    end
+
+    context 'when an exhaustion event is after the query date' do
+      let(:attributes) { { 'order_number' => order_number.quota_order_number_id } }
+      let(:query_date) { Time.zone.today }
+
+      before do
+        create(:quota_exhaustion_event, quota_definition: definition, occurrence_timestamp: 1.day.from_now)
+      end
+
+      it 'is ignored by status filtering (to_fragment point_in_time cutoff)' do
+        exhausted_query = described_class.new(attributes.merge('status' => 'exhausted'), query_date)
+        open_query = described_class.new(attributes.merge('status' => 'open'), query_date)
+
+        expect(exhausted_query.apply(Measure.actual).all).to be_empty
+        expect(open_query.apply(Measure.actual).all).to contain_exactly(measure)
+      end
+    end
+
+    context 'when a suspension period starts after the query date' do
+      let(:attributes) { { 'order_number' => order_number.quota_order_number_id } }
+      let(:query_date) { Time.zone.today }
+
+      before do
+        create(
+          :quota_suspension_period,
+          quota_definition_sid: definition.quota_definition_sid,
+          suspension_start_date: Date.tomorrow,
+          suspension_end_date: 1.year.from_now.to_date,
+        )
+      end
+
+      it 'is ignored by status filtering (to_fragment point_in_time cutoff)' do
+        suspended_query = described_class.new(attributes.merge('status' => 'suspended'), query_date)
+        open_query = described_class.new(attributes.merge('status' => 'open'), query_date)
+
+        expect(suspended_query.apply(Measure.actual).all).to be_empty
+        expect(open_query.apply(Measure.actual).all).to contain_exactly(measure)
       end
     end
   end

--- a/spec/queries/quota_definitions_query_spec.rb
+++ b/spec/queries/quota_definitions_query_spec.rb
@@ -57,4 +57,99 @@ RSpec.describe QuotaDefinitionsQuery do
       expect(query.apply(Measure.actual).all).to contain_exactly(measure)
     end
   end
+
+  describe 'status=exhausted / status=not_exhausted / status=open parity with QuotaDefinition#status' do
+    subject(:query) { described_class.new(attributes, Time.zone.today) }
+
+    let(:order_number) { create(:quota_order_number) }
+    let!(:measure) do
+      create(
+        :measure,
+        :with_goods_nomenclature,
+        ordernumber: order_number.quota_order_number_id,
+        validity_start_date: Time.zone.yesterday,
+      )
+    end
+    let(:definition) do
+      create(
+        :quota_definition,
+        quota_order_number_sid: order_number.quota_order_number_sid,
+        quota_order_number_id: order_number.quota_order_number_id,
+        critical_state: 'N',
+        validity_start_date: Time.zone.yesterday,
+      )
+    end
+
+    context 'when the quota has only a historical exhaustion event (never reopened)' do
+      let(:attributes) { { 'order_number' => order_number.quota_order_number_id } }
+
+      before do
+        create(:quota_exhaustion_event, quota_definition: definition, occurrence_timestamp: 2.days.ago)
+      end
+
+      it 'reports Exhausted, matching QuotaDefinition#status' do
+        expect(definition.reload.status).to eq(QuotaDefinition::STATUS_EXHAUSTED)
+      end
+
+      it 'is returned by status=exhausted' do
+        query = described_class.new(attributes.merge('status' => 'exhausted'), Time.zone.today)
+
+        expect(query.apply(Measure.actual).all).to contain_exactly(measure)
+      end
+
+      it 'is NOT returned by status=not_exhausted or status=open (regression)' do
+        not_exhausted_query = described_class.new(attributes.merge('status' => 'not_exhausted'), Time.zone.today)
+        open_query = described_class.new(attributes.merge('status' => 'open'), Time.zone.today)
+
+        expect(not_exhausted_query.apply(Measure.actual).all).to be_empty
+        expect(open_query.apply(Measure.actual).all).to be_empty
+      end
+    end
+
+    context 'when an older exhaustion event is superseded by a newer reopening event' do
+      let(:attributes) { { 'order_number' => order_number.quota_order_number_id } }
+
+      before do
+        create(:quota_exhaustion_event, quota_definition: definition, occurrence_timestamp: 2.days.ago)
+        create(:quota_reopening_event, quota_definition: definition, occurrence_timestamp: 1.day.ago)
+      end
+
+      it 'reports Open, matching QuotaDefinition#status (the reopening event wins)' do
+        expect(definition.reload.status).to eq(QuotaDefinition::STATUS_OPEN)
+      end
+
+      it 'is returned by status=open and status=not_exhausted, NOT status=exhausted (regression)' do
+        open_query = described_class.new(attributes.merge('status' => 'open'), Time.zone.today)
+        not_exhausted_query = described_class.new(attributes.merge('status' => 'not_exhausted'), Time.zone.today)
+        exhausted_query = described_class.new(attributes.merge('status' => 'exhausted'), Time.zone.today)
+
+        expect(open_query.apply(Measure.actual).all).to contain_exactly(measure)
+        expect(not_exhausted_query.apply(Measure.actual).all).to contain_exactly(measure)
+        expect(exhausted_query.apply(Measure.actual).all).to be_empty
+      end
+    end
+
+    context 'when an older exhaustion event is superseded by a newer balance event' do
+      let(:attributes) { { 'order_number' => order_number.quota_order_number_id } }
+
+      before do
+        create(:quota_exhaustion_event, quota_definition: definition, occurrence_timestamp: 2.days.ago)
+        create(:quota_balance_event, quota_definition: definition, occurrence_timestamp: 1.day.ago)
+      end
+
+      it 'reports Open, matching QuotaDefinition#status (the balance event wins)' do
+        expect(definition.reload.status).to eq(QuotaDefinition::STATUS_OPEN)
+      end
+
+      it 'is returned by status=open and status=not_exhausted, NOT status=exhausted (regression)' do
+        open_query = described_class.new(attributes.merge('status' => 'open'), Time.zone.today)
+        not_exhausted_query = described_class.new(attributes.merge('status' => 'not_exhausted'), Time.zone.today)
+        exhausted_query = described_class.new(attributes.merge('status' => 'exhausted'), Time.zone.today)
+
+        expect(open_query.apply(Measure.actual).all).to contain_exactly(measure)
+        expect(not_exhausted_query.apply(Measure.actual).all).to contain_exactly(measure)
+        expect(exhausted_query.apply(Measure.actual).all).to be_empty
+      end
+    end
+  end
 end

--- a/spec/queries/quota_status_sql_spec.rb
+++ b/spec/queries/quota_status_sql_spec.rb
@@ -1,0 +1,44 @@
+RSpec.describe QuotaStatusSql do
+  describe '#to_fragment' do
+    subject(:fragment) { described_class.new(definition_table:, point_in_time:).to_fragment }
+
+    let(:definition_table) { :quota_definitions }
+    let(:point_in_time) { Time.zone.parse('2026-01-01 12:00:00') }
+
+    it 'returns a CASE expression covering exhausted, suspended, blocked, critical and open outcomes' do
+      expect(fragment.str).to include('CASE')
+      expect(fragment.str).to include("THEN '#{QuotaDefinition::STATUS_EXHAUSTED}'")
+      expect(fragment.str).to include("THEN '#{QuotaDefinition::STATUS_SUSPENDED}'")
+      expect(fragment.str).to include("THEN '#{QuotaDefinition::STATUS_BLOCKED}'")
+      expect(fragment.str).to include("THEN '#{QuotaDefinition::STATUS_CRITICAL}'")
+      expect(fragment.str).to include("ELSE '#{QuotaDefinition::STATUS_OPEN}'")
+    end
+
+    it 'includes all quota event tables in latest-event resolution' do
+      expect(fragment.str).to include('quota_exhaustion_events')
+      expect(fragment.str).to include('quota_balance_events')
+      expect(fragment.str).to include('quota_critical_events')
+      expect(fragment.str).to include('quota_reopening_events')
+      expect(fragment.str).to include('quota_unblocking_events')
+      expect(fragment.str).to include('quota_unsuspension_events')
+    end
+
+    it 'includes expected open-event types in the critical override branch' do
+      expect(fragment.str).to include("'balance', 'reopening', 'unblocking', 'unsuspension'")
+    end
+
+    it 'binds point_in_time for suspension, blocking and critical-state lookups' do
+      expect(fragment.args.length).to eq(5)
+      expect(fragment.args).to all(eq(point_in_time))
+    end
+
+    context 'when using a custom quota definition alias' do
+      let(:definition_table) { :qd }
+
+      it 'qualifies correlated subqueries and critical_state reference with that alias' do
+        expect(fragment.str).to include('"qd"."quota_definition_sid"')
+        expect(fragment.str).to include('"qd"."critical_state"')
+      end
+    end
+  end
+end

--- a/spec/requests/api/v2/quotas_controller_spec.rb
+++ b/spec/requests/api/v2/quotas_controller_spec.rb
@@ -353,5 +353,39 @@ RSpec.describe Api::V2::QuotasController, type: :request do
         expect(response).to have_http_status(:bad_request)
       end
     end
+
+    context 'when status is not one of the allowed values' do
+      let(:params) { { year: [Time.zone.today.year.to_s], status: 'not_a_real_status' } }
+
+      it 'returns 400' do
+        get '/uk/api/quotas/search.json', params: params, headers: request_headers(format: :json)
+
+        expect(response).to have_http_status(:bad_request)
+      end
+    end
+
+    context 'when filtering by a valid status' do
+      QuotaDefinitionsQuery::STATUS_VALUES.each do |status_value|
+        context "with status #{status_value}" do
+          let(:params) { { year: [Time.zone.today.year.to_s], status: status_value } }
+
+          it 'returns a successful response' do
+            get '/uk/api/quotas/search.json', params: params, headers: request_headers(format: :json)
+
+            expect(response).to have_http_status(:ok)
+          end
+        end
+      end
+
+      context 'with a URL-escaped status value (e.g. "not+exhausted")' do
+        let(:params) { { year: [Time.zone.today.year.to_s], status: 'not+exhausted' } }
+
+        it 'returns a successful response' do
+          get '/uk/api/quotas/search.json', params: params, headers: request_headers(format: :json)
+
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
   end
 end

--- a/spec/services/quota_search_service_spec.rb
+++ b/spec/services/quota_search_service_spec.rb
@@ -11,6 +11,32 @@ RSpec.describe QuotaSearchService do
     it 'unescapes status values' do
       expect(service.status).to eq('not_exhausted')
     end
+
+    context 'when status is not included in the allowed values' do
+      let(:filter) { { 'status' => 'not_a_real_status' } }
+
+      it 'raises an invalid status error' do
+        expect { service }.to raise_error(QuotaDefinitionsQuery::InvalidStatus)
+      end
+    end
+
+    context 'when status is blank' do
+      let(:filter) { {} }
+
+      it 'defaults to an empty status' do
+        expect(service.status).to eq('')
+      end
+    end
+
+    QuotaDefinitionsQuery::STATUS_VALUES.each do |status_value|
+      context "when status is #{status_value}" do
+        let(:filter) { { 'status' => status_value } }
+
+        it 'is a valid status' do
+          expect { service }.not_to raise_error
+        end
+      end
+    end
   end
 
   describe '#call' do
@@ -122,6 +148,48 @@ RSpec.describe QuotaSearchService do
       end
 
       it 'returns the correct quota definition' do
+        expect(service.call).to eq([quota_fixtures[:second][:definition]])
+      end
+    end
+
+    context 'when filtering by status suspended' do
+      let(:filter) { { 'status' => 'suspended' } }
+
+      before do
+        create :quota_suspension_period,
+               quota_definition_sid: quota_fixtures[:first][:definition].quota_definition_sid,
+               suspension_start_date: Time.zone.today,
+               suspension_end_date: 1.year.from_now
+      end
+
+      it 'returns the correct quota definition' do
+        expect(service.call).to eq([quota_fixtures[:first][:definition]])
+      end
+    end
+
+    context 'when filtering by status not suspended' do
+      let(:filter) { { 'status' => 'not_suspended' } }
+
+      before do
+        create :quota_suspension_period,
+               quota_definition_sid: quota_fixtures[:first][:definition].quota_definition_sid,
+               suspension_start_date: Time.zone.today,
+               suspension_end_date: 1.year.from_now
+      end
+
+      it 'returns the correct quota definition' do
+        expect(service.call).to eq([quota_fixtures[:second][:definition]])
+      end
+    end
+
+    context 'when filtering by status open' do
+      let(:filter) { { 'status' => 'open' } }
+
+      before do
+        create :quota_exhaustion_event, quota_definition: quota_fixtures[:first][:definition]
+      end
+
+      it 'returns the quota definition that is not exhausted, suspended, blocked or critical' do
         expect(service.call).to eq([quota_fixtures[:second][:definition]])
       end
     end

--- a/spec/swagger/api/v2/quotas_spec.rb
+++ b/spec/swagger/api/v2/quotas_spec.rb
@@ -19,6 +19,9 @@ RSpec.describe 'Quotas', swagger_doc: 'v2/swagger.json', type: :request do
     parameter name: :day, in: :query, required: false,
               schema: { type: :integer },
               description: 'Filter by validity day (1–31)'
+    parameter name: :status, in: :query, required: false,
+              schema: { type: :string, enum: QuotaDefinitionsQuery::STATUS_VALUES },
+              description: 'Filter by quota status (e.g. "open", "exhausted", "blocked", "suspended", etc.)'
     parameter name: :page, in: :query, required: false,
               schema: { type: :integer },
               description: 'Page number (default: 1)'
@@ -94,6 +97,12 @@ RSpec.describe 'Quotas', swagger_doc: 'v2/swagger.json', type: :request do
 
       response '400', 'invalid order_number — must be exactly 6 digits' do
         let(:order_number) { 'invalid' }
+
+        run_test!
+      end
+
+      response '400', 'invalid status — must be one of allowed values' do
+        let(:status) { 'invalid_status' }
 
         run_test!
       end

--- a/spec/swagger/api/v2/quotas_spec.rb
+++ b/spec/swagger/api/v2/quotas_spec.rb
@@ -95,16 +95,18 @@ RSpec.describe 'Quotas', swagger_doc: 'v2/swagger.json', type: :request do
         run_test!
       end
 
-      response '400', 'invalid order_number — must be exactly 6 digits' do
-        let(:order_number) { 'invalid' }
+      response '400', 'invalid request — order_number must be exactly 6 digits, and status must be one of the allowed values' do
+        context 'when order_number is not exactly 6 digits' do
+          let(:order_number) { 'invalid' }
 
-        run_test!
-      end
+          run_test!
+        end
 
-      response '400', 'invalid status — must be one of allowed values' do
-        let(:status) { 'invalid_status' }
+        context 'when status is not one of the allowed values' do
+          let(:status) { 'invalid_status' }
 
-        run_test!
+          run_test!
+        end
       end
     end
   end

--- a/swagger/v2/swagger.json
+++ b/swagger/v2/swagger.json
@@ -6116,7 +6116,7 @@
             }
           },
           "400": {
-            "description": "invalid status — must be one of allowed values"
+            "description": "invalid request — order_number must be exactly 6 digits, and status must be one of the allowed values"
           }
         }
       }

--- a/swagger/v2/swagger.json
+++ b/swagger/v2/swagger.json
@@ -5978,6 +5978,24 @@
           "description": "Filter by validity day (1–31)"
         },
         {
+          "name": "status",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "type": "string",
+            "enum": [
+              "blocked",
+              "exhausted",
+              "not_blocked",
+              "not_exhausted",
+              "suspended",
+              "not_suspended",
+              "open"
+            ]
+          },
+          "description": "Filter by quota status (e.g. \"open\", \"exhausted\", \"blocked\", \"suspended\", etc.)"
+        },
+        {
           "name": "page",
           "in": "query",
           "required": false,
@@ -6098,7 +6116,7 @@
             }
           },
           "400": {
-            "description": "invalid order_number — must be exactly 6 digits"
+            "description": "invalid status — must be one of allowed values"
           }
         }
       }


### PR DESCRIPTION

## What:
Add 'open', 'suspended' and 'not_suspended status filters to the Quotas search API and refactor

## Why:

So consumers can retrieve suspended or open quotas directly instead of paging through all results and filtering client-side.

## Ticket:
https://transformuk.atlassian.net/browse/HMRC-2636

## Risk:
**Risk level:** 🟠

## Reason for rating
It is an additive changes where we are adding new filter in query params, does not change anything existing.

───────────────────────────────────────────────────

Rate the overall risk of deploying this change:

🟢 Green  – Low risk. Good to go, standard review applies.

🟠 Amber  – Medium risk. Socialise with the team before merging.

🔴 Red    – High risk. Requires explicit approval from Thor or Neil before merging.

───────────────────────────────────────────────────

🟢 GREEN – things that are typically low risk:
───────────────────────────────────────────────────
- Dependency bumps with no API changes (e.g. minor/patch gems, npm packages)
- Copy or content changes in GOV.UK-style UI components
- Adding or updating CloudWatch alarms or dashboards (read-only observability)
- New tests or improved test coverage with no production code changes
- Config/env var additions that are purely additive and have safe defaults
- Refactors with full test coverage and no behaviour change
- Terraform formatting or variable renaming with no resource recreation
- S3 lifecycle rule additions (non-destructive, time-delayed effect)

🟠 AMBER – things that need a team conversation first:
───────────────────────────────────────────────────
- Changes to commodity code lookups, measure type logic, or duty calculation
- Modifications to the search indexing pipeline (OpenSearch mappings, synonyms, stop words)
- Changes to declarable goods or quota logic
- New or modified API endpoints that other services (backend, frontend, admin) consume
- Adding or changing feature flags that affect live user journeys
- Infrastructure changes that alter networking, security groups, or IAM permissions in non-production first
- Terraform changes that will cause a resource replacement (check plan output carefully)
- Changes to CI/CD pipeline steps or deployment order dependencies
- S3 bucket policy or access control changes
- Removing or deprecating an endpoint or field that may still be consumed

🔴 RED – requires explicit approval from Thor or Neil:
───────────────────────────────────────────────────
- Dangerous database migrations, especially destructive ones (dropping columns/tables, removing indexes)
- Modifications to how measures, conditions, or footnotes are processed or surfaced
- Changes to the synchronisation mechanism from CDS or HMRC upstream data feeds
- Any change to production AWS infrastructure that cannot be easily rolled back (e.g. RDS parameter groups, KMS key policy, removal of resources)
- Secrets rotation or changes to how credentials are stored, scoped, or accessed
- Changes that affect trader-facing regulatory content or legally significant data (e.g. trade remedies, licensing, prohibitions)
- Significant architectural shifts (e.g. new service boundaries, queue/event topology changes)
