### PR TITLE
fix: refuse to wipe UK tariff notes on an empty extract

### DIFF
--- a/app/lib/customs_tariff_importer/reimporter.rb
+++ b/app/lib/customs_tariff_importer/reimporter.rb
@@ -18,6 +18,15 @@ module CustomsTariffImporter
       content = TariffSynchronizer::FileService.get(update.s3_path).read
       extracted = NotesExtractor.new(update.version, content).call
 
+      # The extractor returns empty hashes rather than raising when no paragraph matches its
+      # heading patterns, so a re-saved .docx with a changed template or heading casing would
+      # otherwise commit the deletes below with nothing to reinsert and wipe every note for
+      # this version. Guard before opening the transaction: there is nothing to roll back yet,
+      # and this depends only on the extract. Mirrors XiCnImporter::Reimporter.
+      if extracted.chapters.empty? && extracted.sections.empty? && extracted.general_rules.empty?
+        raise "Empty extract for #{update.version} — refusing to wipe notes"
+      end
+
       CustomsTariffUpdate.db.transaction do
         CustomsTariffSectionNote.where(customs_tariff_update_version: update.version).delete
         CustomsTariffChapterNote.where(customs_tariff_update_version: update.version).delete

--- a/spec/lib/customs_tariff_importer/reimporter_spec.rb
+++ b/spec/lib/customs_tariff_importer/reimporter_spec.rb
@@ -70,6 +70,34 @@ RSpec.describe CustomsTariffImporter::Reimporter do
       end
     end
 
+    context 'when the document no longer matches the expected headings' do
+      # Simulates GOV.UK re-saving the .docx from a changed template: the headings
+      # are still there for a human reader, but no paragraph matches SECTION_PATTERN,
+      # CHAPTER_PATTERN or GENERAL_RULES_PATTERN, so the extract comes back empty.
+      let(:docx_io) do
+        build_docx(
+          'Section I: Live animals', 'Notes', 'Live animals note.',
+          'Chapter 1: Live animals', 'Notes', 'All live animals are classified here.'
+        )
+      end
+
+      before do
+        create(:customs_tariff_section_note, customs_tariff_update: update, section_id: 1, content: 'Old section note.')
+        create(:customs_tariff_chapter_note, customs_tariff_update: update, chapter_id: '01', content: 'Old chapter note.')
+      end
+
+      it 'raises rather than wiping notes' do
+        expect { reimporter.call(version: update.version) }.to raise_error(/Empty extract/)
+      end
+
+      it 'leaves existing notes intact' do
+        expect { reimporter.call(version: update.version) }.to raise_error(/Empty extract/)
+
+        expect(CustomsTariffSectionNote.where(customs_tariff_update_version: update.version).count).to eq(1)
+        expect(CustomsTariffChapterNote.where(customs_tariff_update_version: update.version).count).to eq(1)
+      end
+    end
+
     context 'when no note records exist yet' do
       it 'inserts extracted notes' do
         expect { reimporter.call }


### PR DESCRIPTION
## What:
`CustomsTariffImporter::Reimporter` now raises `Empty extract for <version> — refusing to wipe notes` when `NotesExtractor` returns no sections, no chapters and no general rules, instead of proceeding to delete and recreate. The check sits before the transaction opens, so the deletes never run.

Added two specs that build a `.docx` whose headings no longer match the extractor patterns, and assert the reimport raises and leaves the existing notes in place.

## Why:
`#reimport` opened one transaction that deleted every `CustomsTariffSectionNote`, `CustomsTariffChapterNote` and `CustomsTariffGeneralRule` for the version and then recreated them from the extract. Nothing checked the extract was non-empty.

`NotesExtractor#parse_notes` is a state machine starting in `:scanning`. If no paragraph matches `SECTION_PATTERN`, `CHAPTER_PATTERN` or `GENERAL_RULES_PATTERN` it returns three empty hashes and does not raise. The concrete trigger is GOV.UK re-saving the source `.docx` from a changed template, or a heading casing change: `CHAPTER_PATTERN` is `/\ACHAPTER\s+(\d+)\z/`, case sensitive and anchored, so "Chapter 1" or "Section I: Live animals" match nothing.

Blast radius: the transaction commits the deletes and zero inserts, so every chapter note, section note and general interpretative rule for that tariff version disappears from the public API and the frontend. `CustomsTariffReimportWorker` is `retry: false` and nothing raised, so the job completed green, with no dead job and no alert. The data loss was silent.

`XiCnImporter::Reimporter` already guards exactly this case (`app/lib/xi_cn_importer/reimporter.rb:31-33`, spec'd at `spec/lib/xi_cn_importer/reimporter_spec.rb:59-77`). Git history shows the UK importer landed first (May and June 2026) and the guard arrived with the XI pipeline in July 2026, so this is an oversight rather than a decision. The backport keeps the same condition, message and error class so both importers fail identically.

Two deliberate choices:

- **Raise rather than return.** In Sidekiq, `retry: false` re-raises out of the local handler into `global`, which runs the registered death handlers, so the exception reaches `SidekiqDeathHandler` and Slack. Returning quietly would swap silent data loss for a silent no-op. `CustomsTariffReimportWorker` does **not** set `slack_alerts: false`, so the alert is not suppressed.
- **Guard before the transaction, not inside it.** The condition depends only on the extract and not on any database state, so there is nothing to roll back. An early raise is easier to read than relying on rollback semantics for correctness, and it matches the XI importer.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:** Additive guard on a path that is currently destructive. The only behaviour change is that a reimport which would have deleted all notes and inserted none now raises instead. Every successful reimport is unaffected, and there is no migration, no API change and no schema change. Covered by new specs mirroring the existing XI coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
