### PR TITLE
fix: three silent failures in the tariff sync pipeline

### DIFF
--- a/app/lib/tariff_synchronizer.rb
+++ b/app/lib/tariff_synchronizer.rb
@@ -21,7 +21,6 @@ module TariffSynchronizer
   self.exception_retry_count = TradeTariffBackend.exception_retry_count
 
   def apply_updates(update_type)
-    applied_updates = []
     import_warnings = []
 
     start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
@@ -39,12 +38,7 @@ module TariffSynchronizer
         import_warnings << event.payload
       end
 
-      date_range = date_range_since_oldest_pending_update
-      date_range.each do |day|
-        applied_updates << perform_update(update_type, day)
-      end
-
-      applied_updates.flatten!
+      applied_updates = apply_each_pending_day(update_type)
 
       if applied_updates.any? && BaseUpdate.pending_or_failed.none?
         duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000).round(2)
@@ -60,6 +54,26 @@ module TariffSynchronizer
     TariffSynchronizer::Instrumentation.lock_failed(phase: 'apply')
   end
 
+  # Applies each pending day in order, stopping at the first day that fails. A
+  # failed update leaves a hole in the oplog sequence: later days' UPDATE and
+  # DELETE rows expect the skipped day's inserts, so applying them corrupts data.
+  def apply_each_pending_day(update_type)
+    applied_updates = []
+
+    date_range_since_oldest_pending_update.each do |day|
+      updates = perform_update(update_type, day)
+      applied_updates.concat(updates)
+
+      failed_updates = updates.select(&:failed?)
+      next if failed_updates.none?
+
+      Instrumentation.apply_aborted(filenames: failed_updates.map(&:filename))
+      break
+    end
+
+    applied_updates
+  end
+
   def date_range_since_oldest_pending_update
     oldest_pending_update = BaseUpdate.oldest_pending
     return [] if oldest_pending_update.blank?
@@ -69,12 +83,10 @@ module TariffSynchronizer
 
   def perform_update(update_type, day)
     updates = update_type.pending_at(day).to_a
-    updates.map do |update|
+    updates.each do |update|
       Instrumentation.file_import_started(filename: update.filename)
-
       BaseUpdateImporter.perform(update)
     end
-    updates
   end
 
   def check_tariff_updates_failures

--- a/app/lib/tariff_synchronizer.rb
+++ b/app/lib/tariff_synchronizer.rb
@@ -1,7 +1,16 @@
+# Redlock::LockAcquisitionError is defined inside redlock/client, which the gem
+# autoloads. Require it so the rescue clauses below can always resolve it.
+require 'redlock/client'
+
 module TariffSynchronizer
+  include Apply
   include Rollback
 
   class FailedUpdatesError < StandardError; end
+
+  # Returned when another process already holds the sync lock. Callers must
+  # branch on this rather than treating it as "nothing to apply".
+  LOCK_UNAVAILABLE = :lock_unavailable
 
   delegate :instrument, :subscribe, to: ActiveSupport::Notifications
 
@@ -50,43 +59,15 @@ module TariffSynchronizer
         true
       end
     end
+  rescue Redlock::LockAcquisitionError
+    # A quorum of Redis servers could not be reached. That is an infrastructure
+    # failure, not a concurrent run, so let it surface to Sidekiq and New Relic.
+    raise
   rescue Redlock::LockError
+    # Another process holds the sync lock and is doing the work. Legitimate, but
+    # the caller must not report a completed run off the back of it.
     TariffSynchronizer::Instrumentation.lock_failed(phase: 'apply')
-  end
-
-  # Applies each pending day in order, stopping at the first day that fails. A
-  # failed update leaves a hole in the oplog sequence: later days' UPDATE and
-  # DELETE rows expect the skipped day's inserts, so applying them corrupts data.
-  def apply_each_pending_day(update_type)
-    applied_updates = []
-
-    date_range_since_oldest_pending_update.each do |day|
-      updates = perform_update(update_type, day)
-      applied_updates.concat(updates)
-
-      failed_updates = updates.select(&:failed?)
-      next if failed_updates.none?
-
-      Instrumentation.apply_aborted(filenames: failed_updates.map(&:filename))
-      break
-    end
-
-    applied_updates
-  end
-
-  def date_range_since_oldest_pending_update
-    oldest_pending_update = BaseUpdate.oldest_pending
-    return [] if oldest_pending_update.blank?
-
-    (oldest_pending_update.issue_date..update_to)
-  end
-
-  def perform_update(update_type, day)
-    updates = update_type.pending_at(day).to_a
-    updates.each do |update|
-      Instrumentation.file_import_started(filename: update.filename)
-      BaseUpdateImporter.perform(update)
-    end
+    LOCK_UNAVAILABLE
   end
 
   def check_tariff_updates_failures

--- a/app/lib/tariff_synchronizer/apply.rb
+++ b/app/lib/tariff_synchronizer/apply.rb
@@ -1,0 +1,40 @@
+module TariffSynchronizer
+  # The day-by-day half of TariffSynchronizer#apply_updates, kept here for the
+  # same reason Rollback is: to keep the host module readable.
+  module Apply
+    # Applies each pending day in order, stopping at the first day that fails. A
+    # failed update leaves a hole in the oplog sequence: later days' UPDATE and
+    # DELETE rows expect the skipped day's inserts, so applying them corrupts data.
+    def apply_each_pending_day(update_type)
+      applied_updates = []
+
+      date_range_since_oldest_pending_update.each do |day|
+        updates = perform_update(update_type, day)
+        applied_updates.concat(updates)
+
+        failed_updates = updates.select(&:failed?)
+        next if failed_updates.none?
+
+        Instrumentation.apply_aborted(filenames: failed_updates.map(&:filename))
+        break
+      end
+
+      applied_updates
+    end
+
+    def date_range_since_oldest_pending_update
+      oldest_pending_update = BaseUpdate.oldest_pending
+      return [] if oldest_pending_update.blank?
+
+      (oldest_pending_update.issue_date..update_to)
+    end
+
+    def perform_update(update_type, day)
+      updates = update_type.pending_at(day).to_a
+      updates.each do |update|
+        Instrumentation.file_import_started(filename: update.filename)
+        BaseUpdateImporter.perform(update)
+      end
+    end
+  end
+end

--- a/app/lib/tariff_synchronizer/instrumentation.rb
+++ b/app/lib/tariff_synchronizer/instrumentation.rb
@@ -20,6 +20,10 @@ module TariffSynchronizer
       instrument('sync_run_completed', duration_ms:, files_downloaded:, files_applied:)
     end
 
+    def sync_run_skipped(reason:)
+      instrument('sync_run_skipped', reason:)
+    end
+
     def sync_run_failed(phase:, error_class:, error_message:)
       instrument('sync_run_failed', phase:, error_class:, error_message:)
     end

--- a/app/lib/tariff_synchronizer/instrumentation.rb
+++ b/app/lib/tariff_synchronizer/instrumentation.rb
@@ -64,6 +64,10 @@ module TariffSynchronizer
       instrument('apply_completed', duration_ms:, files_applied:)
     end
 
+    def apply_aborted(filenames:)
+      instrument('apply_aborted', filenames:)
+    end
+
     def file_import_started(filename:)
       instrument('file_import_started', filename:)
     end

--- a/app/lib/tariff_synchronizer/rollback.rb
+++ b/app/lib/tariff_synchronizer/rollback.rb
@@ -39,8 +39,6 @@ module TariffSynchronizer
           files_count:,
         )
       end
-    rescue Redlock::LockError
-      TariffSynchronizer::Instrumentation.lock_failed(phase: 'rollback')
     end
 
   private

--- a/app/lib/tariff_synchronizer/sync_logger.rb
+++ b/app/lib/tariff_synchronizer/sync_logger.rb
@@ -24,6 +24,15 @@ module TariffSynchronizer
       )
     end
 
+    def sync_run_skipped(event)
+      warn log_entry(
+        event: 'sync_run_skipped',
+        trade_service: event.payload[:service],
+        run_id: event.payload[:run_id],
+        reason: event.payload[:reason],
+      )
+    end
+
     def sync_run_failed(event)
       error log_entry(
         event: 'sync_run_failed',

--- a/app/lib/tariff_synchronizer/sync_logger.rb
+++ b/app/lib/tariff_synchronizer/sync_logger.rb
@@ -126,6 +126,15 @@ module TariffSynchronizer
       )
     end
 
+    def apply_aborted(event)
+      error log_entry(
+        event: 'apply_aborted',
+        trade_service: event.payload[:service],
+        run_id: event.payload[:run_id],
+        filenames: event.payload[:filenames],
+      )
+    end
+
     def file_import_started(event)
       info log_entry(
         event: 'file_import_started',

--- a/app/workers/apply_worker.rb
+++ b/app/workers/apply_worker.rb
@@ -12,7 +12,14 @@ class ApplyWorker
     TariffSynchronizer::Instrumentation.sync_run_started(triggered_by: self.class.name)
     TariffSynchronizer::Instrumentation.apply_started(pending_count: TariffSynchronizer::BaseUpdate.pending.count)
 
-    TradeTariffBackend.uk? ? CdsSynchronizer.apply : TaricSynchronizer.apply
+    apply_result = TradeTariffBackend.uk? ? CdsSynchronizer.apply : TaricSynchronizer.apply
+
+    # Another process holds the sync lock, so nothing was applied here. Reporting
+    # a completed run would hide that from the sync log and the age metric.
+    if apply_result == TariffSynchronizer::LOCK_UNAVAILABLE
+      TariffSynchronizer::Instrumentation.sync_run_skipped(reason: 'lock_unavailable')
+      return
+    end
 
     MaterializeViewHelper.refresh_materialized_view
 

--- a/app/workers/cds_updates_synchronizer_worker.rb
+++ b/app/workers/cds_updates_synchronizer_worker.rb
@@ -53,14 +53,17 @@ class CdsUpdatesSynchronizerWorker
 
     emit_sync_run_completed(start_time)
   rescue TariffSynchronizer::TariffUpdatesRequester::RetriableDownloadError
-    attempt_reschedule_download!(download_retry_count, check_for_todays_file, reapply_data_migrations)
+    # Nothing left to reschedule means the download has given up for good. Ending
+    # normally here would record a Sidekiq success and freeze UK tariff data at
+    # yesterday's state with no failure alarm, so surface it.
+    raise unless attempt_reschedule_download!(download_retry_count, check_for_todays_file, reapply_data_migrations)
   rescue TariffSynchronizer::CdsUpdateDownloader::ListDownloadFailedError => e
     TariffSynchronizer::Instrumentation.sync_run_failed(
       phase: 'download',
       error_class: e.class.name,
       error_message: e.message,
     )
-    attempt_reschedule!
+    raise unless attempt_reschedule!
   ensure
     Thread.current[:tariff_sync_run_id] = nil
   end
@@ -105,14 +108,17 @@ private
     end
   end
 
+  # True when another attempt has been scheduled, false when the retry budget is
+  # spent and the caller must surface the failure.
   def attempt_reschedule_download!(download_retry_count, check_for_todays_file, reapply_data_migrations)
-    delay = TariffSynchronizer.request_throttle.seconds
-
-    if download_retry_count < TariffSynchronizer.retry_count
-      self.class.perform_in(delay, check_for_todays_file, reapply_data_migrations, download_retry_count + 1)
-      TariffSynchronizer::Instrumentation.download_delayed(retry_at: delay.from_now.iso8601)
-    else
+    if download_retry_count >= TariffSynchronizer.retry_count
       TariffSynchronizer::Instrumentation.download_retry_exhausted(url: 'cds')
+      return false
     end
+
+    delay = TariffSynchronizer.request_throttle.seconds
+    self.class.perform_in(delay, check_for_todays_file, reapply_data_migrations, download_retry_count + 1)
+    TariffSynchronizer::Instrumentation.download_delayed(retry_at: delay.from_now.iso8601)
+    true
   end
 end

--- a/app/workers/cds_updates_synchronizer_worker.rb
+++ b/app/workers/cds_updates_synchronizer_worker.rb
@@ -22,7 +22,16 @@ class CdsUpdatesSynchronizerWorker
     end
 
     TariffSynchronizer::Instrumentation.apply_started(pending_count: TariffSynchronizer::BaseUpdate.pending.count)
-    unless CdsSynchronizer.apply # return if nothing changed
+    apply_result = CdsSynchronizer.apply
+
+    # Another process holds the sync lock, so nothing was applied here. Reporting
+    # a completed run would hide that from the sync log and the age metric.
+    if apply_result == TariffSynchronizer::LOCK_UNAVAILABLE
+      TariffSynchronizer::Instrumentation.sync_run_skipped(reason: 'lock_unavailable')
+      return
+    end
+
+    unless apply_result # return if nothing changed
       # A quiet day (nothing pending, nothing failed) must still generate the
       # daily reports - see TaricUpdatesSynchronizerWorker; without this the
       # event-driven ReportWorker never runs on zero-apply days. Skipped when

--- a/app/workers/taric_updates_synchronizer_worker.rb
+++ b/app/workers/taric_updates_synchronizer_worker.rb
@@ -17,7 +17,16 @@ class TaricUpdatesSynchronizerWorker
     TaricSynchronizer.download
 
     TariffSynchronizer::Instrumentation.apply_started(pending_count: TariffSynchronizer::BaseUpdate.pending.count)
-    unless TaricSynchronizer.apply # return if nothing changed
+    apply_result = TaricSynchronizer.apply
+
+    # Another process holds the sync lock, so nothing was applied here. Reporting
+    # a completed run would hide that from the sync log and the age metric.
+    if apply_result == TariffSynchronizer::LOCK_UNAVAILABLE
+      TariffSynchronizer::Instrumentation.sync_run_skipped(reason: 'lock_unavailable')
+      return
+    end
+
+    unless apply_result # return if nothing changed
       # A quiet day (nothing pending, nothing failed - e.g. no TARIC files at
       # weekends) must still generate the daily reports, or Monday's
       # differences report finds no XI CSVs. Skipped when updates are pending

--- a/spec/tariff_synchronizer/tariff_logger_spec.rb
+++ b/spec/tariff_synchronizer/tariff_logger_spec.rb
@@ -10,13 +10,15 @@ RSpec.describe TariffSynchronizer::TariffLogger, :truncation do
       allow(TradeTariffBackend).to receive(
         :with_redis_lock,
       ).and_raise(Redlock::LockError, 'foo')
-      allow(TariffSynchronizer::Instrumentation).to receive(:lock_failed)
+      allow(TariffSynchronizer::Instrumentation).to receive(:rollback_completed)
     end
 
-    it 'emits a lock_failed instrumentation event' do
-      TaricSynchronizer.rollback(Time.zone.today, keep: true)
+    it 'raises rather than reporting a rollback that never happened', :aggregate_failures do
+      expect {
+        TaricSynchronizer.rollback(Time.zone.today, keep: true)
+      }.to raise_error(Redlock::LockError)
 
-      expect(TariffSynchronizer::Instrumentation).to have_received(:lock_failed).with(phase: 'rollback')
+      expect(TariffSynchronizer::Instrumentation).not_to have_received(:rollback_completed)
     end
   end
 

--- a/spec/unit/cds_synchronizer_spec.rb
+++ b/spec/unit/cds_synchronizer_spec.rb
@@ -57,6 +57,21 @@ RSpec.describe CdsSynchronizer, :truncation do
 
         expect(TariffSynchronizer::BaseUpdate).not_to have_received(:failed)
       end
+
+      it 'returns the lock unavailable sentinel rather than a nil no-op' do
+        expect(described_class.apply).to eq(TariffSynchronizer::LOCK_UNAVAILABLE)
+      end
+    end
+
+    context 'when Redis cannot be reached to acquire the lock' do
+      before do
+        allow(TradeTariffBackend).to receive(:with_redis_lock)
+          .and_raise(Redlock::LockAcquisitionError.new('Too many Redis errors', []))
+      end
+
+      it 'lets the infrastructure failure surface' do
+        expect { described_class.apply }.to raise_error(Redlock::LockAcquisitionError)
+      end
     end
 
     context 'with failed CDS updates present' do
@@ -204,14 +219,17 @@ RSpec.describe CdsSynchronizer, :truncation do
     context 'when the Redis lock cannot be acquired' do
       before do
         allow(TradeTariffBackend).to receive(:with_redis_lock).and_raise(Redlock::LockError, 'tariff-lock')
-        allow(TariffSynchronizer::Instrumentation).to receive(:lock_failed)
         allow(TariffSynchronizer::Instrumentation).to receive(:rollback_completed)
       end
 
-      it 'leaves tariff data unchanged and emits lock-failure instrumentation', :aggregate_failures do
-        expect { described_class.rollback(rollback_date) }.not_to change(Measure, :count)
+      it 'raises rather than reporting a rollback that never happened' do
+        expect { described_class.rollback(rollback_date) }.to raise_error(Redlock::LockError)
+      end
 
-        expect(TariffSynchronizer::Instrumentation).to have_received(:lock_failed).with(phase: 'rollback')
+      it 'leaves tariff data unchanged', :aggregate_failures do
+        expect { described_class.rollback(rollback_date) }.to raise_error(Redlock::LockError)
+
+        expect(Measure.count).to eq(2)
         expect(TariffSynchronizer::Instrumentation).not_to have_received(:rollback_completed)
       end
     end

--- a/spec/unit/cds_synchronizer_spec.rb
+++ b/spec/unit/cds_synchronizer_spec.rb
@@ -99,6 +99,51 @@ RSpec.describe CdsSynchronizer, :truncation do
       end
     end
 
+    context 'when an update fails part way through the date range' do
+      let(:first_day) { Time.zone.today - 2 }
+      let(:second_day) { Time.zone.today - 1 }
+
+      before do
+        create(:cds_update, :pending, example_date: first_day)
+        create(:cds_update, :pending, example_date: second_day)
+
+        allow(TradeTariffBackend).to receive(:service).and_return('uk')
+        allow(TradeTariffBackend).to receive(:with_redis_lock).and_yield
+        allow(TariffSynchronizer::BaseUpdateImporter).to receive(:perform) do |update|
+          update.mark_as_failed if update.issue_date == first_day
+        end
+      end
+
+      it 'does not apply the following day on top of the hole' do
+        described_class.apply
+
+        expect(TariffSynchronizer::BaseUpdateImporter).to have_received(:perform).once
+      end
+
+      it 'leaves the following day pending' do
+        described_class.apply
+
+        expect(TariffSynchronizer::CdsUpdate.pending_at(second_day).count).to eq(1)
+      end
+
+      it 'emits an apply_aborted instrumentation event' do
+        allow(TariffSynchronizer::Instrumentation).to receive(:apply_aborted)
+
+        described_class.apply
+
+        expect(TariffSynchronizer::Instrumentation).to have_received(:apply_aborted)
+          .with(filenames: [TariffSynchronizer::CdsUpdate.failed.first.filename])
+      end
+
+      it 'does not report the apply as completed' do
+        allow(TariffSynchronizer::Instrumentation).to receive(:apply_completed)
+
+        described_class.apply
+
+        expect(TariffSynchronizer::Instrumentation).not_to have_received(:apply_completed)
+      end
+    end
+
     context 'with only TARIC failed updates present' do
       before do
         create(:taric_update, :failed, example_date: Time.zone.yesterday)

--- a/spec/workers/apply_worker_spec.rb
+++ b/spec/workers/apply_worker_spec.rb
@@ -63,6 +63,36 @@ RSpec.describe ApplyWorker, type: :worker do
       end
     end
 
+    context 'when the sync lock is held by another process' do
+      let(:service) { 'uk' }
+
+      before do
+        allow(CdsSynchronizer).to receive(:apply).and_return(TariffSynchronizer::LOCK_UNAVAILABLE)
+        allow(TariffSynchronizer::Instrumentation).to receive(:sync_run_completed)
+        allow(TariffSynchronizer::Instrumentation).to receive(:sync_run_skipped)
+
+        perform
+      end
+
+      it 'does not report a completed sync run' do
+        expect(TariffSynchronizer::Instrumentation).not_to have_received(:sync_run_completed)
+      end
+
+      it 'reports the run as skipped' do
+        expect(TariffSynchronizer::Instrumentation).to have_received(:sync_run_skipped)
+          .with(reason: 'lock_unavailable')
+      end
+
+      it 'does not refresh the materialized views' do
+        expect(MaterializeViewHelper).not_to have_received(:refresh_materialized_view)
+      end
+
+      it 'does not fire the tariff updates applied event' do
+        expect(ActiveSupport::Notifications).not_to have_received(:instrument)
+          .with(TradeTariffBackend::TariffUpdateEventListener::TARIFF_UPDATES_APPLIED, anything)
+      end
+    end
+
     context 'when an error is raised' do
       let(:service) { 'uk' }
 

--- a/spec/workers/cds_updates_synchronizer_worker_spec.rb
+++ b/spec/workers/cds_updates_synchronizer_worker_spec.rb
@@ -229,6 +229,25 @@ RSpec.describe CdsUpdatesSynchronizerWorker, type: :worker do
       it { expect(described_class.jobs).to have_attributes length: 1 }
     end
 
+    context 'when ListDownloadFailedError is raised after the cut off time' do
+      let(:cut_off_time) { 5.minutes.ago }
+
+      before do
+        allow(TariffSynchronizer::CdsUpdateDownloader).to receive(:download)
+                                                            .and_raise TariffSynchronizer::CdsUpdateDownloader::ListDownloadFailedError
+      end
+
+      it 'raises rather than ending the job normally' do
+        expect { perform }.to raise_error(TariffSynchronizer::CdsUpdateDownloader::ListDownloadFailedError)
+      end
+
+      it 'does not schedule another attempt', :aggregate_failures do
+        expect { perform }.to raise_error(TariffSynchronizer::CdsUpdateDownloader::ListDownloadFailedError)
+
+        expect(described_class.jobs).to be_empty
+      end
+    end
+
     context 'when a retriable download error is raised' do
       before do
         allow(CdsSynchronizer).to receive(:downloaded_todays_file?).and_return(true)
@@ -254,10 +273,22 @@ RSpec.describe CdsUpdatesSynchronizerWorker, type: :worker do
 
         before { allow(TariffSynchronizer).to receive(:retry_count).and_return(1) }
 
-        it 'does not reschedule the job' do
-          perform
+        it 'raises rather than ending the job normally' do
+          expect { perform }.to raise_error(TariffSynchronizer::TariffUpdatesRequester::RetriableDownloadError)
+        end
+
+        it 'does not reschedule the job', :aggregate_failures do
+          expect { perform }.to raise_error(TariffSynchronizer::TariffUpdatesRequester::RetriableDownloadError)
 
           expect(described_class.jobs).to be_empty
+        end
+
+        it 'still records that the retries are exhausted' do
+          allow(TariffSynchronizer::Instrumentation).to receive(:download_retry_exhausted)
+
+          expect { perform }.to raise_error(TariffSynchronizer::TariffUpdatesRequester::RetriableDownloadError)
+
+          expect(TariffSynchronizer::Instrumentation).to have_received(:download_retry_exhausted).with(url: 'cds')
         end
       end
     end

--- a/spec/workers/cds_updates_synchronizer_worker_spec.rb
+++ b/spec/workers/cds_updates_synchronizer_worker_spec.rb
@@ -191,6 +191,33 @@ RSpec.describe CdsUpdatesSynchronizerWorker, type: :worker do
       end
     end
 
+    context 'when the sync lock is held by another process' do
+      before do
+        allow(CdsSynchronizer).to receive_messages(downloaded_todays_file?: true, apply: TariffSynchronizer::LOCK_UNAVAILABLE)
+        allow(TariffSynchronizer::Instrumentation).to receive(:sync_run_completed)
+        allow(TariffSynchronizer::Instrumentation).to receive(:sync_run_skipped)
+
+        perform
+      end
+
+      it 'does not report a completed sync run' do
+        expect(TariffSynchronizer::Instrumentation).not_to have_received(:sync_run_completed)
+      end
+
+      it 'reports the run as skipped' do
+        expect(TariffSynchronizer::Instrumentation).to have_received(:sync_run_skipped)
+          .with(reason: 'lock_unavailable')
+      end
+
+      it 'does not refresh the materialized views' do
+        expect(GoodsNomenclatures::TreeNode).not_to have_received(:refresh!)
+      end
+
+      it 'does not schedule report generation' do
+        expect(ReportWorker).not_to have_received(:perform_in)
+      end
+    end
+
     context 'when ListDownloadFailedError is raised it creates a retry job' do
       before do
         allow(TariffSynchronizer::CdsUpdateDownloader).to receive(:download)

--- a/spec/workers/rollback_worker_spec.rb
+++ b/spec/workers/rollback_worker_spec.rb
@@ -29,6 +29,24 @@ RSpec.describe RollbackWorker, type: :worker do
       end
     end
 
+    context 'when the sync lock is held by another process' do
+      before do
+        allow(TradeTariffBackend).to receive(:service).and_return('uk')
+        allow(TradeTariffBackend).to receive(:with_redis_lock).and_raise(Redlock::LockError, 'tariff-lock')
+        allow(TariffSynchronizer::Instrumentation).to receive(:sync_run_completed)
+      end
+
+      it 'raises rather than reporting a rollback that never happened' do
+        expect { described_class.new.perform(date) }.to raise_error(Redlock::LockError)
+      end
+
+      it 'does not report a completed sync run', :aggregate_failures do
+        expect { described_class.new.perform(date) }.to raise_error(Redlock::LockError)
+
+        expect(TariffSynchronizer::Instrumentation).not_to have_received(:sync_run_completed)
+      end
+    end
+
     context 'for uk' do
       before do
         allow(TradeTariffBackend).to receive_messages(service: 'uk')

--- a/spec/workers/taric_updates_synchronizer_worker_spec.rb
+++ b/spec/workers/taric_updates_synchronizer_worker_spec.rb
@@ -38,6 +38,40 @@ RSpec.describe TaricUpdatesSynchronizerWorker, type: :worker do
     let(:changes_applied) { true }
     let(:pending_or_failed) { instance_double(Sequel::Dataset, none?: true) }
 
+    context 'when the sync lock is held by another process' do
+      let(:service) { 'xi' }
+
+      before do
+        allow(TaricSynchronizer).to receive(:apply).and_return(TariffSynchronizer::LOCK_UNAVAILABLE)
+        allow(TariffSynchronizer::Instrumentation).to receive(:sync_run_completed)
+        allow(TariffSynchronizer::Instrumentation).to receive(:sync_run_skipped)
+
+        perform
+      end
+
+      it 'does not report a completed sync run' do
+        expect(TariffSynchronizer::Instrumentation).not_to have_received(:sync_run_completed)
+      end
+
+      it 'reports the run as skipped' do
+        expect(TariffSynchronizer::Instrumentation).to have_received(:sync_run_skipped)
+          .with(reason: 'lock_unavailable')
+      end
+
+      it 'does not refresh the materialized views' do
+        expect(GoodsNomenclatures::TreeNode).not_to have_received(:refresh!)
+      end
+
+      it 'does not fire the tariff updates applied event' do
+        expect(ActiveSupport::Notifications).not_to have_received(:instrument)
+          .with(TradeTariffBackend::TariffUpdateEventListener::TARIFF_UPDATES_APPLIED, anything)
+      end
+
+      it 'does not schedule report generation' do
+        expect(ReportWorker).not_to have_received(:perform_in)
+      end
+    end
+
     context 'when on the xi service' do
       before { perform }
 


### PR DESCRIPTION
## What:
Fixes three silent failures in the tariff synchronisation subsystem. In each one the sync reported a completed run when the work did not happen.

**1. A failed apply no longer lets later days apply on top of the hole**

`BaseUpdateImporter#apply` rescues `StandardError`, marks the update failed and returns normally. `apply_updates` then walked the rest of the date range with no break and no failure flag, so a failure on one day did not stop the following days. `check_sequence` runs once at the start of the run, so it cannot see a gap that opens mid-run.

Why it matters: the oplog is a sequence. Later days' UPDATE and DELETE rows expect the skipped day's inserts to be present. Applying them anyway leaves measures, duties and footnotes in a state that neither the skipped day nor the applied days describe, and that data is served to traders and baked into the materialized views. The only backstop was `check_tariff_updates_failures` on the next cycle, a full day later.

How: the day loop now inspects the updates it just imported, and breaks on the first one left in the failed state, emitting a new `apply_aborted` event. Because a failed update stays in `pending_or_failed`, `apply_completed` and the truthy return were already suppressed, so the run no longer claims success either. The loop moved into `TariffSynchronizer::Apply`, mirroring the existing `Rollback` mixin.

**2. Losing the Redis lock no longer reports a completed sync or a completed rollback**

`apply_updates` and `rollback_updates` both rescued `Redlock::LockError` and returned `Instrumentation.lock_failed`, which is `nil` because it instruments with no block. Callers could not tell that apart from "nothing to apply", so `ApplyWorker`, `RollbackWorker` and `CdsUpdatesSynchronizerWorker` all went on to emit `sync_run_completed`.

The worst case was rollback: an operator rolls back to unstick bad data, `RollbackWorker` reports success, nothing was rolled back, and the pending updates then apply over un-rolled-back rows.

How, and the reasoning behind the choice: redlock 2.1.0 does distinguish the two causes, and the fix leans on that.

- Plain `Redlock::LockError` means the lock was held by someone else. That is a legitimate concurrent run, not a failure, and raising would page a human for normal operation. `apply_updates` now returns an explicit sentinel, `TariffSynchronizer::LOCK_UNAVAILABLE`, and the workers branch on it: they emit a new `sync_run_skipped` event instead of `sync_run_completed`, and skip the materialized view refresh and the updates-applied event.
- `Redlock::LockAcquisitionError`, a `LockError` subclass raised when a quorum of Redis servers errored, is infrastructure failure rather than a concurrent run. It is re-raised.
- Rollback raises in both cases. A rollback is operator-initiated and one shot: there is no next cycle to pick it up, so a silent no-op is the worst possible outcome and losing the lock is always worth surfacing there.

Redlock autoloads `Redlock::Client`, and `LockAcquisitionError` is defined inside it, so `redlock/client` is now required explicitly. Without it the rescue clause raises `NameError` whenever the lock is stubbed or never taken.

**3. The CDS download giving up permanently is no longer a Sidekiq success**

Two terminal paths in `CdsUpdatesSynchronizerWorker` ended the job normally. `RetriableDownloadError` reached `attempt_reschedule_download!`, which once the retry budget was spent just instrumented `download_retry_exhausted` and returned. `ListDownloadFailedError`, which is any non-200 from the HMRC list API, was rescued, instrumented, then handed to `attempt_reschedule!`, whose `false` return after the cut-off time was never checked. Both resolve to a single log line via `SyncLogger`, so Sidekiq recorded a success and UK tariff data sat frozen at yesterday's state. The only backstop was `SynchronizerCheckWorker`'s age metric, a latency alarm rather than a failure alarm.

How: `attempt_reschedule_download!` now returns an explicit boolean rather than whatever the instrumentation call happened to return, and both rescue clauses re-raise when no further attempt was scheduled.

## Why:
All three share one shape: a failure path that instruments and returns, so the caller sees a normal return and reports success. The result is inconsistent or stale tariff data served to traders with no failure alarm anywhere.

**The TARIC versus CDS asymmetry is the evidence.** `TaricUpdatesSynchronizerWorker` rescues `StandardError`, instruments `sync_run_failed`, and then raises. `CdsUpdatesSynchronizerWorker` rescues `ListDownloadFailedError` specifically and swallows it. The same class of upstream download failure surfaces on the XI pipeline and is silent on the UK one. That is not a deliberate difference in policy between the two feeds, it is an omission.

One qualification, since the asymmetry does not cover everything: the exhausted-retry path for `RetriableDownloadError` is swallowed in the TARIC worker too. It is still a silent permanent give-up, and it is fixed here on the CDS side only, to keep this PR to the pipeline it is about. The TARIC equivalent is worth a follow-up.

`retry: false` does not suppress alerting. Verified against sidekiq 8.1.7 `lib/sidekiq/job_retry.rb`: the local handler hits `raise e unless msg["retry"]`, which propagates to the global handler, whose else branch runs `@config[:death_handlers]`. `SidekiqDeathHandler` is registered in `config/initializers/sidekiq.rb` and posts to Slack unless the job sets `slack_alerts: false`. None of `ApplyWorker`, `RollbackWorker`, `CdsUpdatesSynchronizerWorker` or `TaricUpdatesSynchronizerWorker` sets that flag, so these raises do alert. New Relic APM runs in the Sidekiq workers, so they are collected there too.

**Behaviour an operator will notice:**

- A concurrent run now surfaces differently. Where a second `ApplyWorker` or `CdsUpdatesSynchronizerWorker` overlapping a first previously logged `lock_failed` and then `sync_run_completed`, it now logs `lock_failed` and `sync_run_skipped` and no completion. Any dashboard or alert counting `sync_run_completed` as "the sync ran today" will see a gap on days where the lock was contended. That gap is honest, but it is new.
- Redis being unreachable now fails the job loudly instead of logging one warn line. Expect a Slack death-handler post and a New Relic error rather than silence.
- A rollback that cannot take the lock now raises. `RollbackWorker` fails visibly instead of reporting success. Operators re-running a rollback will see the failure rather than having to check whether anything moved.
- A CDS apply that hits a failed day stops at that day instead of running the range. Fewer files are applied in that run, and `apply_aborted` names the file. The remaining days stay pending, which is what `check_tariff_updates_failures` will then act on next cycle.
- A permanently failed CDS download now marks the Sidekiq job dead and alerts, instead of completing quietly.
- `TaricUpdatesSynchronizerWorker` had to change too, though it is outside the three bugs. It tested `TaricSynchronizer.apply` for truthiness, and the new sentinel is a symbol and therefore truthy, so on the XI service a lost lock would have been read as "updates applied". It now branches on the sentinel like the other two workers.

## Ticket:
N/A

## Risk:
**Risk level:** 🔴

**Reason for rating:**
This changes the synchronisation mechanism from the CDS and HMRC upstream data feeds, which the template lists as red outright. It also changes failure signalling in a way that will make previously silent conditions page, so the first contended or failed run after deploy will be noisier than the team is used to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
