### PR TITLE
fix: gate the differences report watchdog on actual completion

### DIFF
--- a/app/workers/differences_report_check_worker.rb
+++ b/app/workers/differences_report_check_worker.rb
@@ -7,19 +7,22 @@ class DifferencesReportCheckWorker
     return unless TradeTariffBackend.environment.production?
     return unless TradeTariffBackend.uk?
 
-    last_log = DifferencesLog.max(:date)
+    # Only DifferencesReportWorker writes this key, and only once the report has
+    # been generated and published. Worksheet log rows are deliberately ignored:
+    # a run that crashed after writing 19 of 24 of them has not run the report.
+    last_completion = DifferencesLog.where(key: DifferencesReportWorker::COMPLETION_KEY).max(:date)
 
-    return notify if last_log.blank?
+    return notify if last_completion.blank?
 
-    # Notify if the report hasn't run this week
-    notify if last_log.before?(Date.current.beginning_of_week)
+    # Notify if the report hasn't completed this week
+    notify if last_completion.before?(Date.current.beginning_of_week)
   end
 
 private
 
   def notify
     SlackNotifierService.call(
-      'The differences report has not run this week. Please check the differences report and run it.',
+      'The differences report has not run to completion this week. Please check the differences report and run it.',
     )
   end
 end

--- a/app/workers/differences_report_worker.rb
+++ b/app/workers/differences_report_worker.rb
@@ -1,6 +1,12 @@
 class DifferencesReportWorker
   include Sidekiq::Worker
 
+  # Written to DifferencesLog only once the whole report has been generated and
+  # published. Every worksheet loader writes its own log row before it does any
+  # work, so worksheet rows prove a run started, never that it finished.
+  # DifferencesReportCheckWorker watches for this key alone.
+  COMPLETION_KEY = 'differences_report_completed'.freeze
+
   # retry_in is not a Sidekiq option; sidekiq_retry_in is the supported way to
   # delay retries, giving a late report publication time to appear.
   sidekiq_options retry: 2
@@ -9,6 +15,8 @@ class DifferencesReportWorker
 
   def perform(deliver_email = true)
     differences = generate_differences
+
+    record_completion
 
     if deliver_email
       send_differences_email(differences)
@@ -19,6 +27,14 @@ private
 
   def generate_differences
     Reporting::Differences.generate
+  end
+
+  # Recorded after generation returns, so a crashed or retried run leaves no
+  # marker. A rerun on the same day replaces the day's marker rather than
+  # stacking rows.
+  def record_completion
+    DifferencesLog.where(key: COMPLETION_KEY, date: Time.zone.today).delete
+    DifferencesLog.create(date: Time.zone.today, key: COMPLETION_KEY, value: Time.zone.now.iso8601)
   end
 
   def send_differences_email(differences)

--- a/spec/workers/differences_report_check_worker_spec.rb
+++ b/spec/workers/differences_report_check_worker_spec.rb
@@ -1,6 +1,8 @@
 RSpec.describe DifferencesReportCheckWorker, type: :worker do
   subject(:worker) { described_class.new }
 
+  let(:completion_key) { DifferencesReportWorker::COMPLETION_KEY }
+
   describe '#perform' do
     before do
       allow(SlackNotifierService).to receive(:call).and_call_original
@@ -11,19 +13,29 @@ RSpec.describe DifferencesReportCheckWorker, type: :worker do
       let(:environment) { ActiveSupport::StringInquirer.new('production') }
       let(:uk) { true }
 
-      it 'is happy if the differences report has run this week' do
-        DifferencesLog.create(date: Date.current.beginning_of_week, key: 'foo', value: 'foo')
+      it 'is happy if the differences report completed this week' do
+        DifferencesLog.create(date: Date.current.beginning_of_week, key: completion_key, value: 'completed')
         worker.perform
         expect(SlackNotifierService).not_to have_received(:call)
       end
 
-      it 'is unhappy if the differences report has not run this week' do
-        DifferencesLog.create(date: 10.days.ago, key: 'foo', value: 'foo')
+      it 'is unhappy if the differences report last completed before this week' do
+        DifferencesLog.create(date: 10.days.ago, key: completion_key, value: 'completed')
         worker.perform
         expect(SlackNotifierService).to have_received(:call)
       end
 
-      it 'is unhappy if there is no differences report data' do
+      it 'is unhappy if there is no differences report data at all' do
+        worker.perform
+        expect(SlackNotifierService).to have_received(:call)
+      end
+
+      # Previously a single worksheet log row counted as "the report has run".
+      # Every worksheet loader writes its row before doing any work, so a run
+      # that crashed part way through left rows behind and silenced this check.
+      it 'is unhappy if only worksheet rows were written this week and the run never completed' do
+        DifferencesLog.create(date: Date.current.beginning_of_week, key: 'Reporting::Differences::Loaders::MfnMissing', value: '[]')
+        DifferencesLog.create(date: Date.current.beginning_of_week, key: 'Reporting::Differences::Loaders::Me32', value: '[]')
         worker.perform
         expect(SlackNotifierService).to have_received(:call)
       end
@@ -34,7 +46,7 @@ RSpec.describe DifferencesReportCheckWorker, type: :worker do
       let(:uk) { true }
 
       it 'is always happy' do
-        DifferencesLog.create(date: 10.days.ago, key: 'foo', value: 'foo')
+        DifferencesLog.create(date: 10.days.ago, key: completion_key, value: 'completed')
         worker.perform
         expect(SlackNotifierService).not_to have_received(:call)
       end
@@ -45,7 +57,7 @@ RSpec.describe DifferencesReportCheckWorker, type: :worker do
       let(:uk) { false }
 
       it 'is always happy' do
-        DifferencesLog.create(date: 10.days.ago, key: 'foo', value: 'foo')
+        DifferencesLog.create(date: 10.days.ago, key: completion_key, value: 'completed')
         worker.perform
         expect(SlackNotifierService).not_to have_received(:call)
       end

--- a/spec/workers/differences_report_worker_spec.rb
+++ b/spec/workers/differences_report_worker_spec.rb
@@ -31,5 +31,35 @@ RSpec.describe DifferencesReportWorker, type: :worker do
       it { expect(Reporting::Differences).to have_received(:generate) }
       it { expect(ActionMailer::Base.deliveries.count).to eq(0) }
     end
+
+    context 'when the report completes' do
+      before { worker.perform(false) }
+
+      it 'records a single completion marker for today' do
+        expect(DifferencesLog.where(key: described_class::COMPLETION_KEY, date: Time.zone.today).count).to eq(1)
+      end
+    end
+
+    context 'when the report is run twice in one day' do
+      before do
+        worker.perform(false)
+        worker.perform(false)
+      end
+
+      it 'keeps exactly one completion marker for today' do
+        expect(DifferencesLog.where(key: described_class::COMPLETION_KEY, date: Time.zone.today).count).to eq(1)
+      end
+    end
+
+    context 'when the report raises part way through' do
+      before do
+        allow(Reporting::Differences).to receive(:generate).and_raise(StandardError, 'boom')
+      end
+
+      it 'does not record a completion marker' do
+        expect { worker.perform(false) }.to raise_error(StandardError, 'boom')
+        expect(DifferencesLog.where(key: described_class::COMPLETION_KEY)).to be_empty
+      end
+    end
   end
 end


### PR DESCRIPTION
## What:

The watchdog for the weekly differences report now checks that the report completed. Before, it checked only that a row exists.

`DifferencesReportWorker` writes one `DifferencesLog` row with the key `differences_report_completed`. It writes this row after `Reporting::Differences.generate` returns. `DifferencesReportCheckWorker` now looks for that key only. Before, it used `DifferencesLog.max(:date)`. If the report runs again on the same day, the new row replaces the marker for that day. The rows do not increase in number.

There is no migration. The marker is a usual `DifferencesLog` row with a key that no loader can make. The keys of the loaders are class names, for example `Reporting::Differences::Loaders::Me32`. A status column would be the more complete correction. We can add it later, if the log must show more than yes or no.

The spec that asserted one row with the key `'foo'` was sufficient for the check. That spec showed the defect. Thus this PR replaces it, and does not delete it silently. The new specs use the completion key. A new spec shows that worksheet rows alone are not sufficient for the check.

## Why:

Each worksheet loader calls `save_difference_log` as its first action, before it does work. Thus a log row with the date of today exists after worksheet 1 of approximately 24. The check asked only for `DifferencesLog.max(:date)`. Thus those rows were sufficient to show that the report ran.

This failure caused the change: the XI supplementary units report is missing. Thus the UK differences report stops with an error at `add_missing_supplementary_units_from_uk_worksheet`, which is position 20 of 24. At that time, the system wrote 19 rows. `retry: 2` causes more rows on each attempt, and then the job stops. The check at 1 am on Tuesday sees the rows, decides that the report ran, and says nothing.

The result is that the weekly protection against UK tariff anomalies stops silently. That protection finds missing MFN duties, incorrect quota associations, and ME32 violations. `DifferencesReportWorker` does not include `ScheduledJobHeartbeat`, thus this watchdog is the only monitor.

**This design fails towards an alert, and not away from an alert.** The system writes the marker only on the successful path, after generation returns. In production, generation sends the workbook before it returns. Thus the marker shows that the system generated and published the report, and not that it started the report. Each unwanted condition causes an alert, because it leaves no marker. These conditions are: a stop with an error in the middle of the report, a job that is dead after the two retries, a report that did not run, and an empty table. The set of conditions that the check accepts as healthy is smaller than before. Thus there is no condition that caused an alert before and is silent now. The first check after the deploy causes an alert, unless a full run completed after the deploy. This is the correct direction for a watchdog, and the next successful run clears the alert.

**Relation to #3722.** There is none. That PR changes `Reporting.get_published` and `published_exist?` to read from S3 and not from the CDN. It changes `app/lib/reporting.rb` only. A check of the published S3 object for the correct date was the alternative design for this PR. That design would need #3722 first. It would also need `published_exist?` to change S3 errors into `false`. That behaviour is safe for a watchdog, because it causes an alert. But it connects the watchdog to the access to the bucket and to the format of the object key. The completion marker needs neither of these. Thus the two changes do not use the same files and do not change the same behaviour.

**A different problem, which this PR does not correct.** In `app/lib/reporting/admin_report_registry.rb:116-119`, the `uk_commodities` and `xi_commodities` dependency rows both point to `Reporting::Commodities`. The `available_today?` method of that class calls a private `object_key` with the scope of one service. Thus on the UK admin, the two rows check the UK key. A missing XI commodities report then looks satisfactory. This is the condition that causes the error above. It needs its own PR.

## Ticket:

N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:** This PR changes two workers and their specs. There is no migration and no change to the schema. There is no change to the report or to data that traders see. The only change to the behaviour is that the watchdog causes an alert in more conditions than before. This is the safe direction for a monitor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
