### PR TITLE
fix: stop silently dropping acknowledged notifications and enquiries

### DIFF
--- a/app/services/appendix_5a_populator_service.rb
+++ b/app/services/appendix_5a_populator_service.rb
@@ -102,9 +102,13 @@ private
   end
 
   def enqueue_notifications(pending, new_count, changed_count, removed_count)
-    Notifications::EnqueueService.new(pending, pipeline: 'appendix5a') { |recipient_index|
+    result = Notifications::EnqueueService.new(pending, pipeline: 'appendix5a') { |recipient_index|
       send_to_recipient(recipient_index, new_count, changed_count, removed_count)
     }.call
+
+    return if result.failed_items.empty?
+
+    raise Notifications::EnqueueService::EnqueueFailedError, result.failure_message
   end
 
   def send_to_recipient(recipient_index, new_count, changed_count, removed_count)

--- a/app/services/customs_tariff_update_notifier_service.rb
+++ b/app/services/customs_tariff_update_notifier_service.rb
@@ -27,10 +27,14 @@ class CustomsTariffUpdateNotifierService
     changes = CustomsTariffUpdateChangeSummary.new(update).call
     personalisation = build_personalisation(update, changes)
 
-    Notifications::EnqueueService.new([@version], pipeline: PIPELINE) { |version|
+    result = Notifications::EnqueueService.new([@version], pipeline: PIPELINE) { |version|
       status_check_args = [version]
       Notifications::EmailWorker.perform_async(email, TEMPLATE_ID, personalisation, 'CustomsTariffUpdateNotificationStatusCheckWorker', status_check_args)
     }.call
+
+    return if result.failed_items.empty?
+
+    raise Notifications::EnqueueService::EnqueueFailedError, result.failure_message
   end
 
 private

--- a/app/services/notifications/enqueue_service.rb
+++ b/app/services/notifications/enqueue_service.rb
@@ -3,10 +3,19 @@ require_relative '../../lib/notifications/logger'
 
 module Notifications
   class EnqueueService
+    # Raised by callers when every attempt to enqueue was exhausted. The
+    # service itself still returns a Result: it is the caller that knows
+    # whether an unenqueued notification should fail the surrounding job.
+    class EnqueueFailedError < StandardError; end
+
     MAX_ATTEMPTS = 3
     RETRY_DELAY = 30.seconds
 
-    Result = Data.define(:failed_items, :attempts)
+    Result = Data.define(:failed_items, :attempts, :pipeline) do
+      def failure_message
+        "#{pipeline}: failed to enqueue notification for #{failed_items.join(', ')} after #{attempts} attempts"
+      end
+    end
 
     def initialize(items, pipeline:, max_attempts: MAX_ATTEMPTS, retry_delay: RETRY_DELAY, &enqueue)
       @items = items
@@ -26,12 +35,14 @@ module Notifications
         sleep(@retry_delay) if pending.any? && attempt < @max_attempts
       end
 
+      result = Result.new(failed_items: pending, attempts: attempt, pipeline: @pipeline)
+
       if pending.any?
         Instrumentation.enqueue_failed(pipeline: @pipeline, items: pending, attempts: attempt)
-        notify_slack("#{@pipeline}: failed to enqueue notification for #{pending.join(', ')} after #{attempt} attempts — check logs")
+        notify_slack("#{result.failure_message} — check logs")
       end
 
-      Result.new(failed_items: pending, attempts: attempt)
+      result
     end
 
   private

--- a/app/services/slack_notifier_service.rb
+++ b/app/services/slack_notifier_service.rb
@@ -1,7 +1,16 @@
 class SlackNotifierService
   class << self
     def call(message)
-      notifier.presence&.ping(message)
+      if notifier.blank?
+        # The notifier is only built in production with a webhook configured,
+        # so an absent one used to make this a silent no-op. Callers treat a
+        # Slack ping as their alerting channel, so say when one is dropped.
+        Rails.logger.error('slack_notifier_unconfigured: dropped a Slack message because no notifier is configured')
+
+        return nil
+      end
+
+      notifier.ping(message)
     end
 
   private

--- a/app/workers/enquiry_form/send_submission_email_worker.rb
+++ b/app/workers/enquiry_form/send_submission_email_worker.rb
@@ -1,6 +1,13 @@
 require 'notifications/client'
 
 class EnquiryForm::SendSubmissionEmailWorker
+  # The submission body lives only in Redis under a 1 hour TTL, and the API has
+  # already returned 201 with a reference number to a member of the public. A
+  # miss means we cannot deliver that enquiry, so raise: Sidekiq retries, and a
+  # final failure reaches the death handler and New Relic instead of being
+  # recorded as a success.
+  class MissingSubmissionDataError < StandardError; end
+
   CACHE_KEY_PREFIX = 'enquiry_form'.freeze
   TEMPLATE_ID = NOTIFY_CONFIGURATION.dig(:templates, :enquiry_form, :submission)
 
@@ -23,10 +30,11 @@ private
     form_data = enquiry_form_data(reference)
 
     if form_data.blank?
-      Rails.logger.error(
-        "#{self.class.name}: No data found in cache for reference #{reference} audience=#{audience}",
-      )
-      return
+      message = "#{self.class.name}: No data found in cache for reference #{reference} audience=#{audience}"
+
+      Rails.logger.error(message)
+
+      raise MissingSubmissionDataError, message
     end
 
     delivery = EnquiryForm::Submission.from_cache(form_data).delivery_for(audience)

--- a/app/workers/notifications_worker.rb
+++ b/app/workers/notifications_worker.rb
@@ -1,4 +1,10 @@
 class NotificationsWorker
+  # The notification body lives only in Redis under a 1 hour TTL, and the API
+  # has already answered 202 Accepted to a third party. A miss means we cannot
+  # send that notification, so raise rather than complete: Sidekiq retries, and
+  # a final failure reaches the death handler and New Relic.
+  class MissingNotificationDataError < StandardError; end
+
   include Sidekiq::Worker
 
   # Cap retries: Notify outages must not use Sidekiq's default (25).
@@ -8,20 +14,24 @@ class NotificationsWorker
     notification_data = notification_data(notification_id)
 
     if notification_data.nil?
-      Rails.logger.error("Notification data not found for ID: #{notification_id}")
-    else
-      notifier = GovukNotifier.new
+      message = "Notification data not found for ID: #{notification_id}"
 
-      notifier.send_email(
-        notification_data['email'],
-        notification_data['template_id'],
-        notification_data['personalisation'] || {},
-        notification_data['email_reply_to_id'],
-        notification_data['reference'],
-      )
+      Rails.logger.error(message)
 
-      TradeTariffBackend.redis.del("notification_#{notification_id}")
+      raise MissingNotificationDataError, message
     end
+
+    notifier = GovukNotifier.new
+
+    notifier.send_email(
+      notification_data['email'],
+      notification_data['template_id'],
+      notification_data['personalisation'] || {},
+      notification_data['email_reply_to_id'],
+      notification_data['reference'],
+    )
+
+    TradeTariffBackend.redis.del("notification_#{notification_id}")
   rescue StandardError => e
     Rails.logger.error("Failed to process notification with ID: #{notification_id}: #{e.message}\n#{e.backtrace.join("\n")}")
     raise

--- a/spec/services/appendix5a_populator_service_spec.rb
+++ b/spec/services/appendix5a_populator_service_spec.rb
@@ -173,6 +173,30 @@ RSpec.describe Appendix5aPopulatorService do
       end
     end
 
+    context 'when enqueueing exhausts every attempt' do
+      let(:new_guidance) do
+        {
+          '1123' => {
+            'guidance_cds' => 'bar',
+          },
+        }
+      end
+
+      before do
+        allow(Notifications::EmailWorker).to receive(:perform_async).and_raise('redis down')
+        allow(Notifications::EnqueueService).to receive(:new).and_wrap_original do |original, items, **options, &block|
+          original.call(items, **options, retry_delay: 0, &block)
+        end
+      end
+
+      it 'raises so the worker fails instead of completing with nobody enqueued' do
+        expect { call }.to raise_error(
+          Notifications::EnqueueService::EnqueueFailedError,
+          'appendix5a: failed to enqueue notification for 0, 1 after 3 attempts',
+        )
+      end
+    end
+
     context 'when a recipient index no longer resolves to a configured email' do
       let(:cupid_emails) { ['cupid@example.com', ''] }
       let(:new_guidance) do

--- a/spec/services/customs_tariff_update_notifier_service_spec.rb
+++ b/spec/services/customs_tariff_update_notifier_service_spec.rb
@@ -44,6 +44,23 @@ RSpec.describe CustomsTariffUpdateNotifierService do
       end
     end
 
+    context 'when enqueueing exhausts every attempt' do
+      before do
+        allow(TradeTariffBackend).to receive(:support_email).and_return('support@example.com')
+        allow(Notifications::EmailWorker).to receive(:perform_async).and_raise('redis down')
+        allow(Notifications::EnqueueService).to receive(:new).and_wrap_original do |original, items, **options, &block|
+          original.call(items, **options, retry_delay: 0, &block)
+        end
+      end
+
+      it 'raises so the importer records the notification failure instead of completing silently' do
+        expect { service.call }.to raise_error(
+          Notifications::EnqueueService::EnqueueFailedError,
+          "customs_tariff_update: failed to enqueue notification for #{update.version} after 3 attempts",
+        )
+      end
+    end
+
     context 'when a recipient is configured' do
       before { allow(TradeTariffBackend).to receive(:support_email).and_return('recipient@example.com') }
 

--- a/spec/services/slack_notifier_service_spec.rb
+++ b/spec/services/slack_notifier_service_spec.rb
@@ -6,4 +6,23 @@ RSpec.describe SlackNotifierService do
   end
 
   it { expect(described_class.call('Hello Slack')).to eq('pong') }
+
+  context 'when no notifier is configured' do
+    before do
+      allow(Rails.application.config).to receive(:slack_notifier).and_return(nil)
+      allow(Rails.logger).to receive(:error)
+    end
+
+    it 'logs that the message was dropped instead of silently doing nothing' do
+      described_class.call('Hello Slack')
+
+      expect(Rails.logger).to have_received(:error).with(
+        'slack_notifier_unconfigured: dropped a Slack message because no notifier is configured',
+      )
+    end
+
+    it 'still returns nil rather than raising' do
+      expect(described_class.call('Hello Slack')).to be_nil
+    end
+  end
 end

--- a/spec/workers/enquiry_form/send_submission_email_worker_spec.rb
+++ b/spec/workers/enquiry_form/send_submission_email_worker_spec.rb
@@ -324,13 +324,21 @@ RSpec.describe EnquiryForm::SendSubmissionEmailWorker, type: :worker do
         allow(Rails.logger).to receive(:error).and_call_original
       end
 
+      it 'raises so Sidekiq retries rather than recording a success' do
+        expect { worker.perform(reference) }.to raise_error(
+          described_class::MissingSubmissionDataError,
+          "EnquiryForm::SendSubmissionEmailWorker: No data found in cache for reference #{reference} audience=hmrc",
+        )
+
+        expect(notifier_client).not_to have_received(:send_email)
+      end
+
       it 'triggers an error message' do
-        worker.perform(reference)
+        expect { worker.perform(reference) }.to raise_error(described_class::MissingSubmissionDataError)
 
         expect(Rails.logger).to have_received(:error).with(
           "EnquiryForm::SendSubmissionEmailWorker: No data found in cache for reference #{reference} audience=hmrc",
         )
-        expect(notifier_client).not_to have_received(:send_email)
       end
     end
   end

--- a/spec/workers/enquiry_form/send_trade_tariff_submission_email_worker_spec.rb
+++ b/spec/workers/enquiry_form/send_trade_tariff_submission_email_worker_spec.rb
@@ -60,7 +60,11 @@ RSpec.describe EnquiryForm::SendTradeTariffSubmissionEmailWorker, type: :worker 
     Sidekiq.redis { |conn| conn.del(EnquiryForm::SendSubmissionEmailWorker.cache_key(reference)) }
     allow(Rails.logger).to receive(:error).and_call_original
 
-    worker.perform(reference)
+    expect { worker.perform(reference) }.to raise_error(
+      EnquiryForm::SendSubmissionEmailWorker::MissingSubmissionDataError,
+      'EnquiryForm::SendTradeTariffSubmissionEmailWorker: No data found in cache ' \
+      "for reference #{reference} audience=trade_tariff",
+    )
 
     expect(Rails.logger).to have_received(:error).with(
       'EnquiryForm::SendTradeTariffSubmissionEmailWorker: No data found in cache ' \

--- a/spec/workers/notifications_worker_spec.rb
+++ b/spec/workers/notifications_worker_spec.rb
@@ -53,10 +53,18 @@ RSpec.describe NotificationsWorker, type: :worker do
 
       before do
         allow(Rails.logger).to receive(:error)
-        worker.perform(notification_id)
+      end
+
+      it 'raises so Sidekiq retries rather than recording a success' do
+        expect { worker.perform(notification_id) }.to raise_error(
+          NotificationsWorker::MissingNotificationDataError,
+          "Notification data not found for ID: #{notification_id}",
+        )
       end
 
       it 'logs an error message' do
+        expect { worker.perform(notification_id) }.to raise_error(NotificationsWorker::MissingNotificationDataError)
+
         expect(Rails.logger).to have_received(:error).with("Notification data not found for ID: #{notification_id}")
       end
     end


### PR DESCRIPTION
## What:

This PR corrects three silent failures. Each failure has the same shape. The job does not do the work that we promised to a caller. The job then reports success. Each failure has its own commit and its own red/green test.

**1. The worker loses enquiry form submissions when the Redis cache does not have the data** (`EnquiryForm::SendSubmissionEmailWorker`)

`Api::V2::EnquiryForm::SubmissionsController` writes the body of the submission to Redis. Redis keeps the body for one hour only. When the body is not in Redis, the worker wrote a log entry and stopped. Sidekiq then recorded a success. The worker now writes the same log entry, but it also raises `MissingSubmissionDataError`.

**2. The worker loses third-party notifications in the same conditions** (`NotificationsWorker`)

When `notification_data` was nil, the worker wrote a log entry and continued to a usual end. The nil branch now writes the log entry and raises `MissingNotificationDataError`. The outer `rescue ... raise` was already correct, thus this PR does not change it. The `else` branch becomes a guard clause, because the nil path does not continue.

**3. Two callers get `failed_items` and then discard it** (`Notifications::EnqueueService`)

After `MAX_ATTEMPTS`, the service instruments `enqueue_failed`, sends a message to Slack, and returns a `Result`. `Appendix5aPopulatorService` and `CustomsTariffUpdateNotifierService` ignored this `Result`. Thus `RefreshAppendix5aGuidanceWorker` and the customs tariff import completed in the usual way, but the system put no notification in a queue. The two callers now raise `Notifications::EnqueueService::EnqueueFailedError` when `result.failed_items` is not empty.

The check is at the call site, and not in the service. Only the caller knows if a notification that stays out of the queue must fail the related job. `Result` now also carries the name of the pipeline and a `failure_message`. Thus the caller and the Slack alert use the same words, and we do not write the words two times.

This PR also changes `SlackNotifierService`. When the system asks the service to send a message, but no notifier is configured, the service now writes a log entry at error level. Before this change, the service used `notifier.presence&.ping(message)`. `config/initializers/slack_notifier.rb` makes a notifier in production only, and only when a webhook is set. Thus a lost alert was also silent. The other behaviour does not change. The service still returns and does not raise. This PR does not change the spec that holds `EnqueueService` to rescue a Slack failure.

## Why:

Bugs 1 and 2 are about requests that **we already acknowledged to an external caller**. The enquiry form API returned 201 and a reference number to a member of the public. The notifications API returned 202 Accepted to a third party. After we say yes, a request that we cannot complete is a failure. The only honest result is a result that persons can see. When the worker wrote a log entry and stopped, the system counted the job as completed work. Nothing went to Sidekiq, to the death handler, or to New Relic.

The risk is real, and not only theoretical. The system puts `SendTradeTariffSubmissionEmailWorker` in a queue with `perform_in(5.minutes)`, but Redis keeps the data for one hour. This margin is small if the default queue becomes full. Also, a Redis eviction or failover removes the key immediately.

Bug 3 has the same shape, but one layer higher. The only signals were a log entry and a Slack message. Slack is weaker than it looks, for the reason above. Thus a run that notified nobody looked the same as a successful run.

A raise is a true signal here. I checked these facts, and did not assume them:

- In sidekiq 8.1.7, `lib/sidekiq/job_retry.rb` has `raise e unless msg["retry"]` in `local`. The error goes to `global`. The else branch of `global` runs `@config[:death_handlers]`. Thus `retry: false` does **not** stop the alert.
- `config/initializers/sidekiq.rb` registers `SidekiqDeathHandler`. This handler sends a message to Slack, unless the job sets `slack_alerts: false`.
- New Relic APM runs in the Sidekiq workers in production. Thus New Relic collects an error that a worker raises.

This PR does not change the retry counts. The two workers that read the cache already have a `retry` limit of 3. This limit is correct, because Redis keeps the data for one hour only. The default Sidekiq limit of 25 attempts continues for many hours. Those attempts continue after the key expires, thus they cannot be successful. A quick failure is more honest. Three attempts occur in the one-hour period, thus each retry can be successful.

Please look at this point in the review. For the customs tariff path, `ImportCustomsTariffDocumentWorker` and `ImportXiCnDocumentWorker` put the call to `CustomsTariffUpdateNotifierService` in a `rescue StandardError` for each result. That rescue writes a `customs_tariff_update_notifier_failed` log entry, sends a message to Slack, and continues. Thus those workers catch the new raise, and the import job is still successful. The gain is a different error log that you can find with grep, and a New Relic notice. The gain is not a failed job. A different result needs changes to those importer workers, and those changes are out of the scope of this PR.

## Ticket:

N/A

## Risk:

**Risk level:** 🟠

**Reason for rating:**
This PR changes behaviour on live notification paths. Jobs that completed before, when the cache had no data or the enqueue failed, now fail and retry. Thus expect new Sidekiq retries, new Slack alerts from the death handler, and new New Relic errors. This is the purpose of the change, but it is a change that persons can see in production. Also, `SlackNotifierService` now writes an error log entry each time it sends a message with no configured notifier. There are no changes to data, to the schema, or to the API contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
