### PR TITLE
fix: raise when the identity service refuses a user deletion

### DIFF
--- a/app/lib/identity_api_client.rb
+++ b/app/lib/identity_api_client.rb
@@ -1,4 +1,6 @@
 module IdentityApiClient
+  class DeletionError < StandardError; end
+
   def self.get_email(username)
     return nil unless username
 
@@ -12,7 +14,12 @@ module IdentityApiClient
     return nil unless username
 
     response = user_request(:delete, username)
-    response.success?
+
+    return true if response.success?
+    # Already absent from the identity service, which is the state we wanted.
+    return true if response.status == 404
+
+    raise DeletionError, "Identity deletion for #{username} returned HTTP #{response.status}"
   end
 
   def self.user_request(method, username)

--- a/app/lib/identity_api_client.rb
+++ b/app/lib/identity_api_client.rb
@@ -1,6 +1,4 @@
 module IdentityApiClient
-  class DeletionError < StandardError; end
-
   def self.get_email(username)
     return nil unless username
 
@@ -9,6 +7,8 @@ module IdentityApiClient
       JSON.parse(response.body)['user']['email']
     end
   end
+
+  class DeletionError < StandardError; end
 
   def self.delete_user(username)
     return nil unless username

--- a/app/lib/identity_api_client.rb
+++ b/app/lib/identity_api_client.rb
@@ -16,9 +16,10 @@ module IdentityApiClient
     response = user_request(:delete, username)
 
     return true if response.success?
-    # Already absent from the identity service, which is the state we wanted.
-    return true if response.status == 404
 
+    # No status is treated as an acceptable failure here. The identity service
+    # answers a delete for an unknown user with 200, so anything else means the
+    # deletion did not happen and external_id must stay put.
     raise DeletionError, "Identity deletion for #{username} returned HTTP #{response.status}"
   end
 

--- a/app/workers/external_user_deletion_worker.rb
+++ b/app/workers/external_user_deletion_worker.rb
@@ -18,9 +18,8 @@ class ExternalUserDeletionWorker
         return
       end
 
-      if IdentityApiClient.delete_user(user.external_id)
-        user.update(external_id: nil)
-      end
+      IdentityApiClient.delete_user(user.external_id)
+      user.update(external_id: nil)
     end
   end
 end

--- a/spec/lib/identity_api_client_spec.rb
+++ b/spec/lib/identity_api_client_spec.rb
@@ -59,13 +59,17 @@ RSpec.describe IdentityApiClient do
 
       it { is_expected.to be true }
 
-      context 'when the user is already absent' do
+      # The identity service answers a delete for an unknown user with 200: it
+      # rescues UserNotFoundException and reports success. A 404 therefore means
+      # the request never reached the endpoint, so treating it as a completed
+      # deletion would clear external_id while the Cognito user still exists.
+      context 'when the request does not reach the endpoint' do
         before do
           stub_request(:delete, "#{host}/api/users/#{username}")
             .to_return(status: 404)
         end
 
-        it { is_expected.to be true }
+        it { expect { client }.to raise_error(IdentityApiClient::DeletionError, /HTTP 404/) }
       end
 
       context 'when api errors' do

--- a/spec/lib/identity_api_client_spec.rb
+++ b/spec/lib/identity_api_client_spec.rb
@@ -59,13 +59,31 @@ RSpec.describe IdentityApiClient do
 
       it { is_expected.to be true }
 
+      context 'when the user is already absent' do
+        before do
+          stub_request(:delete, "#{host}/api/users/#{username}")
+            .to_return(status: 404)
+        end
+
+        it { is_expected.to be true }
+      end
+
       context 'when api errors' do
         before do
           stub_request(:delete, "#{host}/api/users/#{username}")
             .to_return(status: 500)
         end
 
-        it { is_expected.to be false }
+        it { expect { client }.to raise_error(IdentityApiClient::DeletionError, /HTTP 500/) }
+      end
+
+      context 'when the request is rate limited' do
+        before do
+          stub_request(:delete, "#{host}/api/users/#{username}")
+            .to_return(status: 429)
+        end
+
+        it { expect { client }.to raise_error(IdentityApiClient::DeletionError, /HTTP 429/) }
       end
     end
   end

--- a/spec/workers/external_user_deletion_worker_spec.rb
+++ b/spec/workers/external_user_deletion_worker_spec.rb
@@ -47,12 +47,24 @@ RSpec.describe ExternalUserDeletionWorker, type: :worker do
       }.to change(user, :external_id).from('abc123').to(nil)
     end
 
-    it 'does not remove external_id if API call fails' do
-      allow(IdentityApiClient).to receive(:delete_user).and_return(false)
+    it 'lets a failed deletion raise so Sidekiq retries it' do
+      allow(IdentityApiClient).to receive(:delete_user)
+        .and_raise(IdentityApiClient::DeletionError, 'Identity deletion for abc123 returned HTTP 429')
 
       expect {
         worker.perform(user.id)
-      }.not_to change(user, :external_id)
+      }.to raise_error(IdentityApiClient::DeletionError)
+    end
+
+    it 'leaves external_id set when the deletion fails' do
+      allow(IdentityApiClient).to receive(:delete_user)
+        .and_raise(IdentityApiClient::DeletionError, 'Identity deletion for abc123 returned HTTP 429')
+
+      expect {
+        worker.perform(user.id)
+      }.to raise_error(IdentityApiClient::DeletionError)
+
+      expect(user.external_id).to eq('abc123')
     end
   end
 


### PR DESCRIPTION
## What:

`IdentityApiClient.delete_user` now raises `DeletionError` on any non-2xx instead of returning `false`.

`ExternalUserDeletionWorker` loses its `if` around the call, because the call now either succeeds or raises and the conditional only implied a failure path that no longer exists.

## Why:

`delete_user` returned `response.success?`, so any non-2xx became `false` and the worker's `if IdentityApiClient.delete_user(...)` did nothing and returned normally. Sidekiq recorded the job as successful, so a deletion the identity service refused left `external_id` set and the identity record in place, with nothing in the logs and no retry.

This is the same swallowed-failure shape as the stop press email lookups in HMRC-2694, and the same 500 rpm WAF limit reaches this call too, since it goes through the same client and the same public host. The consequence differs though: a missed stop press email is an inconvenience, whereas a user who asked to be forgotten remaining in the identity service is a right-to-erasure problem, and we currently have no way of knowing whether it has happened.

An earlier version of this branch treated 404 as success, on the assumption it meant the user was already gone. That was wrong twice over and has been removed. The identity service never answers a delete with 404: `User.destroy` rescues `UserNotFoundException` and returns true, so an unknown user gets a 200, failures are 500 and bad auth is 401. The only 404 in that API is `users#show`, which is the `get_email` path. So the branch was dead, and had it ever fired it could only have meant the request did not reach the endpoint, at which point clearing `external_id` would permanently lose the link to a Cognito user who still exists. That becomes a live concern shortly, since #3719 repoints `IDENTITY_API_HOST` at `identity.tariff.internal` and a routing mismatch during that switch returns a 404 from the edge rather than the application.

## Ticket:

N/A. Found while investigating HMRC-2694 and raised separately, since it is pre-existing on main, independent of the private route work, and carries a different kind of consequence.

## Risk:

**Risk level:** 🟠

**Reason for rating:** Changes the failure behaviour of a live worker. Deletions that previously failed silently will now raise, retry three times and then land in the dead set, so any existing steady-state failure becomes visible as job failures rather than staying hidden. That is the point of the change, but it means the first deploy may surface a backlog of failures that were always happening. No schema, API or infrastructure changes.

## Notes for review:

- `ExternalUserDeletionWorker:21` is the only caller of `delete_user` in the codebase, so the blast radius is one worker.
- Conflicts with trade-tariff/trade-tariff-backend#3719, which adds `LookupError` at the top of the same module. Both PRs add one line in the same place; whichever merges second needs a trivial resolution keeping both error classes.
- Verified with the failing tests first: 5 failures before the change, covering 404, 500, 429 and the two worker paths, then 14 passing after. Full `spec/workers` run is green at 494 examples, and rubocop is clean on all four files.
