### PR TITLE
fix(reporting): read published reports from S3 instead of the public CDN

### DIFF
--- a/app/lib/reporting.rb
+++ b/app/lib/reporting.rb
@@ -1,8 +1,8 @@
 module Reporting
   extend Reportable
 
-  # Raised when a published report cannot be fetched from the reporting CDN,
-  # so callers fail loudly instead of parsing an error page as report content.
+  # Raised when a published report cannot be fetched from the reporting bucket,
+  # so callers fail loudly instead of parsing an error body as report content.
   class FetchError < StandardError; end
 
   class << self
@@ -30,15 +30,16 @@ module Reporting
       end
     end
 
+    # Published reports live in the same reporting bucket this task already
+    # reads and writes, and the reporting CDN is only CloudFront in front of
+    # that bucket. Fetching a report over the public hostname left the VPC
+    # through the NAT gateway, went out to a CloudFront edge and came back to
+    # the very same objects, so read them from S3 instead. published_link is
+    # deliberately left on the CDN host: it produces links for humans to click.
     def get_published(object_key)
-      return get(object_key) unless reporting_cdn_host?
-
-      url = published_link(object_key)
-      response = Faraday.get(url)
-
-      raise FetchError, "GET #{url} returned HTTP #{response.status}" unless response.success?
-
-      response.body
+      get(object_key)
+    rescue Aws::Errors::ServiceError, Seahorse::Client::NetworkingError => e
+      raise FetchError, "GET #{object_key} from the reporting bucket failed: #{e.message}"
     end
 
     def published_link(object_key)
@@ -47,12 +48,13 @@ module Reporting
       File.join(TradeTariffBackend.reporting_cdn_host, object_key)
     end
 
+    # Availability is a question about the object, not about the CDN, so ask S3.
+    # A missing object is already a false from Aws::S3::Object#exists?; an S3
+    # error is treated as "not available" to keep the previous behaviour, where
+    # a failed HEAD never blew up the admin reports page.
     def published_exist?(object_key)
-      return exist?(object_key) unless reporting_cdn_host?
-
-      response = Faraday.head(published_link(object_key))
-      response.success?
-    rescue Faraday::Error
+      exist?(object_key)
+    rescue Aws::Errors::ServiceError, Seahorse::Client::NetworkingError
       false
     end
 

--- a/spec/lib/reporting_spec.rb
+++ b/spec/lib/reporting_spec.rb
@@ -2,66 +2,100 @@ RSpec.describe Reporting do
   let(:cdn_host) { 'https://reporting.trade-tariff.service.gov.uk' }
   let(:object_key) { 'uk/reporting/2026/03/19/commodities_uk_2026_03_19.csv' }
   let(:cdn_url) { File.join(cdn_host, object_key) }
+  let(:reporting_object) { instance_double(Aws::S3::Object) }
 
   before do
     allow(TradeTariffBackend).to receive(:reporting_cdn_host).and_return(cdn_host)
+    allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('production'))
+    allow(described_class).to receive(:object).with(object_key).and_return(reporting_object)
   end
 
   describe '.get_published' do
-    context 'when the report exists on the CDN' do
+    context 'when the report is in the reporting bucket' do
       before do
-        stub_request(:get, cdn_url).to_return(status: 200, body: 'csv-data')
-      end
-
-      it 'fetches report content from the reporting CDN' do
-        expect(described_class.get_published(object_key)).to eq('csv-data')
-      end
-    end
-
-    context 'when the report is missing from the CDN' do
-      before do
-        stub_request(:get, cdn_url).to_return(
-          status: 404,
-          body: '<?xml version="1.0" encoding="UTF-8"?><Error><Code>NoSuchKey</Code></Error>',
+        allow(reporting_object).to receive(:get).and_return(
+          instance_double(Aws::S3::Types::GetObjectOutput, body: StringIO.new('csv-data')),
         )
       end
 
-      it 'raises a fetch error naming the url and status' do
-        expect { described_class.get_published(object_key) }
-          .to raise_error(Reporting::FetchError, "GET #{cdn_url} returned HTTP 404")
+      it 'reads the report from S3' do
+        expect(described_class.get_published(object_key)).to eq('csv-data')
+      end
+
+      it 'does not go out to the public reporting CDN' do
+        described_class.get_published(object_key)
+
+        expect(a_request(:any, cdn_url)).not_to have_been_made
       end
     end
 
-    context 'when the CDN returns a server error' do
+    context 'when the report is missing from the reporting bucket' do
       before do
-        stub_request(:get, cdn_url).to_return(status: 503, body: 'Service Unavailable')
+        allow(reporting_object).to receive(:get).and_raise(
+          Aws::S3::Errors::NoSuchKey.new(nil, 'The specified key does not exist.'),
+        )
       end
 
-      it 'raises a fetch error naming the url and status' do
+      it 'raises a fetch error naming the object key' do
         expect { described_class.get_published(object_key) }
-          .to raise_error(Reporting::FetchError, "GET #{cdn_url} returned HTTP 503")
+          .to raise_error(Reporting::FetchError, /#{Regexp.escape(object_key)}/)
+      end
+    end
+
+    context 'when S3 is unavailable' do
+      before do
+        allow(reporting_object).to receive(:get).and_raise(
+          Aws::S3::Errors::ServiceUnavailable.new(nil, 'Service Unavailable'),
+        )
+      end
+
+      it 'raises a fetch error naming the object key' do
+        expect { described_class.get_published(object_key) }
+          .to raise_error(Reporting::FetchError, /#{Regexp.escape(object_key)}/)
       end
     end
   end
 
   describe '.published_link' do
-    it 'returns the reporting CDN URL' do
+    it 'returns the reporting CDN URL, because the link is for a human to click' do
       expect(described_class.published_link(object_key)).to eq(cdn_url)
     end
   end
 
   describe '.published_exist?' do
-    context 'when the report exists on the CDN' do
-      before do
-        stub_request(:head, cdn_url).to_return(status: 200)
-      end
+    context 'when the report is in the reporting bucket' do
+      before { allow(reporting_object).to receive(:exists?).and_return(true) }
 
       it { expect(described_class.published_exist?(object_key)).to be(true) }
+
+      it 'does not go out to the public reporting CDN' do
+        described_class.published_exist?(object_key)
+
+        expect(a_request(:any, cdn_url)).not_to have_been_made
+      end
     end
 
-    context 'when the report is missing from the CDN' do
+    context 'when the report is missing from the reporting bucket' do
+      before { allow(reporting_object).to receive(:exists?).and_return(false) }
+
+      it { expect(described_class.published_exist?(object_key)).to be(false) }
+    end
+
+    context 'when S3 returns an error' do
       before do
-        stub_request(:head, cdn_url).to_return(status: 404)
+        allow(reporting_object).to receive(:exists?).and_raise(
+          Aws::S3::Errors::ServiceUnavailable.new(nil, 'Service Unavailable'),
+        )
+      end
+
+      it { expect(described_class.published_exist?(object_key)).to be(false) }
+    end
+
+    context 'when S3 cannot be reached' do
+      before do
+        allow(reporting_object).to receive(:exists?).and_raise(
+          Seahorse::Client::NetworkingError.new(SocketError.new('getaddrinfo failed')),
+        )
       end
 
       it { expect(described_class.published_exist?(object_key)).to be(false) }


### PR DESCRIPTION
## What:
Routes `Reporting.get_published` and `Reporting.published_exist?` through the S3 SDK, the way `Reporting.get` and `Reporting.exist?` already do, instead of `Faraday.get` / `Faraday.head` against `https://reporting.trade-tariff.service.gov.uk`.

`Reporting.published_link` is unchanged and still returns the public CDN URL, because it generates links for a human to click in report emails and on the admin reports page.

Failure semantics are preserved rather than inherited:

- `get_published` still raises `Reporting::FetchError` so a caller cannot parse an error body as report content (the behaviour added in b9e2e03e0). It now translates `Aws::Errors::ServiceError` and `Seahorse::Client::NetworkingError` rather than a non-2xx HTTP response, and names the object key.
- `published_exist?` still answers `false` rather than raising when the store cannot be reached, so a blip does not break the admin reports page. A missing object is already a `false` from `Aws::S3::Object#exists?`.

## Why:
These services run as ECS tasks in a shared VPC and should reach their own AWS resources internally. The reporting CDN is CloudFront in front of the very bucket the task already reads and writes, so a worker asking for a report it had uploaded an hour earlier left the VPC through the NAT gateway, went out to a CloudFront edge and came back for the same object.

**Production evidence.** VPC flow logs in account 382373577178, eu-west-2, log group `/aws/vpc-flow-log/vpc-0fec75a5d9acf9f2d`, show exactly one ECS task, private IP 10.0.2.135 (a Sidekiq worker, identifiable by its heavy Valkey 6379 and Postgres 5432 traffic), making roughly 2,500 outbound HTTPS connections in a 6 hour window to CloudFront edge IPs 13.33.153.20/62/69/89 and 18.244.179.x via the NAT gateway at 10.0.101.214. No other task in the VPC talks to CloudFront at all. See the honesty note below on how much of that volume this change actually accounts for.

**The data is already reachable internally.** `terraform/iam.tf` grants every backend and worker task `s3:ListBucket`, `s3:GetObject` and `s3:PutObject` on the whole of `trade-tariff-reporting-<account_id>`, with no prefix restriction, and all four task definitions (`backend_uk`, `backend_xi`, `worker_uk`, `worker_xi`) attach the same `aws_iam_policy.task`. There is one reporting bucket, not one per service: CloudWatch logs for 2026-09-11 show `Reporting::Commodities` uploading `uk/reporting/2026/09/11/commodities_uk_2026_09_11.csv` and `xi/reporting/2026/09/11/commodities_xi_2026_09_11.csv` into it, so the UK differences report can read the XI CSVs directly.

`Reporting::BackfillDifferencesReports` already proved this before the change: it lists the bucket with `bucket.client.list_objects_v2`, then fetched the key it had just listed back over the public CDN, then wrote its copy with `bucket.object(...).put`. S3 either side of a public HTTP hop for the same object.

I ruled out the three plausible innocent explanations for 25b91a2a9 "HMRC-2126: Isolate published report CDN access", which has no commit body:

1. *Different bucket or prefix the task role cannot read* - no. Single bucket, whole-bucket IAM grant, both prefixes written by the same policy.
2. *The `reporting-file-rotations` Lambda rotates or promotes published files* - no. That is `trade-tariff-lambdas-electronic-tariff-file-rotations`, a separate ETF concern. The only narrow-prefix grant on the reporting bucket is the CDS downloader on `changes/uk/*`, which is not the `{uk,xi}/reporting/` keys these methods read.
3. *The CDN deliberately serves the public's view* - no. `module "reporting_cdn"` in `terraform/environments/production/common/cloudfront.tf` has the bucket as its only origin, passes no `function_association` or `lambda_function_association`, and runs the `caching_disabled` cache policy. It was a pure pass-through that was not even buying a cache hit, only NAT egress and edge latency.

Deployed environments are safe because the Dockerfile sets `ENV RAILS_ENV=production`, so the `Rails.env.production?` branch in `get` and `exist?` is taken in dev, staging and production alike. Local development is unaffected and arguably improved: it now uses the same local-file branch that `Reporting::Commodities#generate` already writes to and that `uk_object_key` / `xi_object_key` already special-case with `Rails.env.development?`.

**What I could not prove, and what a reviewer must check before merge:**

- I could not verify the running task's `AWS_REPORTING_BUCKET_NAME` or its IAM role directly. The AWS access available to me was observability-scoped, so ECS, EC2, S3 and Secrets Manager describe calls were denied. I inferred the bucket wiring from Terraform plus production upload log lines. **Someone with production access should confirm the deployed task role really does allow `GetObject` on both `uk/reporting/*` and `xi/reporting/*`, and that KMS decrypt works on the read path** - reads previously went through CloudFront's OAC, so the task's own decrypt permission on `aws_kms_key.s3` has not been exercised for these objects. The `kms:*` on `*` statement in `terraform/iam.tf` says it should be fine, but that is inference, not observation.
- I have not attributed the 2,500 connections specifically to reporting, and I do not believe they all are. The reporting read path is low frequency: four CSV GETs of about 5MB each per differences report run, up to three runs a day with retries, plus HEADs when someone opens the admin reports page, plus one potentially large XLSX fetch in the backfill service. The same worker was also making public-hostname identity lookups until HMRC-2694 landed yesterday, one per recipient, which plausibly accounts for most of that volume. **This PR removes the remaining instance of the bug class in application code; it should not be sold as removing 2,500 connections.**
- `Reporting::Differences` is not exercised end to end by the test suite against a real bucket, so the first real proof is the next scheduled differences report run. Worth watching that run rather than assuming.
- One thing this changes that is worth a reviewer's eye: a report that exists in S3 but has not yet propagated to a CloudFront edge would previously have looked absent. It now looks present. That should only make `available_today?` and the differences report more correct, but it is a behaviour change.

## Ticket:
N/A

## Risk:
**Risk level:** 🟠

**Reason for rating:** Behaviour change on the read path for a trader-facing report set, and the task role's direct `GetObject` plus KMS decrypt on these objects has not been exercised in production before (reads previously went via CloudFront OAC). The blast radius is contained - the differences report and the admin reports page - and rollback is a revert, but the first real proof is the next scheduled run, so it is worth a word with the team rather than a straight merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
