### PR TITLE
Preserve false values in search diagnostics

### DIFF
--- a/app/services/api/internal/search_service.rb
+++ b/app/services/api/internal/search_service.rb
@@ -447,7 +447,7 @@ module Api
           search_model: diagnostics_search_model,
           expand_model: model_configuration('expand_model'),
           filter_prefixes: filter_prefixes,
-        }.compact_blank.tap do |configuration|
+        }.reject { |_key, value| value != false && value.blank? }.tap do |configuration|
           configuration[:hybrid_query_guardrail_enabled] = AdminConfiguration.enabled?('hybrid_query_guardrail_enabled')
           configuration[:search_non_declarables] = diagnostics_search_non_declarables
         end

--- a/app/services/search_diagnostics/request_log_lookup.rb
+++ b/app/services/search_diagnostics/request_log_lookup.rb
@@ -85,7 +85,7 @@ module SearchDiagnostics
       message_fields = parsed_message_fields(message)
       fields = message_fields
         .merge(raw_fields.except('@message', '@timestamp', '@ptr'))
-        .compact_blank
+        .reject { |_key, value| value != false && value.blank? }
       fields['details'] = message_fields['details'] if message_fields['details'].is_a?(Hash) || message_fields['details'].is_a?(Array)
 
       Event.new(

--- a/spec/services/api/internal/search_service_spec.rb
+++ b/spec/services/api/internal/search_service_spec.rb
@@ -117,6 +117,35 @@ RSpec.describe Api::Internal::SearchService do
         captured
       end
 
+      it 'preserves disabled configuration flags' do
+        disabled_flags = %w[
+          interactive_search_enabled
+          interactive_search_duplicate_question_guard_enabled
+          expand_search_enabled
+          expand_search_when_needed_enabled
+          refine_search_with_answers_enabled
+          search_labels_enabled
+          pos_search_enabled
+        ]
+        disabled_flags.each do |flag|
+          allow(AdminConfiguration).to receive(:enabled?).with(flag).and_return(false)
+        end
+
+        configuration = captured_diagnostics_configuration({})
+
+        expect(configuration).to include(disabled_flags.to_h { |flag| [flag.to_sym, false] })
+      end
+
+      it 'omits blank configuration values' do
+        allow(AdminConfiguration).to receive(:integer_value).with('vector_score_threshold').and_return(nil)
+        allow(AdminConfiguration).to receive(:nested_options_value).with('search_model')
+          .and_return(selected: ' ', sub_values: {})
+
+        configuration = captured_diagnostics_configuration({})
+
+        expect(configuration).not_to include(:vector_score_threshold, :search_model, :filter_prefixes)
+      end
+
       it 'reflects a search_non_declarables override of false even though AdminConfiguration reports true, proving || is not used' do
         allow(AdminConfiguration).to receive(:enabled?).with('search_non_declarables').and_return(true)
 

--- a/spec/services/search_diagnostics/request_log_lookup_spec.rb
+++ b/spec/services/search_diagnostics/request_log_lookup_spec.rb
@@ -211,6 +211,52 @@ RSpec.describe SearchDiagnostics::RequestLogLookup do
       )
     end
 
+    context 'with boolean and blank fields' do
+      let(:message_fields) do
+        {
+          pricing_known: false,
+          questions_truncated: true,
+          result_count: 0,
+          reason: nil,
+          query: '',
+          error_message: ' ',
+          added_answers: [],
+          configuration: {},
+          details: { enabled: false, reason: nil, candidates: [] },
+        }
+      end
+      let(:query_results_response) do
+        instance_double(
+          Aws::CloudWatchLogs::Types::GetQueryResultsResponse,
+          status: 'Complete',
+          results: [[
+            result_field('@message', message_fields.to_json),
+            result_field('details', 'projected-details'),
+            result_field('search_type', ''),
+          ]],
+        )
+      end
+
+      it 'preserves booleans and nested details' do
+        expect(lookup.call.events.first.fields).to eq(
+          'pricing_known' => false,
+          'questions_truncated' => true,
+          'result_count' => 0,
+          'details' => { 'enabled' => false, 'reason' => nil, 'candidates' => [] },
+        )
+      end
+
+      [{}, [], [{ enabled: false }]].each do |details|
+        context "with details #{details.inspect}" do
+          let(:message_fields) { super().merge(details:) }
+
+          it 'preserves structured details' do
+            expect(lookup.call.events.first.fields.fetch('details')).to eq(JSON.parse(details.to_json))
+          end
+        end
+      end
+    end
+
     context 'when CloudWatch is still running the query' do
       let(:running_response) do
         instance_double(


### PR DESCRIPTION
## What:
- [x] Retain boolean `false` when extracting search diagnostic fields from CloudWatch log messages.
- [x] Include disabled switches in the configuration snapshot logged for internal search.
- [x] Keep other blank-value filtering and structured nested details unchanged.

## Why:
`compact_blank` discarded explicit false values, making disabled configuration and negative diagnostic flags indistinguishable from missing data. Preserve those values so operators can tell what configuration was used and whether a recorded condition was false.

This changes diagnostic emission and extraction only, not search execution or result selection. Consumers of the admin diagnostics response may now receive boolean `false` for fields that were previously absent; projected CloudWatch string values retain their existing representation. Historical configuration values that were never logged cannot be recovered.

## Ticket:
N/A

## Risk:
**Risk level:** Green (low-risk)

**Reason for rating:** The affected feature is unused and has not yet gone live. This is a diagnostics-only correction to preserve explicit false values, with no changes to search decisions, public tariff endpoints, credentials or infrastructure.