### PR TITLE
fix: stop a failed watchlist email day being lost permanently

### DIFF
--- a/app/models/tariff_changes_job_status.rb
+++ b/app/models/tariff_changes_job_status.rb
@@ -40,6 +40,12 @@ class TariffChangesJobStatus < Sequel::Model(Sequel[:tariff_changes_job_statuses
     update(emails_sent_at: Time.zone.now)
   end
 
+  # Reverses mark_emails_sent! so a date whose emails definitively failed returns to
+  # the pending_emails redrive set. See MyCommoditiesEmailWorker.
+  def mark_emails_pending!
+    update(emails_sent_at: nil)
+  end
+
   def changes_pending?
     changes_generated_at.nil?
   end

--- a/app/workers/my_commodities_email_worker.rb
+++ b/app/workers/my_commodities_email_worker.rb
@@ -4,6 +4,21 @@ class MyCommoditiesEmailWorker
   # Cap retries: Notify outages must not use Sidekiq's default (25) and crowd the default queue.
   sidekiq_options retry: 3
 
+  # The date the orchestrator hands us, and that we parse back out again here.
+  DATE_FORMAT = '%d/%m/%Y'.freeze
+
+  # MyCommoditiesSubscriptionWorker stamps the date as sent as soon as it has enqueued us,
+  # because enqueuing is all it can observe. When a child gives up for good, put the date
+  # back into TariffChangesJobStatus.pending_emails so PopulateTariffChangesWorker redrives
+  # it, rather than losing the day silently.
+  sidekiq_retries_exhausted do |job, exception|
+    _user_id, date, _changes_count = job['args']
+
+    Sidekiq.logger.error("MyCommoditiesEmailWorker exhausted retries for #{date}: #{exception.message}")
+
+    TariffChangesJobStatus.for_date(Date.strptime(date, DATE_FORMAT)).mark_emails_pending! if date.present?
+  end
+
   TEMPLATE_ID = NOTIFY_CONFIGURATION.dig(:templates, :myott, :tariff_change)
   REPLY_TO_ID = NOTIFY_CONFIGURATION.dig(:reply_to, :tariff_management)
 

--- a/app/workers/my_commodities_subscription_worker.rb
+++ b/app/workers/my_commodities_subscription_worker.rb
@@ -4,6 +4,12 @@ class MyCommoditiesSubscriptionWorker
   # Orchestrator only enqueues children; keep retries low to limit duplicate fan-out.
   sidekiq_options retry: 3
 
+  # Stamping only happens once the whole enqueue loop has run without raising. It records
+  # "this date has been handed off", not "every email landed", which is all this worker can
+  # observe. A date with nothing to send is genuinely done, so it is stamped too, otherwise
+  # it would sit in the redrive set forever. Delivery failures are reported back by
+  # MyCommoditiesEmailWorker's sidekiq_retries_exhausted hook, which returns the date to
+  # TariffChangesJobStatus.pending_emails.
   def perform(date = Time.zone.yesterday.iso8601)
     @date = Date.parse(date)
     queue
@@ -12,7 +18,7 @@ class MyCommoditiesSubscriptionWorker
 
   def queue
     users_with_changes.each do |user_id, changes_count|
-      MyCommoditiesEmailWorker.perform_async(user_id, @date.strftime('%d/%m/%Y'), changes_count)
+      MyCommoditiesEmailWorker.perform_async(user_id, @date.strftime(MyCommoditiesEmailWorker::DATE_FORMAT), changes_count)
     end
   end
 

--- a/spec/models/tariff_changes_job_status_spec.rb
+++ b/spec/models/tariff_changes_job_status_spec.rb
@@ -190,6 +190,26 @@ RSpec.describe TariffChangesJobStatus do
     end
   end
 
+  describe '#mark_emails_pending!' do
+    let(:job_status) { create :tariff_changes_job_status, :with_emails_sent }
+
+    it 'clears emails_sent_at' do
+      expect { job_status.mark_emails_pending! }
+        .to(change { job_status.reload.emails_sent_at }.to(nil))
+    end
+
+    it 'returns the date to the pending_emails redrive set' do
+      expect { job_status.mark_emails_pending! }
+        .to(change { described_class.pending_emails.include?(job_status.operation_date) }
+        .from(false).to(true))
+    end
+
+    it 'does not affect changes_generated_at' do
+      expect { job_status.mark_emails_pending! }
+        .not_to(change { job_status.reload.changes_generated_at })
+    end
+  end
+
   describe 'workflow scenarios' do
     let(:job_status) { create :tariff_changes_job_status, operation_date: Date.current }
 

--- a/spec/workers/my_commodities_email_worker_spec.rb
+++ b/spec/workers/my_commodities_email_worker_spec.rb
@@ -21,6 +21,42 @@ RSpec.describe MyCommoditiesEmailWorker, type: :worker do
     end
   end
 
+  describe 'when retries are exhausted' do
+    subject(:exhaust_retries) do
+      described_class.sidekiq_retries_exhausted_block.call(
+        { 'args' => [user.id, date, count] },
+        StandardError.new('Notify is down'),
+      )
+    end
+
+    before { create(:tariff_changes_job_status, :with_emails_sent, operation_date: Date.new(2025, 12, 8)) }
+
+    it 'returns the date to the pending_emails redrive set' do
+      expect { exhaust_retries }
+        .to(change { TariffChangesJobStatus.pending_emails.include?(Date.new(2025, 12, 8)) }
+        .from(false).to(true))
+    end
+
+    it 'clears emails_sent_at for that date' do
+      expect { exhaust_retries }
+        .to(change { TariffChangesJobStatus.for_date(Date.new(2025, 12, 8)).emails_sent_at }.to(nil))
+    end
+
+    it 'leaves changes_generated_at alone so the day is not regenerated' do
+      expect { exhaust_retries }
+        .not_to(change { TariffChangesJobStatus.for_date(Date.new(2025, 12, 8)).changes_generated_at })
+    end
+
+    context 'when the job carried no date' do
+      let(:date) { nil }
+
+      it 'does not touch any job status' do
+        expect { exhaust_retries }
+          .not_to(change { TariffChangesJobStatus.for_date(Date.new(2025, 12, 8)).emails_sent_at })
+      end
+    end
+  end
+
   describe '#perform' do
     context 'when all parameters are valid' do
       it 'sends an email to the user' do

--- a/spec/workers/my_commodities_subscription_worker_spec.rb
+++ b/spec/workers/my_commodities_subscription_worker_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe MyCommoditiesSubscriptionWorker, type: :worker do
         allow(MyCommoditiesEmailWorker).to receive(:perform_async)
       end
 
-      it 'does not queue emails' do
+      it 'does not queue emails and marks the day done, because there is nothing to deliver' do
         instance.perform(date)
 
         expect(MyCommoditiesEmailWorker).not_to have_received(:perform_async)
@@ -71,7 +71,7 @@ RSpec.describe MyCommoditiesSubscriptionWorker, type: :worker do
         allow(MyCommoditiesEmailWorker).to receive(:perform_async)
       end
 
-      it 'does not queue any emails' do
+      it 'does not queue any emails and marks the day done, because there is nothing to deliver' do
         instance.perform(date)
 
         expect(MyCommoditiesEmailWorker).not_to have_received(:perform_async)
@@ -111,11 +111,38 @@ RSpec.describe MyCommoditiesSubscriptionWorker, type: :worker do
         allow(MyCommoditiesEmailWorker).to receive(:perform_async)
       end
 
-      it 'does not queue emails' do
+      it 'does not queue emails and marks the day done, because there is nothing to deliver' do
         instance.perform(date)
 
         expect(MyCommoditiesEmailWorker).not_to have_received(:perform_async)
         expect(status).to have_received(:mark_emails_sent!)
+      end
+    end
+
+    context 'when every queued email exhausts its retries' do
+      let(:user) { create(:public_user, :with_my_commodities_subscription) }
+      let!(:job_status) { create(:tariff_changes_job_status, :pending_email, operation_date: Date.new(2025, 12, 8)) }
+
+      before do
+        subscription = PublicUsers::Subscription.where(user_id: user.id, subscription_type_id: Subscriptions::Type.my_commodities.id).first
+        create(:subscription_target, user_subscriptions_uuid: subscription.uuid, target_id: '1000')
+        create(:tariff_change, operation_date: date, goods_nomenclature_sid: 1000)
+
+        allow(MyCommoditiesEmailWorker).to receive(:perform_async)
+      end
+
+      # This is the silent data-loss regression: the orchestrator cannot know whether a
+      # child ever delivered, so a stamped date must not be a one-way door.
+      it 'leaves the date in the pending_emails redrive set' do
+        instance.perform(date)
+        expect(TariffChangesJobStatus.pending_emails).not_to include(job_status.operation_date)
+
+        MyCommoditiesEmailWorker.sidekiq_retries_exhausted_block.call(
+          { 'args' => [user.id, '08/12/2025', 1] },
+          StandardError.new('Notify is down'),
+        )
+
+        expect(TariffChangesJobStatus.pending_emails).to include(job_status.operation_date)
       end
     end
   end


### PR DESCRIPTION
## What:

`MyCommoditiesSubscriptionWorker` set `emails_sent_at` in each condition, immediately after it put its child jobs in the queue. This PR makes that action reversible. `MyCommoditiesEmailWorker` now has a `sidekiq_retries_exhausted` hook. The hook calls the new `TariffChangesJobStatus#mark_emails_pending!`. Thus the date returns to `pending_emails`, and `PopulateTariffChangesWorker` does the work again.

There are three production files, and each change is small:

- `TariffChangesJobStatus#mark_emails_pending!` removes the value of `emails_sent_at`. It is the same shape as `mark_changes_pending!`, which already exists for the other half of the state machine.
- `MyCommoditiesEmailWorker` gets `DATE_FORMAT` and a `sidekiq_retries_exhausted` block. The block writes a log entry and makes the date pending again.
- `MyCommoditiesSubscriptionWorker` keeps its behaviour. It now uses `MyCommoditiesEmailWorker::DATE_FORMAT`, and does not repeat the literal value. It also has a comment that gives the meaning of the stamp.

**This PR intentionally changes behaviour that specs asserted.** `spec/workers/my_commodities_subscription_worker_spec.rb` asserted `mark_emails_sent!` in each condition, and also in the conditions where the worker put nothing in the queue. This PR keeps those assertions on purpose. Read the Risk section below for the reason. The descriptions of those examples now give the contract, and not only the mechanics. New examples give the new contract. This PR does not delete the old examples.

## Why:

The `queue` method only calls `MyCommoditiesEmailWorker.perform_async(...)` for each user. Thus the orchestrator cannot see if the system delivered the emails. But it set `emails_sent_at` as if it could see this.

`PopulateTariffChangesWorker` uses `TariffChangesJobStatus.pending_emails` for all of its recovery work. That set contains the dates where the system generated the changes, but did not send the emails. After the worker set `emails_sent_at`, the date left the recovery set permanently.

This is the failure: each `MyCommoditiesEmailWorker` child uses all of its 3 retries. An outage of GOV.UK Notify can cause this. Throttling of the identity API can also cause it, because that API now raises `LookupError` after the correction in HMRC-2694. Pressure on Redis can also cause it. The result is that the system sends no watchlist emails for that day. The orchestrator shows green in Sidekiq. No process can select that day again. Thus the system loses one day of subscriber emails, and also the evidence that it must do the day again.

### Options that I examined

1. **A counter for each date. Each child decreases it after a success. The date stays pending until the counter is zero.** I rejected this. It needs new shared mutable state. It has race conditions between concurrent children. It also has a failure mode that does not terminate: if the system loses a child, and the child does not fail (for example, a killed process or a lost Redis job), the counter stays above zero permanently. Then the date never clears, and each recovery run sends the day again. Thus it changes a silent loss into unlimited duplicate emails.
2. **A new `emails_enqueued_at` column that is different from `emails_sent_at`.** I rejected this for now. It needs a migration, which is a larger decision than a correction to a defect. Also, it corrects nothing alone: `pending_emails` would use the new column and give the same behaviour as today. It is useful only together with a record of the delivery for each user and each date. See the subsequent work below.
3. **Keep the stamp as the record of the handoff to the queue, and let a definitive failure of a child reverse it.** I selected this option. It needs no migration and approximately ten lines of production code. It adds no new state. It uses the recovery path that already exists.

Option 3 is the smallest change that removes the silent loss. It also keeps the two halves of the state machine symmetrical. `mark_changes_generated!` and `mark_changes_pending!` already existed. `mark_emails_sent!` and `mark_emails_pending!` are now the same shape.

### Subsequent work, not in this PR

There is no record of a watchlist email for each user and each date. `GovukNotifierAudit` records the response from Notify, but it contains no user and no date of the operation. Thus nothing can answer this question: did user X get the email for date Y? A record of this type, together with `emails_enqueued_at`, would let a recovery run omit the users who already got the email. That would remove the risk of duplicate emails below. That work needs a migration and a decision about the schema, thus it is out of the scope of this PR.

## Ticket:

N/A

## Risk:

**Risk level:** 🟠

**Reason for rating:**
This PR intentionally changes behaviour that specs asserted. It also adds a risk of duplicate emails, which reviewers must examine. It changes a live email journey that users see. But it adds no migration and no new infrastructure.

**Duplicate emails, and the limits of this risk.** A recovery run puts each subscriber for that date in the queue again. This includes each user who got the email on the first run. Thus a partial failure can cause a second watchlist email for some users. This is a real compromise, and I made it with knowledge of the effect:

- A duplicate watchlist email is recoverable, and persons can see it. A day that the system loses silently is neither of these.
- Only `sidekiq_retries_exhausted` makes a date pending again. Temporary errors do not do this, and the job retries as before. Thus this needs a definitive stop after 3 attempts, and not a short problem.
- Each recovery run causes a maximum of one more email for each subscriber that was already successful. It is not a loop. `PopulateTariffChangesWorker` runs on its schedule, thus there is a maximum of one recovery attempt for each run.
- The correct solution is the record of the delivery for each user, as above. That solution needs a migration.

**Termination.** This is the failure mode to examine. The design terminates in each branch:

- Successful path: the orchestrator sets `emails_sent_at`, and no child uses all of its retries. The date leaves `pending_emails` and stays out of the set. This does not change.
- Nothing to send (no subscribers, no targets, or no changes for the date): the worker still sets the stamp. This is the reason that this PR keeps those spec assertions. If the worker removed the stamp for a day with nothing to deliver, the day would stay pending permanently. Then each run would do the day again. That is the failure mode that does not terminate, and we must prevent it.
- Each child fails: the system makes the date pending one time, and the next run does the day again. Each recovery run makes the date pending again only if a child again uses all of its 3 retries. After Notify operates again, the day completes and leaves the set.

**A known problem with the sequence.** In theory, a child can use all of its retries before the orchestrator completes its loop and sets the stamp. Then the system loses the pending state. But in practice, the loop is a compact `perform_async` loop on the results of one query. Also, the first retry backoff in Sidekiq is tens of seconds. Thus this cannot occur with a realistic number of subscribers. A reviewer must look at this.

**Verification:**

```
bundle exec rspec spec/workers/my_commodities_subscription_worker_spec.rb \
  spec/workers/my_commodities_email_worker_spec.rb \
  spec/models/tariff_changes_job_status_spec.rb \
  spec/workers/populate_tariff_changes_worker_spec.rb \
  spec/services/tariff_changes_service_spec.rb
=> 102 examples, 0 failures

bundle exec rubocop <changed files>
=> 6 files inspected, no offenses detected
```

I wrote the tests red first. The 8 new examples all failed against `origin/main` before the production change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
