### PR TITLE
fix: make CDS updates spreadsheet failures visible

### DIFF
--- a/app/lib/cds_importer/excel_writer.rb
+++ b/app/lib/cds_importer/excel_writer.rb
@@ -2,6 +2,13 @@ class CdsImporter
   class ExcelWriter
     SKIPPED_OPERATION = :skipped
 
+    # Fired whenever the spreadsheet could not be built or could not be sent.
+    # CdsUpdateNotificationWorker subscribes to this and fails its job, because there the
+    # spreadsheet is the job's only output. The daily sync, which runs this writer alongside
+    # the record inserter, deliberately does not: a broken report must not fail a data import
+    # that otherwise succeeded.
+    FAILURE_EVENT = 'cds_updates_excel_failed.cds_importer'.freeze
+
     delegate :instrument, to: ActiveSupport::Notifications
 
     def initialize(filename)
@@ -10,7 +17,8 @@ class CdsImporter
       @key = ''
       @instances = []
       @data = {}
-      @failed = false
+      @failures = []
+      @skipped_row_counts = Hash.new(0)
       initiate_excel_file
     end
 
@@ -19,9 +27,7 @@ class CdsImporter
         begin
           write_data(@key, @instances)
         rescue StandardError => e
-          Rails.logger.error "CDS Updates excel: write error #{@key} in #{@filename} - #{e.message}"
-          notify_slack_app(e, @filename)
-          @failed = true
+          report_failure("write error for #{@key} in #{@filename}", exception: e)
         end
         @instances = []
       end
@@ -37,24 +43,67 @@ class CdsImporter
 
       workbook.close
 
-      if TradeTariffBackend.cds_updates_send_email && !@failed
-        TariffSynchronizer::Mailer.cds_updates(xml_to_file_date, workbook.read_string, excel_filename).deliver_now
-      end
+      log_skipped_rows
+      deliver_report
     rescue StandardError => e
-      Rails.logger.error "CDS Updates excel: save file error for #{@filename} - #{e.message}"
-      notify_slack_app(e, @filename)
+      report_failure("save file error for #{@filename}", exception: e)
     end
 
   private
 
     attr_reader :workbook, :filename, :package, :bold_style, :regular_style
 
+    def failed?
+      @failures.any?
+    end
+
+    # Every failure ends up in three places that are actually watched in production: the logs,
+    # New Relic (which the Sidekiq workers run) and an ActiveSupport notification the calling
+    # worker turns into a dead job. The Slack ping is best effort only: the notifier is built
+    # in config/initializers/slack_notifier.rb for production alone and SlackNotifierService
+    # pings through `presence&.`, so it is a silent no-op everywhere else.
+    def report_failure(message, exception: nil)
+      full_message = "CDS Updates excel: #{message}"
+      full_message += " - #{exception.message}" if exception
+      @failures << full_message
+
+      Rails.logger.error full_message
+      NewRelic::Agent.notice_error(exception || full_message)
+      notify_slack_app(full_message, @filename)
+      instrument(FAILURE_EVENT, filename: @filename, message: full_message)
+    end
+
+    def deliver_report
+      return unless TradeTariffBackend.cds_updates_send_email
+
+      if failed?
+        report_failure("report for #{@filename} not sent because #{@failures.size} earlier failure(s) left it incomplete")
+        return
+      end
+
+      TariffSynchronizer::Mailer.cds_updates(xml_to_file_date, workbook.read_string, excel_filename).deliver_now
+    rescue StandardError => e
+      report_failure("delivery failed for #{excel_filename}", exception: e)
+    end
+
+    # An invalid row is a deliberate filter rather than an error (a goods nomenclature change
+    # with no description, for example), so it is logged and counted but does not fail the
+    # report. Counting rather than logging per row keeps a large file from flooding the logs.
+    def log_skipped_rows
+      @skipped_row_counts.each do |key, count|
+        Rails.logger.warn "CDS Updates excel: dropped #{count} invalid #{key} row(s) from #{@filename}"
+      end
+    end
+
     def write_data(key, instances)
       klass = Module.const_get("CdsImporter::ExcelWriter::#{key}")
 
       update = klass.new(instances)
 
-      return unless update.valid?
+      unless update.valid?
+        @skipped_row_counts[key] += 1
+        return
+      end
 
       unless @data.include?(key)
         @data[key] = []
@@ -143,8 +192,8 @@ class CdsImporter
       (col.ord - 'A'.ord).to_i
     end
 
-    def notify_slack_app(exception, filename)
-      SlackNotifierService.call("Warn: CDS Updates report failed for #{filename} - #{exception.message}")
+    def notify_slack_app(message, filename)
+      SlackNotifierService.call("Warn: CDS Updates report failed for #{filename} - #{message}")
     end
   end
 end

--- a/app/workers/cds_update_notification_worker.rb
+++ b/app/workers/cds_update_notification_worker.rb
@@ -1,14 +1,51 @@
 class CdsUpdateNotificationWorker
   include Sidekiq::Worker
 
+  # Both of these fail the job on purpose. The spreadsheet is this job's only output, so a
+  # green job with no spreadsheet is indistinguishable from a quiet day to the tariff team.
+  # retry: false means the job dies on the first raise, which runs SidekiqDeathHandler (this
+  # worker does not set slack_alerts: false) and is recorded by New Relic.
+  class MissingNotificationError < StandardError; end
+  class ReportFailedError < StandardError; end
+
   sidekiq_options queue: :sync, retry: false
 
   def perform(notification_id)
-    if TradeTariffBackend.uk?
-      notification = CdsUpdateNotification.find(id: notification_id)
-      if notification.present?
-        CdsImporter.new(notification.cds_update, handler_classes: [CdsImporter::ExcelWriter]).import
-      end
+    return unless TradeTariffBackend.uk?
+
+    notification = CdsUpdateNotification.find(id: notification_id)
+
+    if notification.nil?
+      raise MissingNotificationError, "CdsUpdateNotification #{notification_id} no longer exists, so no CDS updates spreadsheet was generated"
     end
+
+    cds_update = notification.cds_update
+    failures = generate_report(cds_update)
+
+    return if failures.empty?
+
+    raise ReportFailedError, "CDS updates spreadsheet for #{cds_update.filename} was not delivered: #{failures.join('; ')}"
+  end
+
+private
+
+  # The writer cannot raise: it also runs inside the daily sync, where a broken report must
+  # not fail a data import that otherwise succeeded. It announces failures instead, and this
+  # worker, which has the context to decide, turns them into a dead job. Failures are matched
+  # on filename so a sync running concurrently on the same queue cannot fail this job.
+  def generate_report(cds_update)
+    failures = []
+
+    subscriber = ActiveSupport::Notifications.subscribe(CdsImporter::ExcelWriter::FAILURE_EVENT) do |*, payload|
+      failures << payload[:message] if payload[:filename] == cds_update.filename
+    end
+
+    begin
+      CdsImporter.new(cds_update, handler_classes: [CdsImporter::ExcelWriter]).import
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber)
+    end
+
+    failures
   end
 end

--- a/spec/lib/cds_importer/excel_writer_spec.rb
+++ b/spec/lib/cds_importer/excel_writer_spec.rb
@@ -88,4 +88,164 @@ RSpec.describe CdsImporter::ExcelWriter do
       expect(writer.instance_variable_get(:@instances)).to eq(%w[I1])
     end
   end
+
+  describe 'reporting failures' do
+    let(:mail) { instance_double(ActionMailer::MessageDelivery, deliver_now: true) }
+
+    before do
+      allow(Rails.logger).to receive(:error)
+      allow(Rails.logger).to receive(:warn)
+      allow(NewRelic::Agent).to receive(:notice_error)
+      allow(SlackNotifierService).to receive(:call)
+      allow(ActiveSupport::Notifications).to receive(:instrument).and_call_original
+      allow(TradeTariffBackend).to receive(:cds_updates_send_email).and_return(true)
+      allow(TariffSynchronizer::Mailer).to receive(:cds_updates).and_return(mail)
+      allow(excel_class).to receive(:sort_columns).and_return([])
+    end
+
+    context 'when writing a row raises' do
+      before do
+        allow(excel).to receive(:data_row).and_raise(StandardError, 'boom')
+      end
+
+      it 'logs the error' do
+        writer.process_record(cds_entity)
+        writer.process_record(cds_entity(element_id: 'E2'))
+
+        expect(Rails.logger).to have_received(:error).with(/write error for K in test.xlsx - boom/)
+      end
+
+      it 'records the error in New Relic' do
+        writer.process_record(cds_entity)
+        writer.process_record(cds_entity(element_id: 'E2'))
+
+        expect(NewRelic::Agent).to have_received(:notice_error)
+      end
+
+      it 'instruments the failure event' do
+        writer.process_record(cds_entity)
+        writer.process_record(cds_entity(element_id: 'E2'))
+
+        expect(ActiveSupport::Notifications).to have_received(:instrument).with(
+          described_class::FAILURE_EVENT,
+          hash_including(filename: 'test.xlsx'),
+        )
+      end
+
+      it 'does not raise, so a data import that otherwise succeeded still completes' do
+        writer.process_record(cds_entity)
+
+        expect { writer.process_record(cds_entity(element_id: 'E2')) }.not_to raise_error
+      end
+    end
+
+    context 'when one row failed but the rest of the file wrote cleanly' do
+      before do
+        calls = 0
+        allow(excel).to receive(:data_row) do
+          calls += 1
+          raise StandardError, 'boom' if calls == 1
+
+          []
+        end
+      end
+
+      it 'does not email a report it knows is incomplete' do
+        writer.process_record(cds_entity)
+        writer.process_record(cds_entity(element_id: 'E2'))
+        writer.after_parse
+
+        expect(TariffSynchronizer::Mailer).not_to have_received(:cds_updates)
+      end
+
+      it 'instruments a failure event for the report it did not send' do
+        writer.process_record(cds_entity)
+        writer.process_record(cds_entity(element_id: 'E2'))
+        writer.after_parse
+
+        expect(ActiveSupport::Notifications).to have_received(:instrument).with(
+          described_class::FAILURE_EVENT,
+          hash_including(message: /not sent/),
+        )
+      end
+    end
+
+    context 'when delivering the email raises' do
+      before do
+        allow(mail).to receive(:deliver_now).and_raise(StandardError, 'smtp down')
+      end
+
+      it 'logs the delivery failure' do
+        writer.process_record(cds_entity)
+        writer.after_parse
+
+        expect(Rails.logger).to have_received(:error).with(/delivery failed.*smtp down/)
+      end
+
+      it 'instruments the failure event' do
+        writer.process_record(cds_entity)
+        writer.after_parse
+
+        expect(ActiveSupport::Notifications).to have_received(:instrument).with(
+          described_class::FAILURE_EVENT,
+          hash_including(message: /delivery failed/),
+        )
+      end
+    end
+
+    context 'when building the worksheets raises' do
+      before do
+        allow(excel_class).to receive(:heading).and_raise(StandardError, 'bad sheet')
+      end
+
+      it 'instruments the failure event' do
+        writer.process_record(cds_entity)
+        writer.after_parse
+
+        expect(ActiveSupport::Notifications).to have_received(:instrument).with(
+          described_class::FAILURE_EVENT,
+          hash_including(message: /bad sheet/),
+        )
+      end
+    end
+
+    context 'when a row is not valid' do
+      before do
+        allow(excel).to receive(:valid?).and_return(false)
+      end
+
+      it 'logs the dropped rows' do
+        writer.process_record(cds_entity)
+        writer.after_parse
+
+        expect(Rails.logger).to have_received(:warn).with(/dropped 1 invalid K row/)
+      end
+
+      it 'still sends the report, because an invalid row is a deliberate filter' do
+        writer.process_record(cds_entity)
+        writer.after_parse
+
+        expect(TariffSynchronizer::Mailer).to have_received(:cds_updates)
+      end
+    end
+
+    context 'when everything succeeds' do
+      it 'sends the report' do
+        writer.process_record(cds_entity)
+        writer.after_parse
+
+        expect(TariffSynchronizer::Mailer).to have_received(:cds_updates)
+      end
+
+      it 'instruments no failure event' do
+        writer.process_record(cds_entity)
+        writer.after_parse
+
+        expect(ActiveSupport::Notifications).not_to have_received(:instrument).with(
+          described_class::FAILURE_EVENT,
+          anything,
+        )
+      end
+    end
+  end
 end

--- a/spec/workers/cds_update_notification_worker_spec.rb
+++ b/spec/workers/cds_update_notification_worker_spec.rb
@@ -1,0 +1,80 @@
+RSpec.describe CdsUpdateNotificationWorker, type: :worker do
+  subject(:perform) { described_class.new.perform(notification_id) }
+
+  let(:notification_id) { 1 }
+  let(:cds_update) { instance_double(TariffSynchronizer::CdsUpdate, filename: 'test.gzip') }
+  let(:notification) { instance_double(CdsUpdateNotification, cds_update:) }
+  let(:importer) { instance_double(CdsImporter, import: nil) }
+
+  before do
+    allow(TradeTariffBackend).to receive(:uk?).and_return(true)
+    allow(CdsUpdateNotification).to receive(:find).with(id: notification_id).and_return(notification)
+    allow(CdsImporter).to receive(:new).and_return(importer)
+  end
+
+  it 'alerts on a dead job, because slack_alerts is not disabled for this worker' do
+    expect(described_class.sidekiq_options['slack_alerts']).to be_nil
+  end
+
+  context 'when the notification exists' do
+    it 'generates the spreadsheet' do
+      perform
+
+      expect(CdsImporter).to have_received(:new).with(cds_update, handler_classes: [CdsImporter::ExcelWriter])
+    end
+  end
+
+  context 'when the notification no longer exists' do
+    before do
+      allow(CdsUpdateNotification).to receive(:find).with(id: notification_id).and_return(nil)
+    end
+
+    it 'raises so the job dies loudly instead of reporting success' do
+      expect { perform }.to raise_error(described_class::MissingNotificationError, /1/)
+    end
+  end
+
+  context 'when the writer reports a failure' do
+    before do
+      allow(importer).to receive(:import) do
+        ActiveSupport::Notifications.instrument(
+          CdsImporter::ExcelWriter::FAILURE_EVENT,
+          filename: 'test.gzip',
+          message: 'CDS Updates excel: delivery failed',
+        )
+      end
+    end
+
+    it 'raises so the job does not report success without a spreadsheet' do
+      expect { perform }.to raise_error(described_class::ReportFailedError, /delivery failed/)
+    end
+  end
+
+  context 'when another file reports a failure concurrently' do
+    before do
+      allow(importer).to receive(:import) do
+        ActiveSupport::Notifications.instrument(
+          CdsImporter::ExcelWriter::FAILURE_EVENT,
+          filename: 'other.gzip',
+          message: 'CDS Updates excel: delivery failed',
+        )
+      end
+    end
+
+    it 'ignores the failure' do
+      expect { perform }.not_to raise_error
+    end
+  end
+
+  context 'when the service is XI' do
+    before do
+      allow(TradeTariffBackend).to receive(:uk?).and_return(false)
+    end
+
+    it 'does nothing' do
+      perform
+
+      expect(CdsImporter).not_to have_received(:new)
+    end
+  end
+end


### PR DESCRIPTION
## What:
Makes every failure in the CDS updates spreadsheet path visible instead of swallowed.

`CdsImporter::ExcelWriter` now routes every failure through one `report_failure` method that writes to the logs, records the error in New Relic, pings Slack (best effort) and fires an `ActiveSupport::Notifications` event, `CdsImporter::ExcelWriter::FAILURE_EVENT`. Rows dropped by `valid?` are counted per key and logged once at the end of the parse.

`CdsUpdateNotificationWorker` subscribes to that event for the file it is processing and raises `ReportFailedError` if anything was reported, and raises `MissingNotificationError` when the `CdsUpdateNotification` row has gone.

Five swallows, and the decision taken for each:

| Swallow | Decision | Reason |
|---|---|---|
| `process_record` rescue on a row write | Log, New Relic, event. No raise. | One bad entity must not lose the other 99% of the report. |
| `after_parse` skipping the email when `@failed` | Still does not email a knowingly incomplete report, but now reports that it did not, so the worker raises. | Sending a silently partial spreadsheet is worse than a loud failure the team can re-run. Re-running is just creating another `CdsUpdateNotification`. |
| `after_parse` rescue swallowing a delivery failure | Delivery gets its own rescue with its own message, then log, New Relic, event. No raise. | See below on why the writer cannot raise. |
| `write_data` dropping rows failing `valid?` | Counted and logged as a warning. No raise. | `valid?` is a deliberate filter, not an error: only `GoodsNomenclature` overrides it, for changes with no description. Counting rather than logging per row keeps a large file from flooding the logs. |
| Worker's `if notification.present?` with no `else` | Raise `MissingNotificationError`. | A vanished row means the report will never be generated. There is nothing to salvage and nothing else to report it. |

The writer does not raise because `CdsImporter::DEFAULT_HANDLER_CLASSES` includes `ExcelWriter`, so it also runs inside the daily sync alongside `RecordInserter`. Raising from `after_parse` there would propagate out of `TariffSynchronizer::CdsUpdateImporter#import!` before `mark_as_applied`, failing a data import over a report bug. The raise therefore lives in `CdsUpdateNotificationWorker`, the caller that has the context to decide: there the spreadsheet is the job's only output. Failures are matched on filename so a sync running concurrently on the same `sync` queue cannot fail the wrong job.

`retry: false` does not prevent alerting. Sidekiq's `JobRetry#local` re-raises when `retry` is falsey, which reaches `global`, which runs the configured death handlers, so the first raise runs `SidekiqDeathHandler`. `CdsUpdateNotificationWorker` does not set `slack_alerts: false`, so the death alert fires (subject to `SLACK_FAILURES_ENABLED`).

## Why:
The daily CDS updates spreadsheet could silently never reach the tariff team. One malformed CDS entity, or SMTP being unavailable, and the importer completed, Sidekiq recorded success, there was no retry, and the spreadsheet was never sent. Tariff ops lose a full day of visibility of CDS changes without ever being told: a quiet day and a broken day look identical to them, so the gap is only found later, by accident.

The existing signal was not one that can be relied on. `config/initializers/slack_notifier.rb` builds the notifier only in production and only when a webhook URL is set, and `SlackNotifierService` pings through `notifier.presence&.ping`, so outside production it is a silent no-op. That is why Slack is kept as best effort only and the load-bearing signals are the logs, New Relic (which runs in the Sidekiq workers) and a dead Sidekiq job.

## Ticket:
N/A

## Risk:
**Risk level:** 🟠

**Reason for rating:**
No change to trader-facing or synchronised data, and the writer deliberately still cannot fail a CDS data import. The behaviour change is that `CdsUpdateNotificationWorker` now dies, and alerts, on failures it previously absorbed, so a pre-existing intermittent fault in the spreadsheet will start showing up as dead jobs. That is the point of the change, but it is worth the team knowing before it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
