### PR TITLE
fix: match chapter headings case insensitively in the notes extractor

### DIFF
--- a/app/lib/customs_tariff_importer/notes_extractor.rb
+++ b/app/lib/customs_tariff_importer/notes_extractor.rb
@@ -5,7 +5,7 @@ module CustomsTariffImporter
     WORD_NS = { 'w' => 'http://schemas.openxmlformats.org/wordprocessingml/2006/main' }.freeze
 
     SECTION_PATTERN          = /\ASECTION\s+([IVX]+)\z/i
-    CHAPTER_PATTERN          = /\ACHAPTER\s+(\d+)\z/
+    CHAPTER_PATTERN          = /\ACHAPTER\s+(\d+)\z/i
     CHAPTER_NOTES_PATTERN    = /\AChapter\s+[Nn]otes?\z/i
     ADDITIONAL_NOTES_PATTERN = /\AAdditional\s+[Cc]hapter\s+[Nn]otes?\z/i
     ADDITIONAL_SECTION_NOTES_PATTERN = /\AAdditional\s+[Ss]ection\s+[Nn]otes?\z/i

--- a/spec/lib/customs_tariff_importer/notes_extractor_spec.rb
+++ b/spec/lib/customs_tariff_importer/notes_extractor_spec.rb
@@ -836,6 +836,96 @@ RSpec.describe CustomsTariffImporter::NotesExtractor do
       end
     end
 
+    describe 'chapter heading capitalisation' do
+      it 'recognises a title case chapter heading' do
+        result = parse(['Chapter 1', 'Chapter Notes', 'Live animal content.'])
+
+        expect(result.chapters['01']).to include('Live animal content.')
+      end
+
+      it 'recognises a lower case chapter heading' do
+        result = parse(['chapter 2', 'Chapter Notes', 'Meat content.'])
+
+        expect(result.chapters['02']).to include('Meat content.')
+      end
+
+      it 'still recognises an upper case chapter heading' do
+        result = parse(['CHAPTER 3', 'Chapter Notes', 'Fish content.'])
+
+        expect(result.chapters['03']).to include('Fish content.')
+      end
+
+      it 'treats a title case chapter heading as a boundary between chapters' do
+        result = parse([
+          'Chapter 1',
+          'Chapter Notes',
+          'Live animal content.',
+          'Chapter 2',
+          'Chapter Notes',
+          'Meat content.',
+        ])
+
+        expect(result.chapters).to eq('01' => 'Live animal content.', '02' => 'Meat content.')
+      end
+
+      it 'recognises a title case chapter heading after a section heading' do
+        result = parse(['SECTION I', 'Chapter 1', 'Chapter Notes', 'Live animal content.'])
+
+        expect(result.chapters['01']).to include('Live animal content.')
+      end
+
+      # The pattern is anchored at both ends, so only a paragraph that is exactly
+      # "Chapter <digits>" is a heading. These are the note lines that mention a
+      # chapter and must keep flowing into the note body.
+      it 'does not treat a title case inline chapter reference as a boundary' do
+        result = parse([
+          'CHAPTER 72',
+          'Chapter Notes',
+          '1. Some definition.',
+          'Chapter 72 does not include products of heading 7301.',
+          'More note text.',
+        ])
+
+        expect(result.chapters['72']).to include('More note text.')
+      end
+
+      it 'does not treat a trailing cross reference as a boundary' do
+        result = parse([
+          'CHAPTER 72',
+          'Chapter Notes',
+          '1. Some definition.',
+          'See Chapter 73',
+          'More note text.',
+        ])
+
+        expect(result.chapters['72']).to include('See Chapter 73', 'More note text.')
+      end
+
+      it 'does not treat a chapter reference ending in punctuation as a boundary' do
+        result = parse([
+          'CHAPTER 72',
+          'Chapter Notes',
+          '1. Some definition.',
+          'Chapter 73.',
+          'More note text.',
+        ])
+
+        expect(result.chapters['72']).to include('Chapter 73.', 'More note text.')
+      end
+
+      it 'does not treat a "Chapter notes" heading as a chapter heading' do
+        result = parse(['CHAPTER 4', 'Chapter notes', 'Dairy content.'])
+
+        expect(result.chapters['04']).to eq('Dairy content.')
+      end
+
+      it 'does not treat a subheading notes heading as a chapter heading' do
+        result = parse(['CHAPTER 5', 'Subheading Notes', 'Subheading content.'])
+
+        expect(result.chapters['05']).to include('Subheading content.')
+      end
+    end
+
     describe 'chapter notes without a "Chapter Notes" heading' do
       it 'starts collecting from "Additional chapter notes" when it is the first heading' do
         result = parse([


### PR DESCRIPTION
## What:
Adds the `/i` flag to `CHAPTER_PATTERN` in `CustomsTariffImporter::NotesExtractor`, so `Chapter 1` and `chapter 1` are recognised as chapter headings alongside `CHAPTER 1`. Adds ten specs covering the capitalisation variants and, more importantly, the near misses that must keep being treated as note text.

**This changes matching behaviour.** It is not a refactor. Text that previously flowed into a note body can now be read as a chapter heading. See Risk below for what bounds that.

## Why:
`CHAPTER_PATTERN` is the only one of the twelve patterns in the file that matches a case-varying keyword and lacks `/i`. Every sibling keyword pattern has it, `SECTION_PATTERN` included, so `Section I` is already accepted as a heading today while `Chapter 1` is not. The two other patterns without `/i`, `COMMODITY_CODE_PATTERN` and `NUMBERED_NOTE_PATTERN`, match digits and punctuation rather than a keyword, so the flag would be a no-op for them. This one looks like an oversight rather than a decision.

The failure mode is silent. If a source document writes `Chapter 1`, nothing matches, the state machine never leaves `:scanning`, and `#call` returns three empty hashes without raising. The notes for that version are lost. Draft #3726 adds a guard so an empty extract now fails the import loudly instead of marking the version done forever. That is the right guard to have, but it catches the symptom: the version still imports nothing. This addresses the cause, so the document parses in the first place.

No overlap with #3726, which touches `customs_tariff_importer/importer.rb`, `xi_cn_importer/importer.rb` and their specs. The two are complementary and can land in either order.

## Ticket:
N/A

## Risk:
**Risk level:** 🟠

**Reason for rating:**
Amber because it changes what the notes extractor treats as a chapter boundary, and chapter notes are trader-facing content. It is not a wide change, and here is what bounds it.

The pattern is anchored at both ends (`\A...\z`), so the only strings that newly match are a paragraph whose entire text is `Chapter` or `chapter` followed by whitespace and digits. Nothing with a preceding word, a following word, or trailing punctuation can match. Concretely, these all still flow into the note body, and each now has a spec:

- `Chapter 72 does not include products of heading 7301.` (inline reference in a sentence)
- `See Chapter 73` (trailing cross reference)
- `Chapter 73.` (reference ending in a full stop)
- `Chapter notes` and `Subheading Notes` (no digits, and both are matched by earlier branches in `handle_in_chapter` regardless)

The residual exposure is a paragraph that is exactly `Chapter 5` and is not a heading, for example a bare contents-list entry. That would now open a chapter. This is the same exposure `SECTION_PATTERN` already carries for a bare `Section II` line, so the change does not introduce a new class of risk, it makes chapters consistent with sections.

All 81 examples in `notes_extractor_spec.rb` pass, including the pre-existing `boundary pattern anchoring` group written to catch exactly this kind of over-matching. The full `spec/lib/customs_tariff_importer/` directory is green at 155 examples. `bundle exec rubocop` on both changed files reports no offences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
