### PR TITLE
fix: fail the import when a note extract is wholly empty

### DIFF
--- a/app/lib/customs_tariff_importer/importer.rb
+++ b/app/lib/customs_tariff_importer/importer.rb
@@ -33,6 +33,10 @@ module CustomsTariffImporter
 
       extracted = NotesExtractor.new(fetched.version, fetched.content).call
 
+      if empty_extract?(extracted)
+        raise "Empty extract for #{fetched.version}: refusing to import a version with no notes"
+      end
+
       start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
       CustomsTariffUpdate.db.transaction do
@@ -62,6 +66,14 @@ module CustomsTariffImporter
       )
       record_failure(fetched&.version, e.message)
       Result.new(status: :failed, version: fetched&.version, error: e.message)
+    end
+
+    # A wholly empty extract means the source document parsed to nothing usable. Importing it
+    # would create a CustomsTariffUpdate with no import_error, which CustomsTariffUpdate.imported
+    # treats as a finished version and #import_document then skips forever. Raising routes this
+    # through the rescue below, which records a failed row so the version is retried next run.
+    def empty_extract?(extracted)
+      extracted.chapters.empty? && extracted.sections.empty? && extracted.general_rules.empty?
     end
 
     def create_notes(update, extracted)

--- a/app/lib/xi_cn_importer/importer.rb
+++ b/app/lib/xi_cn_importer/importer.rb
@@ -25,6 +25,10 @@ module XiCnImporter
 
       extracted = NotesExtractor.new(fetched.celex, fetched.html_content).call
 
+      if empty_extract?(extracted)
+        raise "Empty extract for #{fetched.celex}: refusing to import a version with no notes"
+      end
+
       start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       persist_document(fetched, extracted, s3_path)
 
@@ -40,6 +44,15 @@ module XiCnImporter
       )
       record_failure(fetched&.celex, e.message)
       Result.new(status: :failed, celex: fetched&.celex, error: e.message)
+    end
+
+    # A 200 response carrying a placeholder or error page still parses cleanly through the
+    # non-strict Nokogiri::XML in NotesExtractor and yields zero notes. Importing that would
+    # create a CustomsTariffUpdate with no import_error, which CustomsTariffUpdate.imported
+    # treats as a finished version and DocumentFetcher then skips forever. Raising routes this
+    # through the rescue below, which records a failed row so the CELEX is retried next run.
+    def empty_extract?(extracted)
+      extracted.chapters.empty? && extracted.sections.empty? && extracted.general_rules.empty?
     end
 
     def persist_document(fetched, extracted, s3_path)

--- a/spec/lib/customs_tariff_importer/importer_spec.rb
+++ b/spec/lib/customs_tariff_importer/importer_spec.rb
@@ -207,5 +207,43 @@ RSpec.describe CustomsTariffImporter::Importer do
         )
       end
     end
+
+    context 'when the extract contains no notes at all' do
+      let(:extracted_result) do
+        CustomsTariffImporter::NotesExtractor::Result.new(chapters: {}, sections: {}, general_rules: {})
+      end
+
+      it 'returns a failed result rather than marking the version imported' do
+        expect(results.first.status).to eq(:failed)
+      end
+
+      it 'leaves the version eligible for reimport on the next run' do
+        results
+        expect(CustomsTariffUpdate.imported.where(version: '1.30')).to be_empty
+      end
+
+      it 'records the failure reason against the version' do
+        results
+        expect(CustomsTariffUpdate.first(version: '1.30').import_error).to match(/Empty extract/)
+      end
+
+      it 'creates no chapter notes' do
+        expect { results }.not_to change(CustomsTariffChapterNote, :count)
+      end
+
+      it 'emits a document_import_failed instrumentation event' do
+        results
+        expect(CustomsTariffImporter::Instrumentation).to have_received(:document_import_failed).with(
+          version: '1.30',
+          error_class: 'RuntimeError',
+          error_message: /Empty extract/,
+        )
+      end
+
+      it 'does not emit a document_imported instrumentation event' do
+        results
+        expect(CustomsTariffImporter::Instrumentation).not_to have_received(:document_imported)
+      end
+    end
   end
 end

--- a/spec/lib/xi_cn_importer/importer_spec.rb
+++ b/spec/lib/xi_cn_importer/importer_spec.rb
@@ -214,5 +214,45 @@ RSpec.describe XiCnImporter::Importer do
         end
       end
     end
+
+    context 'when the extract contains no notes at all' do
+      let(:extracted_result) do
+        XiCnImporter::NotesExtractor::Result.new(sections: {}, chapters: {}, general_rules: {})
+      end
+
+      it 'returns a failed result rather than marking the CELEX imported' do
+        results = importer.call
+        expect(results.first.status).to eq :failed
+        expect(results.first.error).to match(/Empty extract/)
+      end
+
+      it 'leaves the CELEX eligible for reimport on the next run' do
+        importer.call
+        expect(CustomsTariffUpdate.imported.where(version: fetched_result.celex)).to be_empty
+      end
+
+      it 'records the failure reason against the CELEX' do
+        importer.call
+        expect(CustomsTariffUpdate.first(version: fetched_result.celex).import_error).to match(/Empty extract/)
+      end
+
+      it 'creates no notes' do
+        importer.call
+        expect(CustomsTariffSectionNote.where(customs_tariff_update_version: fetched_result.celex).count).to eq 0
+        expect(CustomsTariffChapterNote.where(customs_tariff_update_version: fetched_result.celex).count).to eq 0
+        expect(CustomsTariffGeneralRule.where(customs_tariff_update_version: fetched_result.celex).count).to eq 0
+      end
+
+      it 'instruments the failed import and not a successful one' do
+        importer.call
+
+        expect(XiCnImporter::Instrumentation).to have_received(:document_import_failed).with(
+          celex: fetched_result.celex,
+          error_class: 'RuntimeError',
+          error_message: /Empty extract/,
+        ).once
+        expect(XiCnImporter::Instrumentation).not_to have_received(:document_imported)
+      end
+    end
   end
 end


### PR DESCRIPTION
## What:
Both `CustomsTariffImporter::Importer` and `XiCnImporter::Importer` now raise when the note extract is wholly empty, instead of persisting an empty version and returning `status: :imported`.

The check sits immediately after extraction:

```ruby
if empty_extract?(extracted)
  raise "Empty extract for #{fetched.version}: refusing to import a version with no notes"
end
```

Raising rather than returning a `Result` directly reuses each importer's existing `rescue StandardError`, which already emits `document_import_failed` instrumentation, writes a failed row via `record_failure`, and returns `Result.new(status: :failed)`. That is deliberate: the goal here is a failed status, not an abort, and the rescue is the only place that produces all three consistently. It also means the S3 archive write, which happens before extraction, is kept for diagnosis.

Specs were written first and observed failing (9 failures) before the guard was added.

## Why:
An empty note extract was being imported as a successful and permanently final tariff version.

Both importers persist notes by iterating the extractor's `chapters`, `sections` and `general_rules` hashes. Empty hashes iterate zero times, so the `CustomsTariffUpdate` row was created with no `import_error` and no notes, and the importer returned `:imported`. `CustomsTariffUpdate.imported` is defined as `import_error IS NULL`, so that row immediately qualified as a finished version.

Three things then went wrong:

1. **The version is skipped forever.** `customs_tariff_importer/importer.rb:21` (UK) and `xi_cn_importer/document_fetcher.rb:82` (XI) both skip any version already in `CustomsTariffUpdate.imported`. A version broken this way could never be retried. A live tariff version would carry no chapter notes, no section notes and no general interpretative rules, permanently.
2. **Subscribers are told it published.** An `:imported` result flows into the worker's `notify_update_recipients`, which calls `CustomsTariffUpdateNotifierService` and emails subscribers to say the version published.
3. **Nobody is alerted.** Nothing raised, so nothing surfaced.

The XI path is the easiest to trigger. `XiCnImporter::NotesExtractor` parses with non-strict `Nokogiri::XML` and returns `[]` when the document has no `body` (`notes_extractor.rb:43-48`), so a 200 response carrying a Cellar placeholder or error page parses to zero notes without raising.

After this change the version keeps an `import_error`, so it is excluded from `CustomsTariffUpdate.imported` and stays eligible for reimport on the next run; the `:failed` result never reaches `notify_update_recipients`; and the worker's existing `notify_completed` posts a Slack alert naming the version. Existing worker specs already cover both of those last two behaviours for `:failed` results.

**Precedent.** `XiCnImporter::Reimporter:31-33` already guards the equivalent case on the reimport path. The correct outcome differs, which is why this is not a copy of it: the reimporter raises to abort a destructive delete of existing notes, whereas here nothing is destroyed and the only goal is that the version is not marked done.

**On `slack_alerts: false` in `ImportCustomsTariffDocumentWorker`.** This was considered and deliberately left alone. The flag makes `SidekiqDeathHandler` return early, but this worker is not silent: it posts its own Slack message from `notify_completed` for any `:failed` result, and from `notify_failed` when `perform` itself raises. Removing the flag would double-alert the raise path rather than restore a missing alert. Git history shows it was added in `2dd627150`, in the same commit that replaced the worker's inline Slack calls, with no stated rationale; the later reintroduction of `notify_completed` and `notify_failed` makes the current arrangement coherent, and the XI worker, which has no `notify_failed`, correctly does not set the flag.

**Follow-up, not fixed here.** In `customs_tariff_importer/notes_extractor.rb`, `CHAPTER_PATTERN = /\ACHAPTER\s+(\d+)\z/` is the only keyword pattern in the file without the `/i` flag, and it is fully anchored. Every sibling keyword pattern is case insensitive, and the XI extractor's equivalent `CHAPTER_HEADING_PATTERN` does carry `/i`. A UK source document writing "Chapter 1" rather than "CHAPTER 1" therefore matches nothing and produces exactly the empty extract this PR guards against. It is left out of this PR on purpose: adding a guard cannot change the output of a good import, whereas relaxing a matching rule can, so it deserves its own change and its own extractor test evidence.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
The guard only fires when the extract is wholly empty, a case that previously produced a tariff version with no notes at all, so no currently successful import changes behaviour. The failure mode of the change is a version being retried on the next scheduled run instead of silently going live empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
