### PR TITLE
fix: raise when an OpenSearch bulk response reports item failures

### DIFF
--- a/app/lib/trade_tariff_backend/bulk_response.rb
+++ b/app/lib/trade_tariff_backend/bulk_response.rb
@@ -1,0 +1,107 @@
+module TradeTariffBackend
+  # OpenSearch answers a `_bulk` request with HTTP 200 even when individual
+  # items in that request failed. The per item outcome only shows up in the
+  # response body, as an `"errors" => true` flag plus an `"error"` object on
+  # each failed item. A caller that ignores the body therefore treats a
+  # partially (or entirely) rejected bulk as a success.
+  #
+  # `check!` inspects that body and raises with enough detail to diagnose the
+  # failure, while keeping the message small enough for a log line or a Slack
+  # alert. A bulk of 500 rejected items must not produce 500 error objects of
+  # output, so we report the first few failures and a count by error type.
+  module BulkResponse
+    BulkError = Class.new(StandardError)
+
+    # A failure that will fail identically on every retry, such as a mapping
+    # error or a malformed document.
+    BulkIndexingError = Class.new(BulkError)
+
+    # Transient backpressure: the cluster's write queue was full and shed the
+    # work. The same documents would very likely succeed later.
+    BulkRejectedError = Class.new(BulkError)
+
+    REJECTED_ERROR_TYPE = 'es_rejected_execution_exception'.freeze
+    UNKNOWN_ERROR_TYPE = 'unknown'.freeze
+
+    # Bounds on the error message. Five failures is enough to spot a pattern,
+    # and the type counts cover the rest.
+    MAX_REPORTED_FAILURES = 5
+    MAX_REASON_LENGTH = 200
+
+    # Returns the response unchanged when every item succeeded, otherwise
+    # raises BulkRejectedError (all failures were queue rejections) or
+    # BulkIndexingError (anything else).
+    def self.check!(response, context)
+      return response unless response.is_a?(Hash)
+      return response unless response['errors']
+
+      failures = failures_in(response)
+
+      # The flag is authoritative: if OpenSearch says something failed we raise
+      # even when we cannot attribute it to an item.
+      raise BulkIndexingError, "#{context}: bulk response reported errors but no item carried an error object (unknown failure)" if failures.empty?
+
+      error_class = failures.all? { |failure| failure[:type] == REJECTED_ERROR_TYPE } ? BulkRejectedError : BulkIndexingError
+
+      raise error_class, message_for(context, failures, response)
+    end
+
+    # Each item is keyed by its operation, e.g.
+    # { "index" => { "_id" => "1", "status" => 429, "error" => { "type" => ..., "reason" => ... } } }
+    def self.failures_in(response)
+      items = response['items']
+      return [] unless items.is_a?(Array)
+
+      failures = []
+
+      items.each do |item|
+        next unless item.is_a?(Hash)
+
+        operation, result = item.first
+        next unless result.is_a?(Hash)
+
+        status = result['status'].to_i
+        error = result['error']
+        next if error.nil? && status < 400
+
+        error = {} unless error.is_a?(Hash)
+
+        failures.push(
+          operation:,
+          id: result['_id'],
+          status: result['status'],
+          type: error['type'].presence || UNKNOWN_ERROR_TYPE,
+          reason: error['reason'].to_s,
+        )
+      end
+
+      failures
+    end
+
+    def self.message_for(context, failures, response)
+      total_items = response['items'].is_a?(Array) ? response['items'].size : failures.size
+      reported = failures.take(MAX_REPORTED_FAILURES).map { |failure| describe_failure(failure) }
+      remainder = failures.size - reported.size
+      reported.push("and #{remainder} more") if remainder.positive?
+
+      "#{context}: #{failures.size} of #{total_items} bulk items failed. " \
+        "Counts by error type: #{counts_by_type(failures)}. " \
+        "First failures: #{reported.join('; ')}"
+    end
+
+    def self.describe_failure(failure)
+      reason = failure[:reason]
+      reason = "#{reason[0, MAX_REASON_LENGTH]}..." if reason.length > MAX_REASON_LENGTH
+
+      "#{failure[:operation]} id=#{failure[:id]} status=#{failure[:status]} #{failure[:type]}: #{reason}"
+    end
+
+    def self.counts_by_type(failures)
+      failures.group_by { |failure| failure[:type] }
+              .map { |type, grouped| "#{type}: #{grouped.size}" }
+              .join(', ')
+    end
+
+    private_class_method :failures_in, :message_for, :describe_failure, :counts_by_type
+  end
+end

--- a/app/services/tariff_knowledge/public_atar_search_refresh.rb
+++ b/app/services/tariff_knowledge/public_atar_search_refresh.rb
@@ -53,11 +53,16 @@ module TariffKnowledge
     end
 
     def bulk_reindex(goods_nomenclatures)
-      TradeTariffBackend.search_client.bulk(
+      response = TradeTariffBackend.search_client.bulk(
         {
           body: goods_nomenclatures.map { |goods_nomenclature| bulk_operation(index, goods_nomenclature) },
         }.merge(TradeTariffBackend.search_client.search_operation_options),
       )
+
+      # A `_bulk` request answers 200 even when individual documents were
+      # rejected, so without this check we would report the ATaR refresh as
+      # done and queue label scoring for documents that never made it in.
+      TradeTariffBackend::BulkResponse.check!(response, 'PublicAtarSearchRefresh')
     end
 
     def index

--- a/app/workers/build_index_page_worker.rb
+++ b/app/workers/build_index_page_worker.rb
@@ -16,10 +16,19 @@ class BuildIndexPageWorker
 
       return true if entries.empty?
 
-      opensearch_client.bulk(
+      response = opensearch_client.bulk(
         body: serialize_for(:index, index, entries),
       )
+
+      # A `_bulk` request answers 200 even when individual documents were
+      # rejected, so without this check a page that indexed nothing would
+      # report success and leave the index silently short of commodities.
+      TradeTariffBackend::BulkResponse.check!(response, "#{index_namespace}/#{index_name} page #{page_number}")
     end
+  rescue TradeTariffBackend::BulkResponse::BulkError
+    # Already carries the index, the page and the failed document ids, and its
+    # class distinguishes transient rejections from permanent failures.
+    raise
   rescue StandardError
     raise IndexingError, "Failed building index: #{index_namespace}/#{index_name} - page #{page_number}"
   end

--- a/spec/lib/trade_tariff_backend/bulk_response_spec.rb
+++ b/spec/lib/trade_tariff_backend/bulk_response_spec.rb
@@ -1,0 +1,110 @@
+RSpec.describe TradeTariffBackend::BulkResponse do
+  describe '.check!' do
+    let(:context) { 'Search::CommodityIndex page 1' }
+
+    def rejection_item(id)
+      {
+        'index' => {
+          '_index' => 'tariff-uk-commodities',
+          '_id' => id,
+          'status' => 429,
+          'error' => {
+            'type' => 'es_rejected_execution_exception',
+            'reason' => 'rejected execution of coordinating operation',
+          },
+        },
+      }
+    end
+
+    def mapping_item(id)
+      {
+        'index' => {
+          '_index' => 'tariff-uk-commodities',
+          '_id' => id,
+          'status' => 400,
+          'error' => {
+            'type' => 'mapper_parsing_exception',
+            'reason' => "failed to parse field [validity_start_date] of type [date] in document with id '#{id}'",
+          },
+        },
+      }
+    end
+
+    it 'returns the response when there are no errors' do
+      response = { 'errors' => false, 'items' => [{ 'index' => { '_id' => '1', 'status' => 201 } }] }
+
+      expect(described_class.check!(response, context)).to eq(response)
+    end
+
+    it 'returns the response when the payload is not a hash' do
+      expect(described_class.check!(true, context)).to be(true)
+    end
+
+    it 'raises a mapping error when an item failed with a permanent error' do
+      response = { 'errors' => true, 'items' => [mapping_item('101'), { 'index' => { '_id' => '102', 'status' => 201 } }] }
+
+      expect { described_class.check!(response, context) }
+        .to raise_error(TradeTariffBackend::BulkResponse::BulkIndexingError, /mapper_parsing_exception/)
+    end
+
+    it 'raises a rejected error when every failure is a queue rejection' do
+      response = { 'errors' => true, 'items' => [rejection_item('101'), rejection_item('102')] }
+
+      expect { described_class.check!(response, context) }
+        .to raise_error(TradeTariffBackend::BulkResponse::BulkRejectedError, /es_rejected_execution_exception/)
+    end
+
+    it 'raises the permanent error class when rejections are mixed with mapping failures' do
+      response = { 'errors' => true, 'items' => [rejection_item('101'), mapping_item('102')] }
+
+      expect { described_class.check!(response, context) }
+        .to raise_error(TradeTariffBackend::BulkResponse::BulkIndexingError)
+    end
+
+    it 'includes the context, the failure count and the failed document ids' do
+      response = { 'errors' => true, 'items' => [mapping_item('101')] }
+
+      expect { described_class.check!(response, context) }
+        .to raise_error(/Search::CommodityIndex page 1: 1 of 1 bulk items failed.*101/m)
+    end
+
+    it 'bounds the message to the first few failures plus a total count' do
+      items = (1..200).map { |id| rejection_item(id.to_s) }
+      response = { 'errors' => true, 'items' => items }
+
+      expect { described_class.check!(response, context) }
+        .to raise_error(TradeTariffBackend::BulkResponse::BulkRejectedError) { |error|
+          expect(error.message).to include('200 of 200 bulk items failed')
+          expect(error.message).to include('and 195 more')
+          expect(error.message.length).to be < 2_000
+          expect(error.message).not_to include('"_id" => "6"')
+        }
+    end
+
+    it 'truncates a very long failure reason' do
+      item = mapping_item('101')
+      item['index']['error']['reason'] = 'x' * 5_000
+      response = { 'errors' => true, 'items' => [item] }
+
+      expect { described_class.check!(response, context) }
+        .to raise_error(TradeTariffBackend::BulkResponse::BulkIndexingError) { |error|
+          expect(error.message.length).to be < 1_000
+          expect(error.message).to include('...')
+        }
+    end
+
+    it 'summarises the failure counts by error type' do
+      response = { 'errors' => true, 'items' => [mapping_item('101'), rejection_item('102'), rejection_item('103')] }
+
+      expect { described_class.check!(response, context) }
+        .to raise_error(/es_rejected_execution_exception: 2/)
+    end
+
+    it 'raises when the flag is set but no item carries an error object' do
+      response = { 'errors' => true, 'items' => [{ 'index' => { '_id' => '1', 'status' => 201 } }] }
+
+      expect { described_class.check!(response, context) }
+        .to raise_error(TradeTariffBackend::BulkResponse::BulkIndexingError, /unknown/)
+    end
+  end
+end

--- a/spec/services/tariff_knowledge/public_atar_search_refresh_spec.rb
+++ b/spec/services/tariff_knowledge/public_atar_search_refresh_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe TariffKnowledge::PublicAtarSearchRefresh do
   describe '.call' do
-    let(:search_client) { object_double(TradeTariffBackend.search_client, bulk: true, search_operation_options: { refresh: true }) }
+    let(:bulk_response) { { 'errors' => false, 'items' => [{ 'index' => { '_id' => '1', 'status' => 200 } }] } }
+    let(:search_client) { object_double(TradeTariffBackend.search_client, bulk: bulk_response, search_operation_options: { refresh: true }) }
 
     before do
       allow(TradeTariffBackend).to receive(:search_client).and_return(search_client)
@@ -44,6 +45,40 @@ RSpec.describe TariffKnowledge::PublicAtarSearchRefresh do
       expect(result).to eq([commodity.goods_nomenclature_sid])
       expect(search_client).to have_received(:bulk).once
       expect(ScoreLabelBatchWorker).to have_received(:perform_async).with([commodity.goods_nomenclature_sid])
+    end
+
+    context 'when the bulk response reports per item failures' do
+      let(:bulk_response) do
+        {
+          'errors' => true,
+          'items' => [
+            {
+              'index' => {
+                '_index' => 'tariff-uk-goods_nomenclatures',
+                '_id' => '101',
+                'status' => 400,
+                'error' => { 'type' => 'mapper_parsing_exception', 'reason' => 'failed to parse field' },
+              },
+            },
+          ],
+        }
+      end
+
+      it 'raises rather than reporting a successful refresh' do
+        create(:commodity, :with_description, :declarable, goods_nomenclature_item_id: '6302100000')
+
+        expect { described_class.call(%w[6302100000]) }.to raise_error(
+          TradeTariffBackend::BulkResponse::BulkIndexingError,
+          /PublicAtarSearchRefresh.*mapper_parsing_exception.*101/m,
+        )
+      end
+
+      it 'does not queue embedding regeneration for a batch that failed to index' do
+        create(:commodity, :with_description, :declarable, goods_nomenclature_item_id: '6302100000')
+
+        expect { described_class.call(%w[6302100000]) }.to raise_error(TradeTariffBackend::BulkResponse::BulkIndexingError)
+        expect(ScoreLabelBatchWorker).not_to have_received(:perform_async)
+      end
     end
 
     context 'when ATaR search is disabled' do

--- a/spec/workers/build_index_page_worker_spec.rb
+++ b/spec/workers/build_index_page_worker_spec.rb
@@ -33,6 +33,82 @@ RSpec.describe BuildIndexPageWorker, type: :worker do
       end
     end
 
+    describe 'when the bulk response reports per item failures' do
+      subject(:perform) { described_class.new.perform 'search', search_index.name_without_namespace, 1 }
+
+      before do
+        TradeTariffBackend.search_client.drop_index(search_index)
+        TradeTariffBackend.search_client.create_index(search_index)
+        create :commodity, :with_description, description: 'test description'
+
+        allow(TradeTariffBackend.opensearch_client).to receive(:bulk).and_return(bulk_response)
+      end
+
+      let(:search_index) { Search::CommodityIndex.new }
+
+      context 'when the failures are queue rejections' do
+        let(:bulk_response) do
+          {
+            'errors' => true,
+            'items' => [
+              {
+                'index' => {
+                  '_index' => search_index.name,
+                  '_id' => '101',
+                  'status' => 429,
+                  'error' => { 'type' => 'es_rejected_execution_exception', 'reason' => 'rejected execution' },
+                },
+              },
+            ],
+          }
+        end
+
+        it 'raises a rejection error carrying the index and page' do
+          expect { perform }.to raise_error(
+            TradeTariffBackend::BulkResponse::BulkRejectedError,
+            /search\/CommodityIndex page 1.*es_rejected_execution_exception/m,
+          )
+        end
+      end
+
+      context 'when the failures are permanent' do
+        let(:bulk_response) do
+          {
+            'errors' => true,
+            'items' => [
+              {
+                'index' => {
+                  '_index' => search_index.name,
+                  '_id' => '101',
+                  'status' => 400,
+                  'error' => { 'type' => 'mapper_parsing_exception', 'reason' => 'failed to parse field' },
+                },
+              },
+            ],
+          }
+        end
+
+        it 'raises an indexing error carrying the failed document id' do
+          expect { perform }.to raise_error(
+            TradeTariffBackend::BulkResponse::BulkIndexingError,
+            /mapper_parsing_exception.*101/m,
+          )
+        end
+      end
+
+      context 'when the bulk request itself raises' do
+        let(:bulk_response) { nil }
+
+        before do
+          allow(TradeTariffBackend.opensearch_client).to receive(:bulk).and_raise(Faraday::ConnectionFailed, 'boom')
+        end
+
+        it 'still converts transport failures into an IndexingError' do
+          expect { perform }.to raise_error(described_class::IndexingError, /Failed building index/)
+        end
+      end
+    end
+
     describe 'build index page with old worker params' do
       before do
         # Make sure index is fresh


### PR DESCRIPTION
## What:
Adds `TradeTariffBackend::BulkResponse.check!` and calls it from both places that issue an OpenSearch `_bulk` request, so a bulk whose items failed now raises instead of returning quietly.

- `app/workers/build_index_page_worker.rb`
- `app/services/tariff_knowledge/public_atar_search_refresh.rb`

Two error classes, both descending from `BulkError`:

- `BulkRejectedError` when every failure is `es_rejected_execution_exception`, which is transient backpressure from a full write queue
- `BulkIndexingError` for anything else, for example a mapping error, which will fail identically on every retry

The error message is bounded on purpose. A bulk of 500 rejected items must not produce 500 error objects in a log line or an unreadable Slack attachment, so it reports the failure count out of the batch size, a count by error type, and the first five failures with their document ids, each reason truncated to 200 characters.

Transport level failures in `BuildIndexPageWorker` still become `IndexingError` exactly as before. Only the new bulk errors pass through unwrapped, because they already carry the index, the page number and the failed document ids, and their class is what tells you whether a retry would help.

## Why:
OpenSearch answers a `_bulk` request with HTTP 200 even when individual documents in the batch were rejected. The per item outcome lives only in the response body, as an `"errors": true` flag plus an `"error"` object on each failed item. Both call sites discarded that body, so a partially or entirely failed bulk looked exactly like a clean one.

The scenario this hides in production: `ReindexModelsWorker` (`retry: false`) drops the index and enqueues a `BuildIndexPageWorker` per page. A full reindex is when the cluster is under its heaviest write load, which is precisely when it sheds work with `es_rejected_execution_exception`. A page whose documents were all rejected returned success, and because `BuildIndexPageWorker` is also `retry: false` there was no retry, no dead job, no Slack alert and no New Relic error. The index was left permanently short of commodities and search returned nothing for them, with no signal anywhere.

`PublicAtarSearchRefresh` had the same hole with an extra consequence: it went on to queue `ScoreLabelBatchWorker` for documents that never made it into the index.

**Note for reviewers, this may surface failures that have been invisible until now.** That is the point of the change, but expect it: the first reindex after deploy could fail loudly where it previously passed quietly. If it does, the error message names the index, the page and the failing document ids, and the error class tells you whether it is transient (`BulkRejectedError`, retry) or permanent (`BulkIndexingError`, fix the document or the mapping).

**A recommendation, not changed here.** `BuildIndexPageWorker` is `retry: false`. That was survivable while failures were silent, but now that queue rejections raise, a single burst of backpressure during a reindex will fail a page with no automatic recovery. `BulkRejectedError` is exactly the case that a bounded retry with backoff would clear on its own. I would suggest a follow up giving the worker something like `retry: 3` with `sidekiq_retry_in` backing off, or retrying only on `BulkRejectedError`, but that changes the reindex failure behaviour more broadly than this fix should, so I have left it for a separate conversation.

Alerting is unaffected by `retry: false` and works today. Verified against sidekiq 8.1.7 `lib/sidekiq/job_retry.rb`: `local` hits `raise e unless msg["retry"]`, which propagates to `global`, whose else branch runs the configured death handlers. `SidekiqDeathHandler` posts to Slack unless the job sets `slack_alerts: false`, and neither `BuildIndexPageWorker` nor `ReindexModelsWorker` sets it, so both already alert. New Relic collects the raised error as well.

Written red/green: the specs stub a 200 response carrying `"errors": true` and assert the raise, the error class, the bounded message and the truncation.

## Ticket:
N/A

## Risk:
**Risk level:** 🟠

**Reason for rating:**
It touches the search indexing pipeline and turns a class of previously silent failure into a raised error, so a reindex that has been quietly dropping documents will now fail visibly and alert. No change to what is indexed or how documents are serialised, only to whether a failed bulk is noticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
